### PR TITLE
ci: Add API breaking change detection workflow

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -1,0 +1,104 @@
+name: API Semver Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  semver-check:
+    name: API Breaking Change Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
+        with:
+          toolchain: stable
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2
+        with:
+          cache-on-failure: true
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@71b48393496777ee11188c07a34d48b048a985cd  # v2
+        with:
+          tool: cargo-semver-checks
+
+      - name: Check for breaking changes
+        id: check
+        env:
+          CARGO_TERM_COLOR: never
+        run: |
+          WORKSPACE_ROOT=$(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_root')
+          PACKAGES=""
+          while IFS=' ' read -r name manifest_path; do
+            rel_dir="${manifest_path#"${WORKSPACE_ROOT}"/}"
+            rel_dir="${rel_dir%/Cargo.toml}"
+            if git cat-file -e "origin/main:${rel_dir}/Cargo.toml" 2>/dev/null; then
+              PACKAGES="${PACKAGES} --package ${name}"
+            else
+              echo "Skipping new crate '${name}' (not present in baseline)"
+            fi
+          done < <(cargo metadata --no-deps --format-version 1 | \
+            jq -r '.packages[] | select(any(.targets[]; .kind[] == "lib")) | "\(.name) \(.manifest_path)"')
+
+          if [ -z "${PACKAGES}" ]; then
+            echo "No pre-existing library crates to check against baseline."
+            echo "breaking=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # shellcheck disable=SC2086
+          if cargo semver-checks ${PACKAGES} --baseline-rev origin/main > semver-output.txt 2>&1; then
+            echo "breaking=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "breaking=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post breaking change comment
+        if: steps.check.outputs.breaking == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const fs = require('fs');
+            const output = fs.readFileSync('semver-output.txt', 'utf8');
+            const body = [
+              '## Breaking API Changes Detected',
+              '',
+              'This PR introduces breaking changes to the public API.',
+              'If this is intentional, consider bumping the major version.',
+              '',
+              '<details><summary>semver-checks output</summary>',
+              '',
+              '```',
+              output.trim(),
+              '```',
+              '',
+              '</details>',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+
+      - name: Fail on breaking changes
+        if: steps.check.outputs.breaking == 'true'
+        run: |
+          cat semver-output.txt
+          exit 1

--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
@@ -43,7 +44,8 @@ jobs:
         env:
           CARGO_TERM_COLOR: never
         run: |
-          WORKSPACE_ROOT=$(cargo metadata --no-deps --format-version 1 | jq -r '.workspace_root')
+          METADATA=$(cargo metadata --no-deps --format-version 1)
+          WORKSPACE_ROOT=$(echo "${METADATA}" | jq -r '.workspace_root')
           PACKAGES=""
           while IFS=' ' read -r name manifest_path; do
             rel_dir="${manifest_path#"${WORKSPACE_ROOT}"/}"
@@ -53,7 +55,7 @@ jobs:
             else
               echo "Skipping new crate '${name}' (not present in baseline)"
             fi
-          done < <(cargo metadata --no-deps --format-version 1 | \
+          done < <(echo "${METADATA}" | \
             jq -r '.packages[] | select(any(.targets[]; .kind[] == "lib")) | "\(.name) \(.manifest_path)"')
 
           if [ -z "${PACKAGES}" ]; then
@@ -75,8 +77,14 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const output = fs.readFileSync('semver-output.txt', 'utf8');
+            const raw = fs.readFileSync('semver-output.txt', 'utf8').trim();
+            const MAX_OUTPUT = 60_000;
+            const output = raw.length > MAX_OUTPUT
+              ? raw.slice(0, MAX_OUTPUT) + '\n\n[output truncated]'
+              : raw;
+            const marker = '<!-- semver-check -->';
             const body = [
+              marker,
               '## Breaking API Changes Detected',
               '',
               'This PR introduces breaking changes to the public API.',
@@ -85,17 +93,32 @@ jobs:
               '<details><summary>semver-checks output</summary>',
               '',
               '```',
-              output.trim(),
+              output,
               '```',
               '',
               '</details>',
             ].join('\n');
-            await github.rest.issues.createComment({
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body,
             });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }
 
       - name: Fail on breaking changes
         if: steps.check.outputs.breaking == 'true'

--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+      types:
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   contents: read
@@ -23,6 +27,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Check PR title for breaking change intent
+        id: pr-title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # Matches: feat!: ..., fix(scope)!: ..., or breaking: ...
+          if echo "$TITLE" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$TITLE" | grep -qE '^breaking(\(.+\))?:'; then
+            echo "declared=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "declared=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7  # stable
@@ -71,33 +87,78 @@ jobs:
             echo "breaking=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Post breaking change comment
-        if: steps.check.outputs.breaking == 'true'
+      - name: Post semver comment
+        if: >
+          steps.check.outputs.breaking == 'true' ||
+          steps.pr-title.outputs.declared == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        env:
+          BREAKING: ${{ steps.check.outputs.breaking }}
+          DECLARED: ${{ steps.pr-title.outputs.declared }}
         with:
           script: |
             const fs = require('fs');
-            const raw = fs.readFileSync('semver-output.txt', 'utf8').trim();
-            const MAX_OUTPUT = 60_000;
-            const output = raw.length > MAX_OUTPUT
-              ? raw.slice(0, MAX_OUTPUT) + '\n\n[output truncated]'
-              : raw;
+            const breaking = process.env.BREAKING === 'true';
+            const declared = process.env.DECLARED === 'true';
             const marker = '<!-- semver-check -->';
-            const body = [
-              marker,
-              '## Breaking API Changes Detected',
-              '',
-              'This PR introduces breaking changes to the public API.',
-              'If this is intentional, consider bumping the major version.',
-              '',
-              '<details><summary>semver-checks output</summary>',
-              '',
-              '```',
-              output,
-              '```',
-              '',
-              '</details>',
-            ].join('\n');
+
+            let body;
+            if (breaking && !declared) {
+              const raw = fs.readFileSync('semver-output.txt', 'utf8').trim();
+              const MAX_OUTPUT = 60_000;
+              const output = raw.length > MAX_OUTPUT
+                ? raw.slice(0, MAX_OUTPUT) + '\n\n[output truncated]'
+                : raw;
+              body = [
+                marker,
+                '## Breaking API Changes Detected',
+                '',
+                'This PR introduces breaking API changes, but the PR title does not declare them.',
+                'Either fix the breaking changes, or update the PR title to signal intent:',
+                '- Use the `!` convention: `feat!: ...`, `fix!: ...`',
+                '- Or use the `breaking` type: `breaking: ...`',
+                '',
+                '<details><summary>semver-checks output</summary>',
+                '',
+                '```',
+                output,
+                '```',
+                '',
+                '</details>',
+              ].join('\n');
+            } else if (breaking && declared) {
+              const raw = fs.readFileSync('semver-output.txt', 'utf8').trim();
+              const MAX_OUTPUT = 60_000;
+              const output = raw.length > MAX_OUTPUT
+                ? raw.slice(0, MAX_OUTPUT) + '\n\n[output truncated]'
+                : raw;
+              body = [
+                marker,
+                '## Breaking API Changes (Intentional)',
+                '',
+                'Breaking API changes detected and declared in the PR title.',
+                'Ensure the major version is bumped before merging.',
+                '',
+                '<details><summary>semver-checks output</summary>',
+                '',
+                '```',
+                output,
+                '```',
+                '',
+                '</details>',
+              ].join('\n');
+            } else {
+              // !breaking && declared
+              body = [
+                marker,
+                '## No API Breaking Changes Detected',
+                '',
+                'The PR title signals breaking changes, but `cargo-semver-checks` found none.',
+                'If the breaking change is behavioral, CLI, or config-level (not public Rust API), this is expected.',
+                'Otherwise, consider removing the `!` or `breaking` type from the PR title.',
+              ].join('\n');
+            }
+
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
@@ -120,8 +181,32 @@ jobs:
               });
             }
 
-      - name: Fail on breaking changes
-        if: steps.check.outputs.breaking == 'true'
+      - name: Delete stale semver comment
+        if: >
+          steps.check.outputs.breaking == 'false' &&
+          steps.pr-title.outputs.declared == 'false'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        with:
+          script: |
+            const marker = '<!-- semver-check -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.deleteComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+            }
+
+      - name: Fail on undeclared breaking changes
+        if: >
+          steps.check.outputs.breaking == 'true' &&
+          steps.pr-title.outputs.declared == 'false'
         run: |
           cat semver-output.txt
           exit 1

--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -33,11 +33,23 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Matches: feat!: ..., fix(scope)!: ..., or breaking: ...
-          if echo "$TITLE" | grep -qE '^[a-z]+(\(.+\))?!:' || echo "$TITLE" | grep -qE '^breaking(\(.+\))?:'; then
-            echo "declared=true" >> "$GITHUB_OUTPUT"
+          MAJOR=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\([0-9]*\)\.[0-9]*\.[0-9]*".*/\1/')
+          if [ "$MAJOR" = "0" ]; then
+            # 0.x.x: breaking changes bump the minor version, declared with feat:
+            echo "pre_v1=true" >> "$GITHUB_OUTPUT"
+            if echo "$TITLE" | grep -qE '^feat(\(.+\))?:'; then
+              echo "declared=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "declared=false" >> "$GITHUB_OUTPUT"
+            fi
           else
-            echo "declared=false" >> "$GITHUB_OUTPUT"
+            # v1+: breaking changes bump the major version, declared with breaking: type
+            echo "pre_v1=false" >> "$GITHUB_OUTPUT"
+            if echo "$TITLE" | grep -qE '^breaking(\(.+\))?:'; then
+              echo "declared=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "declared=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Setup toolchain
@@ -95,11 +107,13 @@ jobs:
         env:
           BREAKING: ${{ steps.check.outputs.breaking }}
           DECLARED: ${{ steps.pr-title.outputs.declared }}
+          PRE_V1: ${{ steps.pr-title.outputs.pre_v1 }}
         with:
           script: |
             const fs = require('fs');
             const breaking = process.env.BREAKING === 'true';
             const declared = process.env.DECLARED === 'true';
+            const preV1 = process.env.PRE_V1 === 'true';
             const marker = '<!-- semver-check -->';
 
             let body;
@@ -109,14 +123,21 @@ jobs:
               const output = raw.length > MAX_OUTPUT
                 ? raw.slice(0, MAX_OUTPUT) + '\n\n[output truncated]'
                 : raw;
+              const hint = preV1
+                ? [
+                    'Either fix the breaking changes, or update the PR title to signal intent:',
+                    '- Use `feat: ...` to bump the minor version (breaking changes on 0.x.x)',
+                  ]
+                : [
+                    'Either fix the breaking changes, or update the PR title to signal intent:',
+                    '- Use `breaking: ...` to declare a major version bump',
+                  ];
               body = [
                 marker,
                 '## Breaking API Changes Detected',
                 '',
                 'This PR introduces breaking API changes, but the PR title does not declare them.',
-                'Either fix the breaking changes, or update the PR title to signal intent:',
-                '- Use the `!` convention: `feat!: ...`, `fix!: ...`',
-                '- Or use the `breaking` type: `breaking: ...`',
+                ...hint,
                 '',
                 '<details><summary>semver-checks output</summary>',
                 '',
@@ -132,12 +153,15 @@ jobs:
               const output = raw.length > MAX_OUTPUT
                 ? raw.slice(0, MAX_OUTPUT) + '\n\n[output truncated]'
                 : raw;
+              const versionNote = preV1
+                ? 'Ensure the minor version is bumped before merging (breaking changes on 0.x.x bump the minor).'
+                : 'Ensure the major version is bumped before merging.';
               body = [
                 marker,
                 '## Breaking API Changes (Intentional)',
                 '',
                 'Breaking API changes detected and declared in the PR title.',
-                'Ensure the major version is bumped before merging.',
+                versionNote,
                 '',
                 '<details><summary>semver-checks output</summary>',
                 '',
@@ -149,13 +173,16 @@ jobs:
               ].join('\n');
             } else {
               // !breaking && declared
+              const titleHint = preV1
+                ? 'Otherwise, consider using `fix:` instead of `feat:` in the PR title.'
+                : 'Otherwise, consider removing the `breaking` type from the PR title.';
               body = [
                 marker,
                 '## No API Breaking Changes Detected',
                 '',
                 'The PR title signals breaking changes, but `cargo-semver-checks` found none.',
                 'If the breaking change is behavioral, CLI, or config-level (not public Rust API), this is expected.',
-                'Otherwise, consider removing the `!` or `breaking` type from the PR title.',
+                titleHint,
               ].join('\n');
             }
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/semver-check.yaml` that runs `cargo-semver-checks` on every PR targeting `main`
- Posts a PR comment with the full `semver-checks` output when breaking public API changes are detected, then fails the job
- Automatically handles new crates: uses `cargo metadata` to enumerate all library crates, then `git cat-file` to skip any that don't exist in `origin/main` — avoiding errors when a PR introduces a brand-new crate alongside changes to existing ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)