### PR TITLE
feat: replace binary search fallback with generic Brent solver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,6 +3254,7 @@ dependencies = [
 name = "fynd-core"
 version = "0.1.0"
 dependencies = [
+ "alloy",
  "async-channel",
  "async-trait",
  "chrono",

--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -29,4 +29,5 @@ metrics.workspace = true
 typetag.workspace = true
 
 [dev-dependencies]
+alloy = { version = "1.0", default-features = false }
 rstest.workspace = true

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -947,7 +947,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let paths = MostLiquidAlgorithm::find_paths(
             manager.graph(),
@@ -980,8 +980,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(2)),
-            ("pool2", &token_b, &token_c, MockProtocolSim::new(3)),
+            ("pool1", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("pool2", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         let paths = MostLiquidAlgorithm::find_paths(
@@ -1018,7 +1018,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         // A->B->A path requires min_hops=2, max_hops=2
         // Since the graph is bidirectional, we should get A->B->A path
@@ -1057,7 +1057,7 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, _) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
         let market = market_read(&market);
 
         // Add token C to graph but not to market (A->B->C)
@@ -1083,7 +1083,7 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let (market, manager) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         // Remove the component but keep tokens and graph
         let mut market_write = market.try_write().unwrap();
@@ -1113,7 +1113,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
             AlgorithmConfig::new(1, 1, Duration::from_millis(100)).unwrap(),
@@ -1146,9 +1146,9 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market(vec![
-            ("best", &token_a, &token_b, MockProtocolSim::new(3).with_gas(10)),
-            ("low_out", &token_a, &token_b, MockProtocolSim::new(2).with_gas(5)),
-            ("high_gas", &token_a, &token_b, MockProtocolSim::new(4).with_gas(30)),
+            ("best", &token_a, &token_b, MockProtocolSim::new(3.0).with_gas(10)),
+            ("low_out", &token_a, &token_b, MockProtocolSim::new(2.0).with_gas(5)),
+            ("high_gas", &token_a, &token_b, MockProtocolSim::new(4.0).with_gas(30)),
         ]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
@@ -1179,7 +1179,7 @@ mod tests {
         let token_c = token(0x03, "C"); // Disconnected
 
         let (market, manager) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let algorithm = MostLiquidAlgorithm::new();
         let order = order(&token_a, &token_c, ONE_ETH, OrderSide::Sell);
@@ -1197,8 +1197,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(2)),
-            ("pool2", &token_b, &token_c, MockProtocolSim::new(3)),
+            ("pool1", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("pool2", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
@@ -1228,8 +1228,8 @@ mod tests {
 
         // Set up market with both pools using new API
         let mut market = SharedMarketData::new();
-        let pool1_state = MockProtocolSim::new(2);
-        let pool2_state = MockProtocolSim::new(3); // Higher multiplier but no edge weight
+        let pool1_state = MockProtocolSim::new(2.0);
+        let pool2_state = MockProtocolSim::new(3.0); // Higher multiplier but no edge weight
 
         let pool1_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
         let pool2_comp = component("pool2", &[token_a.clone(), token_b.clone()]);
@@ -1295,7 +1295,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let mut market = SharedMarketData::new();
-        let pool_state = MockProtocolSim::new(2);
+        let pool_state = MockProtocolSim::new(2.0);
         let pool_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
 
         // Set gas price (required for simulation)
@@ -1339,7 +1339,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
         let mut market_write = market.try_write().unwrap();
 
         // Set a non-zero gas price so gas cost exceeds tiny output
@@ -1386,7 +1386,7 @@ mod tests {
             "pool1",
             &token_a,
             &token_b,
-            MockProtocolSim::new(2).with_liquidity(1000),
+            MockProtocolSim::new(2.0).with_liquidity(1000),
         )]);
 
         let algorithm = MostLiquidAlgorithm::new();
@@ -1405,7 +1405,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let mut market = SharedMarketData::new();
-        let pool_state = MockProtocolSim::new(2);
+        let pool_state = MockProtocolSim::new(2.0);
         let pool_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
 
         // DO NOT set gas price - this is what we're testing
@@ -1450,7 +1450,7 @@ mod tests {
         // MockProtocolSim::get_amount_out multiplies by spot_price when token_in < token_out.
         // After the first swap, spot_price increments to 3.
         let (market, manager) =
-            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2))]);
+            setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         // Use min_hops=2 to require at least 2 hops (circular)
         let algorithm = MostLiquidAlgorithm::with_config(
@@ -1492,10 +1492,10 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(10)), /* Direct: 1-hop, high
-                                                                        * output */
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(2)), // 2-hop path
-            ("pool_cb", &token_c, &token_b, MockProtocolSim::new(3)), // 2-hop path
+            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(10.0)), /* Direct: 1-hop, high
+                                                                          * output */
+            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(2.0)), // 2-hop path
+            ("pool_cb", &token_c, &token_b, MockProtocolSim::new(3.0)), // 2-hop path
         ]);
 
         // min_hops=2 should skip the 1-hop direct path
@@ -1529,8 +1529,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3)),
+            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         // max_hops=1 cannot reach C from A (needs 2 hops)
@@ -1559,11 +1559,11 @@ mod tests {
 
         // Create many parallel pools to ensure multiple paths need processing
         let (market, manager) = setup_market(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(1)),
-            ("pool2", &token_a, &token_b, MockProtocolSim::new(2)),
-            ("pool3", &token_a, &token_b, MockProtocolSim::new(3)),
-            ("pool4", &token_a, &token_b, MockProtocolSim::new(4)),
-            ("pool5", &token_a, &token_b, MockProtocolSim::new(5)),
+            ("pool1", &token_a, &token_b, MockProtocolSim::new(1.0)),
+            ("pool2", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("pool3", &token_a, &token_b, MockProtocolSim::new(3.0)),
+            ("pool4", &token_a, &token_b, MockProtocolSim::new(4.0)),
+            ("pool5", &token_a, &token_b, MockProtocolSim::new(5.0)),
         ]);
 
         // timeout=0ms should timeout after processing some paths

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -169,9 +169,12 @@ impl ProtocolSim for MockProtocolSim {
         // liquidity represents max amount of tokens we can receive (max output)
         let buy_limit = BigUint::from(self.liquidity);
 
-        // sell_limit = buy_limit / (spot_price * (1 - fee))
         const PRECISION: u64 = 1_000_000_000_000;
-        let effective_price = self.spot_price * (1.0 - self.fee);
+        let effective_price = if sell_token < buy_token {
+            self.spot_price * (1.0 - self.fee)
+        } else {
+            (1.0 - self.fee) / self.spot_price
+        };
         let price_scaled = (effective_price * PRECISION as f64) as u128;
         let sell_limit = (&buy_limit * PRECISION) / price_scaled;
 
@@ -645,7 +648,7 @@ mod tests {
         let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
 
         let (sell_limit, buy_limit) = sim
-            .get_limits(Bytes::default(), Bytes::default())
+            .get_limits(addr(1).into(), addr(2).into())
             .unwrap();
 
         assert_eq!(buy_limit, BigUint::from(8_000u64));
@@ -662,7 +665,7 @@ mod tests {
             .with_fee(0.5);
 
         let (sell_limit, buy_limit) = sim
-            .get_limits(Bytes::default(), Bytes::default())
+            .get_limits(addr(1).into(), addr(2).into())
             .unwrap();
 
         assert_eq!(buy_limit, BigUint::from(1_000u64));
@@ -788,14 +791,28 @@ mod tests {
     }
 
     #[test]
-    fn get_limits_without_token_decimals_is_backward_compatible() {
+    fn get_limits_without_token_decimals_assumes_equal_decimals() {
         let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
 
         let (sell_limit, _) = sim
-            .get_limits(Bytes::default(), Bytes::default())
+            .get_limits(addr(1).into(), addr(2).into())
             .unwrap();
 
         assert_eq!(sell_limit, BigUint::from(2_000u64));
+    }
+
+    #[test]
+    fn get_limits_uses_reciprocal_price_for_reverse_direction() {
+        // spot_price=4 means low→high rate is 4, so high→low rate is 1/4
+        // sell_limit = buy_limit / ((1-fee)/spot_price) = buy_limit * spot_price / (1-fee)
+        let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
+
+        let (sell_limit, buy_limit) = sim
+            .get_limits(addr(2).into(), addr(1).into())
+            .unwrap();
+
+        assert_eq!(buy_limit, BigUint::from(8_000u64));
+        assert_eq!(sell_limit, BigUint::from(32_000u64)); // 8000 * 4
     }
 
     // ==================== Mock vs UniV2 Comparison Test ====================

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -648,7 +648,7 @@ mod tests {
         let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
 
         let (sell_limit, buy_limit) = sim
-            .get_limits(addr(1).into(), addr(2).into())
+            .get_limits(addr(1), addr(2))
             .unwrap();
 
         assert_eq!(buy_limit, BigUint::from(8_000u64));
@@ -665,7 +665,7 @@ mod tests {
             .with_fee(0.5);
 
         let (sell_limit, buy_limit) = sim
-            .get_limits(addr(1).into(), addr(2).into())
+            .get_limits(addr(1), addr(2))
             .unwrap();
 
         assert_eq!(buy_limit, BigUint::from(1_000u64));
@@ -795,7 +795,7 @@ mod tests {
         let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
 
         let (sell_limit, _) = sim
-            .get_limits(addr(1).into(), addr(2).into())
+            .get_limits(addr(1), addr(2))
             .unwrap();
 
         assert_eq!(sell_limit, BigUint::from(2_000u64));
@@ -808,7 +808,7 @@ mod tests {
         let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
 
         let (sell_limit, buy_limit) = sim
-            .get_limits(addr(2).into(), addr(1).into())
+            .get_limits(addr(2), addr(1))
             .unwrap();
 
         assert_eq!(buy_limit, BigUint::from(8_000u64));

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -191,12 +191,16 @@ pub fn addr(b: u8) -> Address {
     Address::from([b; 20])
 }
 
-/// Creates a test token with the given address byte and symbol.
+/// Creates a test token with the given address byte and symbol (18 decimals).
 pub fn token(addr_b: u8, symbol: &str) -> Token {
+    token_with_decimals(addr_b, symbol, 18)
+}
+
+pub fn token_with_decimals(addr_b: u8, symbol: &str, decimals: u32) -> Token {
     Token {
         address: addr(addr_b),
         symbol: symbol.to_string(),
-        decimals: 18,
+        decimals,
         tax: Default::default(),
         gas: vec![],
         chain: Chain::Ethereum,

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -11,7 +11,10 @@ use tycho_simulation::{
         models::{protocol::ProtocolComponent, token::Token, Address, Chain},
         simulation::{
             errors::{SimulationError, TransitionError},
-            protocol_sim::{Balances, GetAmountOutResult, ProtocolSim},
+            protocol_sim::{
+                Balances, GetAmountOutResult, PoolSwap, ProtocolSim, QueryPoolSwapParams,
+                SwapConstraint,
+            },
         },
         Bytes,
     },
@@ -188,6 +191,24 @@ impl ProtocolSim for MockProtocolSim {
         };
 
         Ok((sell_limit, buy_limit))
+    }
+
+    fn query_pool_swap(&self, params: &QueryPoolSwapParams) -> Result<PoolSwap, SimulationError> {
+        let token_in = params.token_in();
+        let token_out = params.token_out();
+
+        match params.swap_constraint() {
+            SwapConstraint::TradeLimitPrice { .. } => {
+                let (sell_limit, _) =
+                    self.get_limits(token_in.address.clone(), token_out.address.clone())?;
+                let result = self.get_amount_out(sell_limit.clone(), token_in, token_out)?;
+                Ok(PoolSwap::new(sell_limit, result.amount, result.new_state, None))
+            }
+            _ => Err(SimulationError::InvalidInput(
+                "MockProtocolSim only supports TradeLimitPrice".to_string(),
+                None,
+            )),
+        }
     }
 
     fn delta_transition(

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -4,7 +4,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use chrono::NaiveDateTime;
 use num_bigint::BigUint;
-use num_traits::ToPrimitive;
 use tokio::sync::RwLock;
 use tycho_simulation::{
     tycho_core::{
@@ -41,21 +40,25 @@ pub const ONE_ETH: u128 = 1_000_000_000_000_000_000;
 pub struct MockProtocolSim {
     /// Pre-fee exchange rate from smaller-address token to larger-address token
     /// (e.g., if token A address < token B address, amount_B = amount_A * spot_price * (1 - fee))
-    pub spot_price: u32,
+    pub spot_price: f64,
     /// Gas to report for each swap
     pub gas: u64,
     /// Liquidity limit
     pub liquidity: u128,
     /// Fee percentage
     pub fee: f64,
+    /// Token decimals by address, used for decimal-aware get_limits scaling.
+    /// When empty, get_limits assumes equal decimals (backward-compatible).
+    #[serde(default)]
+    pub token_decimals: HashMap<Bytes, u32>,
 }
 
 impl MockProtocolSim {
-    pub fn new(spot_price: u32) -> Self {
+    pub fn new(spot_price: f64) -> Self {
         Self { spot_price, ..Default::default() }
     }
 
-    pub fn with_spot_price(mut self, spot_price: u32) -> Self {
+    pub fn with_spot_price(mut self, spot_price: f64) -> Self {
         self.spot_price = spot_price;
         self
     }
@@ -74,11 +77,25 @@ impl MockProtocolSim {
         self.fee = fee;
         self
     }
+
+    pub fn with_tokens(mut self, tokens: &[Token]) -> Self {
+        for token in tokens {
+            self.token_decimals
+                .insert(token.address.clone(), token.decimals);
+        }
+        self
+    }
 }
 
 impl Default for MockProtocolSim {
     fn default() -> Self {
-        Self { spot_price: 2, gas: 50_000, liquidity: u128::MAX, fee: 0.0 }
+        Self {
+            spot_price: 2.0,
+            gas: 50_000,
+            liquidity: u128::MAX,
+            fee: 0.0,
+            token_decimals: HashMap::new(),
+        }
     }
 }
 
@@ -90,8 +107,7 @@ impl ProtocolSim for MockProtocolSim {
 
     /// Returns a direction-dependent spot price with fee markup applied.
     fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
-        let post_fee_spot_price = self.spot_price.to_f64().unwrap() / (1.0 - self.fee);
-        // In order to have asymmetric spot prices based on token order, we define:
+        let post_fee_spot_price = self.spot_price / (1.0 - self.fee);
         if base.address < quote.address {
             Ok(post_fee_spot_price)
         } else {
@@ -105,46 +121,71 @@ impl ProtocolSim for MockProtocolSim {
         token_in: &Token,
         token_out: &Token,
     ) -> Result<GetAmountOutResult, SimulationError> {
-        // Check liquidity limit
-        if amount_in > BigUint::from(self.liquidity) {
+        // amount_out = amount_in * effective_price * 10^(dec_out - dec_in)
+        // effective_price includes direction and fee
+        const PRECISION: u64 = 1_000_000_000_000;
+        let effective_price = if token_in.address < token_out.address {
+            self.spot_price * (1.0 - self.fee)
+        } else {
+            (1.0 - self.fee) / self.spot_price
+        };
+        let price_scaled = (effective_price * PRECISION as f64) as u128;
+        let amount_out = (&amount_in * price_scaled) / PRECISION;
+
+        let decimal_diff = token_out.decimals as i32 - token_in.decimals as i32;
+        let amount_out = if decimal_diff >= 0 {
+            amount_out * BigUint::from(10u64).pow(decimal_diff as u32)
+        } else {
+            amount_out / BigUint::from(10u64).pow((-decimal_diff) as u32)
+        };
+
+        // Check liquidity limit against output (liquidity = max receivable tokens)
+        if amount_out > BigUint::from(self.liquidity) {
             return Err(SimulationError::InvalidInput(
                 "amount exceeds available liquidity".to_string(),
                 None,
             ));
         }
 
-        // amount_out = amount_in * directed_spot_price * (1 - fee)
-        // Where directed_spot_price depends on token order
-        let precision = 1_000_000u64;
-        let fee_multiplier = precision - (self.fee * precision as f64) as u64;
-        let amount_out = if token_in.address < token_out.address {
-            (&amount_in * self.spot_price * fee_multiplier) / precision
-        } else {
-            (&amount_in * fee_multiplier) / self.spot_price / precision
-        };
-
         // Return new state with incremented spot_price to simulate state change
         let new_state = Box::new(MockProtocolSim {
-            spot_price: self.spot_price + 1,
+            spot_price: self.spot_price + 1.0,
             gas: self.gas,
             liquidity: self.liquidity,
             fee: self.fee,
+            token_decimals: self.token_decimals.clone(),
         });
         Ok(GetAmountOutResult::new(amount_out, BigUint::from(self.gas), new_state))
     }
 
     fn get_limits(
         &self,
-        _sell_token: Bytes,
-        _buy_token: Bytes,
+        sell_token: Bytes,
+        buy_token: Bytes,
     ) -> Result<(BigUint, BigUint), SimulationError> {
         // liquidity represents max amount of tokens we can receive (max output)
         let buy_limit = BigUint::from(self.liquidity);
 
-        // sell_limit: amount of tokens needed to get max output amount
-        let fee_bps = (self.fee * 1_000_000.0) as u64;
-        let fee_multiplier = 1_000_000u64 - fee_bps;
-        let sell_limit = (&buy_limit * 1_000_000u64) / (self.spot_price as u64) / fee_multiplier;
+        // sell_limit = buy_limit / (spot_price * (1 - fee))
+        const PRECISION: u64 = 1_000_000_000_000;
+        let effective_price = self.spot_price * (1.0 - self.fee);
+        let price_scaled = (effective_price * PRECISION as f64) as u128;
+        let sell_limit = (&buy_limit * PRECISION) / price_scaled;
+
+        // Scale sell_limit by 10^(sell_dec - buy_dec) to convert from buy-token-scale
+        // to sell-token-scale. Only applies when token decimals are known.
+        let sell_limit = if let (Some(&sell_dec), Some(&buy_dec)) =
+            (self.token_decimals.get(&sell_token), self.token_decimals.get(&buy_token))
+        {
+            let decimal_diff = sell_dec as i32 - buy_dec as i32;
+            if decimal_diff >= 0 {
+                sell_limit * BigUint::from(10u64).pow(decimal_diff as u32)
+            } else {
+                sell_limit / BigUint::from(10u64).pow((-decimal_diff) as u32)
+            }
+        } else {
+            sell_limit
+        };
 
         Ok((sell_limit, buy_limit))
     }
@@ -174,7 +215,7 @@ impl ProtocolSim for MockProtocolSim {
         other
             .as_any()
             .downcast_ref::<Self>()
-            .map(|o| o.spot_price == self.spot_price)
+            .map(|o| (o.spot_price - self.spot_price).abs() < f64::EPSILON)
             .unwrap_or(false)
     }
 }
@@ -362,6 +403,8 @@ pub mod fixtures {
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
     /// Helper to create two tokens with specific address ordering.
@@ -373,13 +416,20 @@ mod tests {
         (token_low, token_high)
     }
 
+    fn ordered_tokens_with_decimals(dec_low: u32, dec_high: u32) -> (Token, Token) {
+        let token_low = token_with_decimals(0x01, "LOW", dec_low);
+        let token_high = token_with_decimals(0x02, "HIGH", dec_high);
+        assert!(token_low.address < token_high.address);
+        (token_low, token_high)
+    }
+
     // ==================== Builder & Default Tests ====================
 
     #[test]
     fn default_values_are_as_expected() {
         let sim = MockProtocolSim::default();
 
-        assert_eq!(sim.spot_price, 2);
+        assert_eq!(sim.spot_price, 2.0);
         assert_eq!(sim.gas, 50_000);
         assert_eq!(sim.liquidity, u128::MAX);
         assert_eq!(sim.fee, 0.0);
@@ -387,9 +437,9 @@ mod tests {
 
     #[test]
     fn new_sets_spot_price_with_defaults() {
-        let sim = MockProtocolSim::new(10);
+        let sim = MockProtocolSim::new(10.0);
 
-        assert_eq!(sim.spot_price, 10);
+        assert_eq!(sim.spot_price, 10.0);
         assert_eq!(sim.gas, 50_000); // default
         assert_eq!(sim.liquidity, u128::MAX); // default
         assert_eq!(sim.fee, 0.0); // default
@@ -397,13 +447,13 @@ mod tests {
 
     #[test]
     fn builder_methods_chain_correctly() {
-        let sim = MockProtocolSim::new(1)
-            .with_spot_price(5)
+        let sim = MockProtocolSim::new(1.0)
+            .with_spot_price(5.0)
             .with_gas(100_000)
             .with_liquidity(1_000_000)
             .with_fee(0.003);
 
-        assert_eq!(sim.spot_price, 5);
+        assert_eq!(sim.spot_price, 5.0);
         assert_eq!(sim.gas, 100_000);
         assert_eq!(sim.liquidity, 1_000_000);
         assert_eq!(sim.fee, 0.003);
@@ -428,7 +478,7 @@ mod tests {
     #[test]
     fn spot_price_asymmetric_based_on_token_order() {
         let (token_low, token_high) = ordered_tokens();
-        let sim = MockProtocolSim::new(4); // spot_price = 4, no fee
+        let sim = MockProtocolSim::new(4.0); // spot_price = 4, no fee
 
         // When base < quote: returns spot_price
         let price_low_to_high = sim
@@ -448,7 +498,7 @@ mod tests {
         let (token_low, token_high) = ordered_tokens();
         // spot_price = 2, fee = 50% (0.5) for easy calculation
         // post_fee_spot_price = 2 / (1 - 0.5) = 4
-        let sim = MockProtocolSim::new(2).with_fee(0.5);
+        let sim = MockProtocolSim::new(2.0).with_fee(0.5);
 
         // When base < quote: returns post_fee_spot_price = 4.0
         let price_low_to_high = sim
@@ -468,7 +518,7 @@ mod tests {
     #[test]
     fn get_amount_out_multiplies_by_spot_price_low_to_high() {
         let (token_low, token_high) = ordered_tokens();
-        let sim = MockProtocolSim::new(3); // spot_price = 3, no fee
+        let sim = MockProtocolSim::new(3.0); // spot_price = 3, no fee
 
         // When token_in < token_out: amount_out = amount_in * spot_price
         let result = sim
@@ -481,7 +531,7 @@ mod tests {
     #[test]
     fn get_amount_out_divides_by_spot_price_high_to_low() {
         let (token_low, token_high) = ordered_tokens();
-        let sim = MockProtocolSim::new(4); // spot_price = 4, no fee
+        let sim = MockProtocolSim::new(4.0); // spot_price = 4, no fee
 
         // When token_in > token_out: amount_out = amount_in / spot_price
         let result = sim
@@ -496,7 +546,7 @@ mod tests {
         let (token_low, token_high) = ordered_tokens();
         // spot_price = 2, fee = 10% (0.1)
         // amount_out = amount_in * spot_price * (1 - fee) = 1000 * 2 * 0.9 = 1800
-        let sim = MockProtocolSim::new(2).with_fee(0.1);
+        let sim = MockProtocolSim::new(2.0).with_fee(0.1);
 
         let result = sim
             .get_amount_out(BigUint::from(1000u64), &token_low, &token_high)
@@ -520,7 +570,7 @@ mod tests {
     #[test]
     fn get_amount_out_returns_new_state_with_incremented_spot_price() {
         let (token_low, token_high) = ordered_tokens();
-        let sim = MockProtocolSim::new(5)
+        let sim = MockProtocolSim::new(5.0)
             .with_gas(60_000)
             .with_fee(0.01);
 
@@ -534,7 +584,7 @@ mod tests {
             .as_any()
             .downcast_ref::<MockProtocolSim>()
             .unwrap();
-        assert_eq!(new_state.spot_price, 6); // incremented from 5
+        assert_eq!(new_state.spot_price, 6.0); // incremented from 5
         assert_eq!(new_state.gas, 60_000); // preserved
         assert_eq!(new_state.fee, 0.01); // preserved
     }
@@ -559,7 +609,7 @@ mod tests {
 
     #[test]
     fn get_limits_returns_liquidity_as_buy_limit() {
-        let sim = MockProtocolSim::new(2).with_liquidity(10_000);
+        let sim = MockProtocolSim::new(2.0).with_liquidity(10_000);
 
         let (_, buy_limit) = sim
             .get_limits(Bytes::default(), Bytes::default())
@@ -571,7 +621,7 @@ mod tests {
     #[test]
     fn get_limits_calculates_sell_limit_from_buy_limit_and_spot_price() {
         // sell_limit = buy_limit / spot_price (when no fee)
-        let sim = MockProtocolSim::new(4).with_liquidity(8_000);
+        let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
 
         let (sell_limit, buy_limit) = sim
             .get_limits(Bytes::default(), Bytes::default())
@@ -586,7 +636,7 @@ mod tests {
         // With fee, sell_limit = buy_limit / spot_price / (1 - fee)
         // spot_price = 2, liquidity = 1000, fee = 0.5 (50%)
         // sell_limit = 1000 / 2 / 0.5 = 1000
-        let sim = MockProtocolSim::new(2)
+        let sim = MockProtocolSim::new(2.0)
             .with_liquidity(1_000)
             .with_fee(0.5);
 
@@ -602,7 +652,7 @@ mod tests {
 
     #[test]
     fn clone_box_creates_independent_copy() {
-        let sim = MockProtocolSim::new(7)
+        let sim = MockProtocolSim::new(7.0)
             .with_gas(80_000)
             .with_fee(0.02);
         let cloned: Box<dyn ProtocolSim> = sim.clone_box();
@@ -611,18 +661,217 @@ mod tests {
             .as_any()
             .downcast_ref::<MockProtocolSim>()
             .unwrap();
-        assert_eq!(cloned_mock.spot_price, 7);
+        assert_eq!(cloned_mock.spot_price, 7.0);
         assert_eq!(cloned_mock.gas, 80_000);
         assert_eq!(cloned_mock.fee, 0.02);
     }
 
     #[test]
     fn eq_compares_spot_price_only() {
-        let sim1 = MockProtocolSim::new(5).with_gas(100);
-        let sim2 = MockProtocolSim::new(5).with_gas(200); // different gas, same spot_price
-        let sim3 = MockProtocolSim::new(6).with_gas(100); // same gas, different spot_price
+        let sim1 = MockProtocolSim::new(5.0).with_gas(100);
+        let sim2 = MockProtocolSim::new(5.0).with_gas(200); // different gas, same spot_price
+        let sim3 = MockProtocolSim::new(6.0).with_gas(100); // same gas, different spot_price
 
         assert!(sim1.eq(&sim2)); // same spot_price -> equal
         assert!(!sim1.eq(&sim3)); // different spot_price -> not equal
+    }
+
+    // ==================== Mixed-Decimal get_amount_out() Tests ====================
+
+    #[rstest]
+    #[case::high_to_low_decimals(18, 6, 2000.0, 1_000_000_000_000_000_000u128, 2_000_000_000u128)]
+    #[case::low_to_high_decimals(6, 18, 2000.0, 1_000_000u128, 2_000_000_000_000_000_000_000u128)]
+    #[case::same_decimals(
+        18,
+        18,
+        2000.0,
+        1_000_000_000_000_000_000u128,
+        2_000_000_000_000_000_000_000u128
+    )]
+    fn get_amount_out_scales_by_decimals(
+        #[case] dec_low: u32,
+        #[case] dec_high: u32,
+        #[case] spot_price: f64,
+        #[case] amount_in: u128,
+        #[case] expected_out: u128,
+    ) {
+        let (token_low, token_high) = ordered_tokens_with_decimals(dec_low, dec_high);
+        let sim = MockProtocolSim::new(spot_price);
+
+        let result = sim
+            .get_amount_out(BigUint::from(amount_in), &token_low, &token_high)
+            .unwrap();
+
+        assert_eq!(result.amount, BigUint::from(expected_out));
+    }
+
+    #[rstest]
+    #[case::high_to_low_decimals(18, 6, 4.0, 4_000_000u128, 1_000_000_000_000_000_000u128)]
+    #[case::low_to_high_decimals(6, 18, 4.0, 4_000_000_000_000_000_000u128, 1_000_000u128)]
+    #[case::same_decimals(
+        18,
+        18,
+        4.0,
+        4_000_000_000_000_000_000u128,
+        1_000_000_000_000_000_000u128
+    )]
+    fn get_amount_out_reverse_direction_scales_by_decimals(
+        #[case] dec_low: u32,
+        #[case] dec_high: u32,
+        #[case] spot_price: f64,
+        #[case] amount_in: u128,
+        #[case] expected_out: u128,
+    ) {
+        let (token_low, token_high) = ordered_tokens_with_decimals(dec_low, dec_high);
+        let sim = MockProtocolSim::new(spot_price);
+
+        // high→low: amount_out = amount_in / spot_price * 10^(dec_low - dec_high)
+        let result = sim
+            .get_amount_out(BigUint::from(amount_in), &token_high, &token_low)
+            .unwrap();
+
+        assert_eq!(result.amount, BigUint::from(expected_out));
+    }
+
+    // ==================== Mixed-Decimal get_limits() Tests ====================
+
+    #[rstest]
+    #[case::high_sell_low_buy(18, 6, 4.0, 8_000)]
+    #[case::low_sell_high_buy(6, 18, 4.0, 8_000)]
+    fn get_limits_scales_sell_limit_by_decimals(
+        #[case] sell_dec: u32,
+        #[case] buy_dec: u32,
+        #[case] spot_price: f64,
+        #[case] liquidity: u128,
+    ) {
+        let sell_token = token_with_decimals(0x01, "SELL", sell_dec);
+        let buy_token = token_with_decimals(0x02, "BUY", buy_dec);
+        let sim = MockProtocolSim::new(spot_price)
+            .with_liquidity(liquidity)
+            .with_tokens(&[sell_token.clone(), buy_token.clone()]);
+
+        let (sell_limit, buy_limit) = sim
+            .get_limits(sell_token.address, buy_token.address)
+            .unwrap();
+
+        assert_eq!(buy_limit, BigUint::from(liquidity));
+
+        let base_sell_limit = BigUint::from((liquidity as f64 / spot_price) as u128);
+        let decimal_diff = sell_dec as i32 - buy_dec as i32;
+        let expected_sell_limit = if decimal_diff >= 0 {
+            base_sell_limit * BigUint::from(10u64).pow(decimal_diff as u32)
+        } else {
+            base_sell_limit / BigUint::from(10u64).pow((-decimal_diff) as u32)
+        };
+        assert_eq!(sell_limit, expected_sell_limit);
+    }
+
+    #[test]
+    fn get_limits_without_token_decimals_is_backward_compatible() {
+        let sim = MockProtocolSim::new(4.0).with_liquidity(8_000);
+
+        let (sell_limit, _) = sim
+            .get_limits(Bytes::default(), Bytes::default())
+            .unwrap();
+
+        assert_eq!(sell_limit, BigUint::from(2_000u64));
+    }
+
+    // ==================== Mock vs UniV2 Comparison Test ====================
+
+    #[rstest]
+    #[case::same_decimals(18, 18, 1000, 2000)]
+    #[case::high_to_low(18, 6, 1000, 2_000_000)]
+    #[case::low_to_high(6, 18, 2_000_000, 1000)]
+    fn mock_matches_univ2_for_small_swaps(
+        #[case] dec_in: u32,
+        #[case] dec_out: u32,
+        #[case] human_reserve_in: u64,
+        #[case] human_reserve_out: u64,
+    ) {
+        use alloy::primitives::U256;
+        use tycho_simulation::evm::protocol::uniswap_v2::state::UniswapV2State;
+
+        let token_in = token_with_decimals(0x01, "IN", dec_in);
+        let token_out = token_with_decimals(0x02, "OUT", dec_out);
+
+        let reserve_in = U256::from(human_reserve_in) * U256::from(10u64).pow(U256::from(dec_in));
+        let reserve_out =
+            U256::from(human_reserve_out) * U256::from(10u64).pow(U256::from(dec_out));
+        let univ2 = UniswapV2State::new(reserve_in, reserve_out);
+
+        // Derive mock spot_price from UniV2's spot_price
+        let univ2_spot = univ2
+            .spot_price(&token_in, &token_out)
+            .expect("UniV2 spot_price should succeed");
+        let mock_spot_price = human_reserve_out as f64 / human_reserve_in as f64;
+        let liquidity = human_reserve_out as u128 * 10u128.pow(dec_out);
+        let sim = MockProtocolSim::new(mock_spot_price)
+            .with_liquidity(liquidity)
+            .with_tokens(&[token_in.clone(), token_out.clone()]);
+
+        // 1) spot_price should match (within rounding tolerance)
+        let mock_spot = sim
+            .spot_price(&token_in, &token_out)
+            .expect("mock spot_price should succeed");
+        let spot_price_ratio = mock_spot / univ2_spot;
+        assert!(
+            (0.99..=1.01).contains(&spot_price_ratio),
+            "spot_price mismatch: mock={mock_spot}, univ2={univ2_spot}"
+        );
+
+        // 2) get_amount_out for a small swap (0.1% of reserve) should be close
+        let small_amount_in = BigUint::from(human_reserve_in) * BigUint::from(10u64).pow(dec_in) /
+            BigUint::from(1000u64);
+
+        let univ2_result = univ2
+            .get_amount_out(small_amount_in.clone(), &token_in, &token_out)
+            .expect("UniV2 get_amount_out should succeed");
+        let mock_result = sim
+            .get_amount_out(small_amount_in, &token_in, &token_out)
+            .expect("mock get_amount_out should succeed");
+
+        let univ2_out: f64 = univ2_result
+            .amount
+            .to_string()
+            .parse()
+            .unwrap();
+        let mock_out: f64 = mock_result
+            .amount
+            .to_string()
+            .parse()
+            .unwrap();
+        let amount_out_ratio = mock_out / univ2_out;
+        assert!(
+            (0.99..=1.01).contains(&amount_out_ratio),
+            "get_amount_out mismatch: mock={mock_out}, univ2={univ2_out}"
+        );
+
+        // 3) get_limits: mock's sell_limit should be in the same order of magnitude as UniV2
+        let univ2_limits = univ2
+            .get_limits(token_in.address.clone(), token_out.address.clone())
+            .expect("UniV2 get_limits should succeed");
+        let mock_limits = sim
+            .get_limits(token_in.address.clone(), token_out.address.clone())
+            .expect("mock get_limits should succeed");
+
+        let univ2_sell: f64 = univ2_limits
+            .0
+            .to_string()
+            .parse()
+            .unwrap();
+        let mock_sell: f64 = mock_limits
+            .0
+            .to_string()
+            .parse()
+            .unwrap();
+        if univ2_sell > 0.0 && mock_sell > 0.0 {
+            let sell_limit_ratio = mock_sell / univ2_sell;
+            assert!(
+                (0.1..=10.0).contains(&sell_limit_ratio),
+                "get_limits sell_limit order of magnitude mismatch: mock={mock_sell}, \
+                 univ2={univ2_sell}"
+            );
+        }
     }
 }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -1,7 +1,7 @@
 //! Pool depth computation.
 //!
-//! Computes liquidity depths for all pools using `query_pool_swap` when available,
-//! falling back to binary search with `get_amount_out`.
+//! Computes liquidity depths for all pools using `query_pool_swap`, falling back to
+//! the generic Brent solver from tycho-simulation when the pool doesn't implement it natively.
 //! Depth represents the maximum input amount before reaching the configured slippage
 //! threshold from the spot price.
 //!
@@ -16,13 +16,11 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use itertools::Itertools;
 use num_bigint::BigUint;
-use num_traits::{One, Zero};
+use num_traits::Zero;
 use tracing::{debug, instrument, warn, Span};
 use tycho_simulation::{
-    tycho_common::{
-        models::token::Token,
-        simulation::{errors::SimulationError, protocol_sim::ProtocolSim},
-    },
+    evm::query_pool_swap::query_pool_swap,
+    tycho_common::simulation::errors::SimulationError,
     tycho_core::simulation::protocol_sim::{Price, QueryPoolSwapParams, SwapConstraint},
 };
 
@@ -40,8 +38,9 @@ use crate::{
 
 /// Computes pool depths for all pools in all directions.
 ///
-/// For each pool and token pair, uses binary search to find the maximum input
-/// amount that results in at most the configured slippage from spot price.
+/// For each pool and token pair, uses `query_pool_swap` (with Brent solver fallback)
+/// to find the maximum input amount that results in at most the configured slippage
+/// from spot price.
 #[derive(Debug)]
 pub struct PoolDepthComputation {
     slippage_threshold: f64,
@@ -68,106 +67,6 @@ impl PoolDepthComputation {
             )));
         }
         Ok(Self { slippage_threshold })
-    }
-
-    /// Binary search to find the maximum amount_in with acceptable slippage.
-    ///
-    /// Measures price impact by comparing the post-swap spot price against the initial spot price.
-    /// Both prices are on the same basis (buy-side), avoiding fee mismatches that occur when
-    /// comparing effective price (amount_out/amount_in) against spot price.
-    ///
-    /// Uses `get_limits()` for the upper bound and assumes that it returns a simulatable input
-    /// amount.
-    ///
-    /// As we never exceed the upper bound, we assume that if the simulation errors, it's because
-    /// we are below the lower bound of valid amounts, and thus should increase the lower bound.
-    /// This assumes that the simulation should not have errors in the valid range.
-    ///
-    /// # Behavior
-    /// - Simulation errors indicate we're outside valid range → adjust bounds accordingly
-    /// - Spot price errors are propagated as `SimulationFailed`
-    fn find_depth_binary_search(
-        &self,
-        sim_state: &dyn ProtocolSim,
-        token_in: &Token,
-        token_out: &Token,
-        component_id: &ComponentId,
-    ) -> Result<BigUint, ComputationError> {
-        let (max_input, _) = sim_state
-            .get_limits(token_in.address.clone(), token_out.address.clone())
-            .map_err(|e| {
-                ComputationError::SimulationFailed(format!(
-                    "get_limits failed for pool {component_id} {}/{}: {e}",
-                    token_in.address, token_out.address
-                ))
-            })?;
-
-        if max_input.is_zero() {
-            return Ok(BigUint::zero());
-        }
-
-        let initial_price = sim_state
-            .spot_price(token_in, token_out)
-            .map_err(|e| {
-                ComputationError::SimulationFailed(format!(
-                    "spot_price failed for pool {component_id} {}/{}: {e}",
-                    token_in.address, token_out.address
-                ))
-            })?;
-
-        // Check if the limit itself doesn't exceed slippage — if so, depth is the limit
-        if let Ok(result) = sim_state.get_amount_out(max_input.clone(), token_in, token_out) {
-            if let Ok(new_price) = result
-                .new_state
-                .spot_price(token_in, token_out)
-            {
-                let price_impact = ((new_price - initial_price) / initial_price).abs();
-                if price_impact <= self.slippage_threshold {
-                    return Ok(max_input);
-                }
-            }
-        }
-
-        let mut low = BigUint::one();
-        let mut high = max_input;
-        let mut best_valid = None;
-
-        while low < high {
-            let mid = (&low + &high) / 2u32;
-
-            match sim_state.get_amount_out(mid.clone(), token_in, token_out) {
-                Ok(result) => {
-                    let new_price = result
-                        .new_state
-                        .spot_price(token_in, token_out)
-                        .map_err(|e| {
-                            ComputationError::SimulationFailed(format!(
-                                "post-swap spot_price failed for pool {component_id} {}/{}: \
-                                     {e}",
-                                token_in.address, token_out.address
-                            ))
-                        })?;
-                    let price_impact = ((new_price - initial_price) / initial_price).abs();
-
-                    if price_impact <= self.slippage_threshold {
-                        best_valid = Some(mid.clone());
-                        low = mid + BigUint::one();
-                    } else {
-                        high = mid;
-                    }
-                }
-                Err(_) => {
-                    low = mid + BigUint::one();
-                }
-            }
-        }
-
-        best_valid.ok_or(ComputationError::NoValidResult {
-            reason: format!(
-                "could not find valid depth for pool {component_id} {}/{}",
-                token_in.address, token_out.address
-            ),
-        })
     }
 }
 
@@ -335,24 +234,27 @@ impl DerivedComputation for PoolDepthComputation {
                     },
                 );
 
-                // Try query_pool_swap first, fall back to binary search if not supported
                 let depth_result = match sim_state.query_pool_swap(&params) {
-                    Ok(swap) => Ok(swap.amount_in().clone()),
+                    Ok(swap) => Ok(swap),
                     Err(SimulationError::FatalError(msg))
                         if msg == "query_pool_swap not implemented" =>
                     {
-                        self.find_depth_binary_search(sim_state, token_in, token_out, component_id)
+                        query_pool_swap(sim_state, &params)
                     }
                     Err(SimulationError::InvalidInput(msg, _))
                         if msg.contains("does not support TradeLimitPrice") =>
                     {
-                        self.find_depth_binary_search(sim_state, token_in, token_out, component_id)
+                        query_pool_swap(sim_state, &params)
                     }
-                    Err(e) => Err(ComputationError::SimulationFailed(format!(
+                    Err(e) => Err(e),
+                }
+                .map(|swap| swap.amount_in().clone())
+                .map_err(|e| {
+                    ComputationError::SimulationFailed(format!(
                         "query_pool_swap failed for {}/{}: {e}",
                         token_in.address, token_out.address
-                    ))),
-                };
+                    ))
+                });
 
                 match depth_result {
                     Ok(depth) => {
@@ -362,7 +264,7 @@ impl DerivedComputation for PoolDepthComputation {
                     Err(e) => {
                         // Diagnostic: probe with 1 unit to understand why depth search failed
                         let probe_info = sim_state
-                            .get_amount_out(BigUint::one(), token_in, token_out)
+                            .get_amount_out(BigUint::from(1u32), token_in, token_out)
                             .map(|r| format!("amount_out={}", r.amount))
                             .unwrap_or_else(|e| format!("sim_error={e}"));
                         let limits_info = sim_state
@@ -397,6 +299,7 @@ impl DerivedComputation for PoolDepthComputation {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
+    use tycho_simulation::tycho_common::simulation::protocol_sim::ProtocolSim;
 
     use super::*;
     use crate::{
@@ -479,97 +382,6 @@ mod tests {
             matches!(result, Err(ComputationError::MissingDependency("spot_prices"))),
             "should return MissingDependency for spot_prices, got {result:?}"
         );
-    }
-
-    /// MockProtocolSim increments spot_price by 1 on each swap.
-    /// With spot_price=100 (no fee), price impact = 1/100 = 1% which equals the default
-    /// threshold, so the limit itself passes → depth = sell_limit.
-    /// With zero liquidity, depth is zero.
-    #[rstest]
-    #[case::within_threshold(100.0, 1_000_000, 10_000)]
-    #[case::zero_for_zero_liquidity(100.0, 0, 0)]
-    fn test_binary_search_finds_depth_within_threshold(
-        #[case] spot_price: f64,
-        #[case] liquidity: u128,
-        #[case] expected_depth: u64,
-    ) {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        let sim = MockProtocolSim::new(spot_price).with_liquidity(liquidity);
-        let comp = PoolDepthComputation::default();
-
-        let depth = comp
-            .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
-            .unwrap();
-
-        assert_eq!(
-            depth,
-            BigUint::from(expected_depth),
-            "expected depth {expected_depth} for spot_price={spot_price}, liquidity={liquidity}"
-        );
-    }
-
-    /// When price impact always exceeds the threshold (spot_price=1, impact=100%),
-    /// binary search returns NoValidResult.
-    #[test]
-    fn test_binary_search_returns_error_when_all_amounts_exceed_threshold() {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        let sim = MockProtocolSim::new(1.0).with_liquidity(1_000_000);
-        let comp = PoolDepthComputation::default();
-
-        let result = comp.find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into());
-
-        assert!(
-            matches!(result, Err(ComputationError::NoValidResult { .. })),
-            "expected NoValidResult when price impact always exceeds threshold, got {result:?}"
-        );
-    }
-
-    /// With a higher slippage threshold (50%), spot_price=1 (impact=100%) still fails,
-    /// but spot_price=2 (impact=50%) passes.
-    #[test]
-    fn test_binary_search_respects_custom_slippage_threshold() {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        let comp = PoolDepthComputation::new(0.5).unwrap();
-
-        // spot_price=2: new_state has spot_price=3, impact = |3 - 2| / 2 = 1/2 = 50%
-        let sim = MockProtocolSim::new(2.0).with_liquidity(1_000_000);
-        let depth = comp
-            .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
-            .unwrap();
-
-        // sell_limit = liquidity / spot_price = 1_000_000 / 2 = 500_000
-        assert_eq!(depth, BigUint::from(500_000u64));
-    }
-
-    /// Verify that the binary search uses spot price impact (not effective price).
-    /// With a fee, effective price differs from spot price, but the binary search
-    /// should only consider spot price changes.
-    #[test]
-    fn test_binary_search_uses_spot_price_not_effective_price() {
-        let token_a = token(0x01, "A");
-        let token_b = token(0x02, "B");
-
-        // spot_price=200, fee=1%. The mock's spot_price() includes fee markup: raw/(1-fee).
-        // After swap: new spot_price=201. Price impact based on spot prices:
-        // initial = 200/0.99, new = 201/0.99 → impact = |new-initial|/initial = 1/200 = 0.5%
-        // With default threshold 1%, this should pass (impact <= threshold).
-        let sim = MockProtocolSim::new(200.0)
-            .with_liquidity(1_000_000)
-            .with_fee(0.01);
-        let comp = PoolDepthComputation::default();
-
-        let depth = comp
-            .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
-            .unwrap();
-
-        // Should find a valid depth (the limit itself passes)
-        assert!(depth > BigUint::zero(), "should find valid depth for high-fee pool");
     }
 
     #[rstest]
@@ -730,5 +542,141 @@ mod tests {
             "post-swap price impact {price_impact:.4} should be near slippage {slippage} \
              for {decimals_in}/{decimals_out} decimals"
         );
+    }
+
+    /// Exercises the Brent solver fallback path with realistic UniV2 pool states to verify
+    /// it produces sensible depth values. This validates that the Price construction
+    /// approach in compute() is correct across a range of real-world token pairs.
+    ///
+    /// Three pools covering the key decimal configurations encountered in production:
+    ///   - WETH/USDC: 18/6 decimals, ~$2000 price, ~$10M liquidity
+    ///   - WETH/WBTC: 18/8 decimals, ~15 price, ~$5M liquidity
+    ///   - USDC/USDT: 6/6 decimals, ~1 price, ~$50M liquidity
+    #[test]
+    fn test_brent_solver_with_realistic_pools() {
+        use alloy::primitives::U256;
+        use tycho_simulation::evm::{
+            protocol::uniswap_v2::state::UniswapV2State, query_pool_swap::query_pool_swap,
+        };
+
+        struct PoolCase {
+            name: &'static str,
+            token_in: tycho_simulation::tycho_core::models::token::Token,
+            token_out: tycho_simulation::tycho_core::models::token::Token,
+            reserve_in_human: u64,
+            reserve_out_human: u64,
+        }
+
+        // WETH reserve ~5000 ETH, USDC reserve ~10M USDC  → ~$2000/ETH, ~$10M TVL
+        // WETH reserve ~333 ETH, WBTC reserve ~5000 WBTC  → ~15 WBTC/WETH, ~$5M TVL
+        // USDC reserve ~25M, USDT reserve ~25M            → ~1:1, ~$50M TVL
+        let cases = vec![
+            PoolCase {
+                name: "WETH(18)/USDC(6)",
+                token_in: token_with_decimals(0x01, "WETH", 18),
+                token_out: token_with_decimals(0x02, "USDC", 6),
+                reserve_in_human: 5_000,
+                reserve_out_human: 10_000_000,
+            },
+            PoolCase {
+                name: "WETH(18)/WBTC(8)",
+                token_in: token_with_decimals(0x01, "WETH", 18),
+                token_out: token_with_decimals(0x02, "WBTC", 8),
+                reserve_in_human: 5_000,
+                reserve_out_human: 333,
+            },
+            PoolCase {
+                name: "USDC(6)/USDT(6)",
+                token_in: token_with_decimals(0x01, "USDC", 6),
+                token_out: token_with_decimals(0x02, "USDT", 6),
+                reserve_in_human: 25_000_000,
+                reserve_out_human: 25_000_000,
+            },
+        ];
+
+        let slippage = 0.01_f64;
+        const SCALE_EXP: i32 = 18;
+
+        for case in &cases {
+            let decimals_in = case.token_in.decimals;
+            let decimals_out = case.token_out.decimals;
+
+            let reserve_in =
+                U256::from(case.reserve_in_human) * U256::from(10u64).pow(U256::from(decimals_in));
+            let reserve_out = U256::from(case.reserve_out_human) *
+                U256::from(10u64).pow(U256::from(decimals_out));
+            let univ2 = UniswapV2State::new(reserve_in, reserve_out);
+
+            let spot_price = univ2
+                .spot_price(&case.token_in, &case.token_out)
+                .unwrap_or_else(|e| panic!("[{}] spot_price failed: {e}", case.name));
+
+            let min_price = spot_price * (1.0 - slippage);
+
+            let decimal_diff = decimals_in as i32 - decimals_out as i32;
+            let denominator_exp = SCALE_EXP + decimal_diff;
+            assert!(
+                denominator_exp >= 0,
+                "[{}] denominator_exp would be negative: {denominator_exp}",
+                case.name
+            );
+
+            let numerator = BigUint::from((min_price * 10_f64.powi(SCALE_EXP)) as u128);
+            let denominator = BigUint::from(10u64).pow(denominator_exp as u32);
+            let limit_price = Price::new(numerator, denominator);
+
+            let limit_price_f64 = min_price;
+
+            let params = QueryPoolSwapParams::new(
+                case.token_in.clone(),
+                case.token_out.clone(),
+                SwapConstraint::TradeLimitPrice {
+                    limit: limit_price,
+                    tolerance: 0.0,
+                    min_amount_in: None,
+                    max_amount_in: None,
+                },
+            );
+
+            let result = query_pool_swap(&univ2, &params)
+                .unwrap_or_else(|e| panic!("[{}] query_pool_swap failed: {e}", case.name));
+
+            let amount_in = result.amount_in();
+            assert!(!amount_in.is_zero(), "[{}] amount_in (depth) should be non-zero", case.name);
+
+            let post_swap_spot = result
+                .new_state()
+                .spot_price(&case.token_in, &case.token_out)
+                .unwrap_or_else(|e| panic!("[{}] post-swap spot_price failed: {e}", case.name));
+            let price_impact = ((post_swap_spot - spot_price) / spot_price).abs();
+
+            let amount_in_human = {
+                let raw: f64 = amount_in
+                    .to_string()
+                    .parse()
+                    .unwrap_or(0.0);
+                raw / 10_f64.powi(decimals_in as i32)
+            };
+
+            println!(
+                "[{}] spot_price={:.6}, limit_price={:.6}, amount_in={} ({:.4} human), \
+                 post_swap_spot={:.6}, price_impact={:.4}%",
+                case.name,
+                spot_price,
+                limit_price_f64,
+                amount_in,
+                amount_in_human,
+                post_swap_spot,
+                price_impact * 100.0
+            );
+
+            assert!(
+                price_impact <= slippage + 0.005,
+                "[{}] price impact {:.4}% exceeds slippage {:.4}% + tolerance",
+                case.name,
+                price_impact * 100.0,
+                slippage * 100.0
+            );
+        }
     }
 }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -284,15 +284,32 @@ impl DerivedComputation for PoolDepthComputation {
                     continue;
                 };
 
-                // Calculate minimum acceptable price at slippage threshold
                 let min_price = spot_price * (1.0 - self.slippage_threshold);
 
-                // Convert the f64 price to a BigUint / BigUint price representation by scaling
-                const SCALE: u128 = 10u128.pow(18);
-                let min_price_scaled = (min_price * SCALE as f64) as u128;
+                // Price is a raw fraction (numerator/denominator) that query_pool_swap
+                // converts back to f64 by multiplying by 10^(dec_in - dec_out). We keep
+                // the f64→u128 multiply at a fixed precision scale and absorb the decimal
+                // adjustment into the BigUint denominator.
+                const SCALE_EXP: i32 = 18;
+                let decimal_diff = token_in.decimals as i32 - token_out.decimals as i32;
+                let denominator_exp = SCALE_EXP + decimal_diff;
+                if denominator_exp < 0 {
+                    warn!(
+                        component_id,
+                        token_in = %token_in.address,
+                        token_out = %token_out.address,
+                        "extreme decimal mismatch ({}→{}), skipping pair",
+                        token_in.decimals, token_out.decimals
+                    );
+                    pool_depths.remove(&key);
+                    failed += 1;
+                    continue;
+                }
 
-                // Skip pairs where the scaled price rounds to zero (extremely small spot price)
-                if min_price_scaled == 0 {
+                let numerator = BigUint::from((min_price * 10_f64.powi(SCALE_EXP)) as u128);
+                let denominator = BigUint::from(10u64).pow(denominator_exp as u32);
+
+                if numerator.is_zero() {
                     warn!(
                         component_id,
                         token_in = %token_in.address,
@@ -305,7 +322,7 @@ impl DerivedComputation for PoolDepthComputation {
                     continue;
                 }
 
-                let limit_price = Price::new(BigUint::from(min_price_scaled), BigUint::from(SCALE));
+                let limit_price = Price::new(numerator, denominator);
 
                 let params = QueryPoolSwapParams::new(
                     token_in.clone(),
@@ -383,7 +400,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        algorithm::test_utils::{setup_market, token, MockProtocolSim},
+        algorithm::test_utils::{setup_market, token, token_with_decimals, MockProtocolSim},
         derived::{
             store::DerivedData,
             types::{PoolDepthKey, SpotPrices},
@@ -555,18 +572,26 @@ mod tests {
         assert!(depth > BigUint::zero(), "should find valid depth for high-fee pool");
     }
 
+    #[rstest]
+    #[case::same_decimals_price_100(18, 18, 100)]
+    #[case::high_to_low_price_100(18, 6, 100)]
+    #[case::low_to_high_price_100(6, 18, 100)]
+    #[case::same_decimals_price_2000(18, 18, 2000)]
+    #[case::high_to_low_price_2000(18, 6, 2000)]
     #[tokio::test]
-    async fn test_compute_integration() {
-        let eth = token(0, "ETH");
-        let usdc = token(1, "USDC");
+    async fn test_compute_integration(
+        #[case] decimals_in: u32,
+        #[case] decimals_out: u32,
+        #[case] spot_price: u32,
+    ) {
+        let eth = token_with_decimals(0, "ETH", decimals_in);
+        let usdc = token_with_decimals(1, "USDC", decimals_out);
 
-        // Use spot_price=100 so price impact (1/100 = 1%) equals the default threshold.
-        // The mock increments spot_price by 1 on each swap, so new_state.spot_price=101.
         let (market, _) = setup_market(vec![(
             "pool",
             &eth,
             &usdc,
-            MockProtocolSim::new(100).with_liquidity(1_000_000),
+            MockProtocolSim::new(spot_price).with_liquidity(1_000_000),
         )]);
         let derived = DerivedData::new_shared();
         let spot_comp = SpotPriceComputation::new();
@@ -593,7 +618,6 @@ mod tests {
             .await
             .expect("computation should succeed");
 
-        // Should have depths for both directions: ETH→USDC and USDC→ETH
         assert_eq!(pool_depths.len(), 2, "should have depths for both directions");
 
         let key_eth_usdc: PoolDepthKey = ("pool".into(), eth.address.clone(), usdc.address.clone());
@@ -602,12 +626,91 @@ mod tests {
         assert!(pool_depths.contains_key(&key_eth_usdc), "should have depth for ETH→USDC");
         assert!(pool_depths.contains_key(&key_usdc_eth), "should have depth for USDC→ETH");
 
-        // With spot_price=100, price impact = 1% which equals threshold → limit passes.
-        // sell_limit = liquidity / spot_price = 1_000_000 / 100 = 10_000
-        let expected_depth = BigUint::from(10_000u64);
+        // sell_limit = liquidity / spot_price (mock's get_limits is direction/decimal agnostic)
+        let expected_depth = BigUint::from(1_000_000u64 / spot_price as u64);
         assert_eq!(pool_depths.get(&key_eth_usdc).unwrap(), &expected_depth, "ETH→USDC depth");
-        // For USDC→ETH (addr 0x01 > addr 0x00): sell_limit = liquidity * spot_price (inverted)
-        // Actually get_limits is direction-agnostic in the mock, so same sell_limit
         assert_eq!(pool_depths.get(&key_usdc_eth).unwrap(), &expected_depth, "USDC→ETH depth");
+    }
+
+    /// Verify that Price construction in compute() correctly handles decimal scaling
+    /// across mixed-decimal token pairs (e.g. WETH(18)/USDC(6)).
+    ///
+    /// Uses the shared `query_pool_swap` function directly because UniV2's trait
+    /// method rejects TradeLimitPrice, but the shared function works with any
+    /// ProtocolSim via get_amount_out/spot_price.
+    #[rstest]
+    #[case::same_decimals(18, 18, 1000, 2000)]
+    #[case::high_to_low(18, 6, 1000, 2_000_000)]
+    #[case::low_to_high(6, 18, 2_000_000, 1000)]
+    #[case::small_difference(8, 18, 100, 2000)]
+    #[test]
+    fn test_decimal_scaling_with_real_univ2(
+        #[case] decimals_in: u32,
+        #[case] decimals_out: u32,
+        #[case] tokens_in_reserve: u64,
+        #[case] tokens_out_reserve: u64,
+    ) {
+        use alloy::primitives::U256;
+        use tycho_simulation::evm::{
+            protocol::uniswap_v2::state::UniswapV2State, query_pool_swap::query_pool_swap,
+        };
+
+        let token_in = token_with_decimals(0x01, "IN", decimals_in);
+        let token_out = token_with_decimals(0x02, "OUT", decimals_out);
+
+        let reserve_in =
+            U256::from(tokens_in_reserve) * U256::from(10u64).pow(U256::from(decimals_in));
+        let reserve_out =
+            U256::from(tokens_out_reserve) * U256::from(10u64).pow(U256::from(decimals_out));
+        let univ2 = UniswapV2State::new(reserve_in, reserve_out);
+
+        let spot_price = univ2
+            .spot_price(&token_in, &token_out)
+            .expect("spot_price should succeed");
+
+        let slippage = 0.01;
+        let min_price = spot_price * (1.0 - slippage);
+
+        let decimal_diff = token_in.decimals as i32 - token_out.decimals as i32;
+        let numerator = BigUint::from((min_price * 10_f64.powi(18)) as u128);
+        let denominator = BigUint::from(10u64).pow((18 + decimal_diff) as u32);
+
+        let limit_price = Price::new(numerator, denominator);
+
+        let params = QueryPoolSwapParams::new(
+            token_in.clone(),
+            token_out.clone(),
+            SwapConstraint::TradeLimitPrice {
+                limit: limit_price,
+                tolerance: 0.0,
+                min_amount_in: None,
+                max_amount_in: None,
+            },
+        );
+
+        let result = query_pool_swap(&univ2, &params);
+        assert!(
+            result.is_ok(),
+            "query_pool_swap should succeed for {decimals_in}/{decimals_out} decimals, \
+             got error: {:?}",
+            result.err()
+        );
+
+        let swap = result.unwrap();
+        assert!(
+            !swap.amount_in().is_zero(),
+            "amount_in should be non-zero for {decimals_in}/{decimals_out} decimals"
+        );
+
+        let post_swap_spot = swap
+            .new_state()
+            .spot_price(&token_in, &token_out)
+            .expect("post-swap spot_price should succeed");
+        let price_impact = ((post_swap_spot - spot_price) / spot_price).abs();
+        assert!(
+            price_impact <= slippage + 0.005,
+            "post-swap price impact {price_impact:.4} should be near slippage {slippage} \
+             for {decimals_in}/{decimals_out} decimals"
+        );
     }
 }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -467,7 +467,7 @@ mod tests {
         let eth = token(0, "ETH");
         let usdc = token(1, "USDC");
 
-        let (market, _) = setup_market(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000))]);
+        let (market, _) = setup_market(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000.0))]);
         let derived = DerivedData::new_shared(); // No spot prices
         let changed = ChangedComponents::default();
 
@@ -486,10 +486,10 @@ mod tests {
     /// threshold, so the limit itself passes → depth = sell_limit.
     /// With zero liquidity, depth is zero.
     #[rstest]
-    #[case::within_threshold(100, 1_000_000, 10_000)]
-    #[case::zero_for_zero_liquidity(100, 0, 0)]
+    #[case::within_threshold(100.0, 1_000_000, 10_000)]
+    #[case::zero_for_zero_liquidity(100.0, 0, 0)]
     fn test_binary_search_finds_depth_within_threshold(
-        #[case] spot_price: u32,
+        #[case] spot_price: f64,
         #[case] liquidity: u128,
         #[case] expected_depth: u64,
     ) {
@@ -517,7 +517,7 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        let sim = MockProtocolSim::new(1).with_liquidity(1_000_000);
+        let sim = MockProtocolSim::new(1.0).with_liquidity(1_000_000);
         let comp = PoolDepthComputation::default();
 
         let result = comp.find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into());
@@ -538,7 +538,7 @@ mod tests {
         let comp = PoolDepthComputation::new(0.5).unwrap();
 
         // spot_price=2: new_state has spot_price=3, impact = |3 - 2| / 2 = 1/2 = 50%
-        let sim = MockProtocolSim::new(2).with_liquidity(1_000_000);
+        let sim = MockProtocolSim::new(2.0).with_liquidity(1_000_000);
         let depth = comp
             .find_depth_binary_search(&sim, &token_a, &token_b, &"mock_pool".into())
             .unwrap();
@@ -559,7 +559,7 @@ mod tests {
         // After swap: new spot_price=201. Price impact based on spot prices:
         // initial = 200/0.99, new = 201/0.99 → impact = |new-initial|/initial = 1/200 = 0.5%
         // With default threshold 1%, this should pass (impact <= threshold).
-        let sim = MockProtocolSim::new(200)
+        let sim = MockProtocolSim::new(200.0)
             .with_liquidity(1_000_000)
             .with_fee(0.01);
         let comp = PoolDepthComputation::default();
@@ -573,16 +573,16 @@ mod tests {
     }
 
     #[rstest]
-    #[case::same_decimals_price_100(18, 18, 100)]
-    #[case::high_to_low_price_100(18, 6, 100)]
-    #[case::low_to_high_price_100(6, 18, 100)]
-    #[case::same_decimals_price_2000(18, 18, 2000)]
-    #[case::high_to_low_price_2000(18, 6, 2000)]
+    #[case::same_decimals_price_100(18, 18, 100.0)]
+    #[case::high_to_low_price_100(18, 6, 100.0)]
+    #[case::low_to_high_price_100(6, 18, 100.0)]
+    #[case::same_decimals_price_2000(18, 18, 2000.0)]
+    #[case::high_to_low_price_2000(18, 6, 2000.0)]
     #[tokio::test]
     async fn test_compute_integration(
         #[case] decimals_in: u32,
         #[case] decimals_out: u32,
-        #[case] spot_price: u32,
+        #[case] spot_price: f64,
     ) {
         let eth = token_with_decimals(0, "ETH", decimals_in);
         let usdc = token_with_decimals(1, "USDC", decimals_out);
@@ -591,7 +591,9 @@ mod tests {
             "pool",
             &eth,
             &usdc,
-            MockProtocolSim::new(spot_price).with_liquidity(1_000_000),
+            MockProtocolSim::new(spot_price)
+                .with_liquidity(1_000_000)
+                .with_tokens(&[eth.clone(), usdc.clone()]),
         )]);
         let derived = DerivedData::new_shared();
         let spot_comp = SpotPriceComputation::new();
@@ -626,10 +628,26 @@ mod tests {
         assert!(pool_depths.contains_key(&key_eth_usdc), "should have depth for ETH→USDC");
         assert!(pool_depths.contains_key(&key_usdc_eth), "should have depth for USDC→ETH");
 
-        // sell_limit = liquidity / spot_price (mock's get_limits is direction/decimal agnostic)
-        let expected_depth = BigUint::from(1_000_000u64 / spot_price as u64);
-        assert_eq!(pool_depths.get(&key_eth_usdc).unwrap(), &expected_depth, "ETH→USDC depth");
-        assert_eq!(pool_depths.get(&key_usdc_eth).unwrap(), &expected_depth, "USDC→ETH depth");
+        // sell_limit = liquidity / spot_price * 10^(sell_dec - buy_dec)
+        let expected_depth = |sell_dec: u32, buy_dec: u32| -> BigUint {
+            let base = BigUint::from((1_000_000.0 / spot_price) as u64);
+            let decimal_diff = sell_dec as i32 - buy_dec as i32;
+            if decimal_diff >= 0 {
+                base * BigUint::from(10u64).pow(decimal_diff as u32)
+            } else {
+                base / BigUint::from(10u64).pow((-decimal_diff) as u32)
+            }
+        };
+        assert_eq!(
+            pool_depths.get(&key_eth_usdc).unwrap(),
+            &expected_depth(decimals_in, decimals_out),
+            "ETH→USDC depth"
+        );
+        assert_eq!(
+            pool_depths.get(&key_usdc_eth).unwrap(),
+            &expected_depth(decimals_out, decimals_in),
+            "USDC→ETH depth"
+        );
     }
 
     /// Verify that Price construction in compute() correctly handles decimal scaling

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -299,7 +299,9 @@ impl DerivedComputation for PoolDepthComputation {
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
-    use tycho_simulation::tycho_common::simulation::protocol_sim::ProtocolSim;
+    use tycho_simulation::{
+        tycho_common::simulation::protocol_sim::ProtocolSim, tycho_core::models::token::Token,
+    };
 
     use super::*;
     use crate::{
@@ -390,6 +392,7 @@ mod tests {
     #[case::low_to_high_price_100(6, 18, 100.0)]
     #[case::same_decimals_price_2000(18, 18, 2000.0)]
     #[case::high_to_low_price_2000(18, 6, 2000.0)]
+    #[case::low_to_high_price_2000(6, 18, 2000.0)]
     #[tokio::test]
     async fn test_compute_integration(
         #[case] decimals_in: u32,
@@ -440,10 +443,11 @@ mod tests {
         assert!(pool_depths.contains_key(&key_eth_usdc), "should have depth for ETH→USDC");
         assert!(pool_depths.contains_key(&key_usdc_eth), "should have depth for USDC→ETH");
 
-        // sell_limit = liquidity / spot_price * 10^(sell_dec - buy_dec)
-        let expected_depth = |sell_dec: u32, buy_dec: u32| -> BigUint {
-            let base = BigUint::from((1_000_000.0 / spot_price) as u64);
-            let decimal_diff = sell_dec as i32 - buy_dec as i32;
+        let expected_depth = |sell_token: &Token, buy_token: &Token| -> BigUint {
+            let effective_price =
+                if sell_token.address < buy_token.address { spot_price } else { 1.0 / spot_price };
+            let base = BigUint::from((1_000_000.0 / effective_price) as u64);
+            let decimal_diff = sell_token.decimals as i32 - buy_token.decimals as i32;
             if decimal_diff >= 0 {
                 base * BigUint::from(10u64).pow(decimal_diff as u32)
             } else {
@@ -452,12 +456,12 @@ mod tests {
         };
         assert_eq!(
             pool_depths.get(&key_eth_usdc).unwrap(),
-            &expected_depth(decimals_in, decimals_out),
+            &expected_depth(&eth, &usdc),
             "ETH→USDC depth"
         );
         assert_eq!(
             pool_depths.get(&key_usdc_eth).unwrap(),
-            &expected_depth(decimals_out, decimals_in),
+            &expected_depth(&usdc, &eth),
             "USDC→ETH depth"
         );
     }

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -186,14 +186,14 @@ mod tests {
     /// - When base < quote: returns spot_price
     /// - When base > quote: returns 1/spot_price
     #[rstest]
-    #[case::low_to_high(0x01, 0x02, 2, 2.0)]
-    #[case::high_to_low(0x02, 0x01, 2, 0.5)]
-    #[case::spot_price_4_low_to_high(0x01, 0x02, 4, 4.0)]
-    #[case::spot_price_4_high_to_low(0x02, 0x01, 4, 0.25)]
+    #[case::low_to_high(0x01, 0x02, 2.0, 2.0)]
+    #[case::high_to_low(0x02, 0x01, 2.0, 0.5)]
+    #[case::spot_price_4_low_to_high(0x01, 0x02, 4.0, 4.0)]
+    #[case::spot_price_4_high_to_low(0x02, 0x01, 4.0, 0.25)]
     fn spot_price_direction(
         #[case] in_addr: u8,
         #[case] out_addr: u8,
-        #[case] mock_spot_price: u32,
+        #[case] mock_spot_price: f64,
         #[case] expected_price: f64,
     ) {
         let token_in = token(in_addr, "IN");

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -622,7 +622,7 @@ mod tests {
         let usdc = token(1, "USDC");
 
         let (graph_manager, spot_prices) =
-            setup_graph_and_spot_prices(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000))])
+            setup_graph_and_spot_prices(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000.0))])
                 .await;
 
         let computation = computation_for(&eth.address);
@@ -649,8 +649,8 @@ mod tests {
         let target = token(3, "TARGET");
 
         let (graph, spot_prices) = setup_graph_and_spot_prices(vec![
-            ("hop1", &eth, &mid, MockProtocolSim::new(2)),
-            ("hop2", &mid, &target, MockProtocolSim::new(3)),
+            ("hop1", &eth, &mid, MockProtocolSim::new(2.0)),
+            ("hop2", &mid, &target, MockProtocolSim::new(3.0)),
         ])
         .await;
 
@@ -683,9 +683,9 @@ mod tests {
         let c = token(4, "C");
 
         let (graph, spot_prices) = setup_graph_and_spot_prices(vec![
-            ("eth_a", &eth, &a, MockProtocolSim::new(2)),
-            ("a_b", &a, &b, MockProtocolSim::new(2)),
-            ("b_c", &b, &c, MockProtocolSim::new(2)),
+            ("eth_a", &eth, &a, MockProtocolSim::new(2.0)),
+            ("a_b", &a, &b, MockProtocolSim::new(2.0)),
+            ("b_c", &b, &c, MockProtocolSim::new(2.0)),
         ])
         .await;
 
@@ -721,8 +721,8 @@ mod tests {
 
         // Two pools with different spot prices
         let (graph, spot_prices) = setup_graph_and_spot_prices(vec![
-            ("pool_low", &eth, &usdc, MockProtocolSim::new(1000)),
-            ("pool_high", &eth, &usdc, MockProtocolSim::new(2000)),
+            ("pool_low", &eth, &usdc, MockProtocolSim::new(1000.0)),
+            ("pool_high", &eth, &usdc, MockProtocolSim::new(2000.0)),
         ])
         .await;
 
@@ -787,7 +787,7 @@ mod tests {
             "pool",
             &eth,
             &usdc,
-            MockProtocolSim::new(2000)
+            MockProtocolSim::new(2000.0)
                 .with_gas(gas_units)
                 .with_fee(0.1),
         )])
@@ -837,7 +837,7 @@ mod tests {
         let eth = token(0, "ETH");
         let usdc = token(1, "USDC");
 
-        let spot_price: u32 = 2000;
+        let spot_price: f64 = 2000.0;
         let gas_units: u64 = 50_000;
 
         let (market, derived) = setup_test_env(vec![(
@@ -918,20 +918,20 @@ mod tests {
                 "eth_a",
                 &eth,
                 &a,
-                MockProtocolSim::new(2)
+                MockProtocolSim::new(2.0)
                     .with_fee(0.1)
                     .with_gas(0),
             ),
-            ("a_c", &a, &c, MockProtocolSim::new(5).with_gas(0)),
+            ("a_c", &a, &c, MockProtocolSim::new(5.0).with_gas(0)),
             (
                 "eth_b",
                 &eth,
                 &b,
-                MockProtocolSim::new(3)
+                MockProtocolSim::new(3.0)
                     .with_fee(0.05)
                     .with_gas(0),
             ),
-            ("b_c", &b, &c, MockProtocolSim::new(2).with_gas(0)),
+            ("b_c", &b, &c, MockProtocolSim::new(2.0).with_gas(0)),
         ])
         .await;
         let changed = ChangedComponents::default();
@@ -997,7 +997,7 @@ mod tests {
         let usdc = token(1, "USDC");
 
         // Create market without spot prices set
-        let (market, _) = setup_market(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000))]);
+        let (market, _) = setup_market(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000.0))]);
         let derived = DerivedData::new_shared(); // No spot prices
         let changed = ChangedComponents::default();
 
@@ -1020,7 +1020,7 @@ mod tests {
 
         // Create a pool that doesn't include ETH (gas token)
         let (market, derived) =
-            setup_test_env(vec![("usdc_dai", &usdc, &dai, MockProtocolSim::new(1))]).await;
+            setup_test_env(vec![("usdc_dai", &usdc, &dai, MockProtocolSim::new(1.0))]).await;
         let changed = ChangedComponents::default();
 
         let computation = computation_for(&eth.address);
@@ -1049,7 +1049,7 @@ mod tests {
         let mut market = SharedMarketData::new();
         let comp = component("pool", &[eth.clone(), usdc.clone()]);
         market.upsert_components(std::iter::once(comp));
-        market.update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000)) as _)]);
+        market.update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market.upsert_tokens([eth.clone(), usdc.clone()]);
         let market = SharedMarketData::new_shared();
 

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -409,7 +409,7 @@ mod tests {
         let usdc = token(2, "USDC");
 
         let (market, _) =
-            setup_market(vec![("eth_usdc", &eth, &usdc, MockProtocolSim::new(2000).with_gas(0))]);
+            setup_market(vec![("eth_usdc", &eth, &usdc, MockProtocolSim::new(2000.0).with_gas(0))]);
 
         let config = ComputationManagerConfig::new().with_gas_token(eth.address.clone());
         let (mut manager, _event_rx) = ComputationManager::new(config, market).unwrap();

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -243,8 +243,8 @@ mod tests {
         ]);
         market.upsert_tokens([token_a.clone(), token_b.clone(), token_c.clone()]);
         market.update_states([
-            ("pool_ab".to_string(), Box::new(MockProtocolSim::new(2)) as Box<dyn ProtocolSim>),
-            ("pool_bc".to_string(), Box::new(MockProtocolSim::new(3)) as Box<dyn ProtocolSim>),
+            ("pool_ab".to_string(), Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>),
+            ("pool_bc".to_string(), Box::new(MockProtocolSim::new(3.0)) as Box<dyn ProtocolSim>),
         ]);
         market.update_gas_price(BlockGasPrice {
             block_number: 1,


### PR DESCRIPTION
## Summary

- Replace the hand-rolled binary search fallback in pool depth computation with tycho-simulation's generic `query_pool_swap` free function (Brent solver)
- Implement `query_pool_swap` on `MockProtocolSim` for `TradeLimitPrice` constraint
- Add `test_brent_solver_with_realistic_pools` test covering WETH/USDC (18/6), WETH/WBTC (18/8), and USDC/USDT (6/6) with realistic reserves

This is a re-introduction of the Brent solver that was reverted in PR #46. The decimal scaling fix in the base branch (`mp/fix-mock-spot-price`, PR #47) resolves the root cause of the original failure (`Target > spot` error for mixed-decimal pairs).

### E2E validation

Ran fynd locally against `tycho-beta` with `uniswap_v2,uniswap_v3` protocols. Tested 30 quotes across 7 pair directions (WETH/USDC, USDC/WETH, WETH/WBTC, WBTC/WETH, DAI/USDC, USDC/USDT, WETH/DAI) at multiple amounts (0.01 ETH to 1000 ETH). All returned successfully with sensible prices and no errors.

## Test plan

- [x] `cargo nextest run -p fynd-core` — 236 pass, 0 fail
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — clean
- [x] E2E: `curl -X POST http://localhost:3000/v1/solve` with real pool states across mixed-decimal pairs and multiple amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)