### PR TITLE
fix: reduce lock hold duration on the depth calculator

### DIFF
--- a/src/derived/computations/pool_depth.rs
+++ b/src/derived/computations/pool_depth.rs
@@ -24,6 +24,8 @@ use tycho_simulation::{
     tycho_core::simulation::protocol_sim::{Price, QueryPoolSwapParams, SwapConstraint},
 };
 
+use std::collections::HashSet;
+
 use crate::{
     derived::{
         computation::{ComputationId, DerivedComputation},
@@ -32,7 +34,7 @@ use crate::{
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::PoolDepths,
     },
-    feed::market_data::SharedMarketDataRef,
+    feed::market_data::{SharedMarketData, SharedMarketDataRef},
     types::ComponentId,
 };
 
@@ -182,47 +184,60 @@ impl DerivedComputation for PoolDepthComputation {
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<Self::Output, ComputationError> {
-        let market = market.read().await;
-        let store_guard = store.read().await;
+        // Fetch all data needed for the computation under short-lived locks, then drop guards
+        // so the feed can consume the next message while we run the heavy loop.
+        let (snapshot, spot_prices, mut pool_depths, components_to_compute) = {
+            let market_guard = market.read().await;
+            let store_guard = store.read().await;
 
-        // Get precomputed spot prices (required dependency)
-        let spot_prices = store_guard
-            .spot_prices()
-            .ok_or(ComputationError::MissingDependency(SpotPriceComputation::ID))?;
+            // Get precomputed spot prices (required dependency)
+            let spot_prices = store_guard
+                .spot_prices()
+                .ok_or(ComputationError::MissingDependency(SpotPriceComputation::ID))?
+                .clone();
 
-        // Start with existing depths (or empty for full recompute)
-        let mut pool_depths = if changed.is_full_recompute {
-            PoolDepths::new()
-        } else {
-            store_guard
-                .pool_depths()
-                .cloned()
-                .unwrap_or_default()
+            // Start with existing depths (or empty for full recompute)
+            let mut pool_depths = if changed.is_full_recompute {
+                PoolDepths::new()
+            } else {
+                store_guard
+                    .pool_depths()
+                    .cloned()
+                    .unwrap_or_default()
+            };
+
+            // Remove pool depths for removed components
+            for component_id in &changed.removed {
+                pool_depths.retain(|key, _| &key.0 != component_id);
+            }
+
+            let topology = market_guard.component_topology();
+
+            // Determine which components to compute
+            let components_to_compute: Vec<ComponentId> = if changed.is_full_recompute {
+                topology.keys().cloned().collect()
+            } else {
+                changed
+                    .added
+                    .keys()
+                    .chain(changed.updated.iter())
+                    .cloned()
+                    .collect()
+            };
+
+            let component_ids: HashSet<ComponentId> = components_to_compute.iter().cloned().collect();
+            let snapshot: SharedMarketData = market_guard.extract_subset(&component_ids);
+
+            (snapshot, spot_prices, pool_depths, components_to_compute)
         };
 
-        // Remove pool depths for removed components
-        for component_id in &changed.removed {
-            pool_depths.retain(|key, _| &key.0 != component_id);
-        }
-
-        let topology = market.component_topology();
-        let tokens = market.token_registry_ref();
-
-        // Determine which components to compute
-        let components_to_compute: Vec<_> = if changed.is_full_recompute {
-            topology.keys().collect()
-        } else {
-            changed
-                .added
-                .keys()
-                .chain(changed.updated.iter())
-                .collect()
-        };
+        let topology = snapshot.component_topology();
+        let tokens = snapshot.token_registry_ref();
 
         let mut succeeded = 0usize;
         let mut failed = 0usize;
 
-        for component_id in components_to_compute {
+        for component_id in &components_to_compute {
             // Get token addresses: changed.added for new components, topology for existing
             let token_addresses = changed
                 .added
@@ -233,7 +248,7 @@ impl DerivedComputation for PoolDepthComputation {
                 continue; // Component might have been removed in the meantime
             };
 
-            let Some(sim_state) = market.get_simulation_state(component_id) else {
+            let Some(sim_state) = snapshot.get_simulation_state(component_id) else {
                 warn!(component_id, "missing simulation state, skipping pool");
                 pool_depths.retain(|key, _| &key.0 != component_id);
                 continue;

--- a/src/derived/computations/pool_depth.rs
+++ b/src/derived/computations/pool_depth.rs
@@ -11,6 +11,8 @@
 //! available in the [`DerivedDataStore`](crate::derived::store::DerivedDataStore).
 //! Ensure `SpotPriceComputation` runs before this computation.
 
+use std::collections::HashSet;
+
 use async_trait::async_trait;
 use itertools::Itertools;
 use num_bigint::BigUint;
@@ -23,8 +25,6 @@ use tycho_simulation::{
     },
     tycho_core::simulation::protocol_sim::{Price, QueryPoolSwapParams, SwapConstraint},
 };
-
-use std::collections::HashSet;
 
 use crate::{
     derived::{
@@ -184,8 +184,7 @@ impl DerivedComputation for PoolDepthComputation {
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<Self::Output, ComputationError> {
-        // Fetch all data needed for the computation under short-lived locks, then drop guards
-        // so the feed can consume the next message while we run the heavy loop.
+        // Fetch all data needed for the computation under short-lived locks, then drop guards.
         let (snapshot, spot_prices, mut pool_depths, components_to_compute) = {
             let market_guard = market.read().await;
             let store_guard = store.read().await;
@@ -225,7 +224,10 @@ impl DerivedComputation for PoolDepthComputation {
                     .collect()
             };
 
-            let component_ids: HashSet<ComponentId> = components_to_compute.iter().cloned().collect();
+            let component_ids: HashSet<ComponentId> = components_to_compute
+                .iter()
+                .cloned()
+                .collect();
             let snapshot: SharedMarketData = market_guard.extract_subset(&component_ids);
 
             (snapshot, spot_prices, pool_depths, components_to_compute)


### PR DESCRIPTION
Problem: currently the depth calculation holds the shared market state lock for the entire duration of its calculations. On chains whose block time is faster than the depth calculator, this causes us to fall behind on consuming blocks as the tycho-feed cannot get a write lock until the depth calculations complete.

Solution: on the depth calculator we instead hold the lock long enough to clone any data relevant to the calculations it needs to do. Thereafter we drop the lock and proceed with the slow calculations in the background.