### PR TITLE
fix: Remove rocketpool from tutorial

### DIFF
--- a/examples/tutorial/main.rs
+++ b/examples/tutorial/main.rs
@@ -480,8 +480,9 @@ async fn fetch_amm_components(
     // TODO: Remove balancerv3 filtering
     let amm_protocols: Vec<_> = protocol_systems
         .iter()
-        .filter(|p| !p.starts_with("rfq:") && !p.contains("balancer_v3"))
-        .cloned()
+        .filter(|p| {
+            !p.starts_with("rfq:") && !p.contains("balancer_v3") && !p.contains("rocketpool")
+        })
         .collect();
 
     for protocol in amm_protocols {


### PR DESCRIPTION
Without this we get the error
```
Error: "Failed to fetch components for rocketpool: Fatal error: Failed to parse response: Error: expected value at line 1 column 1, Body: Unknown extractor: rocketpool"
```
