### PR TITLE
feat: export OpenAPI spec via fynd openapi subcommand

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,29 @@ jobs:
       - name: Rustfmt
         run: cargo +${{steps.toolchain.outputs.name}} fmt --all --check
 
+  openapi_drift:
+    name: OpenAPI Spec Drift Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Check OpenAPI spec is up to date
+        run: |
+          cargo run -- openapi > /tmp/openapi.json
+          if ! diff -q clients/openapi.json /tmp/openapi.json > /dev/null 2>&1; then
+            echo "clients/openapi.json is out of date. Run 'cargo run -- openapi > clients/openapi.json' and commit."
+            diff clients/openapi.json /tmp/openapi.json
+            exit 1
+          fi
+
   security_audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
           cache-on-failure: true
       - name: Check OpenAPI spec is up to date
         run: |
-          cargo run -- openapi > /tmp/openapi.json
+          cargo run --locked -- openapi > /tmp/openapi.json
           if ! diff -q clients/openapi.json /tmp/openapi.json > /dev/null 2>&1; then
             echo "clients/openapi.json is out of date. Run 'cargo run -- openapi > clients/openapi.json' and commit."
             diff clients/openapi.json /tmp/openapi.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,6 +3248,7 @@ dependencies = [
  "tracing-subscriber 0.3.22",
  "tycho-execution",
  "tycho-simulation",
+ "utoipa 5.4.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,12 @@ opentelemetry-otlp = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 
+# Serialization (for OpenAPI spec output)
+serde_json = { workspace = true }
+
+# OpenAPI (for ApiDoc::openapi() trait)
+utoipa = { workspace = true }
+
 # Tycho (for Chain type in CLI)
 tycho-simulation = { workspace = true }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ COPY --from=builder /app/target/release/fynd /usr/local/bin/fynd
 
 EXPOSE 3000 9898
 
-ENTRYPOINT ["/usr/local/bin/fynd"]
+ENTRYPOINT ["/usr/local/bin/fynd", "serve"]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ export RPC_URL=https://eth.llamarpc.com
 export RUST_LOG=info
 
 # Run
-cargo run --release -- \
+cargo run --release serve -- \
   --tycho-url tycho-beta.propellerheads.xyz \
   --rpc-url $RPC_URL \
   --protocols uniswap_v2,uniswap_v3
@@ -60,7 +60,7 @@ The solver starts on `http://localhost:3000` by default.
 You can include RFQ (Request-for-Quote) protocols alongside on-chain protocols:
 
 ```bash
-cargo run --release -- \
+cargo run --release serve -- \
   --tycho-url tycho-beta.propellerheads.xyz \
   --rpc-url $RPC_URL \
   --protocols uniswap_v2,uniswap_v3,rfq:bebop

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -1,0 +1,478 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "fynd-rpc",
+    "description": "HTTP RPC server for Fynd DEX router",
+    "license": {
+      "name": "MIT",
+      "identifier": "MIT"
+    },
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/v1/health": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "GET /v1/health - Health check endpoint.",
+        "description": "Returns the current health status of the service.",
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "description": "Service healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Data stale",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/solve": {
+      "post": {
+        "tags": [
+          "solver"
+        ],
+        "summary": "POST /v1/solve - Submit a solve request.",
+        "description": "Accepts a `SolutionRequest` and returns a `Solution` with the best routes found, or an error\nif the request could not be filled.\n\n# Errors\n\n- 400 Bad Request: Invalid request format\n- 422 Unprocessable Entity: No routes found\n- 503 Service Unavailable: Queue full or service overloaded\n- 504 Gateway Timeout: Solve timeout",
+        "operationId": "solve",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SolutionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Solve completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Solution"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "No route found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "Solve timeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BlockInfo": {
+        "type": "object",
+        "description": "Block information at which a quote was computed.\n\nQuotes are only valid for the block at which they were computed. Market\nconditions may change in subsequent blocks.",
+        "required": [
+          "number",
+          "hash",
+          "timestamp"
+        ],
+        "properties": {
+          "hash": {
+            "type": "string",
+            "description": "Block hash as a hex string.",
+            "example": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+          },
+          "number": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Block number.",
+            "example": 21000000,
+            "minimum": 0
+          },
+          "timestamp": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Block timestamp in Unix seconds.",
+            "example": 1730000000,
+            "minimum": 0
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "description": "Error response body.",
+        "required": [
+          "error",
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "BAD_REQUEST"
+          },
+          "details": {},
+          "error": {
+            "type": "string",
+            "example": "bad request: no orders provided"
+          }
+        }
+      },
+      "HealthStatus": {
+        "type": "object",
+        "description": "Health check response.",
+        "required": [
+          "healthy",
+          "last_update_ms",
+          "num_solver_pools"
+        ],
+        "properties": {
+          "healthy": {
+            "type": "boolean",
+            "description": "Whether the service is healthy.",
+            "example": true
+          },
+          "last_update_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time since last market update in milliseconds.",
+            "example": 1250,
+            "minimum": 0
+          },
+          "num_solver_pools": {
+            "type": "integer",
+            "description": "Number of active solver pools.",
+            "example": 2,
+            "minimum": 0
+          }
+        }
+      },
+      "Order": {
+        "type": "object",
+        "description": "A single swap order to be solved.\n\nAn order specifies an intent to swap one token for another.",
+        "required": [
+          "token_in",
+          "token_out",
+          "amount",
+          "side",
+          "sender"
+        ],
+        "properties": {
+          "amount": {
+            "type": "string",
+            "description": "Amount to swap, interpreted according to `side` (in token units, as decimal string).",
+            "example": "1000000000000000000"
+          },
+          "receiver": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Address that will receive the output tokens.\n\nDefaults to `sender` if not specified.",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          },
+          "sender": {
+            "type": "string",
+            "description": "Address that will send the input tokens.",
+            "example": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+          },
+          "side": {
+            "$ref": "#/components/schemas/OrderSide",
+            "description": "Whether this is a sell (exact input) or buy (exact output) order."
+          },
+          "token_in": {
+            "type": "string",
+            "description": "Input token address (the token being sold).",
+            "example": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          },
+          "token_out": {
+            "type": "string",
+            "description": "Output token address (the token being bought).",
+            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          }
+        }
+      },
+      "OrderSide": {
+        "type": "string",
+        "description": "Specifies the side of an order: sell (exact input) or buy (exact output).\n\nCurrently only `Sell` is supported. `Buy` will be added in a future version.",
+        "enum": [
+          "sell"
+        ]
+      },
+      "OrderSolution": {
+        "type": "object",
+        "description": "Solution for a single [`Order`].\n\nContains the route to execute (if found), along with expected amounts,\ngas estimates, and status information.",
+        "required": [
+          "order_id",
+          "status",
+          "amount_in",
+          "amount_out",
+          "gas_estimate",
+          "amount_out_net_gas",
+          "block"
+        ],
+        "properties": {
+          "amount_in": {
+            "type": "string",
+            "description": "Amount of input token (in token units, as decimal string).",
+            "example": "1000000000000000000"
+          },
+          "amount_out": {
+            "type": "string",
+            "description": "Amount of output token (in token units, as decimal string).",
+            "example": "3500000000"
+          },
+          "amount_out_net_gas": {
+            "type": "string",
+            "description": "Amount out minus gas cost in output token terms.\nUsed by OrderManager to compare solutions from different solvers.",
+            "example": "3498000000"
+          },
+          "block": {
+            "$ref": "#/components/schemas/BlockInfo",
+            "description": "Block at which this quote was computed."
+          },
+          "gas_estimate": {
+            "type": "string",
+            "description": "Estimated gas cost for executing this route (as decimal string).",
+            "example": "150000"
+          },
+          "order_id": {
+            "type": "string",
+            "description": "ID of the order this solution corresponds to.",
+            "example": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+          },
+          "price_impact_bps": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Price impact in basis points (1 bip = 0.01%)."
+          },
+          "route": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Route",
+                "description": "The route to execute, if a valid route was found."
+              }
+            ]
+          },
+          "status": {
+            "$ref": "#/components/schemas/SolutionStatus",
+            "description": "Status indicating whether a route was found."
+          }
+        }
+      },
+      "Route": {
+        "type": "object",
+        "description": "A route consisting of one or more sequential swaps.\n\nA route describes the path through liquidity pools to execute a swap.\nFor multi-hop swaps, the output of each swap becomes the input of the next.",
+        "required": [
+          "swaps"
+        ],
+        "properties": {
+          "swaps": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Swap"
+            },
+            "description": "Ordered sequence of swaps to execute."
+          }
+        }
+      },
+      "Solution": {
+        "type": "object",
+        "description": "Complete solution for a [`SolutionRequest`].\n\nContains a solution for each order in the request, along with aggregate\ngas estimates and timing information.",
+        "required": [
+          "orders",
+          "total_gas_estimate",
+          "solve_time_ms"
+        ],
+        "properties": {
+          "orders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderSolution"
+            },
+            "description": "Solutions for each order, in the same order as the request."
+          },
+          "solve_time_ms": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Time taken to compute this solution, in milliseconds.",
+            "example": 12,
+            "minimum": 0
+          },
+          "total_gas_estimate": {
+            "type": "string",
+            "description": "Total estimated gas for executing all swaps (as decimal string).",
+            "example": "150000"
+          }
+        }
+      },
+      "SolutionOptions": {
+        "type": "object",
+        "description": "Options to customize the solving behavior.",
+        "properties": {
+          "max_gas": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Maximum gas cost allowed for a solution. Solutions exceeding this are filtered out.",
+            "example": "500000"
+          },
+          "min_responses": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Minimum number of solver responses to wait for before returning.\nIf `None` or `0`, waits for all solvers to respond (or timeout).\n\nUse the `/health` endpoint to check `num_solver_pools` before setting this value.\nValues exceeding the number of active solver pools are clamped internally.",
+            "minimum": 0
+          },
+          "timeout_ms": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64",
+            "description": "Timeout in milliseconds. If `None`, uses server default.",
+            "example": 2000,
+            "minimum": 0
+          }
+        }
+      },
+      "SolutionRequest": {
+        "type": "object",
+        "description": "Request to solve one or more swap orders.",
+        "required": [
+          "orders"
+        ],
+        "properties": {
+          "options": {
+            "$ref": "#/components/schemas/SolutionOptions",
+            "description": "Optional solving parameters that apply to all orders."
+          },
+          "orders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Order"
+            },
+            "description": "Orders to solve."
+          }
+        }
+      },
+      "SolutionStatus": {
+        "type": "string",
+        "description": "Status of an order solution.",
+        "enum": [
+          "success",
+          "no_route_found",
+          "insufficient_liquidity",
+          "timeout",
+          "not_ready"
+        ]
+      },
+      "Swap": {
+        "type": "object",
+        "description": "A single swap within a route.\n\nRepresents an atomic swap on a specific liquidity pool (component).",
+        "required": [
+          "component_id",
+          "protocol",
+          "token_in",
+          "token_out",
+          "amount_in",
+          "amount_out",
+          "gas_estimate"
+        ],
+        "properties": {
+          "amount_in": {
+            "type": "string",
+            "description": "Amount of input token (in token units, as decimal string).",
+            "example": "1000000000000000000"
+          },
+          "amount_out": {
+            "type": "string",
+            "description": "Amount of output token (in token units, as decimal string).",
+            "example": "3500000000"
+          },
+          "component_id": {
+            "type": "string",
+            "description": "Identifier of the liquidity pool component.",
+            "example": "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc"
+          },
+          "gas_estimate": {
+            "type": "string",
+            "description": "Estimated gas cost for this swap (as decimal string).",
+            "example": "150000"
+          },
+          "protocol": {
+            "type": "string",
+            "description": "Protocol system identifier (e.g., \"uniswap_v2\", \"uniswap_v3\", \"vm:balancer\").",
+            "example": "uniswap_v2"
+          },
+          "token_in": {
+            "type": "string",
+            "description": "Input token address.",
+            "example": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          },
+          "token_out": {
+            "type": "string",
+            "description": "Output token address.",
+            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     depends_on:
       - tempo
     command:
+      - "serve"
       - "--chain"
       - "${CHAIN:-Ethereum}"
       - "--protocols"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,22 @@ use fynd_rpc::config::defaults;
 #[derive(Parser, PartialEq, Debug)]
 #[command(name = "fynd", version, about, long_about = None)]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Available subcommands.
+#[derive(clap::Subcommand, PartialEq, Debug)]
+pub enum Commands {
+    /// Run the solver HTTP server
+    Serve(Box<ServeArgs>),
+    /// Print the OpenAPI spec as JSON to stdout
+    Openapi,
+}
+
+/// Arguments for the `serve` subcommand.
+#[derive(clap::Args, PartialEq, Debug)]
+pub struct ServeArgs {
     /// Target chain (e.g. Ethereum)
     #[arg(short, long, default_value = "Ethereum")]
     pub chain: String,
@@ -91,6 +107,7 @@ mod cli_tests {
     fn test_arg_parsing() {
         let cli = Cli::try_parse_from(vec![
             "fynd",
+            "serve",
             "--chain",
             "Ethereum",
             "--http-host",
@@ -112,21 +129,25 @@ mod cli_tests {
         ])
         .expect("parse errored");
 
-        assert_eq!(cli.chain, "Ethereum");
-        assert_eq!(cli.http_host, "127.0.0.1");
-        assert_eq!(cli.http_port, 8080);
-        assert_eq!(cli.tycho_api_key, Some("test-key".to_string()));
-        assert_eq!(cli.rpc_url, "https://rpc.example.com");
-        assert_eq!(cli.tycho_url, "wss://custom.tycho.url");
-        assert_eq!(cli.protocols, vec!["uniswap_v2", "uniswap_v3"]);
-        assert_eq!(cli.min_tvl, 20.0);
-        assert_eq!(cli.worker_pools_config, PathBuf::from("new_worker_pools.toml"));
+        let Commands::Serve(args) = cli.command else {
+            panic!("expected Serve command");
+        };
+        assert_eq!(args.chain, "Ethereum");
+        assert_eq!(args.http_host, "127.0.0.1");
+        assert_eq!(args.http_port, 8080);
+        assert_eq!(args.tycho_api_key, Some("test-key".to_string()));
+        assert_eq!(args.rpc_url, "https://rpc.example.com");
+        assert_eq!(args.tycho_url, "wss://custom.tycho.url");
+        assert_eq!(args.protocols, vec!["uniswap_v2", "uniswap_v3"]);
+        assert_eq!(args.min_tvl, 20.0);
+        assert_eq!(args.worker_pools_config, PathBuf::from("new_worker_pools.toml"));
     }
 
     #[test]
     fn test_arg_parsing_defaults() {
         let cli = Cli::try_parse_from(vec![
             "fynd",
+            "serve",
             "--rpc-url",
             "https://rpc.example.com",
             "--protocols",
@@ -134,25 +155,29 @@ mod cli_tests {
         ])
         .expect("parse errored");
 
-        assert_eq!(cli.chain, "Ethereum");
-        assert_eq!(cli.http_host, "0.0.0.0");
-        assert_eq!(cli.http_port, 3000);
-        assert_eq!(cli.tycho_api_key, None);
-        assert_eq!(cli.rpc_url, "https://rpc.example.com");
-        assert_eq!(cli.tycho_url, "localhost:4242");
-        assert_eq!(cli.protocols, vec!["uniswap_v2"]);
-        assert_eq!(cli.min_tvl, 10.0);
-        assert_eq!(cli.tvl_buffer_multiplier, 1.1);
-        assert_eq!(cli.gas_refresh_interval_secs, 30);
-        assert_eq!(cli.reconnect_delay_secs, 5);
-        assert_eq!(cli.order_manager_timeout_ms, 100);
-        assert_eq!(cli.order_manager_min_responses, 0);
+        let Commands::Serve(args) = cli.command else {
+            panic!("expected Serve command");
+        };
+        assert_eq!(args.chain, "Ethereum");
+        assert_eq!(args.http_host, "0.0.0.0");
+        assert_eq!(args.http_port, 3000);
+        assert_eq!(args.tycho_api_key, None);
+        assert_eq!(args.rpc_url, "https://rpc.example.com");
+        assert_eq!(args.tycho_url, "localhost:4242");
+        assert_eq!(args.protocols, vec!["uniswap_v2"]);
+        assert_eq!(args.min_tvl, 10.0);
+        assert_eq!(args.tvl_buffer_multiplier, 1.1);
+        assert_eq!(args.gas_refresh_interval_secs, 30);
+        assert_eq!(args.reconnect_delay_secs, 5);
+        assert_eq!(args.order_manager_timeout_ms, 100);
+        assert_eq!(args.order_manager_min_responses, 0);
     }
 
     #[test]
     fn test_arg_parsing_default_worker_pools() {
         let cli = Cli::try_parse_from(vec![
             "fynd",
+            "serve",
             "--tycho-api-key",
             "test-key",
             "--rpc-url",
@@ -162,13 +187,23 @@ mod cli_tests {
         ])
         .expect("parse errored");
 
-        assert_eq!(cli.worker_pools_config, PathBuf::from("worker_pools.toml"));
+        let Commands::Serve(args) = cli.command else {
+            panic!("expected Serve command");
+        };
+        assert_eq!(args.worker_pools_config, PathBuf::from("worker_pools.toml"));
     }
 
     #[test]
     fn test_arg_parsing_missing_required_args() {
-        // rpc_url required
-        let args = Cli::try_parse_from(vec!["fynd", "--protocols", "uniswap_v2"]);
+        // rpc_url is required; clear any ambient env var so the test is deterministic
+        std::env::remove_var("RPC_URL");
+        let args = Cli::try_parse_from(vec!["fynd", "serve", "--protocols", "uniswap_v2"]);
         assert!(args.is_err());
+    }
+
+    #[test]
+    fn test_openapi_subcommand() {
+        let cli = Cli::try_parse_from(vec!["fynd", "openapi"]).expect("parse errored");
+        assert_eq!(cli.command, Commands::Openapi);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,9 +7,9 @@
 //! # Usage
 //!
 //! ```bash
-//! fynd --rpc-url $RPC_URL \
-//!      --tycho-url tycho-beta.propellerheads.xyz \
-//!      --protocols uniswap_v2,uniswap_v3
+//! fynd serve --rpc-url $RPC_URL \
+//!            --tycho-url tycho-beta.propellerheads.xyz \
+//!            --protocols uniswap_v2,uniswap_v3
 //! ```
 //!
 //! See `fynd --help` for all available options.
@@ -25,7 +25,7 @@ use fynd_rpc::{
 };
 
 mod cli;
-use cli::Cli;
+use cli::{Cli, Commands};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig;
@@ -40,8 +40,21 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilte
 
 fn main() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();
-    run_solver(cli).map_err(|e| anyhow!("{}", e))?;
-    Ok(())
+    match cli.command {
+        Commands::Openapi => {
+            use utoipa::OpenApi as _;
+            let spec = fynd_rpc::api::ApiDoc::openapi();
+            // Safety: OpenAPI spec serialization only fails on non-string map keys,
+            // which utoipa never produces.
+            let json = serde_json::to_string_pretty(&spec).expect("spec serialization cannot fail");
+            println!("{json}");
+            Ok(())
+        }
+        Commands::Serve(serve_args) => {
+            run_solver(*serve_args).map_err(|e| anyhow!("{}", e))?;
+            Ok(())
+        }
+    }
 }
 
 /// Errors that can occur during solver operation.
@@ -151,41 +164,41 @@ fn create_metrics_exporter() -> tokio::task::JoinHandle<()> {
 
 /// Sets up the solver (loads config, parses chain, builds solver).
 /// Returns setup errors if any step fails.
-async fn setup_solver(cli: &Cli) -> Result<fynd_rpc::builder::Fynd, SolverError> {
+async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, SolverError> {
     // Load worker pools config
     let pools_config =
-        WorkerPoolsConfig::load_from_file(&cli.worker_pools_config).map_err(|e| {
+        WorkerPoolsConfig::load_from_file(&args.worker_pools_config).map_err(|e| {
             SolverError::SetupError(format!("failed to load worker pools config: {}", e))
         })?;
 
     // Parse chain
-    let chain = parse_chain(&cli.chain)
+    let chain = parse_chain(&args.chain)
         .map_err(|e| SolverError::SetupError(format!("failed to parse chain: {}", e)))?;
 
     // Build solver with all fields from CLI
     let mut builder = FyndBuilder::new(
         chain,
         pools_config.pools,
-        cli.tycho_url.clone(),
-        cli.rpc_url.clone(),
-        cli.protocols.clone(),
+        args.tycho_url.clone(),
+        args.rpc_url.clone(),
+        args.protocols.clone(),
     )
-    .http_host(cli.http_host.clone())
-    .http_port(cli.http_port)
-    .min_tvl(cli.min_tvl)
-    .tvl_buffer_multiplier(cli.tvl_buffer_multiplier)
-    .gas_refresh_interval(Duration::from_secs(cli.gas_refresh_interval_secs))
-    .reconnect_delay(Duration::from_secs(cli.reconnect_delay_secs))
-    .order_manager_timeout(Duration::from_millis(cli.order_manager_timeout_ms))
-    .order_manager_min_responses(cli.order_manager_min_responses);
+    .http_host(args.http_host.clone())
+    .http_port(args.http_port)
+    .min_tvl(args.min_tvl)
+    .tvl_buffer_multiplier(args.tvl_buffer_multiplier)
+    .gas_refresh_interval(Duration::from_secs(args.gas_refresh_interval_secs))
+    .reconnect_delay(Duration::from_secs(args.reconnect_delay_secs))
+    .order_manager_timeout(Duration::from_millis(args.order_manager_timeout_ms))
+    .order_manager_min_responses(args.order_manager_min_responses);
 
-    if cli.disable_tls {
+    if args.disable_tls {
         builder = builder.disable_tls();
     }
-    if let Some(api_key) = &cli.tycho_api_key {
+    if let Some(api_key) = &args.tycho_api_key {
         builder = builder.tycho_api_key(api_key.clone());
     }
-    if let Some(blacklist_path) = &cli.blacklist_config {
+    if let Some(blacklist_path) = &args.blacklist_config {
         let blacklist = BlacklistConfig::load_from_file(blacklist_path).map_err(|e| {
             SolverError::SetupError(format!("failed to load blacklist config: {}", e))
         })?;
@@ -201,14 +214,14 @@ async fn setup_solver(cli: &Cli) -> Result<fynd_rpc::builder::Fynd, SolverError>
 }
 
 #[tokio::main]
-async fn run_solver(cli: Cli) -> Result<(), SolverError> {
+async fn run_solver(args: cli::ServeArgs) -> Result<(), SolverError> {
     let provider = create_tracing_subscriber();
     info!("Starting Fynd");
 
     let _metrics_task = create_metrics_exporter();
 
     // Setup solver (handles setup errors)
-    let solver = setup_solver(&cli).await?;
+    let solver = setup_solver(&args).await?;
 
     // Run with graceful shutdown
     // The shutdown signal stops the server, which causes solver.run() to complete


### PR DESCRIPTION
## Summary

- Refactors the CLI from a flat command to a subcommand structure: `fynd serve` runs the solver, `fynd openapi` prints the OpenAPI spec as JSON to stdout
- Commits the generated spec as `clients/openapi.json` — source of truth for TypeScript client generation
- Adds a `openapi_drift` CI job that fails if `clients/openapi.json` is out of sync with the binary

## Changes

- `src/cli.rs`: Renamed `Cli` → `ServeArgs`; added `Commands` enum with `Serve(Box<ServeArgs>)` and `Openapi` variants; new top-level `Cli` with `#[command(subcommand)]`
- `src/main.rs`: Dispatches on `cli.command`; `setup_solver` now takes `&ServeArgs`; `Openapi` arm serializes `ApiDoc::openapi()` to stdout
- `docker-compose.yml`: Prefixed command with `"serve"`
- `Cargo.toml`: Added `serde_json` and `utoipa` as regular dependencies
- `.github/workflows/ci.yaml`: Added `openapi_drift` job
- `clients/openapi.json`: Generated OpenAPI 3.1.0 spec

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo run -- openapi | diff - clients/openapi.json` produces no output
- [ ] `cargo run -- serve --help` shows serve args
- [ ] `docker-compose up` still starts the solver correctly

Part of ENG-5591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)