### PR TITLE
refactor: rename Solver as SolverWorker

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ Tycho Solver is a high-performance solver built on Tycho for finding optimal swa
 │                       CPU-bound route computation                           │
 │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │
 │  │  Worker 1   │  │  Worker 2   │  │  Worker 3   │  │  Worker N   │        │
-│  │  (Solver)   │  │  (Solver)   │  │  (Solver)   │  │  (Solver)   │        │
+│  │(SolverWorker)│ │(SolverWorker)│ │(SolverWorker)│ │(SolverWorker)│        │
 │  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────┘        │
 └──────────────────────────────────┬──────────────────────────────────────────┘
                                    │ Reads shared data
@@ -77,7 +77,7 @@ Tycho Solver is a high-performance solver built on Tycho for finding optimal swa
                     ┌──────────────┼──────────────┐
                     ▼              ▼              ▼
               ┌──────────┐   ┌──────────┐   ┌──────────┐
-              │ Solver 1 │   │ Solver 2 │   │ Solver N │
+              │SolverWorker│ │SolverWorker│ │SolverWorker│
               │ GraphMgr │   │ GraphMgr │   │ GraphMgr │
               │ updates  │   │ updates  │   │ updates  │
               │ graph    │   │ graph    │   │ graph    │
@@ -125,7 +125,7 @@ impl TaskQueueHandle {
 
 **File:** `src/worker_pool.rs`
 
-**Responsibility:** Manage dedicated compute threads, each owning a Solver instance.
+**Responsibility:** Manage dedicated compute threads, each owning a SolverWorker instance.
 
 ```rust
 pub struct WorkerPool {
@@ -138,7 +138,7 @@ pub struct WorkerPool {
 
 ### 4. SharedMarketData
 
-**File:** `src/market_data.rs`
+**File:** `src/feed/market_data.rs`
 
 **Responsibility:** Single source of truth for all market data. Updated by TychoFeed only.
 
@@ -189,7 +189,7 @@ Algorithms specify their graph type and graph manager via associated types, allo
 
 ### 6. TychoFeed
 
-**File:** `src/tycho_feed.rs`
+**File:** `src/feed/tycho_feed.rs`
 
 **Responsibility:** Connect to Tycho Stream, update SharedMarketData, broadcast events.
 
@@ -197,9 +197,9 @@ Algorithms specify their graph type and graph manager via associated types, allo
 
 ### 7. MarketEvent (Event Bus)
 
-**File:** `src/events.rs`
+**File:** `src/feed/events.rs`
 
-**Responsibility:** Define events broadcast from Indexer to Solvers.
+**Responsibility:** Define events broadcast from TychoFeed to SolverWorkers.
 
 ```rust
 pub enum MarketEvent {
@@ -213,16 +213,16 @@ pub enum MarketEvent {
 
 ---
 
-### 8. Solver
+### 8. SolverWorker
 
-**File:** `src/solver.rs`
+**File:** `src/worker.rs`
 
 **Responsibility:** Initialize graph on startup, subscribe to events, execute algorithm.
 
-The solver is generic over the algorithm type and automatically infers the graph type and graph manager from the algorithm's associated types.
+The solver worker is generic over the algorithm type and automatically infers the graph type and graph manager from the algorithm's associated types.
 
 ```rust
-pub struct Solver<A>
+pub struct SolverWorker<A>
 where
     A: Algorithm,
     A::GraphType: Send + Sync,
@@ -232,12 +232,12 @@ where
     graph_manager: A::GraphManager,  // Maintains the graph internally
     market_data: SharedMarketDataRef,
     event_rx: broadcast::Receiver<MarketEvent>,
-    config: SolverConfig,
+    config: WorkerConfig,
     initialized: bool,
 }
 ```
 
-The solver initializes the graph on startup by reading the component topology from SharedMarketData and calling `graph_manager.initialize_graph()`. The graph manager then maintains the graph internally and updates it based on market events. When solving, the solver gets the graph from the graph manager via `graph_manager.graph()`.
+The solver worker initializes the graph on startup by reading the component topology from SharedMarketData and calling `graph_manager.initialize_graph()`. The graph manager then maintains the graph internally and updates it based on market events. When solving, the solver worker gets the graph from the graph manager via `graph_manager.graph()`.
 
 ---
 
@@ -293,7 +293,7 @@ impl Algorithm for MostLiquidAlgorithm {
 
 - Algorithms are **stateless** - they receive graphs as parameters
 - Each algorithm specifies its preferred graph type and graph manager via associated types
-- The solver automatically creates the graph manager using `Default::default()`
+- The solver worker automatically creates the graph manager using `Default::default()`
 - Graph managers handle converting `HashMap<ComponentId, Vec<Address>>` to the algorithm's graph type
 - This allows algorithms to use different graph crates (petgraph, custom, etc.) and leverage built-in algorithms
 
@@ -319,13 +319,8 @@ impl Algorithm for MostLiquidAlgorithm {
                               └─────┬─────┘     └─────▲─────┘
                                     │                 │
                               ┌─────▼─────┐           │
-                              │  Worker   │───────────┘
-                              │  (picks)  │  response
-                              └─────┬─────┘
-                                    │
-                              ┌─────▼─────┐
-                              │  Solver   │
-                              │  .solve() │
+                              │SolverWorker│──────────┘
+                              │  .solve()  │  response
                               └─────┬─────┘
                                     │
               ┌─────────────────────┼─────────────────────┐
@@ -365,7 +360,7 @@ impl Algorithm for MostLiquidAlgorithm {
                                     ┌──────────┼──────────┐
                                     ▼          ▼          ▼
                               ┌──────────┐┌──────────┐┌──────────┐
-                              │ Solver 1 ││ Solver 2 ││ Solver N │
+                              │SolverWorker││SolverWorker││SolverWorker│
                               │ GraphMgr ││ GraphMgr ││ GraphMgr │
                               │ updates  ││ updates  ││ updates  │
                               │ graph    ││ graph    ││ graph    │
@@ -382,7 +377,7 @@ impl Algorithm for MostLiquidAlgorithm {
 │                     Actix Runtime (async, I/O bound)                    │
 │                                                                         │
 │  ┌───────────────┐  ┌───────────────┐  ┌───────────────┐               │
-│  │  HTTP Server  │  │   Indexer     │  │   Response    │               │
+│  │  HTTP Server  │  │   TychoFeed   │  │   Response    │               │
 │  │   Handlers    │  │   Task        │  │   Collector   │               │
 │  └───────────────┘  └───────────────┘  └───────────────┘               │
 └─────────────────────────────────────────────────────────────────────────┘
@@ -393,7 +388,7 @@ impl Algorithm for MostLiquidAlgorithm {
 │  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐         │
 │  │   Thread 1      │  │   Thread 2      │  │   Thread N      │         │
 │  │   ┌─────────┐   │  │   ┌─────────┐   │  │   ┌─────────┐   │         │
-│  │   │ Solver  │   │  │   │ Solver  │   │  │   │ Solver  │   │         │
+│  │   │SolverWorker│ │  │   │SolverWorker│ │  │   │SolverWorker│ │         │
 │  │   │ (graph  │   │  │   │ (graph  │   │  │   │ (graph  │   │         │
 │  │   │ manager │   │  │   │ manager │   │  │   │ manager │   │         │
 │  │   │ maintains│   │  │   │ maintains│   │  │   │ maintains│   │         │
@@ -405,7 +400,7 @@ impl Algorithm for MostLiquidAlgorithm {
 Communication:
   - HTTP → Workers: mpsc channel (SolveTask)
   - Workers → HTTP: oneshot channel (SolveResult)
-  - Indexer → Workers: broadcast channel (MarketEvent)
+  - TychoFeed → Workers: broadcast channel (MarketEvent)
   - All → SharedMarketData: Arc<RwLock<>> (read-heavy)
 ```
 
@@ -430,18 +425,19 @@ src/
 │   ├── internal.rs           # SolveTask, SolveError
 │   └── primitives.rs         # ComponentId, Address, etc.
 │
-├── market_data.rs            # SharedMarketData
-├── events.rs                 # MarketEvent enum
-│
 ├── graph/                    # Graph management
 │   ├── mod.rs                # GraphManager trait, Edge, Path
 │   └── petgraph.rs           # PetgraphGraphManager
 │
 ├── task_queue.rs             # TaskQueue, TaskQueueHandle
 ├── worker_pool.rs            # WorkerPool
-├── solver.rs                 # Solver
+├── worker.rs                 # SolverWorker
 │
-├── tycho_feed.rs             # TychoFeed
+├── feed/                     # Market data feed
+│   ├── mod.rs
+│   ├── market_data.rs        # SharedMarketData
+│   ├── events.rs             # MarketEvent enum
+│   └── tycho_feed.rs         # TychoFeed
 │
 └── algorithm/                # Algorithm implementations
     ├── mod.rs                # Algorithm trait

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,9 +75,9 @@ pub mod algorithm;
 pub mod api;
 pub mod feed;
 pub mod graph;
-pub mod solver;
 pub mod task_queue;
 pub mod types;
+pub mod worker;
 pub mod worker_pool;
 
 // Re-export commonly used types at crate root
@@ -90,11 +90,11 @@ pub use feed::{
     TychoFeedConfig, TychoFeedError,
 };
 pub use graph::{GraphManager, Path};
-pub use solver::{Solver, SolverConfig};
 pub use task_queue::{TaskQueue, TaskQueueConfig, TaskQueueHandle};
 pub use types::{
     solution::{Order, SolutionOptions, SolutionRequest},
     ComponentId, GasPrice, HealthStatus, OrderSolution, ProtocolSystem, Route, Solution,
     SolutionStatus, SolveError, SolveResult, SolveTask, Swap, TaskId,
 };
+pub use worker::{SolverWorker, WorkerConfig};
 pub use worker_pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig};

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ use tracing_subscriber::FmtSubscriber;
 use tycho_solver::{
     api::{configure_app, AppState, HealthTracker},
     feed::market_data::SharedMarketData,
-    solver::SolverConfig,
     task_queue::{TaskQueue, TaskQueueConfig},
+    worker::WorkerConfig,
     worker_pool::{WorkerPoolBuilder, WorkerPoolConfig},
     TychoFeed, TychoFeedConfig,
 };
@@ -88,12 +88,12 @@ async fn main() -> std::io::Result<()> {
         TychoFeed::new(tycho_feed_config, Arc::clone(&market_data), health_tracker.clone());
 
     // Create worker pool
-    let solver_config = SolverConfig::default();
-    let worker_pool_config = WorkerPoolConfig { num_workers: config.num_workers, solver_config };
+    let worker_config = WorkerConfig::default();
+    let worker_pool_config = WorkerPoolConfig { num_workers: config.num_workers, worker_config };
 
     let worker_pool = WorkerPoolBuilder::new()
         .num_workers(worker_pool_config.num_workers)
-        .solver_config(worker_pool_config.solver_config)
+        .worker_config(worker_pool_config.worker_config)
         .build(task_rx, Arc::clone(&market_data), event_rx);
 
     info!(num_workers = worker_pool.num_workers(), "worker pool started");

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,7 +1,7 @@
-//! Solver component that processes solve requests.
+//! A Solver Worker that processes solve requests.
 //!
-//! Each worker thread owns a Solver instance. The solver:
-//! - Initializes graph from market topology (HashMap<ComponentId, Vec<Address>>)
+//! The Solver Worker:
+//! - Initializes graph from market topology (via a GraphManager)
 //! - Holds a reference to SharedMarketData (for state lookups)
 //! - Subscribes to MarketEvents to keep local topology in sync
 //! - Uses an Algorithm to find routes
@@ -22,34 +22,24 @@ use crate::{
 
 /// Configuration for a Solver instance.
 #[derive(Debug, Clone)]
-pub struct SolverConfig {
-    /// Name of the algorithm to use.
-    pub algorithm_name: String,
+pub struct WorkerConfig {
     /// Maximum hops to search.
     pub max_hops: usize,
     /// Timeout for solving.
     pub timeout: Duration,
 }
 
-impl Default for SolverConfig {
+impl Default for WorkerConfig {
     fn default() -> Self {
-        Self {
-            algorithm_name: "most_liquid".to_string(),
-            max_hops: 3,
-            timeout: Duration::from_millis(100),
-        }
+        Self { max_hops: 3, timeout: Duration::from_millis(100) }
     }
 }
 
-/// A solver instance that processes solve requests.
+/// A solver worker instance that processes solve requests.
 ///
-/// Each worker thread owns one Solver. The solver initializes the graph on startup
-/// from SharedMarketData, and the graph manager maintains the graph and updates it
-/// based on market events.
-///
-/// The solver is generic over the algorithm type `A`, and automatically infers
-/// the graph type `G` and graph manager type from the algorithm.
-pub struct Solver<A>
+/// The solver worker initializes the graph on startup from SharedMarketData, and the graph
+/// manager maintains the graph and updates it based on market events.
+pub struct SolverWorker<A>
 where
     A: Algorithm,
     A::GraphType: Send + Sync,
@@ -64,12 +54,12 @@ where
     /// Receiver for market events.
     event_rx: broadcast::Receiver<MarketEvent>,
     /// Configuration.
-    config: SolverConfig,
+    config: WorkerConfig,
     /// Whether the graph has been initialized.
     initialized: bool,
 }
 
-impl<A> Solver<A>
+impl<A> SolverWorker<A>
 where
     A: Algorithm,
     A::GraphType: Send + Sync,
@@ -89,7 +79,7 @@ where
         market_data: SharedMarketDataRef,
         event_rx: broadcast::Receiver<MarketEvent>,
         algorithm: A,
-        config: SolverConfig,
+        config: WorkerConfig,
     ) -> Self {
         Self {
             algorithm,
@@ -273,7 +263,7 @@ where
     }
 
     /// Returns the config.
-    pub fn config(&self) -> &SolverConfig {
+    pub fn config(&self) -> &WorkerConfig {
         &self.config
     }
 }

--- a/src/worker_pool.rs
+++ b/src/worker_pool.rs
@@ -14,8 +14,8 @@ use tracing::{error, info, warn};
 use crate::{
     algorithm::MostLiquidAlgorithm,
     feed::{events::MarketEvent, market_data::SharedMarketDataRef},
-    solver::{Solver, SolverConfig},
     types::SolveTask,
+    worker::{SolverWorker, WorkerConfig},
 };
 
 /// Configuration for the worker pool.
@@ -24,12 +24,12 @@ pub struct WorkerPoolConfig {
     /// Number of worker threads.
     pub num_workers: usize,
     /// Configuration for each solver.
-    pub solver_config: SolverConfig,
+    pub worker_config: WorkerConfig,
 }
 
 impl Default for WorkerPoolConfig {
     fn default() -> Self {
-        Self { num_workers: num_cpus::get(), solver_config: SolverConfig::default() }
+        Self { num_workers: num_cpus::get(), worker_config: WorkerConfig::default() }
     }
 }
 
@@ -67,7 +67,7 @@ impl WorkerPool {
             let task_rx = Arc::clone(&task_rx);
             let market_data = Arc::clone(&market_data);
             let event_rx = event_rx.resubscribe();
-            let solver_config = config.solver_config.clone();
+            let worker_config = config.worker_config.clone();
             let mut shutdown_rx = shutdown_tx.subscribe();
 
             let handle = thread::Builder::new()
@@ -82,17 +82,17 @@ impl WorkerPool {
                     rt.block_on(async move {
                         // Create algorithm
                         let algorithm = MostLiquidAlgorithm::with_config(
-                            solver_config.max_hops,
-                            solver_config.timeout.as_millis() as u64,
+                            worker_config.max_hops,
+                            worker_config.timeout.as_millis() as u64,
                         );
 
                         // Create solver (graph type and manager are automatically inferred from
                         // algorithm)
-                        let mut solver =
-                            Solver::new(market_data, event_rx, algorithm, solver_config);
+                        let mut worker =
+                            SolverWorker::new(market_data, event_rx, algorithm, worker_config);
 
                         // Initialize solver graph
-                        solver.initialize_graph().await;
+                        worker.initialize_graph().await;
 
                         info!(worker_id, "worker started");
 
@@ -115,7 +115,7 @@ impl WorkerPool {
                                             let _wait_time = task.wait_time();
 
                                             // Process the task
-                                            let result = solver.solve(&task.request).await;
+                                            let result = worker.solve(&task.request).await;
 
                                             if let Err(ref e) = result {
                                                 warn!(
@@ -186,8 +186,8 @@ impl WorkerPoolBuilder {
         self
     }
 
-    pub fn solver_config(mut self, config: SolverConfig) -> Self {
-        self.config.solver_config = config;
+    pub fn worker_config(mut self, config: WorkerConfig) -> Self {
+        self.config.worker_config = config;
         self
     }
 


### PR DESCRIPTION
For clarity we will refer to the entire system as a 'Solver' and the individual internal solving processes as 'SolverWorkers'.