### PR TITLE
feat: extend models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,7 +3246,6 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.3.22",
- "tycho-execution",
  "tycho-simulation",
 ]
 
@@ -3274,6 +3273,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tycho-execution",
  "tycho-simulation",
  "typetag",
  "uuid",
@@ -3300,6 +3300,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-actix-web",
+ "tycho-execution",
  "tycho-simulation",
  "utoipa 5.4.0",
  "utoipa-swagger-ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7374,8 +7374,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.163.1"
-source = "git+https://github.com/propeller-heads/tycho-execution?branch=kt%2Fmake_use_transfer_type_serde#45acf8084e6cdc2369877e82eb4fd994d90cf38a"
+version = "0.164.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705d52bcdd86c43d5a1027be5537b26541ee43a252bd6a21e242050e8916794b"
 dependencies = [
  "alloy",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3286,6 +3286,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "fynd-core",
+ "hex",
  "metrics",
  "num-bigint",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.3.22",
+ "tycho-execution",
  "tycho-simulation",
 ]
 
@@ -7373,18 +7374,14 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.160.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45694f91323ec97a2dafc200b34f9286988fa704b0fa3cef71254e2e314028e9"
+version = "0.161.0"
 dependencies = [
  "alloy",
  "chrono",
  "clap",
  "dotenv",
  "hex",
- "lazy_static",
  "num-bigint",
- "num-traits",
  "once_cell",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7374,7 +7374,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.161.0"
+version = "0.163.1"
+source = "git+https://github.com/propeller-heads/tycho-execution?branch=kt%2Fmake_use_transfer_type_serde#45acf8084e6cdc2369877e82eb4fd994d90cf38a"
 dependencies = [
  "alloy",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Tycho
 tycho-simulation = ">=0.234.0"
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution", branch = "kt/make_use_transfer_type_serde", features = ["evm"] }
+tycho-execution = { version = ">=0.164.0", features = ["evm"] }
 typetag = "0.2"
 
 # Graph algorithms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
+tycho-execution = { workspace = true }
 
 [workspace]
 members = ["fynd-core", "fynd-rpc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Tycho
 tycho-simulation = ">=0.234.0"
-tycho-execution = { version = ">=0.155.0", features = ["evm"] }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-execution", branch = "kt/make_use_transfer_type_serde", features = ["evm"] }
 typetag = "0.2"
 
 # Graph algorithms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,13 @@ tycho-simulation = { workspace = true }
 [dev-dependencies]
 rstest = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
-tycho-execution = { version = ">=0.155.0", features = ["evm"] }
-alloy = { version = "1.0", features = ["providers", "signer-local", "rpc-types-eth", "eip712", "node-bindings"] }
+alloy = { version = "1.0", features = [
+    "providers",
+    "signer-local",
+    "rpc-types-eth",
+    "eip712",
+    "node-bindings",
+] }
 alloy-chains = "0.2"
 dialoguer = "0.11"
 dotenv = "0.15"
@@ -89,6 +94,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Tycho
 tycho-simulation = ">=0.234.0"
+tycho-execution = { version = ">=0.155.0", features = ["evm"] }
 typetag = "0.2"
 
 # Graph algorithms

--- a/examples/benchmark/config.rs
+++ b/examples/benchmark/config.rs
@@ -191,6 +191,11 @@ fn create_default_request() -> Result<SolutionRequest, Box<dyn std::error::Error
             sender: Address::from_str("0x0000000000000000000000000000000000000001")?,
             receiver: None,
         }],
-        options: SolutionOptions { timeout_ms: Some(10000), min_responses: None, max_gas: None },
+        options: SolutionOptions {
+            timeout_ms: Some(10000),
+            min_responses: None,
+            max_gas: None,
+            encoding_options: None,
+        },
     })
 }

--- a/examples/tutorial/main.rs
+++ b/examples/tutorial/main.rs
@@ -27,7 +27,7 @@ use alloy::{
 use alloy_chains::NamedChain;
 use clap::Parser;
 use dialoguer::{theme::ColorfulTheme, Select};
-use fynd_core::{Order, OrderSide, Route, Solution, SolutionOptions, SolutionRequest};
+use fynd_core::{Order, OrderSide, Route, Solution, SolutionOptions, SolutionRequest, Transaction};
 use fynd_rpc::{builder::parse_chain, HealthStatus};
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
@@ -38,7 +38,7 @@ use tycho_execution::encoding::{
         approvals::permit2::PermitSingle, encoder_builders::TychoRouterEncoderBuilder,
         swap_encoder::swap_encoder_registry::SwapEncoderRegistry,
     },
-    models::{EncodedSolution, Solution as ExecutionSolution, Transaction, UserTransferType},
+    models::{EncodedSolution, Solution as ExecutionSolution, UserTransferType},
 };
 use tycho_simulation::{
     evm::protocol::u256_num::biguint_to_u256,

--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -27,6 +27,7 @@ thiserror.workspace = true
 tracing.workspace = true
 metrics.workspace = true
 typetag.workspace = true
+tycho-execution.workspace = true
 
 [dev-dependencies]
 alloy = { version = "1.0", default-features = false }

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -317,6 +317,8 @@ impl MostLiquidAlgorithm {
                 amount_in: current_amount.clone(),
                 amount_out: result.amount.clone(),
                 gas_estimate: result.gas,
+                protocol_component: component.clone(),
+                protocol_state: state.clone_box(),
             });
 
             // Store new state as override for next hops
@@ -1130,6 +1132,7 @@ mod tests {
         assert_eq!(result.route.swaps.len(), 1);
         assert_eq!(result.route.swaps[0].amount_in, BigUint::from(ONE_ETH));
         assert_eq!(result.route.swaps[0].amount_out, BigUint::from(ONE_ETH * 2));
+        assert_eq!(result.gas_price, BigUint::from(100u128));
     }
 
     #[tokio::test]
@@ -1172,6 +1175,7 @@ mod tests {
         assert_eq!(result.route.swaps[0].component_id, "best");
         assert_eq!(result.route.swaps[0].amount_out, BigUint::from(3000u64));
         assert_eq!(result.net_amount_out, BigInt::from(2000)); // 3000 - 1000
+        assert_eq!(result.gas_price, BigUint::from(100u128));
     }
 
     #[tokio::test]
@@ -1220,6 +1224,7 @@ mod tests {
         assert_eq!(result.route.swaps[0].component_id, "pool1".to_string());
         assert_eq!(result.route.swaps[1].amount_out, BigUint::from(ONE_ETH * 2 * 3));
         assert_eq!(result.route.swaps[1].component_id, "pool2".to_string());
+        assert_eq!(result.gas_price, BigUint::from(100u128));
     }
 
     #[tokio::test]

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -1132,7 +1132,6 @@ mod tests {
         assert_eq!(result.route.swaps.len(), 1);
         assert_eq!(result.route.swaps[0].amount_in, BigUint::from(ONE_ETH));
         assert_eq!(result.route.swaps[0].amount_out, BigUint::from(ONE_ETH * 2));
-        assert_eq!(result.gas_price, BigUint::from(100u128));
     }
 
     #[tokio::test]
@@ -1175,7 +1174,6 @@ mod tests {
         assert_eq!(result.route.swaps[0].component_id, "best");
         assert_eq!(result.route.swaps[0].amount_out, BigUint::from(3000u64));
         assert_eq!(result.net_amount_out, BigInt::from(2000)); // 3000 - 1000
-        assert_eq!(result.gas_price, BigUint::from(100u128));
     }
 
     #[tokio::test]
@@ -1224,7 +1222,6 @@ mod tests {
         assert_eq!(result.route.swaps[0].component_id, "pool1".to_string());
         assert_eq!(result.route.swaps[1].amount_out, BigUint::from(ONE_ETH * 2 * 3));
         assert_eq!(result.route.swaps[1].component_id, "pool2".to_string());
-        assert_eq!(result.gas_price, BigUint::from(100u128));
     }
 
     #[tokio::test]

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -336,13 +336,15 @@ impl MostLiquidAlgorithm {
             .map(|s| s.amount_out.clone())
             .unwrap_or_else(|| BigUint::ZERO);
 
+        let gas_price = market
+            .gas_price()
+            .ok_or(AlgorithmError::DataNotFound { kind: "gas price", id: None })?
+            .effective_gas_price()
+            .clone();
+
         let net_amount_out = if let Some(last_swap) = route.swaps.last() {
             let total_gas = route.total_gas();
-            let gas_price = market
-                .gas_price()
-                .ok_or(AlgorithmError::DataNotFound { kind: "gas price", id: None })?
-                .effective_gas_price();
-            let gas_cost_wei = &total_gas * gas_price;
+            let gas_cost_wei = &total_gas * &gas_price;
 
             // Convert gas cost to output token terms using token prices
             let gas_cost_in_output_token: Option<BigUint> = token_prices
@@ -365,7 +367,7 @@ impl MostLiquidAlgorithm {
             BigInt::from(output_amount)
         };
 
-        Ok(RouteResult { route, net_amount_out })
+        Ok(RouteResult { route, net_amount_out, gas_price })
     }
 }
 

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -467,18 +467,18 @@ mod tests {
     }
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-    struct MockProtocolSim {
+    struct FeedMockProtocolSim {
         id: f64,
     }
 
-    impl MockProtocolSim {
+    impl FeedMockProtocolSim {
         fn new(id: f64) -> Self {
             Self { id }
         }
     }
 
     #[typetag::serde]
-    impl ProtocolSim for MockProtocolSim {
+    impl ProtocolSim for FeedMockProtocolSim {
         fn get_amount_out(
             &self,
             amount_in: BigUint,
@@ -493,7 +493,7 @@ mod tests {
         }
 
         fn fee(&self) -> f64 {
-            // We use .fee() to get the id of the MockProtocolSim in the tests for our assertions.
+            // We use .fee() to get the id of the FeedMockProtocolSim in the tests for our assertions.
             self.id
         }
 
@@ -783,7 +783,7 @@ mod tests {
         let mut states = HashMap::new();
         states.insert(
             component_id.to_string(),
-            Box::new(MockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
+            Box::new(FeedMockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
         );
 
         let update = Update::new(12345, states.clone(), new_pairs);
@@ -826,7 +826,7 @@ mod tests {
         // Now update its state
 
         // Create an update with state information
-        let new_state = Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>;
+        let new_state = Box::new(FeedMockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>;
         let update = Update::new(
             12345,
             HashMap::from([(component_id.to_string(), new_state)]),
@@ -1234,7 +1234,7 @@ mod tests {
         let mut initial_states = HashMap::new();
         initial_states.insert(
             allowed_id.to_string(),
-            Box::new(MockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
+            Box::new(FeedMockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
         );
 
         let update = Update::new(12345, initial_states, new_pairs);
@@ -1249,11 +1249,11 @@ mod tests {
         let mut states = HashMap::new();
         states.insert(
             blacklisted_id.to_string(),
-            Box::new(MockProtocolSim::new(99.0)) as Box<dyn ProtocolSim>,
+            Box::new(FeedMockProtocolSim::new(99.0)) as Box<dyn ProtocolSim>,
         );
         states.insert(
             allowed_id.to_string(),
-            Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+            Box::new(FeedMockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
         );
 
         let update = Update::new(12346, states, HashMap::new());

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -493,7 +493,8 @@ mod tests {
         }
 
         fn fee(&self) -> f64 {
-            // We use .fee() to get the id of the FeedMockProtocolSim in the tests for our assertions.
+            // We use .fee() to get the id of the FeedMockProtocolSim in the tests for our
+            // assertions.
             self.id
         }
 

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -34,8 +34,9 @@ pub use algorithm::{Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgori
 pub use order_manager::{config::OrderManagerConfig, OrderManager, SolverPoolHandle};
 pub use types::{
     BlockInfo, ComponentId, EncodingOptions, Order, OrderSide, OrderSolution, OrderValidationError,
-    RouteValidationError, SingleOrderSolution, Solution, SolutionOptions, SolutionRequest,
-    SolutionStatus, SolveError, SolveResult, Swap, TaskId, Transaction,
+    PermitDetails, PermitSingle, Route, RouteValidationError, SingleOrderSolution, Solution,
+    SolutionOptions, SolutionRequest, SolutionStatus, SolveError, SolveResult, Swap, TaskId,
+    Transaction, UserTransferType,
 };
 pub use worker_pool::{
     pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig},

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -33,7 +33,7 @@ pub mod worker_pool;
 pub use algorithm::{Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgorithm};
 pub use order_manager::{config::OrderManagerConfig, OrderManager, SolverPoolHandle};
 pub use types::{
-    BlockInfo, ComponentId, Order, OrderSide, OrderSolution, OrderValidationError, Route,
+    BlockInfo, ComponentId, EncodingOptions, Order, OrderSide, OrderSolution, OrderValidationError,
     RouteValidationError, SingleOrderSolution, Solution, SolutionOptions, SolutionRequest,
     SolutionStatus, SolveError, SolveResult, Swap, TaskId, Transaction,
 };

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -35,7 +35,7 @@ pub use order_manager::{config::OrderManagerConfig, OrderManager, SolverPoolHand
 pub use types::{
     BlockInfo, ComponentId, Order, OrderSide, OrderSolution, OrderValidationError, Route,
     RouteValidationError, SingleOrderSolution, Solution, SolutionOptions, SolutionRequest,
-    SolutionStatus, SolveError, SolveResult, Swap, TaskId,
+    SolutionStatus, SolveError, SolveResult, Swap, TaskId, Transaction,
 };
 pub use worker_pool::{
     pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig},

--- a/fynd-core/src/order_manager/mod.rs
+++ b/fynd-core/src/order_manager/mod.rs
@@ -308,6 +308,7 @@ impl OrderManager {
                 amount_out_net_gas: BigUint::ZERO,
                 block: any_sol.block.clone(),
                 algorithm: String::new(),
+                gas_price: None,
                 transaction: None,
             }
         } else {
@@ -353,6 +354,7 @@ impl OrderManager {
                 amount_out_net_gas: BigUint::ZERO,
                 block: BlockInfo { number: 0, hash: String::new(), timestamp: 0 },
                 algorithm: String::new(),
+                gas_price: None,
                 transaction: None,
             }
         }
@@ -404,6 +406,7 @@ mod tests {
                 amount_out_net_gas: BigUint::from(amount_out_net_gas),
                 block: BlockInfo { number: 1, hash: "0x123".to_string(), timestamp: 1000 },
                 algorithm: "test".to_string(),
+                gas_price: None,
                 transaction: None,
             },
             solve_time_ms: 5,
@@ -586,6 +589,7 @@ mod tests {
                     amount_out_net_gas: BigUint::from(900u64),
                     block: BlockInfo { number: 1, hash: "0x123".to_string(), timestamp: 1000 },
                     algorithm: "test".to_string(),
+                    gas_price: None,
                     transaction: None,
                 },
             )],

--- a/fynd-core/src/order_manager/mod.rs
+++ b/fynd-core/src/order_manager/mod.rs
@@ -308,6 +308,7 @@ impl OrderManager {
                 amount_out_net_gas: BigUint::ZERO,
                 block: any_sol.block.clone(),
                 algorithm: String::new(),
+                transaction: None,
             }
         } else {
             // No responses at all - determine status from failure types
@@ -352,6 +353,7 @@ impl OrderManager {
                 amount_out_net_gas: BigUint::ZERO,
                 block: BlockInfo { number: 0, hash: String::new(), timestamp: 0 },
                 algorithm: String::new(),
+                transaction: None,
             }
         }
     }
@@ -402,6 +404,7 @@ mod tests {
                 amount_out_net_gas: BigUint::from(amount_out_net_gas),
                 block: BlockInfo { number: 1, hash: "0x123".to_string(), timestamp: 1000 },
                 algorithm: "test".to_string(),
+                transaction: None,
             },
             solve_time_ms: 5,
         }
@@ -583,6 +586,7 @@ mod tests {
                     amount_out_net_gas: BigUint::from(900u64),
                     block: BlockInfo { number: 1, hash: "0x123".to_string(), timestamp: 1000 },
                     algorithm: "test".to_string(),
+                    transaction: None,
                 },
             )],
             failed_solvers: vec![],

--- a/fynd-core/src/order_manager/mod.rs
+++ b/fynd-core/src/order_manager/mod.rs
@@ -596,6 +596,7 @@ mod tests {
             timeout_ms: None,
             min_responses: None,
             max_gas: max_gas.map(BigUint::from),
+            encoding_options: None,
         };
 
         let manager = OrderManager::new(vec![], OrderManagerConfig::default());

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -83,6 +83,10 @@ pub enum SolveError {
     /// No workers are ready to solve.
     #[error("no workers ready: {0}")]
     NotReady(String),
+
+    /// Error when encoding
+    #[error("failed to encode: {0}")]
+    FailedEncoding(String),
 }
 
 impl SolveError {

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -18,7 +18,7 @@ pub use internal::{SolveError, SolveResult, SolveTask, TaskId};
 pub use primitives::*;
 // Re-export public solution types
 pub use solution::{
-    BlockInfo, Order, OrderSide, OrderSolution, OrderValidationError, Route, RouteResult,
+    BlockInfo, EncodingOptions, Order, OrderSide, OrderSolution, OrderValidationError, Route,
     RouteValidationError, SingleOrderSolution, Solution, SolutionOptions, SolutionRequest,
     SolutionRequest, SolutionStatus, Swap, Transaction,
 };

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -20,5 +20,5 @@ pub use primitives::*;
 pub use solution::{
     BlockInfo, Order, OrderSide, OrderSolution, OrderValidationError, Route, RouteResult,
     RouteValidationError, SingleOrderSolution, Solution, SolutionOptions, SolutionRequest,
-    SolutionStatus, Swap,
+    SolutionRequest, SolutionStatus, Swap, Transaction,
 };

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -18,7 +18,7 @@ pub use internal::{SolveError, SolveResult, SolveTask, TaskId};
 pub use primitives::*;
 // Re-export public solution types
 pub use solution::{
-    BlockInfo, EncodingOptions, Order, OrderSide, OrderSolution, OrderValidationError, Route,
-    RouteValidationError, SingleOrderSolution, Solution, SolutionOptions, SolutionRequest,
-    SolutionRequest, SolutionStatus, Swap, Transaction,
+    BlockInfo, EncodingOptions, Order, OrderSide, OrderSolution, OrderValidationError,
+    PermitSingle, Route, RouteResult, RouteValidationError, SingleOrderSolution, Solution,
+    SolutionOptions, SolutionRequest, SolutionStatus, Swap, Transaction,
 };

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -19,6 +19,7 @@ pub use primitives::*;
 // Re-export public solution types
 pub use solution::{
     BlockInfo, EncodingOptions, Order, OrderSide, OrderSolution, OrderValidationError,
-    PermitSingle, Route, RouteResult, RouteValidationError, SingleOrderSolution, Solution,
-    SolutionOptions, SolutionRequest, SolutionStatus, Swap, Transaction,
+    PermitDetails, PermitSingle, Route, RouteResult, RouteValidationError, SingleOrderSolution,
+    Solution, SolutionOptions, SolutionRequest, SolutionStatus, Swap, Transaction,
+    UserTransferType,
 };

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -68,6 +68,7 @@ pub struct SolutionOptions {
     pub encoding_options: Option<EncodingOptions>,
 }
 
+/// Options to customize the encoding behavior.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EncodingOptions {
@@ -267,6 +268,7 @@ pub struct OrderSolution {
     /// Effective gas price (in wei) at the time the route was computed.
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub gas_price: Option<BigUint>,
+    /// An encoded EVM transaction ready to be submitted on-chain.
     pub transaction: Option<Transaction>,
 }
 

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -765,7 +765,31 @@ mod tests {
             "token_out": "0x0202020202020202020202020202020202020202",
             "amount_in": "1000000000000000000",
             "amount_out": "999000000000000000",
-            "gas_estimate": "150000"
+            "gas_estimate": "150000",
+            "protocol_component": {
+                "id": "test-pool",
+                "protocol_system": "uniswap_v2",
+                "protocol_type_name": "swap",
+                "chain": "ethereum",
+                "tokens": [
+                    "0x0101010101010101010101010101010101010101",
+                    "0x0202020202020202020202020202020202020202"
+                ],
+                "contract_addresses": [],
+                "static_attributes": {},
+                "change": "Update",
+                "creation_tx": "0x",
+                "created_at": "1970-01-01T00:00:00"
+            },
+            "protocol_state": {
+                "protocol": "MockProtocolSim",
+                "state": {
+                    "spot_price": 2,
+                    "gas": 50000,
+                    "liquidity": 340282366920938463463374607431768211455,
+                    "fee": 0.0
+                }
+            }
         }"#;
 
         let swap: Swap = serde_json::from_str(json).unwrap();

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -20,7 +20,11 @@ use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use tycho_simulation::{tycho_common::models::Address, tycho_core::models::token::Token};
+pub use tycho_execution::encoding::models::UserTransferType;
+use tycho_simulation::{
+    tycho_common::models::Address,
+    tycho_core::{models::token::Token, Bytes},
+};
 use uuid::Uuid;
 
 use super::primitives::ComponentId;
@@ -57,6 +61,22 @@ pub struct SolutionOptions {
     #[serde_as(as = "Option<DisplayFromStr>")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_gas: Option<BigUint>,
+    pub encoding_options: Option<EncodingOptions>,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EncodingOptions {
+    pub slippage: f64,
+    /// Token transfer method. Defaults to `TransferFrom`.
+    #[serde(default = "default_transfer_type")]
+    pub transfer_type: UserTransferType,
+    /// Permit2 single-token authorization. Required when using `TransferFromPermit2`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permit: Option<PermitSingle>,
+    /// Permit2 signature (65 bytes). Required when `permit` is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Bytes>,
 }
 
 // ============================================================================
@@ -447,6 +467,10 @@ pub struct Transaction {
 // PRIVATE HELPERS
 // ============================================================================
 
+/// Generates a unique order ID using UUID v4.
+fn default_transfer_type() -> UserTransferType {
+    UserTransferType::TransferFrom
+}
 /// Generates a unique order ID using UUID v4.
 fn generate_order_id() -> String {
     Uuid::new_v4().to_string()

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -79,6 +79,36 @@ pub struct EncodingOptions {
     pub signature: Option<Bytes>,
 }
 
+/// A single permit for permit2 token transfer authorization.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermitSingle {
+    /// The permit details (token, amount, expiration, nonce).
+    pub details: PermitDetails,
+    /// Address authorized to spend the tokens (typically the router).
+    pub spender: Bytes,
+    /// Deadline timestamp for the permit signature.
+    #[serde_as(as = "DisplayFromStr")]
+    pub sig_deadline: BigUint,
+}
+
+/// Details for a permit2 single-token permit.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermitDetails {
+    /// Token address for which the permit is granted.
+    pub token: Bytes,
+    /// Amount of tokens approved.
+    #[serde_as(as = "DisplayFromStr")]
+    pub amount: BigUint,
+    /// Expiration timestamp for the permit.
+    #[serde_as(as = "DisplayFromStr")]
+    pub expiration: BigUint,
+    /// Nonce to prevent replay attacks.
+    #[serde_as(as = "DisplayFromStr")]
+    pub nonce: BigUint,
+}
+
 // ============================================================================
 // RESPONSE TYPES
 // ============================================================================

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -429,6 +429,19 @@ impl Swap {
     }
 }
 
+/// An encoded EVM transaction ready to be submitted on-chain.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Transaction {
+    /// Contract address to call.
+    pub to: Bytes,
+    /// Native token value to send with the transaction.
+    #[serde_as(as = "DisplayFromStr")]
+    pub value: num_bigint::BigUint,
+    /// ABI-encoded calldata.
+    pub data: Vec<u8>,
+}
+
 // ============================================================================
 // PRIVATE HELPERS
 // ============================================================================

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -474,7 +474,7 @@ pub struct Swap {
     /// Estimated gas cost for this swap (as decimal string).
     #[serde_as(as = "DisplayFromStr")]
     pub gas_estimate: BigUint,
-    /// Protocol component description.
+    /// Protocol component to perform the swap.
     pub protocol_component: ProtocolComponent,
     /// Protocol state used to perform the swap.
     pub protocol_state: Box<dyn ProtocolSim>,

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -23,7 +23,11 @@ use serde_with::{serde_as, DisplayFromStr};
 pub use tycho_execution::encoding::models::UserTransferType;
 use tycho_simulation::{
     tycho_common::models::Address,
-    tycho_core::{models::token::Token, Bytes},
+    tycho_core::{
+        models::{protocol::ProtocolComponent, token::Token},
+        simulation::protocol_sim::ProtocolSim,
+        Bytes,
+    },
 };
 use uuid::Uuid;
 
@@ -468,10 +472,14 @@ pub struct Swap {
     /// Estimated gas cost for this swap (as decimal string).
     #[serde_as(as = "DisplayFromStr")]
     pub gas_estimate: BigUint,
+    pub protocol_component: ProtocolComponent,
+    pub protocol_state: Box<dyn ProtocolSim>,
 }
 
 impl Swap {
     /// Creates a new swap with an auto-calculated gas estimate.
+    // All arguments correspond directly to struct fields; no grouping makes sense here.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         component_id: ComponentId,
         protocol: String,
@@ -480,8 +488,20 @@ impl Swap {
         amount_in: BigUint,
         amount_out: BigUint,
         gas_estimate: BigUint,
+        protocol_component: ProtocolComponent,
+        protocol_state: Box<dyn ProtocolSim>,
     ) -> Self {
-        Self { component_id, protocol, token_in, token_out, amount_in, amount_out, gas_estimate }
+        Self {
+            component_id,
+            protocol,
+            token_in,
+            token_out,
+            amount_in,
+            amount_out,
+            gas_estimate,
+            protocol_component,
+            protocol_state,
+        }
     }
 }
 
@@ -516,6 +536,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::algorithm::test_utils::{component, token, MockProtocolSim};
 
     fn make_address(byte: u8) -> Address {
         Address::from([byte; 20])
@@ -534,6 +555,8 @@ mod tests {
     }
 
     fn make_swap(token_in_byte: u8, token_out_byte: u8, amount_in: u64, amount_out: u64) -> Swap {
+        let token_in = token(token_in_byte, "TIN");
+        let token_out = token(token_out_byte, "TOUT");
         Swap {
             component_id: "pool-1".to_string(),
             protocol: "uniswap_v2".to_string(),
@@ -542,6 +565,8 @@ mod tests {
             amount_in: BigUint::from(amount_in),
             amount_out: BigUint::from(amount_out),
             gas_estimate: BigUint::from(100_000u64),
+            protocol_component: component("test-pool", &[token_in, token_out]),
+            protocol_state: Box::new(MockProtocolSim::default()),
         }
     }
 

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -80,7 +80,7 @@ pub struct EncodingOptions {
     pub permit: Option<PermitSingle>,
     /// Permit2 signature (65 bytes). Required when `permit` is set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub signature: Option<Bytes>,
+    pub permit2_signature: Option<Bytes>,
 }
 
 /// A single permit for permit2 token transfer authorization.

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -522,7 +522,7 @@ pub struct Transaction {
 // PRIVATE HELPERS
 // ============================================================================
 
-/// Generates a unique order ID using UUID v4.
+/// Generates a default UserTransferType value.
 fn default_transfer_type() -> UserTransferType {
     UserTransferType::TransferFrom
 }

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -230,6 +230,9 @@ pub struct OrderSolution {
     /// Algorithm that found this solution (internal use only).
     #[serde(skip)]
     pub algorithm: String,
+    /// Effective gas price (in wei) at the time the route was computed.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub gas_price: Option<BigUint>,
     pub transaction: Option<Transaction>,
 }
 
@@ -310,6 +313,8 @@ pub struct RouteResult {
     pub route: Route,
     /// Net amount out after accounting for gas costs in output token terms.
     pub net_amount_out: BigInt,
+    /// Effective gas price (in wei) at the time the route was computed.
+    pub gas_price: BigUint,
 }
 
 impl Route {

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -474,7 +474,9 @@ pub struct Swap {
     /// Estimated gas cost for this swap (as decimal string).
     #[serde_as(as = "DisplayFromStr")]
     pub gas_estimate: BigUint,
+    /// Protocol component description.
     pub protocol_component: ProtocolComponent,
+    /// Protocol state used to perform the swap.
     pub protocol_state: Box<dyn ProtocolSim>,
 }
 

--- a/fynd-core/src/types/solution.rs
+++ b/fynd-core/src/types/solution.rs
@@ -210,6 +210,7 @@ pub struct OrderSolution {
     /// Algorithm that found this solution (internal use only).
     #[serde(skip)]
     pub algorithm: String,
+    pub transaction: Option<Transaction>,
 }
 
 /// Status of an order solution.

--- a/fynd-core/src/worker_pool/task_queue.rs
+++ b/fynd-core/src/worker_pool/task_queue.rs
@@ -157,6 +157,7 @@ mod tests {
                 amount_out_net_gas: BigUint::from(990u64),
                 block: BlockInfo { number: 1, hash: "0x123".to_string(), timestamp: 1000 },
                 algorithm: "test".to_string(),
+                transaction: None,
             },
             solve_time_ms: 5,
         }

--- a/fynd-core/src/worker_pool/task_queue.rs
+++ b/fynd-core/src/worker_pool/task_queue.rs
@@ -157,6 +157,7 @@ mod tests {
                 amount_out_net_gas: BigUint::from(990u64),
                 block: BlockInfo { number: 1, hash: "0x123".to_string(), timestamp: 1000 },
                 algorithm: "test".to_string(),
+                gas_price: None,
                 transaction: None,
             },
             solve_time_ms: 5,

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -235,6 +235,7 @@ where
                     amount_out_net_gas,
                     block: block_info.clone(),
                     algorithm: self.algorithm.name().to_string(),
+                    gas_price: Some(result.gas_price),
                     transaction: None,
                 }
             }

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -235,6 +235,7 @@ where
                     amount_out_net_gas,
                     block: block_info.clone(),
                     algorithm: self.algorithm.name().to_string(),
+                    transaction: None,
                 }
             }
             Err(err) => {

--- a/fynd-rpc/Cargo.toml
+++ b/fynd-rpc/Cargo.toml
@@ -25,8 +25,8 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-actix-web.workspace = true
 metrics.workspace = true
-hex.workspace = true
-tycho-execution = { version = ">=0.155.0", features = ["evm"] }
+hex = "0.4"
+tycho-execution.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/fynd-rpc/Cargo.toml
+++ b/fynd-rpc/Cargo.toml
@@ -26,6 +26,7 @@ tracing.workspace = true
 tracing-actix-web.workspace = true
 metrics.workspace = true
 hex.workspace = true
+tycho-execution = { version = ">=0.155.0", features = ["evm"] }
 
 [dev-dependencies]
 rstest.workspace = true

--- a/fynd-rpc/Cargo.toml
+++ b/fynd-rpc/Cargo.toml
@@ -25,6 +25,7 @@ anyhow.workspace = true
 tracing.workspace = true
 tracing-actix-web.workspace = true
 metrics.workspace = true
+hex.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -6,7 +6,10 @@
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use tycho_simulation::{tycho_common::models::Address, tycho_core::Bytes};
+use tycho_simulation::{
+    tycho_common::models::Address,
+    tycho_core::{dto::ProtocolComponent, simulation::protocol_sim::ProtocolSim, Bytes},
+};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -314,6 +317,10 @@ pub struct Swap {
     #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String, example = "150000")]
     pub gas_estimate: BigUint,
+    #[schema(value_type = Object)]
+    pub protocol_component: ProtocolComponent,
+    #[schema(value_type = Object)]
+    pub protocol_state: Box<dyn ProtocolSim>,
 }
 
 // ============================================================================
@@ -548,6 +555,8 @@ impl From<fynd_core::Swap> for Swap {
             amount_in: core.amount_in,
             amount_out: core.amount_out,
             gas_estimate: core.gas_estimate,
+            protocol_component: core.protocol_component.into(),
+            protocol_state: core.protocol_state,
         }
     }
 }

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -77,6 +77,42 @@ pub struct EncodingOptions {
     pub signature: Option<Bytes>,
 }
 
+/// A single permit for permit2 token transfer authorization.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PermitSingle {
+    /// The permit details (token, amount, expiration, nonce).
+    pub details: PermitDetails,
+    /// Address authorized to spend the tokens (typically the router).
+    #[schema(value_type = String, example = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
+    pub spender: Bytes,
+    /// Deadline timestamp for the permit signature.
+    #[serde_as(as = "DisplayFromStr")]
+    #[schema(value_type = String, example = "1893456000")]
+    pub sig_deadline: BigUint,
+}
+
+/// Details for a permit2 single-token permit.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PermitDetails {
+    /// Token address for which the permit is granted.
+    #[schema(value_type = String, example = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
+    pub token: Bytes,
+    /// Amount of tokens approved.
+    #[serde_as(as = "DisplayFromStr")]
+    #[schema(value_type = String, example = "1000000000000000000")]
+    pub amount: BigUint,
+    /// Expiration timestamp for the permit.
+    #[serde_as(as = "DisplayFromStr")]
+    #[schema(value_type = String, example = "1893456000")]
+    pub expiration: BigUint,
+    /// Nonce to prevent replay attacks.
+    #[serde_as(as = "DisplayFromStr")]
+    #[schema(value_type = String, example = "0")]
+    pub nonce: BigUint,
+}
+
 // ============================================================================
 // RESPONSE TYPES
 // ============================================================================
@@ -381,6 +417,16 @@ impl From<SolutionOptions> for fynd_core::SolutionOptions {
     }
 }
 
+impl From<UserTransferType> for fynd_core::UserTransferType {
+    fn from(dto: UserTransferType) -> Self {
+        match dto {
+            UserTransferType::TransferFromPermit2 => Self::TransferFromPermit2,
+            UserTransferType::TransferFrom => Self::TransferFrom,
+            UserTransferType::None => Self::None,
+        }
+    }
+}
+
 impl From<EncodingOptions> for fynd_core::EncodingOptions {
     fn from(dto: EncodingOptions) -> Self {
         Self {
@@ -389,6 +435,18 @@ impl From<EncodingOptions> for fynd_core::EncodingOptions {
             permit: dto.permit.map(Into::into),
             signature: dto.signature,
         }
+    }
+}
+
+impl From<PermitSingle> for fynd_core::PermitSingle {
+    fn from(dto: PermitSingle) -> Self {
+        Self { details: dto.details.into(), spender: dto.spender, sig_deadline: dto.sig_deadline }
+    }
+}
+
+impl From<PermitDetails> for fynd_core::PermitDetails {
+    fn from(dto: PermitDetails) -> Self {
+        Self { token: dto.token, amount: dto.amount, expiration: dto.expiration, nonce: dto.nonce }
     }
 }
 

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -77,7 +77,7 @@ pub struct EncodingOptions {
     /// Permit2 signature (65 bytes, hex-encoded). Required when `permit` is set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "0xabcd...")]
-    pub signature: Option<Bytes>,
+    pub permit2_signature: Option<Bytes>,
 }
 
 /// A single permit for permit2 token transfer authorization.
@@ -440,7 +440,7 @@ impl From<EncodingOptions> for fynd_core::EncodingOptions {
             slippage: dto.slippage,
             transfer_type: dto.transfer_type.into(),
             permit: dto.permit.map(Into::into),
-            signature: dto.signature,
+            permit2_signature: dto.permit2_signature,
         }
     }
 }

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -319,7 +319,7 @@ pub struct Swap {
     #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String, example = "150000")]
     pub gas_estimate: BigUint,
-    /// Protocol component description.
+    /// Protocol component to perform the swap.
     #[schema(value_type = Object)]
     pub protocol_component: ProtocolComponent,
     /// Protocol state used to perform the swap.

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -193,6 +193,11 @@ pub struct OrderSolution {
     pub amount_out_net_gas: BigUint,
     /// Block at which this quote was computed.
     pub block: BlockInfo,
+    /// Effective gas price (in wei) at the time the route was computed.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "20000000000")]
+    pub gas_price: Option<BigUint>,
     pub transaction: Option<Transaction>,
 }
 
@@ -439,6 +444,7 @@ impl From<fynd_core::OrderSolution> for OrderSolution {
             price_impact_bps: core.price_impact_bps,
             amount_out_net_gas: core.amount_out_net_gas,
             block: core.block.into(),
+            gas_price: core.gas_price,
             transaction: core.transaction.map(Into::into),
         }
     }

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -62,6 +62,7 @@ pub enum UserTransferType {
     None,
 }
 
+/// Options to customize the encoding behavior.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct EncodingOptions {
@@ -237,6 +238,7 @@ pub struct OrderSolution {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "20000000000")]
     pub gas_price: Option<BigUint>,
+    /// An encoded EVM transaction ready to be submitted on-chain.
     pub transaction: Option<Transaction>,
 }
 

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -6,7 +6,7 @@
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
-use tycho_simulation::tycho_common::models::Address;
+use tycho_simulation::{tycho_common::models::Address, tycho_core::Bytes};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -43,6 +43,38 @@ pub struct SolutionOptions {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Option<String>, example = "500000")]
     pub max_gas: Option<BigUint>,
+    pub encoding_options: Option<EncodingOptions>,
+}
+
+/// Token transfer method for moving funds into Tycho execution.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UserTransferType {
+    /// Use Permit2 for token transfer. Requires `permit` and `signature`.
+    TransferFromPermit2,
+    /// Use standard ERC-20 approval and `transferFrom`. Default.
+    #[default]
+    TransferFrom,
+    /// Use funds already present in the Tycho Router (no transfer performed).
+    None,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EncodingOptions {
+    #[serde_as(as = "DisplayFromStr")]
+    #[schema(example = "0.001")]
+    pub slippage: f64,
+    /// Token transfer method. Defaults to `transfer_from`.
+    #[serde(default)]
+    pub transfer_type: UserTransferType,
+    /// Permit2 single-token authorization. Required when using `transfer_from_permit2`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permit: Option<PermitSingle>,
+    /// Permit2 signature (65 bytes, hex-encoded). Required when `permit` is set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, example = "0xabcd...")]
+    pub signature: Option<Bytes>,
 }
 
 // ============================================================================
@@ -335,7 +367,23 @@ impl From<SolutionRequest> for fynd_core::SolutionRequest {
 
 impl From<SolutionOptions> for fynd_core::SolutionOptions {
     fn from(dto: SolutionOptions) -> Self {
-        Self { timeout_ms: dto.timeout_ms, min_responses: dto.min_responses, max_gas: dto.max_gas }
+        Self {
+            timeout_ms: dto.timeout_ms,
+            min_responses: dto.min_responses,
+            max_gas: dto.max_gas,
+            encoding_options: dto.encoding_options.map(Into::into),
+        }
+    }
+}
+
+impl From<EncodingOptions> for fynd_core::EncodingOptions {
+    fn from(dto: EncodingOptions) -> Self {
+        Self {
+            slippage: dto.slippage,
+            transfer_type: dto.transfer_type.into(),
+            permit: dto.permit.map(Into::into),
+            signature: dto.signature,
+        }
     }
 }
 
@@ -469,7 +517,12 @@ mod tests {
                 sender: make_address(0xAA),
                 receiver: None,
             }],
-            options: SolutionOptions { timeout_ms: Some(5000), min_responses: None, max_gas: None },
+            options: SolutionOptions {
+                timeout_ms: Some(5000),
+                min_responses: None,
+                max_gas: None,
+                encoding_options: None,
+            },
         };
 
         let core: fynd_core::SolutionRequest = dto.clone().into();

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -161,6 +161,7 @@ pub struct OrderSolution {
     pub amount_out_net_gas: BigUint,
     /// Block at which this quote was computed.
     pub block: BlockInfo,
+    pub transaction: Option<Transaction>,
 }
 
 /// Status of an order solution.
@@ -390,6 +391,7 @@ impl From<fynd_core::OrderSolution> for OrderSolution {
             price_impact_bps: core.price_impact_bps,
             amount_out_net_gas: core.amount_out_net_gas,
             block: core.block.into(),
+            transaction: core.transaction.map(Into::into),
         }
     }
 }

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -243,6 +243,61 @@ pub struct Swap {
 }
 
 // ============================================================================
+// ENCODING TYPES
+// ============================================================================
+
+/// An encoded EVM transaction ready to be submitted on-chain.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Transaction {
+    /// Contract address to call.
+    #[schema(value_type = String, example = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
+    pub to: Bytes,
+
+    /// Native token value to send with the transaction (as decimal string).
+    #[serde_as(as = "DisplayFromStr")]
+    #[schema(value_type = String, example = "0")]
+    pub value: BigUint,
+
+    /// ABI-encoded calldata as hex string.
+    #[schema(value_type = String, example = "0x1234567890abcdef")]
+    #[serde(serialize_with = "serialize_bytes_hex", deserialize_with = "deserialize_bytes_hex")]
+    pub data: Vec<u8>,
+}
+
+// ============================================================================
+// CUSTOM SERIALIZATION
+// ============================================================================
+
+/// Serializes Vec<u8> to hex string with 0x prefix.
+fn serialize_bytes_hex<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&format!("0x{}", hex::encode(bytes)))
+}
+
+/// Deserializes hex string (with or without 0x prefix) to Vec<u8>.
+fn deserialize_bytes_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    let s = s.strip_prefix("0x").unwrap_or(&s);
+    hex::decode(s).map_err(serde::de::Error::custom)
+}
+
+// ============================================================================
+// CONVERSIONS: Transaction DTO <-> Core
+// ============================================================================
+
+impl From<fynd_core::types::Transaction> for Transaction {
+    fn from(core: fynd_core::Transaction) -> Self {
+        Self { to: core.to, value: core.value, data: core.data }
+    }
+}
+
+// ============================================================================
 // HEALTH CHECK TYPES
 // ============================================================================
 

--- a/fynd-rpc/src/api/dto.rs
+++ b/fynd-rpc/src/api/dto.rs
@@ -319,8 +319,10 @@ pub struct Swap {
     #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String, example = "150000")]
     pub gas_estimate: BigUint,
+    /// Protocol component description.
     #[schema(value_type = Object)]
     pub protocol_component: ProtocolComponent,
+    /// Protocol state used to perform the swap.
     #[schema(value_type = Object)]
     pub protocol_state: Box<dyn ProtocolSim>,
 }

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -68,6 +68,7 @@ impl ResponseError for ApiError {
                 SolveError::InvalidOrder(_) => "INVALID_ORDER",
                 SolveError::Internal(_) => "INTERNAL_ERROR",
                 SolveError::NotReady(_) => "NOT_READY",
+                SolveError::FailedEncoding(_) => "FAILED_ENCODING",
             },
             ApiError::ServiceOverloaded => "SERVICE_OVERLOADED",
             ApiError::Internal(_) => "INTERNAL_ERROR",


### PR DESCRIPTION
- adds FailedEncoding variant to SolveError
- creates Transaction
- adds transaction to OrderSolution
- adds encoding_options to SolutionOptions
- adds gas_price to OrderSolution 
- sets gas_price in MostLiquid
- add the protocol component and protocol state

Note:
 **#[schema(value_type = Object)]** annotation for `ProtocolComponent` is necessary. 
 This can be removed if `tycho-commo`n is bumped to a version that uses utoipa v5