### PR TITLE
feat: add fynd-client Rust crate with three-phase API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3251,6 +3251,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fynd-client"
+version = "0.1.0"
+dependencies = [
+ "alloy",
+ "alloy-chains",
+ "futures 0.3.32",
+ "num-bigint",
+ "num-traits",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "fynd-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,17 +3255,13 @@ name = "fynd-client"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "alloy-chains",
- "futures 0.3.32",
  "num-bigint",
- "num-traits",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
  "thiserror 1.0.69",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ num-bigint = { workspace = true }
 num-traits = { workspace = true }
 
 [workspace]
-members = ["fynd-core", "fynd-rpc"]
+members = ["fynd-core", "fynd-rpc", "clients/rust"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -15,21 +15,15 @@ serde_with = { version = "3", features = ["std"] }
 
 # Ethereum types and signing
 alloy = { version = "1.0", features = ["providers", "rpc-types-eth", "network", "transport-http", "rpc-client", "consensus", "eips"] }
-alloy-chains = "0.2"
 
 # Async
 tokio = { version = "1", features = ["full"] }
-futures = "0.3"
 
 # Big integers
 num-bigint = { version = "0.4", features = ["serde"] }
-num-traits = "0.2"
 
 # Error handling
 thiserror = "1"
-
-# Logging
-tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "fynd-client"
+version = "0.1.0"
+edition = "2021"
+description = "Rust client for the fynd DEX solver"
+
+[dependencies]
+# HTTP
+reqwest = { version = "0.12", features = ["json"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_with = { version = "3", features = ["std"] }
+
+# Ethereum types and signing
+alloy = { version = "1.0", features = ["providers", "rpc-types-eth", "network", "transport-http", "rpc-client", "consensus", "eips"] }
+alloy-chains = "0.2"
+
+# Async
+tokio = { version = "1", features = ["full"] }
+futures = "0.3"
+
+# Big integers
+num-bigint = { version = "0.4", features = ["serde"] }
+num-traits = "0.2"
+
+# Error handling
+thiserror = "1"
+
+# Logging
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -1,0 +1,394 @@
+use std::sync::Arc;
+
+use alloy::eips::eip2718::Encodable2718;
+use alloy::network::Ethereum;
+use alloy::primitives::{Address, U256};
+use alloy::providers::{Provider, ProviderBuilder};
+use num_bigint::BigUint;
+use reqwest::Client;
+
+use crate::{
+    error::FyndClientError,
+    execution::{ExecutionReceipt, TransactionHandle},
+    signing::{FyndPayload, SignablePayload, SignedOrder},
+    types::{BlockInfo, Order, OrderSide, OrderSolution, Route, SolutionBackend, Swap},
+    wire::{WireOrder, WireOrderSide, WireOrderSolution, WireSolutionRequest, WireSolutionStatus},
+};
+
+pub struct FyndClient {
+    base_url: String,
+    http: Client,
+}
+
+impl FyndClient {
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self { base_url: base_url.into(), http: Client::new() }
+    }
+
+    /// Phase 1: Get a priced route from the solver.
+    ///
+    /// The returned quote is valid for the block it was computed in.
+    /// Re-quote if submission is delayed by more than one or two blocks.
+    pub async fn quote(&self, order: Order) -> Result<OrderSolution, FyndClientError> {
+        let wire_order = to_wire_order(&order);
+        let request = WireSolutionRequest { orders: vec![wire_order] };
+
+        let response = self
+            .http
+            .post(format!("{}/v1/solve", self.base_url))
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response
+                .text()
+                .await
+                .unwrap_or_default();
+            return Err(FyndClientError::UnexpectedResponse(format!(
+                "solver returned {}: {}",
+                status, body
+            )));
+        }
+
+        let wire_solution: crate::wire::WireSolution = response.json().await?;
+        let wire_order_solution = wire_solution
+            .orders
+            .into_iter()
+            .next()
+            .ok_or_else(|| {
+                FyndClientError::UnexpectedResponse("empty orders in response".to_string())
+            })?;
+
+        from_wire_order_solution(wire_order_solution)
+    }
+
+    /// Phase 2: Build the signable payload for a quote.
+    ///
+    /// Fetches current nonce and gas fees from the chain via `rpc_url`,
+    /// then assembles an unsigned EIP-1559 transaction.
+    ///
+    /// The returned `SignablePayload` exposes `signing_hash()` — pass this to
+    /// your external signer (hardware wallet, KMS, etc.) and then call
+    /// `assemble_signed_order()` with the resulting signature.
+    ///
+    /// Note: the contract address is `Address::ZERO` and calldata is empty
+    /// until the server populates these fields in a future update.
+    pub async fn signable_payload(
+        &self,
+        solution: &OrderSolution,
+        sender: Address,
+        rpc_url: &str,
+    ) -> Result<SignablePayload, FyndClientError> {
+        let provider = build_provider(rpc_url).await?;
+
+        let chain_id = provider
+            .get_chain_id()
+            .await
+            .map_err(|e| FyndClientError::Rpc(e.to_string()))?;
+
+        let nonce = provider
+            .get_transaction_count(sender)
+            .await
+            .map_err(|e| FyndClientError::Rpc(e.to_string()))?;
+
+        let fee_estimate = provider
+            .estimate_eip1559_fees()
+            .await
+            .map_err(|e| FyndClientError::Rpc(e.to_string()))?;
+
+        let gas_limit = solution
+            .gas_estimate
+            .to::<u64>()
+            .saturating_add(50_000);
+
+        let SolutionBackend::Fynd { ref calldata } = solution.backend;
+
+        // Contract address is Address::ZERO and calldata is empty.
+        // The server will populate these in a future update.
+        let tx = alloy::consensus::TxEip1559 {
+            chain_id,
+            nonce,
+            max_fee_per_gas: fee_estimate.max_fee_per_gas,
+            max_priority_fee_per_gas: fee_estimate.max_priority_fee_per_gas,
+            gas_limit,
+            to: alloy::primitives::TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: alloy::primitives::Bytes::from(calldata.clone()),
+            access_list: Default::default(),
+        };
+
+        Ok(SignablePayload::Fynd(FyndPayload { tx }))
+    }
+
+    /// Phase 3: Broadcast a signed order to the blockchain.
+    ///
+    /// Returns an `ExecutionReceipt` that can be `.settle()`d to wait for confirmation.
+    pub async fn execute(
+        &self,
+        signed_order: SignedOrder,
+        token_out: Address,
+        receiver: Address,
+        rpc_url: &str,
+    ) -> Result<ExecutionReceipt, FyndClientError> {
+        let provider = build_provider(rpc_url).await?;
+
+        let SignedOrder::Fynd { envelope } = signed_order else {
+            return Err(FyndClientError::UnexpectedResponse(
+                "Turbine not yet implemented".to_string(),
+            ));
+        };
+
+        let mut encoded = Vec::new();
+        (*envelope).encode_2718(&mut encoded);
+
+        let tx_hash = *provider
+            .send_raw_transaction(&encoded)
+            .await
+            .map_err(|e| FyndClientError::Rpc(e.to_string()))?
+            .tx_hash();
+
+        Ok(ExecutionReceipt::Transaction(TransactionHandle {
+            tx_hash,
+            provider,
+            token_out,
+            receiver,
+        }))
+    }
+}
+
+/// Builds a type-erased provider from a URL string.
+async fn build_provider(rpc_url: &str) -> Result<Arc<dyn Provider<Ethereum>>, FyndClientError> {
+    let provider = ProviderBuilder::new()
+        .connect(rpc_url)
+        .await
+        .map_err(|e| FyndClientError::Rpc(e.to_string()))?;
+    Ok(Arc::new(provider) as Arc<dyn Provider<Ethereum>>)
+}
+
+// ── Conversion helpers ────────────────────────────────────────────────────────
+
+fn biguint_from_u256(v: U256) -> BigUint {
+    BigUint::from_bytes_be(&v.to_be_bytes::<32>())
+}
+
+fn u256_from_biguint(v: &BigUint) -> U256 {
+    let bytes = v.to_bytes_be();
+    // BigUint values from the solver are token amounts and gas estimates;
+    // values exceeding U256 are impossible in practice.
+    assert!(bytes.len() <= 32, "BigUint from server exceeds U256 range");
+    let mut padded = [0u8; 32];
+    padded[32 - bytes.len()..].copy_from_slice(&bytes);
+    U256::from_be_bytes(padded)
+}
+
+fn parse_address(s: &str) -> Result<Address, FyndClientError> {
+    s.parse::<Address>()
+        .map_err(|e| FyndClientError::UnexpectedResponse(e.to_string()))
+}
+
+fn to_wire_order(order: &Order) -> WireOrder {
+    WireOrder {
+        token_in: format!("{:#x}", order.token_in),
+        token_out: format!("{:#x}", order.token_out),
+        amount: biguint_from_u256(order.amount),
+        side: match order.side {
+            OrderSide::Sell => WireOrderSide::Sell,
+        },
+        sender: format!("{:#x}", order.sender),
+        receiver: order
+            .receiver
+            .map(|a| format!("{:#x}", a)),
+    }
+}
+
+fn from_wire_order_solution(w: WireOrderSolution) -> Result<OrderSolution, FyndClientError> {
+    match w.status {
+        WireSolutionStatus::Success => {}
+        WireSolutionStatus::NoRouteFound => {
+            return Err(FyndClientError::NoRouteFound { order_id: w.order_id })
+        }
+        WireSolutionStatus::InsufficientLiquidity => {
+            return Err(FyndClientError::InsufficientLiquidity { order_id: w.order_id })
+        }
+        WireSolutionStatus::Timeout => {
+            return Err(FyndClientError::Timeout { order_id: w.order_id })
+        }
+        WireSolutionStatus::NotReady => return Err(FyndClientError::NotReady),
+    }
+
+    let route = w
+        .route
+        .map(|r| {
+            r.swaps
+                .into_iter()
+                .map(|s| {
+                    Ok(Swap {
+                        component_id: s.component_id,
+                        protocol: s.protocol,
+                        token_in: parse_address(&s.token_in)?,
+                        token_out: parse_address(&s.token_out)?,
+                        amount_in: u256_from_biguint(&s.amount_in),
+                        amount_out: u256_from_biguint(&s.amount_out),
+                        gas_estimate: u256_from_biguint(&s.gas_estimate),
+                    })
+                })
+                .collect::<Result<Vec<_>, FyndClientError>>()
+                .map(|swaps| Route { swaps })
+        })
+        .transpose()?;
+
+    Ok(OrderSolution {
+        order_id: w.order_id,
+        amount_in: u256_from_biguint(&w.amount_in),
+        amount_out: u256_from_biguint(&w.amount_out),
+        gas_estimate: u256_from_biguint(&w.gas_estimate),
+        price_impact_bps: w.price_impact_bps,
+        block: BlockInfo {
+            number: w.block.number,
+            hash: w.block.hash,
+            timestamp: w.block.timestamp,
+        },
+        route,
+        backend: SolutionBackend::Fynd { calldata: vec![] },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wire::{WireBlockInfo, WireOrderSolution, WireSolutionStatus};
+    use num_bigint::BigUint;
+
+    fn make_wire_solution_success() -> WireOrderSolution {
+        WireOrderSolution {
+            order_id: "test-order-1".to_string(),
+            status: WireSolutionStatus::Success,
+            route: None,
+            amount_in: BigUint::from(1_000_000_000_000_000_000u64),
+            amount_out: BigUint::from(3_500_000_000u64),
+            gas_estimate: BigUint::from(150_000u64),
+            price_impact_bps: Some(10),
+            amount_out_net_gas: BigUint::from(3_498_000_000u64),
+            block: WireBlockInfo {
+                number: 21_000_000,
+                hash: "0xabcd".to_string(),
+                timestamp: 1_730_000_000,
+            },
+        }
+    }
+
+    #[test]
+    fn test_to_wire_order_sell() {
+        let order = Order {
+            token_in: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+                .parse()
+                .expect("valid address"),
+            token_out: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+                .parse()
+                .expect("valid address"),
+            amount: U256::from(1_000_000_000_000_000_000u64),
+            side: OrderSide::Sell,
+            sender: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+                .parse()
+                .expect("valid address"),
+            receiver: None,
+        };
+
+        let wire = to_wire_order(&order);
+
+        assert_eq!(wire.token_in.to_lowercase(), "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+        assert_eq!(wire.token_out.to_lowercase(), "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        assert_eq!(wire.amount, BigUint::from(1_000_000_000_000_000_000u64));
+        assert!(wire.receiver.is_none());
+    }
+
+    #[test]
+    fn test_to_wire_order_with_receiver() {
+        let receiver: Address = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+            .parse()
+            .expect("valid address");
+        let order = Order {
+            token_in: Address::ZERO,
+            token_out: Address::ZERO,
+            amount: U256::from(100u64),
+            side: OrderSide::Sell,
+            sender: Address::ZERO,
+            receiver: Some(receiver),
+        };
+
+        let wire = to_wire_order(&order);
+        assert!(wire.receiver.is_some());
+    }
+
+    #[test]
+    fn test_from_wire_order_solution_success() {
+        let wire = make_wire_solution_success();
+        let solution = from_wire_order_solution(wire).expect("should succeed");
+
+        assert_eq!(solution.order_id, "test-order-1");
+        assert_eq!(solution.amount_in, U256::from(1_000_000_000_000_000_000u64));
+        assert_eq!(solution.amount_out, U256::from(3_500_000_000u64));
+        assert_eq!(solution.gas_estimate, U256::from(150_000u64));
+        assert_eq!(solution.price_impact_bps, Some(10));
+        assert_eq!(solution.block.number, 21_000_000);
+        assert!(solution.route.is_none());
+    }
+
+    #[test]
+    fn test_from_wire_order_solution_no_route() {
+        let wire = WireOrderSolution {
+            status: WireSolutionStatus::NoRouteFound,
+            ..make_wire_solution_success()
+        };
+        let err = from_wire_order_solution(wire).expect_err("should be error");
+        assert!(matches!(err, FyndClientError::NoRouteFound { .. }));
+    }
+
+    #[test]
+    fn test_from_wire_order_solution_insufficient_liquidity() {
+        let wire = WireOrderSolution {
+            status: WireSolutionStatus::InsufficientLiquidity,
+            ..make_wire_solution_success()
+        };
+        let err = from_wire_order_solution(wire).expect_err("should be error");
+        assert!(matches!(err, FyndClientError::InsufficientLiquidity { .. }));
+    }
+
+    #[test]
+    fn test_from_wire_order_solution_timeout() {
+        let wire = WireOrderSolution {
+            status: WireSolutionStatus::Timeout,
+            ..make_wire_solution_success()
+        };
+        let err = from_wire_order_solution(wire).expect_err("should be error");
+        assert!(matches!(err, FyndClientError::Timeout { .. }));
+    }
+
+    #[test]
+    fn test_from_wire_order_solution_not_ready() {
+        let wire = WireOrderSolution {
+            status: WireSolutionStatus::NotReady,
+            ..make_wire_solution_success()
+        };
+        let err = from_wire_order_solution(wire).expect_err("should be error");
+        assert!(matches!(err, FyndClientError::NotReady));
+    }
+
+    #[test]
+    fn test_biguint_u256_roundtrip() {
+        let original = U256::from(1_000_000_000_000_000_000u64);
+        let biguint = biguint_from_u256(original);
+        let back = u256_from_biguint(&biguint);
+        assert_eq!(original, back);
+    }
+
+    #[test]
+    fn test_biguint_u256_zero() {
+        let original = U256::ZERO;
+        let biguint = biguint_from_u256(original);
+        let back = u256_from_biguint(&biguint);
+        assert_eq!(original, back);
+    }
+}

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -15,6 +15,7 @@ use crate::{
     wire::{WireOrder, WireOrderSide, WireOrderSolution, WireSolutionRequest, WireSolutionStatus},
 };
 
+#[derive(Clone)]
 pub struct FyndClient {
     base_url: String,
     http: Client,
@@ -173,14 +174,17 @@ fn biguint_from_u256(v: U256) -> BigUint {
     BigUint::from_bytes_be(&v.to_be_bytes::<32>())
 }
 
-fn u256_from_biguint(v: &BigUint) -> U256 {
+fn u256_from_biguint(v: &BigUint) -> Result<U256, FyndClientError> {
     let bytes = v.to_bytes_be();
-    // BigUint values from the solver are token amounts and gas estimates;
-    // values exceeding U256 are impossible in practice.
-    assert!(bytes.len() <= 32, "BigUint from server exceeds U256 range");
+    if bytes.len() > 32 {
+        return Err(FyndClientError::UnexpectedResponse(format!(
+            "server returned a value exceeding U256 range ({} bytes)",
+            bytes.len()
+        )));
+    }
     let mut padded = [0u8; 32];
     padded[32 - bytes.len()..].copy_from_slice(&bytes);
-    U256::from_be_bytes(padded)
+    Ok(U256::from_be_bytes(padded))
 }
 
 fn parse_address(s: &str) -> Result<Address, FyndClientError> {
@@ -229,9 +233,9 @@ fn from_wire_order_solution(w: WireOrderSolution) -> Result<OrderSolution, FyndC
                         protocol: s.protocol,
                         token_in: parse_address(&s.token_in)?,
                         token_out: parse_address(&s.token_out)?,
-                        amount_in: u256_from_biguint(&s.amount_in),
-                        amount_out: u256_from_biguint(&s.amount_out),
-                        gas_estimate: u256_from_biguint(&s.gas_estimate),
+                        amount_in: u256_from_biguint(&s.amount_in)?,
+                        amount_out: u256_from_biguint(&s.amount_out)?,
+                        gas_estimate: u256_from_biguint(&s.gas_estimate)?,
                     })
                 })
                 .collect::<Result<Vec<_>, FyndClientError>>()
@@ -241,9 +245,9 @@ fn from_wire_order_solution(w: WireOrderSolution) -> Result<OrderSolution, FyndC
 
     Ok(OrderSolution {
         order_id: w.order_id,
-        amount_in: u256_from_biguint(&w.amount_in),
-        amount_out: u256_from_biguint(&w.amount_out),
-        gas_estimate: u256_from_biguint(&w.gas_estimate),
+        amount_in: u256_from_biguint(&w.amount_in)?,
+        amount_out: u256_from_biguint(&w.amount_out)?,
+        gas_estimate: u256_from_biguint(&w.gas_estimate)?,
         price_impact_bps: w.price_impact_bps,
         block: BlockInfo {
             number: w.block.number,
@@ -380,7 +384,7 @@ mod tests {
     fn test_biguint_u256_roundtrip() {
         let original = U256::from(1_000_000_000_000_000_000u64);
         let biguint = biguint_from_u256(original);
-        let back = u256_from_biguint(&biguint);
+        let back = u256_from_biguint(&biguint).expect("valid U256");
         assert_eq!(original, back);
     }
 
@@ -388,7 +392,15 @@ mod tests {
     fn test_biguint_u256_zero() {
         let original = U256::ZERO;
         let biguint = biguint_from_u256(original);
-        let back = u256_from_biguint(&biguint);
+        let back = u256_from_biguint(&biguint).expect("valid U256");
         assert_eq!(original, back);
+    }
+
+    #[test]
+    fn test_biguint_u256_overflow_returns_error() {
+        // 33 bytes of 0xff exceeds U256 (32 bytes)
+        let oversized = BigUint::from_bytes_be(&[0xffu8; 33]);
+        let err = u256_from_biguint(&oversized).expect_err("should be an error");
+        assert!(matches!(err, FyndClientError::UnexpectedResponse(_)));
     }
 }

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -1,0 +1,21 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FyndClientError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("no route found for order {order_id}")]
+    NoRouteFound { order_id: String },
+    #[error("insufficient liquidity for order {order_id}")]
+    InsufficientLiquidity { order_id: String },
+    #[error("solver timeout for order {order_id}")]
+    Timeout { order_id: String },
+    #[error("solver not ready")]
+    NotReady,
+    #[error("RPC error: {0}")]
+    Rpc(String),
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("unexpected response: {0}")]
+    UnexpectedResponse(String),
+}

--- a/clients/rust/src/execution.rs
+++ b/clients/rust/src/execution.rs
@@ -1,0 +1,85 @@
+use std::sync::Arc;
+
+use alloy::network::Ethereum;
+use alloy::primitives::{Address, TxHash, U256};
+use alloy::providers::Provider;
+
+use crate::error::FyndClientError;
+
+/// A handle to a submitted transaction, resolves to a `SettledOrder`.
+pub struct TransactionHandle {
+    pub(crate) tx_hash: TxHash,
+    pub(crate) provider: Arc<dyn Provider<Ethereum>>,
+    pub(crate) token_out: Address,
+    pub(crate) receiver: Address,
+}
+
+/// An order that has been confirmed on-chain.
+#[derive(Debug, Clone)]
+pub struct SettledOrder {
+    pub tx_hash: TxHash,
+    /// Amount of output token actually received, derived from on-chain Transfer logs.
+    pub amount_received: U256,
+    pub block_number: u64,
+}
+
+/// Receipt returned after broadcasting a signed order.
+pub enum ExecutionReceipt {
+    /// Transaction was submitted; poll `settle()` to wait for confirmation.
+    Transaction(TransactionHandle),
+    /// Turbine intent — not yet implemented.
+    Intent,
+}
+
+// keccak256("Transfer(address,address,uint256)")
+const TRANSFER_TOPIC: alloy::primitives::B256 =
+    alloy::primitives::b256!("ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef");
+
+impl TransactionHandle {
+    /// Waits for the transaction to be confirmed and returns the settled order.
+    ///
+    /// Derives `amount_received` from on-chain ERC-20 Transfer event logs —
+    /// no debug RPC required.
+    pub async fn settle(self) -> Result<SettledOrder, FyndClientError> {
+        let receipt = self
+            .provider
+            .get_transaction_receipt(self.tx_hash)
+            .await
+            .map_err(|e| FyndClientError::Rpc(e.to_string()))?
+            .ok_or_else(|| FyndClientError::Rpc("transaction not found".to_string()))?;
+
+        let block_number = receipt
+            .block_number
+            .ok_or_else(|| FyndClientError::Rpc("receipt missing block number".to_string()))?;
+
+        let amount_received = receipt
+            .inner
+            .logs()
+            .iter()
+            .filter(|log| {
+                log.address() == self.token_out
+                    && log.topics().first() == Some(&TRANSFER_TOPIC)
+                    && log
+                        .topics()
+                        .get(2)
+                        .map(|t| {
+                            // indexed `to` address is padded to 32 bytes
+                            let addr_bytes = &t.0[12..];
+                            addr_bytes == self.receiver.as_slice()
+                        })
+                        .unwrap_or(false)
+            })
+            .filter_map(|log| {
+                // Transfer value is in data (non-indexed)
+                let data = log.data().data.as_ref();
+                if data.len() >= 32 {
+                    Some(U256::from_be_slice(&data[..32]))
+                } else {
+                    None
+                }
+            })
+            .fold(U256::ZERO, |acc, v| acc + v);
+
+        Ok(SettledOrder { tx_hash: self.tx_hash, amount_received, block_number })
+    }
+}

--- a/clients/rust/src/execution.rs
+++ b/clients/rust/src/execution.rs
@@ -7,6 +7,7 @@ use alloy::providers::Provider;
 use crate::error::FyndClientError;
 
 /// A handle to a submitted transaction, resolves to a `SettledOrder`.
+#[derive(Clone)]
 pub struct TransactionHandle {
     pub(crate) tx_hash: TxHash,
     pub(crate) provider: Arc<dyn Provider<Ethereum>>,

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,0 +1,21 @@
+//! Rust client for the fynd DEX solver.
+//!
+//! Provides a three-phase interface for executing trades:
+//! 1. **Quote** — [`FyndClient::quote`] — get a priced route from the solver
+//! 2. **Sign** — [`FyndClient::signable_payload`] — build an unsigned transaction; sign externally
+//! 3. **Execute** — [`FyndClient::execute`] — broadcast the signed transaction to the blockchain
+
+pub mod client;
+pub mod error;
+pub mod execution;
+pub mod signing;
+pub mod types;
+mod wire;
+
+pub use client::FyndClient;
+pub use error::FyndClientError;
+pub use execution::{ExecutionReceipt, SettledOrder, TransactionHandle};
+pub use signing::{
+    assemble_signed_order, FyndPayload, SignablePayload, SignedOrder, TurbinePayload,
+};
+pub use types::{BlockInfo, Order, OrderSide, OrderSolution, Route, Swap};

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -5,11 +5,11 @@
 //! 2. **Sign** — [`FyndClient::signable_payload`] — build an unsigned transaction; sign externally
 //! 3. **Execute** — [`FyndClient::execute`] — broadcast the signed transaction to the blockchain
 
-pub mod client;
-pub mod error;
-pub mod execution;
-pub mod signing;
-pub mod types;
+mod client;
+mod error;
+mod execution;
+mod signing;
+mod types;
 mod wire;
 
 pub use client::FyndClient;

--- a/clients/rust/src/signing.rs
+++ b/clients/rust/src/signing.rs
@@ -1,0 +1,63 @@
+use alloy::consensus::{SignableTransaction, TxEip1559, TxEnvelope};
+use alloy::primitives::Signature;
+
+use crate::error::FyndClientError;
+
+/// The payload the caller must sign to execute a trade.
+///
+/// Call `signing_hash()` to get the hash to sign, then pass the signature
+/// to `assemble_signed_order()`.
+#[derive(Debug, Clone)]
+pub enum SignablePayload {
+    /// Direct Fynd execution path.
+    Fynd(FyndPayload),
+    /// Turbine intent path (not yet implemented — stub for future use).
+    Turbine(TurbinePayload),
+}
+
+#[derive(Debug, Clone)]
+pub struct FyndPayload {
+    /// The EIP-1559 transaction to sign, minus the signature.
+    pub(crate) tx: TxEip1559,
+}
+
+/// Placeholder for the Turbine signing path.
+#[derive(Debug, Clone)]
+pub struct TurbinePayload {
+    _private: (),
+}
+
+impl SignablePayload {
+    /// Returns the hash the caller should sign.
+    pub fn signing_hash(&self) -> alloy::primitives::B256 {
+        match self {
+            SignablePayload::Fynd(p) => p.tx.signature_hash(),
+            SignablePayload::Turbine(_) => {
+                unimplemented!("Turbine signing not yet implemented")
+            }
+        }
+    }
+}
+
+/// A signed, ready-to-broadcast order.
+#[derive(Debug, Clone)]
+pub enum SignedOrder {
+    Fynd { envelope: Box<TxEnvelope> },
+    Turbine { _private: () },
+}
+
+/// Combines the signable payload with a signature to produce a signed order.
+pub fn assemble_signed_order(
+    payload: SignablePayload,
+    signature: Signature,
+) -> Result<SignedOrder, FyndClientError> {
+    match payload {
+        SignablePayload::Fynd(p) => {
+            let signed_tx = p.tx.into_signed(signature);
+            Ok(SignedOrder::Fynd { envelope: Box::new(TxEnvelope::Eip1559(signed_tx)) })
+        }
+        SignablePayload::Turbine(_) => {
+            Err(FyndClientError::UnexpectedResponse("Turbine not yet implemented".to_string()))
+        }
+    }
+}

--- a/clients/rust/src/signing.rs
+++ b/clients/rust/src/signing.rs
@@ -29,12 +29,17 @@ pub struct TurbinePayload {
 
 impl SignablePayload {
     /// Returns the hash the caller should sign.
-    pub fn signing_hash(&self) -> alloy::primitives::B256 {
+    ///
+    /// # Errors
+    ///
+    /// Returns `FyndClientError::UnexpectedResponse` if called on the `Turbine` variant,
+    /// which is not yet implemented.
+    pub fn signing_hash(&self) -> Result<alloy::primitives::B256, crate::error::FyndClientError> {
         match self {
-            SignablePayload::Fynd(p) => p.tx.signature_hash(),
-            SignablePayload::Turbine(_) => {
-                unimplemented!("Turbine signing not yet implemented")
-            }
+            SignablePayload::Fynd(p) => Ok(p.tx.signature_hash()),
+            SignablePayload::Turbine(_) => Err(crate::error::FyndClientError::UnexpectedResponse(
+                "Turbine signing not yet implemented".to_string(),
+            )),
         }
     }
 }

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -1,0 +1,62 @@
+use alloy::primitives::{Address, U256};
+
+/// An order to get a quote for.
+#[derive(Debug, Clone)]
+pub struct Order {
+    pub token_in: Address,
+    pub token_out: Address,
+    /// Amount in token units.
+    pub amount: U256,
+    pub side: OrderSide,
+    pub sender: Address,
+    pub receiver: Option<Address>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrderSide {
+    Sell,
+}
+
+/// A priced route returned by the solver, bound to a specific block.
+///
+/// Re-quote if submission is delayed by more than a block or two.
+#[derive(Debug, Clone)]
+pub struct OrderSolution {
+    pub order_id: String,
+    pub amount_in: U256,
+    pub amount_out: U256,
+    pub gas_estimate: U256,
+    pub price_impact_bps: Option<i32>,
+    pub block: BlockInfo,
+    pub route: Option<Route>,
+    /// Internal raw response needed to build `SignablePayload`.
+    pub(crate) backend: SolutionBackend,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SolutionBackend {
+    Fynd { calldata: Vec<u8> },
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockInfo {
+    pub number: u64,
+    pub hash: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct Route {
+    pub swaps: Vec<Swap>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Swap {
+    pub component_id: String,
+    pub protocol: String,
+    pub token_in: Address,
+    pub token_out: Address,
+    pub amount_in: U256,
+    pub amount_out: U256,
+    pub gas_estimate: U256,
+}

--- a/clients/rust/src/wire.rs
+++ b/clients/rust/src/wire.rs
@@ -1,0 +1,101 @@
+//! HTTP wire types mirroring `fynd-rpc/src/api/dto.rs` for deserialization.
+//!
+//! These types are kept internal — callers work with the public types in `types.rs`.
+
+use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WireOrder {
+    pub token_in: String,
+    pub token_out: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub amount: BigUint,
+    pub side: WireOrderSide,
+    pub sender: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub receiver: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WireOrderSide {
+    Sell,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WireSolutionRequest {
+    pub orders: Vec<WireOrder>,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+pub struct WireSolution {
+    pub orders: Vec<WireOrderSolution>,
+    // Preserved for completeness with the server DTO; not used locally.
+    #[allow(dead_code)]
+    #[serde_as(as = "DisplayFromStr")]
+    pub total_gas_estimate: BigUint,
+    #[allow(dead_code)]
+    pub solve_time_ms: u64,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+pub struct WireOrderSolution {
+    pub order_id: String,
+    pub status: WireSolutionStatus,
+    pub route: Option<WireRoute>,
+    #[serde_as(as = "DisplayFromStr")]
+    pub amount_in: BigUint,
+    #[serde_as(as = "DisplayFromStr")]
+    pub amount_out: BigUint,
+    #[serde_as(as = "DisplayFromStr")]
+    pub gas_estimate: BigUint,
+    pub price_impact_bps: Option<i32>,
+    // Preserved for completeness with the server DTO; not used locally.
+    #[allow(dead_code)]
+    #[serde_as(as = "DisplayFromStr")]
+    pub amount_out_net_gas: BigUint,
+    pub block: WireBlockInfo,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum WireSolutionStatus {
+    Success,
+    NoRouteFound,
+    InsufficientLiquidity,
+    Timeout,
+    NotReady,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct WireBlockInfo {
+    pub number: u64,
+    pub hash: String,
+    pub timestamp: u64,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+pub struct WireRoute {
+    pub swaps: Vec<WireSwap>,
+}
+
+#[serde_as]
+#[derive(Debug, Deserialize)]
+pub struct WireSwap {
+    pub component_id: String,
+    pub protocol: String,
+    pub token_in: String,
+    pub token_out: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub amount_in: BigUint,
+    #[serde_as(as = "DisplayFromStr")]
+    pub amount_out: BigUint,
+    #[serde_as(as = "DisplayFromStr")]
+    pub gas_estimate: BigUint,
+}


### PR DESCRIPTION
## Summary

- Adds `clients/rust/` as a new `fynd-client` Cargo workspace member
- Implements the three-phase trade execution interface: `quote()` → `signable_payload()` → `execute()`
- Public API uses chain-agnostic `alloy::primitives` types (`Address`, `U256`); Ethereum-specific types are confined to the signing layer
- Settlement derives the received amount from on-chain ERC-20 Transfer logs — no debug RPC required
- Turbine path (`SignablePayload::Turbine`, `ExecutionReceipt::Intent`) is stubbed for future use; calldata is empty until the server populates it

## Changes

- `clients/rust/Cargo.toml`: New crate with `reqwest`, `alloy 1.0`, `thiserror`, `serde_with`
- `clients/rust/src/lib.rs`: Public re-exports
- `clients/rust/src/error.rs`: `FyndClientError` covering all failure modes
- `clients/rust/src/types.rs`: `Order`, `OrderSolution`, `BlockInfo`, `Route`, `Swap` (chain-agnostic)
- `clients/rust/src/wire.rs`: Internal HTTP wire types mirroring `fynd-rpc` DTOs
- `clients/rust/src/signing.rs`: `SignablePayload` discriminated union, `SignedOrder`, `assemble_signed_order()`
- `clients/rust/src/execution.rs`: `TransactionHandle`, `SettledOrder`, ERC-20 log parsing
- `clients/rust/src/client.rs`: `FyndClient` with `quote()`, `signable_payload()`, `execute()`
- `Cargo.toml`: Added `clients/rust` to workspace members

## Test plan

- [ ] `cargo build -p fynd-client` passes
- [ ] `cargo test -p fynd-client` — 9 unit tests pass (wire type conversions)
- [ ] `cargo clippy -p fynd-client --all-targets -- -D warnings` clean
- [ ] `cargo check --workspace` — full workspace still compiles

Part of ENG-5591.

🤖 Generated with [Claude Code](https://claude.com/claude-code)