### PR TITLE
fix(test-utils): align MockProtocolSim spot_price convention with get_amount_out

### DIFF
--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -1447,7 +1447,7 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        // MockProtocolSim multiplies by spot_price for ALL directions (doesn't use reciprocal).
+        // MockProtocolSim::get_amount_out multiplies by spot_price when token_in < token_out.
         // After the first swap, spot_price increments to 3.
         let (market, manager) =
             setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -39,7 +39,7 @@ pub const ONE_ETH: u128 = 1_000_000_000_000_000_000;
 // TODO: Consider moving MockProtocolSim to the tycho-common
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MockProtocolSim {
-    /// Sport price is a pre-fee ration of token with larger address to smaller address
+    /// Pre-fee exchange rate from smaller-address token to larger-address token
     /// (e.g., if token A address < token B address, amount_B = amount_A * spot_price * (1 - fee))
     pub spot_price: u32,
     /// Gas to report for each swap
@@ -88,14 +88,14 @@ impl ProtocolSim for MockProtocolSim {
         self.fee
     }
 
-    /// Note that spot_price does not account for swap direction
+    /// Returns a direction-dependent spot price with fee markup applied.
     fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
         let post_fee_spot_price = self.spot_price.to_f64().unwrap() / (1.0 - self.fee);
         // In order to have asymmetric spot prices based on token order, we define:
         if base.address < quote.address {
-            Ok(1.0 / post_fee_spot_price)
-        } else {
             Ok(post_fee_spot_price)
+        } else {
+            Ok(1.0 / post_fee_spot_price)
         }
     }
 
@@ -426,17 +426,17 @@ mod tests {
         let (token_low, token_high) = ordered_tokens();
         let sim = MockProtocolSim::new(4); // spot_price = 4, no fee
 
-        // When base < quote: returns 1/spot_price
+        // When base < quote: returns spot_price
         let price_low_to_high = sim
             .spot_price(&token_low, &token_high)
             .unwrap();
-        assert_eq!(price_low_to_high, 0.25); // 1/4
+        assert_eq!(price_low_to_high, 4.0);
 
-        // When base > quote: returns spot_price
+        // When base > quote: returns 1/spot_price
         let price_high_to_low = sim
             .spot_price(&token_high, &token_low)
             .unwrap();
-        assert_eq!(price_high_to_low, 4.0);
+        assert_eq!(price_high_to_low, 0.25); // 1/4
     }
 
     #[test]
@@ -446,17 +446,17 @@ mod tests {
         // post_fee_spot_price = 2 / (1 - 0.5) = 4
         let sim = MockProtocolSim::new(2).with_fee(0.5);
 
-        // When base < quote: returns 1/post_fee_spot_price = 1/4 = 0.25
+        // When base < quote: returns post_fee_spot_price = 4.0
         let price_low_to_high = sim
             .spot_price(&token_low, &token_high)
             .unwrap();
-        assert_eq!(price_low_to_high, 0.25);
+        assert_eq!(price_low_to_high, 4.0);
 
-        // When base > quote: returns post_fee_spot_price = 4.0
+        // When base > quote: returns 1/post_fee_spot_price = 1/4 = 0.25
         let price_high_to_low = sim
             .spot_price(&token_high, &token_low)
             .unwrap();
-        assert_eq!(price_high_to_low, 4.0);
+        assert_eq!(price_high_to_low, 0.25);
     }
 
     // ==================== get_amount_out() Tests ====================

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -520,7 +520,7 @@ mod tests {
 
         let comp = PoolDepthComputation::new(0.5).unwrap();
 
-        // spot_price=2: new_state has spot_price=3, impact = |1/3 - 1/2| / (1/2) = 1/3 ≈ 33% <= 50%
+        // spot_price=2: new_state has spot_price=3, impact = |3 - 2| / 2 = 1/2 = 50%
         let sim = MockProtocolSim::new(2).with_liquidity(1_000_000);
         let depth = comp
             .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
@@ -538,11 +538,11 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        // spot_price=100, fee=1%. The mock's spot_price() includes fee markup: raw/(1-fee).
-        // After swap: new spot_price=101. Price impact based on spot prices:
-        // initial = 1/(100/0.99), new = 1/(101/0.99) → impact = |new-initial|/initial = 1/100 = 1%
+        // spot_price=200, fee=1%. The mock's spot_price() includes fee markup: raw/(1-fee).
+        // After swap: new spot_price=201. Price impact based on spot prices:
+        // initial = 200/0.99, new = 201/0.99 → impact = |new-initial|/initial = 1/200 = 0.5%
         // With default threshold 1%, this should pass (impact <= threshold).
-        let sim = MockProtocolSim::new(100)
+        let sim = MockProtocolSim::new(200)
             .with_liquidity(1_000_000)
             .with_fee(0.01);
         let comp = PoolDepthComputation::default();

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -183,13 +183,13 @@ mod tests {
     }
 
     /// MockProtocolSim spot_price behavior:
-    /// - When base < quote: returns 1/spot_price
-    /// - When base > quote: returns spot_price
+    /// - When base < quote: returns spot_price
+    /// - When base > quote: returns 1/spot_price
     #[rstest]
-    #[case::low_to_high(0x01, 0x02, 2, 0.5)]
-    #[case::high_to_low(0x02, 0x01, 2, 2.0)]
-    #[case::spot_price_4_low_to_high(0x01, 0x02, 4, 0.25)]
-    #[case::spot_price_4_high_to_low(0x02, 0x01, 4, 4.0)]
+    #[case::low_to_high(0x01, 0x02, 2, 2.0)]
+    #[case::high_to_low(0x02, 0x01, 2, 0.5)]
+    #[case::spot_price_4_low_to_high(0x01, 0x02, 4, 4.0)]
+    #[case::spot_price_4_high_to_low(0x02, 0x01, 4, 0.25)]
     fn spot_price_direction(
         #[case] in_addr: u8,
         #[case] out_addr: u8,


### PR DESCRIPTION
## Summary

- **Fix `MockProtocolSim::spot_price()` to match `get_amount_out()` convention**: `spot_price(base, quote)` now returns the marginal rate in the same direction as `get_amount_out(base, quote)`, consistent with other ProtocolSim like UniswapV2State
- **Update all affected test assertions and comments** across `test_utils.rs`, `spot_price.rs`, `pool_depth.rs`, and `most_liquid.rs`
- **Bump `spot_price` from 100 to 200** in `test_binary_search_uses_spot_price_not_effective_price` to avoid a floating-point boundary edge case at exactly 1% impact

## Test plan

- [x] `cargo nextest run -p fynd-core` — all 220 tests pass
- [x] `cargo +nightly fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)