### PR TITLE
refactor(pool-depth): replace binary search fallback with generic Brent solver

### DIFF
--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -11,7 +11,10 @@ use tycho_simulation::{
         models::{protocol::ProtocolComponent, token::Token, Address, Chain},
         simulation::{
             errors::{SimulationError, TransitionError},
-            protocol_sim::{Balances, GetAmountOutResult, ProtocolSim},
+            protocol_sim::{
+                Balances, GetAmountOutResult, PoolSwap, ProtocolSim, QueryPoolSwapParams,
+                SwapConstraint,
+            },
         },
         Bytes,
     },
@@ -188,6 +191,24 @@ impl ProtocolSim for MockProtocolSim {
         };
 
         Ok((sell_limit, buy_limit))
+    }
+
+    fn query_pool_swap(&self, params: &QueryPoolSwapParams) -> Result<PoolSwap, SimulationError> {
+        let token_in = params.token_in();
+        let token_out = params.token_out();
+
+        match params.swap_constraint() {
+            SwapConstraint::TradeLimitPrice { .. } => {
+                let (sell_limit, _) =
+                    self.get_limits(token_in.address.clone(), token_out.address.clone())?;
+                let result = self.get_amount_out(sell_limit.clone(), token_in, token_out)?;
+                Ok(PoolSwap::new(sell_limit, result.amount, result.new_state, None))
+            }
+            _ => Err(SimulationError::InvalidInput(
+                "MockProtocolSim only supports TradeLimitPrice".to_string(),
+                None,
+            )),
+        }
     }
 
     fn delta_transition(

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -1,7 +1,7 @@
 //! Pool depth computation.
 //!
-//! Computes liquidity depths for all pools using `query_pool_swap` when available,
-//! falling back to binary search with `get_amount_out`.
+//! Computes liquidity depths for all pools using `query_pool_swap`, falling back to
+//! the generic Brent solver from tycho-simulation when the pool doesn't implement it natively.
 //! Depth represents the maximum input amount before reaching the configured slippage
 //! threshold from the spot price.
 //!
@@ -16,13 +16,11 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use itertools::Itertools;
 use num_bigint::BigUint;
-use num_traits::{One, Zero};
+use num_traits::Zero;
 use tracing::{debug, instrument, warn, Span};
 use tycho_simulation::{
-    tycho_common::{
-        models::token::Token,
-        simulation::{errors::SimulationError, protocol_sim::ProtocolSim},
-    },
+    evm::query_pool_swap::query_pool_swap,
+    tycho_common::simulation::errors::SimulationError,
     tycho_core::simulation::protocol_sim::{Price, QueryPoolSwapParams, SwapConstraint},
 };
 
@@ -40,8 +38,9 @@ use crate::{
 
 /// Computes pool depths for all pools in all directions.
 ///
-/// For each pool and token pair, uses binary search to find the maximum input
-/// amount that results in at most the configured slippage from spot price.
+/// For each pool and token pair, uses `query_pool_swap` (with Brent solver fallback)
+/// to find the maximum input amount that results in at most the configured slippage
+/// from spot price.
 #[derive(Debug)]
 pub struct PoolDepthComputation {
     slippage_threshold: f64,
@@ -68,106 +67,6 @@ impl PoolDepthComputation {
             )));
         }
         Ok(Self { slippage_threshold })
-    }
-
-    /// Binary search to find the maximum amount_in with acceptable slippage.
-    ///
-    /// Measures price impact by comparing the post-swap spot price against the initial spot price.
-    /// Both prices are on the same basis (buy-side), avoiding fee mismatches that occur when
-    /// comparing effective price (amount_out/amount_in) against spot price.
-    ///
-    /// Uses `get_limits()` for the upper bound and assumes that it returns a simulatable input
-    /// amount.
-    ///
-    /// As we never exceed the upper bound, we assume that if the simulation errors, it's because
-    /// we are below the lower bound of valid amounts, and thus should increase the lower bound.
-    /// This assumes that the simulation should not have errors in the valid range.
-    ///
-    /// # Behavior
-    /// - Simulation errors indicate we're outside valid range → adjust bounds accordingly
-    /// - Spot price errors are propagated as `SimulationFailed`
-    fn find_depth_binary_search(
-        &self,
-        sim_state: &dyn ProtocolSim,
-        token_in: &Token,
-        token_out: &Token,
-        component_id: &ComponentId,
-    ) -> Result<BigUint, ComputationError> {
-        let (max_input, _) = sim_state
-            .get_limits(token_in.address.clone(), token_out.address.clone())
-            .map_err(|e| {
-                ComputationError::SimulationFailed(format!(
-                    "get_limits failed for pool {component_id} {}/{}: {e}",
-                    token_in.address, token_out.address
-                ))
-            })?;
-
-        if max_input.is_zero() {
-            return Ok(BigUint::zero());
-        }
-
-        let initial_price = sim_state
-            .spot_price(token_in, token_out)
-            .map_err(|e| {
-                ComputationError::SimulationFailed(format!(
-                    "spot_price failed for pool {component_id} {}/{}: {e}",
-                    token_in.address, token_out.address
-                ))
-            })?;
-
-        // Check if the limit itself doesn't exceed slippage — if so, depth is the limit
-        if let Ok(result) = sim_state.get_amount_out(max_input.clone(), token_in, token_out) {
-            if let Ok(new_price) = result
-                .new_state
-                .spot_price(token_in, token_out)
-            {
-                let price_impact = ((new_price - initial_price) / initial_price).abs();
-                if price_impact <= self.slippage_threshold {
-                    return Ok(max_input);
-                }
-            }
-        }
-
-        let mut low = BigUint::one();
-        let mut high = max_input;
-        let mut best_valid = None;
-
-        while low < high {
-            let mid = (&low + &high) / 2u32;
-
-            match sim_state.get_amount_out(mid.clone(), token_in, token_out) {
-                Ok(result) => {
-                    let new_price = result
-                        .new_state
-                        .spot_price(token_in, token_out)
-                        .map_err(|e| {
-                            ComputationError::SimulationFailed(format!(
-                                "post-swap spot_price failed for pool {component_id} {}/{}: \
-                                     {e}",
-                                token_in.address, token_out.address
-                            ))
-                        })?;
-                    let price_impact = ((new_price - initial_price) / initial_price).abs();
-
-                    if price_impact <= self.slippage_threshold {
-                        best_valid = Some(mid.clone());
-                        low = mid + BigUint::one();
-                    } else {
-                        high = mid;
-                    }
-                }
-                Err(_) => {
-                    low = mid + BigUint::one();
-                }
-            }
-        }
-
-        best_valid.ok_or(ComputationError::NoValidResult {
-            reason: format!(
-                "could not find valid depth for pool {component_id} {}/{}",
-                token_in.address, token_out.address
-            ),
-        })
     }
 }
 
@@ -335,24 +234,27 @@ impl DerivedComputation for PoolDepthComputation {
                     },
                 );
 
-                // Try query_pool_swap first, fall back to binary search if not supported
                 let depth_result = match sim_state.query_pool_swap(&params) {
-                    Ok(swap) => Ok(swap.amount_in().clone()),
+                    Ok(swap) => Ok(swap),
                     Err(SimulationError::FatalError(msg))
                         if msg == "query_pool_swap not implemented" =>
                     {
-                        self.find_depth_binary_search(sim_state, token_in, token_out, component_id)
+                        query_pool_swap(sim_state, &params)
                     }
                     Err(SimulationError::InvalidInput(msg, _))
                         if msg.contains("does not support TradeLimitPrice") =>
                     {
-                        self.find_depth_binary_search(sim_state, token_in, token_out, component_id)
+                        query_pool_swap(sim_state, &params)
                     }
-                    Err(e) => Err(ComputationError::SimulationFailed(format!(
+                    Err(e) => Err(e),
+                }
+                .map(|swap| swap.amount_in().clone())
+                .map_err(|e| {
+                    ComputationError::SimulationFailed(format!(
                         "query_pool_swap failed for {}/{}: {e}",
                         token_in.address, token_out.address
-                    ))),
-                };
+                    ))
+                });
 
                 match depth_result {
                     Ok(depth) => {
@@ -362,7 +264,7 @@ impl DerivedComputation for PoolDepthComputation {
                     Err(e) => {
                         // Diagnostic: probe with 1 unit to understand why depth search failed
                         let probe_info = sim_state
-                            .get_amount_out(BigUint::one(), token_in, token_out)
+                            .get_amount_out(BigUint::from(1u32), token_in, token_out)
                             .map(|r| format!("amount_out={}", r.amount))
                             .unwrap_or_else(|e| format!("sim_error={e}"));
                         let limits_info = sim_state
@@ -397,6 +299,7 @@ impl DerivedComputation for PoolDepthComputation {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use tycho_simulation::tycho_common::simulation::protocol_sim::ProtocolSim;
 
     use super::*;
     use crate::{
@@ -479,97 +382,6 @@ mod tests {
             matches!(result, Err(ComputationError::MissingDependency("spot_prices"))),
             "should return MissingDependency for spot_prices, got {result:?}"
         );
-    }
-
-    /// MockProtocolSim increments spot_price by 1 on each swap.
-    /// With spot_price=100 (no fee), price impact = 1/100 = 1% which equals the default
-    /// threshold, so the limit itself passes → depth = sell_limit.
-    /// With zero liquidity, depth is zero.
-    #[rstest]
-    #[case::within_threshold(100.0, 1_000_000, 10_000)]
-    #[case::zero_for_zero_liquidity(100.0, 0, 0)]
-    fn test_binary_search_finds_depth_within_threshold(
-        #[case] spot_price: f64,
-        #[case] liquidity: u128,
-        #[case] expected_depth: u64,
-    ) {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        let sim = MockProtocolSim::new(spot_price).with_liquidity(liquidity);
-        let comp = PoolDepthComputation::default();
-
-        let depth = comp
-            .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
-            .unwrap();
-
-        assert_eq!(
-            depth,
-            BigUint::from(expected_depth),
-            "expected depth {expected_depth} for spot_price={spot_price}, liquidity={liquidity}"
-        );
-    }
-
-    /// When price impact always exceeds the threshold (spot_price=1, impact=100%),
-    /// binary search returns NoValidResult.
-    #[test]
-    fn test_binary_search_returns_error_when_all_amounts_exceed_threshold() {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        let sim = MockProtocolSim::new(1.0).with_liquidity(1_000_000);
-        let comp = PoolDepthComputation::default();
-
-        let result = comp.find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into());
-
-        assert!(
-            matches!(result, Err(ComputationError::NoValidResult { .. })),
-            "expected NoValidResult when price impact always exceeds threshold, got {result:?}"
-        );
-    }
-
-    /// With a higher slippage threshold (50%), spot_price=1 (impact=100%) still fails,
-    /// but spot_price=2 (impact=50%) passes.
-    #[test]
-    fn test_binary_search_respects_custom_slippage_threshold() {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        let comp = PoolDepthComputation::new(0.5).unwrap();
-
-        // spot_price=2: new_state has spot_price=3, impact = |3 - 2| / 2 = 1/2 = 50%
-        let sim = MockProtocolSim::new(2.0).with_liquidity(1_000_000);
-        let depth = comp
-            .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
-            .unwrap();
-
-        // sell_limit = liquidity / spot_price = 1_000_000 / 2 = 500_000
-        assert_eq!(depth, BigUint::from(500_000u64));
-    }
-
-    /// Verify that the binary search uses spot price impact (not effective price).
-    /// With a fee, effective price differs from spot price, but the binary search
-    /// should only consider spot price changes.
-    #[test]
-    fn test_binary_search_uses_spot_price_not_effective_price() {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        // spot_price=200, fee=1%. The mock's spot_price() includes fee markup: raw/(1-fee).
-        // After swap: new spot_price=201. Price impact based on spot prices:
-        // initial = 200/0.99, new = 201/0.99 → impact = |new-initial|/initial = 1/200 = 0.5%
-        // With default threshold 1%, this should pass (impact <= threshold).
-        let sim = MockProtocolSim::new(200.0)
-            .with_liquidity(1_000_000)
-            .with_fee(0.01);
-        let comp = PoolDepthComputation::default();
-
-        let depth = comp
-            .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
-            .unwrap();
-
-        // Should find a valid depth (the limit itself passes)
-        assert!(depth > BigUint::zero(), "should find valid depth for high-fee pool");
     }
 
     #[rstest]
@@ -730,5 +542,141 @@ mod tests {
             "post-swap price impact {price_impact:.4} should be near slippage {slippage} \
              for {decimals_in}/{decimals_out} decimals"
         );
+    }
+
+    /// Exercises the Brent solver fallback path with realistic UniV2 pool states to verify
+    /// it produces sensible depth values. This validates that the Price construction
+    /// approach in compute() is correct across a range of real-world token pairs.
+    ///
+    /// Three pools covering the key decimal configurations encountered in production:
+    ///   - WETH/USDC: 18/6 decimals, ~$2000 price, ~$10M liquidity
+    ///   - WETH/WBTC: 18/8 decimals, ~15 price, ~$5M liquidity
+    ///   - USDC/USDT: 6/6 decimals, ~1 price, ~$50M liquidity
+    #[test]
+    fn test_brent_solver_with_realistic_pools() {
+        use alloy::primitives::U256;
+        use tycho_simulation::evm::{
+            protocol::uniswap_v2::state::UniswapV2State, query_pool_swap::query_pool_swap,
+        };
+
+        struct PoolCase {
+            name: &'static str,
+            token_in: tycho_simulation::tycho_core::models::token::Token,
+            token_out: tycho_simulation::tycho_core::models::token::Token,
+            reserve_in_human: u64,
+            reserve_out_human: u64,
+        }
+
+        // WETH reserve ~5000 ETH, USDC reserve ~10M USDC  → ~$2000/ETH, ~$10M TVL
+        // WETH reserve ~333 ETH, WBTC reserve ~5000 WBTC  → ~15 WBTC/WETH, ~$5M TVL
+        // USDC reserve ~25M, USDT reserve ~25M            → ~1:1, ~$50M TVL
+        let cases = vec![
+            PoolCase {
+                name: "WETH(18)/USDC(6)",
+                token_in: token_with_decimals(0x01, "WETH", 18),
+                token_out: token_with_decimals(0x02, "USDC", 6),
+                reserve_in_human: 5_000,
+                reserve_out_human: 10_000_000,
+            },
+            PoolCase {
+                name: "WETH(18)/WBTC(8)",
+                token_in: token_with_decimals(0x01, "WETH", 18),
+                token_out: token_with_decimals(0x02, "WBTC", 8),
+                reserve_in_human: 5_000,
+                reserve_out_human: 333,
+            },
+            PoolCase {
+                name: "USDC(6)/USDT(6)",
+                token_in: token_with_decimals(0x01, "USDC", 6),
+                token_out: token_with_decimals(0x02, "USDT", 6),
+                reserve_in_human: 25_000_000,
+                reserve_out_human: 25_000_000,
+            },
+        ];
+
+        let slippage = 0.01_f64;
+        const SCALE_EXP: i32 = 18;
+
+        for case in &cases {
+            let decimals_in = case.token_in.decimals;
+            let decimals_out = case.token_out.decimals;
+
+            let reserve_in =
+                U256::from(case.reserve_in_human) * U256::from(10u64).pow(U256::from(decimals_in));
+            let reserve_out = U256::from(case.reserve_out_human) *
+                U256::from(10u64).pow(U256::from(decimals_out));
+            let univ2 = UniswapV2State::new(reserve_in, reserve_out);
+
+            let spot_price = univ2
+                .spot_price(&case.token_in, &case.token_out)
+                .unwrap_or_else(|e| panic!("[{}] spot_price failed: {e}", case.name));
+
+            let min_price = spot_price * (1.0 - slippage);
+
+            let decimal_diff = decimals_in as i32 - decimals_out as i32;
+            let denominator_exp = SCALE_EXP + decimal_diff;
+            assert!(
+                denominator_exp >= 0,
+                "[{}] denominator_exp would be negative: {denominator_exp}",
+                case.name
+            );
+
+            let numerator = BigUint::from((min_price * 10_f64.powi(SCALE_EXP)) as u128);
+            let denominator = BigUint::from(10u64).pow(denominator_exp as u32);
+            let limit_price = Price::new(numerator, denominator);
+
+            let limit_price_f64 = min_price;
+
+            let params = QueryPoolSwapParams::new(
+                case.token_in.clone(),
+                case.token_out.clone(),
+                SwapConstraint::TradeLimitPrice {
+                    limit: limit_price,
+                    tolerance: 0.0,
+                    min_amount_in: None,
+                    max_amount_in: None,
+                },
+            );
+
+            let result = query_pool_swap(&univ2, &params)
+                .unwrap_or_else(|e| panic!("[{}] query_pool_swap failed: {e}", case.name));
+
+            let amount_in = result.amount_in();
+            assert!(!amount_in.is_zero(), "[{}] amount_in (depth) should be non-zero", case.name);
+
+            let post_swap_spot = result
+                .new_state()
+                .spot_price(&case.token_in, &case.token_out)
+                .unwrap_or_else(|e| panic!("[{}] post-swap spot_price failed: {e}", case.name));
+            let price_impact = ((post_swap_spot - spot_price) / spot_price).abs();
+
+            let amount_in_human = {
+                let raw: f64 = amount_in
+                    .to_string()
+                    .parse()
+                    .unwrap_or(0.0);
+                raw / 10_f64.powi(decimals_in as i32)
+            };
+
+            println!(
+                "[{}] spot_price={:.6}, limit_price={:.6}, amount_in={} ({:.4} human), \
+                 post_swap_spot={:.6}, price_impact={:.4}%",
+                case.name,
+                spot_price,
+                limit_price_f64,
+                amount_in,
+                amount_in_human,
+                post_swap_spot,
+                price_impact * 100.0
+            );
+
+            assert!(
+                price_impact <= slippage + 0.005,
+                "[{}] price impact {:.4}% exceeds slippage {:.4}% + tolerance",
+                case.name,
+                price_impact * 100.0,
+                slippage * 100.0
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Replace the hand-rolled binary search fallback in pool depth computation with tycho-simulation's generic `query_pool_swap` free function (Brent solver)
- Implement `query_pool_swap` on `MockProtocolSim` for `TradeLimitPrice` constraint
- Add `test_brent_solver_with_realistic_pools` test covering WETH/USDC (18/6), WETH/WBTC (18/8), and USDC/USDT (6/6) with realistic reserves

This is a re-introduction of the Brent solver that was reverted in PR #46. The decimal scaling fix in the base branch (`mp/fix-depth-decimal-scaling`) resolves the root cause of the original failure (`Target > spot` error for mixed-decimal pairs).

### E2E validation

Ran fynd locally against `tycho-beta` with `uniswap_v2,uniswap_v3` protocols. Tested 30 quotes across 7 pair directions (WETH/USDC, USDC/WETH, WETH/WBTC, WBTC/WETH, DAI/USDC, USDC/USDT, WETH/DAI) at multiple amounts (0.01 ETH to 1000 ETH). All returned successfully with sensible prices and no errors.

## Test plan

- [x] `cargo nextest run -p fynd-core` — 236 pass, 0 fail
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — clean
- [x] E2E: `curl -X POST http://localhost:3000/v1/solve` with real pool states across mixed-decimal pairs and multiple amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)