### PR TITLE
feat: add @fynd/client TypeScript package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,25 @@ jobs:
           npm ci
           npx tsc --noEmit
 
+  check_ts_client:
+    name: TypeScript client typecheck + lint + test
+    needs: typescript_autogen_drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1  # v4.2.0
+        with:
+          version: "10.30.3"
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+          cache-dependency-path: clients/typescript/pnpm-lock.yaml
+      - run: pnpm --dir clients/typescript install --frozen-lockfile
+      - run: pnpm --dir clients/typescript --filter @fynd/client run typecheck
+      - run: pnpm --dir clients/typescript --filter @fynd/client run lint
+      - run: pnpm --dir clients/typescript --filter @fynd/client run test
+
   security_audit:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -127,6 +127,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: clients/typescript/pnpm-lock.yaml
       - run: pnpm --dir clients/typescript install --frozen-lockfile
+      - run: pnpm --dir clients/typescript --filter @fynd/autogen run build
       - run: pnpm --dir clients/typescript --filter @fynd/client run typecheck
       - run: pnpm --dir clients/typescript --filter @fynd/client run lint
       - run: pnpm --dir clients/typescript --filter @fynd/client run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target/
 /.idea/
 /.vscode/
+clients/typescript/client/dist/
+clients/typescript/node_modules/

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "paths": {
     "/v1/health": {

--- a/clients/typescript/.gitignore
+++ b/clients/typescript/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/clients/typescript/client/.gitignore
+++ b/clients/typescript/client/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/clients/typescript/client/package.json
+++ b/clients/typescript/client/package.json
@@ -10,6 +10,7 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "files": ["dist"],
   "scripts": {
     "build":     "tsc",
     "typecheck": "tsc --noEmit",

--- a/clients/typescript/client/package.json
+++ b/clients/typescript/client/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@fynd/client",
+  "version": "0.1.0",
+  "private": true,
+  "description": "TypeScript client for the Fynd DEX router",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build":     "tsc",
+    "typecheck": "tsc --noEmit",
+    "lint":      "oxlint src/",
+    "test":      "vitest run"
+  },
+  "dependencies": {
+    "@fynd/autogen": "workspace:*",
+    "viem": "2.46.3"
+  },
+  "devDependencies": {
+    "typescript": "5.8.2",
+    "oxlint":     "1.51.0",
+    "vitest":     "4.0.18"
+  }
+}

--- a/clients/typescript/client/src/client.test.ts
+++ b/clients/typescript/client/src/client.test.ts
@@ -53,7 +53,6 @@ function makeClientWithHttpMock(
       return Promise.resolve({ data: undefined, error: undefined, response: {} });
     }),
   };
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (client as any).http = httpMock;
   return client;
 }
@@ -167,7 +166,6 @@ describe('FyndClient.quote — retry path', () => {
       }),
       GET: vi.fn(),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (client as any).http = httpMock;
 
     const quote = await client.quote({
@@ -198,7 +196,6 @@ describe('FyndClient.quote — retry path', () => {
       }),
       GET: vi.fn(),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (client as any).http = httpMock;
 
     await expect(
@@ -207,6 +204,38 @@ describe('FyndClient.quote — retry path', () => {
       }),
     ).rejects.toThrow(FyndError);
     expect(callCount).toBe(1);
+  });
+
+  it('exhausts all retries and throws on all-retryable failure', async () => {
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      retry:         { maxAttempts: 2, initialBackoffMs: 1, maxBackoffMs: 5 },
+    });
+
+    let callCount = 0;
+    const httpMock = {
+      POST: vi.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve({
+          data:     undefined,
+          error:    { code: 'QUEUE_FULL', error: 'queue full' },
+          response: {},
+        });
+      }),
+      GET: vi.fn(),
+    };
+    (client as any).http = httpMock;
+
+    await expect(
+      client.quote({
+        order: { tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: 1000n, side: 'sell', sender: SENDER },
+      }),
+    ).rejects.toThrow(FyndError);
+    // All attempts should have been made before giving up
+    expect(callCount).toBe(2);
   });
 });
 
@@ -232,6 +261,21 @@ describe('FyndClient.health', () => {
 });
 
 describe('FyndClient.signablePayload', () => {
+  it('throws for turbine backend (not yet implemented)', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const turbineQuote = { ...makeDummyQuote(), backend: 'turbine' as const };
+    await expect(client.signablePayload(turbineQuote)).rejects.toThrow(
+      'not implemented: Turbine backend signing',
+    );
+  });
+
   it('throws CONFIG error when provider is not set', async () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',

--- a/clients/typescript/client/src/client.test.ts
+++ b/clients/typescript/client/src/client.test.ts
@@ -1,0 +1,703 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FyndClient } from './client.js';
+import { FyndError } from './error.js';
+import type { EthProvider, MinimalReceipt, FyndClientOptions } from './client.js';
+import type { Address, Hex } from './types.js';
+
+const ROUTER  = '0x1111111111111111111111111111111111111111' as Address;
+const SENDER  = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as Address;
+const TOKEN_IN  = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as Address;
+const TOKEN_OUT = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as Address;
+
+// Build a mock provider with all methods returning sensible defaults
+function makeMockProvider(): { [K in keyof EthProvider]: ReturnType<typeof vi.fn> } & EthProvider {
+  return {
+    getTransactionCount:    vi.fn().mockResolvedValue(5),
+    estimateFeesPerGas:     vi.fn().mockResolvedValue({ maxFeePerGas: 20n, maxPriorityFeePerGas: 2n }),
+    call:                   vi.fn().mockResolvedValue({ data: undefined }),
+    estimateGas:            vi.fn().mockResolvedValue(150000n),
+    sendRawTransaction:     vi.fn().mockResolvedValue('0xtxhash' as Hex),
+    getTransactionReceipt:  vi.fn().mockResolvedValue(null),
+  };
+}
+
+// Minimal mock that replaces the openapi-fetch HTTP layer
+function makeClientWithHttpMock(
+  solveResponse: { status: number; data?: unknown },
+  healthResponse?: { status: number; data?: unknown },
+  opts?: Partial<FyndClientOptions>,
+): FyndClient {
+  const client = new FyndClient({
+    baseUrl:       'http://localhost:8080',
+    chainId:       1,
+    routerAddress: ROUTER,
+    sender:        SENDER,
+    ...opts,
+  });
+
+  // Override the private http client by accessing it via a cast
+  const httpMock = {
+    POST: vi.fn().mockImplementation(() => {
+      if (solveResponse.status >= 200 && solveResponse.status < 300) {
+        return Promise.resolve({ data: solveResponse.data, error: undefined, response: {} });
+      }
+      return Promise.resolve({ data: undefined, error: solveResponse.data, response: {} });
+    }),
+    GET: vi.fn().mockImplementation(() => {
+      if (healthResponse) {
+        if (healthResponse.status >= 200 && healthResponse.status < 300) {
+          return Promise.resolve({ data: healthResponse.data, error: undefined, response: {} });
+        }
+        return Promise.resolve({ data: undefined, error: healthResponse.data, response: {} });
+      }
+      return Promise.resolve({ data: undefined, error: undefined, response: {} });
+    }),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (client as any).http = httpMock;
+  return client;
+}
+
+const wireSolution = {
+  orders: [
+    {
+      order_id:           'order-1',
+      status:             'success',
+      amount_in:          '1000',
+      amount_out:         '3500',
+      amount_out_net_gas: '3498',
+      gas_estimate:       '150000',
+      route:              null,
+      price_impact_bps:   null,
+      block: { hash: '0xabc', number: 100, timestamp: 1000000 },
+    },
+  ],
+  total_gas_estimate: '150000',
+  solve_time_ms:      10,
+};
+
+describe('FyndClient.quote — happy path', () => {
+  it('returns a Quote with correct fields', async () => {
+    const client = makeClientWithHttpMock({ status: 200, data: wireSolution });
+    const quote = await client.quote({
+      order: { tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: 1000n, side: 'sell', sender: SENDER },
+    });
+    expect(quote.orderId).toBe('order-1');
+    expect(quote.status).toBe('success');
+    expect(quote.backend).toBe('fynd');
+    expect(quote.amountIn).toBe(1000n);
+    expect(quote.amountOut).toBe(3500n);
+    expect(quote.gasEstimate).toBe(150000n);
+    expect(quote.tokenOut).toBe(TOKEN_OUT);
+  });
+
+  it('receiver defaults to sender when Order.receiver is absent', async () => {
+    const client = makeClientWithHttpMock({ status: 200, data: wireSolution });
+    const quote = await client.quote({
+      order: { tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: 1000n, side: 'sell', sender: SENDER },
+    });
+    expect(quote.receiver).toBe(SENDER);
+  });
+
+  it('receiver uses Order.receiver when present', async () => {
+    const altReceiver = '0x2222222222222222222222222222222222222222' as Address;
+    const client = makeClientWithHttpMock({ status: 200, data: wireSolution });
+    const quote = await client.quote({
+      order: {
+        tokenIn:  TOKEN_IN,
+        tokenOut: TOKEN_OUT,
+        amount:   1000n,
+        side:     'sell',
+        sender:   SENDER,
+        receiver: altReceiver,
+      },
+    });
+    expect(quote.receiver).toBe(altReceiver);
+  });
+});
+
+describe('FyndClient.quote — error path', () => {
+  it('throws FyndError with NO_ROUTE_FOUND code', async () => {
+    const client = makeClientWithHttpMock({
+      status: 422,
+      data:   { code: 'NO_ROUTE_FOUND', error: 'no route' },
+    });
+    await expect(
+      client.quote({
+        order: { tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: 1000n, side: 'sell', sender: SENDER },
+      }),
+    ).rejects.toThrow(FyndError);
+
+    try {
+      await client.quote({
+        order: { tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: 1000n, side: 'sell', sender: SENDER },
+      });
+    } catch (e) {
+      expect(e instanceof FyndError).toBe(true);
+      if (e instanceof FyndError) {
+        expect(e.code).toBe('NO_ROUTE_FOUND');
+        expect(e.isRetryable()).toBe(false);
+      }
+    }
+  });
+});
+
+describe('FyndClient.quote — retry path', () => {
+  it('retries on QUEUE_FULL and succeeds on second attempt', async () => {
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      retry:         { maxAttempts: 3, initialBackoffMs: 1, maxBackoffMs: 10 },
+    });
+
+    let callCount = 0;
+    const httpMock = {
+      POST: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Promise.resolve({
+            data:     undefined,
+            error:    { code: 'QUEUE_FULL', error: 'queue full' },
+            response: {},
+          });
+        }
+        return Promise.resolve({ data: wireSolution, error: undefined, response: {} });
+      }),
+      GET: vi.fn(),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (client as any).http = httpMock;
+
+    const quote = await client.quote({
+      order: { tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: 1000n, side: 'sell', sender: SENDER },
+    });
+    expect(callCount).toBe(2);
+    expect(quote.status).toBe('success');
+  });
+
+  it('does not retry on non-retryable errors', async () => {
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      retry:         { maxAttempts: 3, initialBackoffMs: 1 },
+    });
+
+    let callCount = 0;
+    const httpMock = {
+      POST: vi.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve({
+          data:     undefined,
+          error:    { code: 'BAD_REQUEST', error: 'bad request' },
+          response: {},
+        });
+      }),
+      GET: vi.fn(),
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (client as any).http = httpMock;
+
+    await expect(
+      client.quote({
+        order: { tokenIn: TOKEN_IN, tokenOut: TOKEN_OUT, amount: 1000n, side: 'sell', sender: SENDER },
+      }),
+    ).rejects.toThrow(FyndError);
+    expect(callCount).toBe(1);
+  });
+});
+
+describe('FyndClient.health', () => {
+  it('returns HealthStatus on 200', async () => {
+    const client = makeClientWithHttpMock(
+      { status: 200, data: wireSolution },
+      { status: 200, data: { healthy: true, last_update_ms: 500, num_solver_pools: 3 } },
+    );
+    const health = await client.health();
+    expect(health.healthy).toBe(true);
+    expect(health.lastUpdateMs).toBe(500);
+    expect(health.numSolverPools).toBe(3);
+  });
+
+  it('throws FyndError on 503', async () => {
+    const client = makeClientWithHttpMock(
+      { status: 200, data: wireSolution },
+      { status: 503, data: { code: 'STALE_DATA', error: 'data stale' } },
+    );
+    await expect(client.health()).rejects.toThrow(FyndError);
+  });
+});
+
+describe('FyndClient.signablePayload', () => {
+  it('throws CONFIG error when provider is not set', async () => {
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+    });
+    const quote = { ...makeDummyQuote() };
+    await expect(client.signablePayload(quote)).rejects.toThrow(FyndError);
+    try {
+      await client.signablePayload(quote);
+    } catch (e) {
+      expect(e instanceof FyndError && e.code).toBe('CONFIG');
+    }
+  });
+
+  it('throws CONFIG error when no sender configured', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      provider,
+      // no sender
+    });
+    const quote = makeDummyQuote();
+    await expect(client.signablePayload(quote)).rejects.toThrow(FyndError);
+    try {
+      await client.signablePayload(quote);
+    } catch (e) {
+      expect(e instanceof FyndError && e.code).toBe('CONFIG');
+    }
+  });
+
+  it('builds transaction with correct to and value', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = makeDummyQuote();
+    const payload = await client.signablePayload(quote);
+    expect(payload.kind).toBe('fynd');
+    expect(payload.payload.tx.to).toBe(ROUTER);
+    expect(payload.payload.tx.value).toBe(0n);
+    expect(payload.payload.tx.data).toBe('0x');
+  });
+
+  it('uses hints.sender over options.sender', async () => {
+    const provider = makeMockProvider();
+    const altSender = '0x9999999999999999999999999999999999999999' as Address;
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = makeDummyQuote();
+    await client.signablePayload(quote, { sender: altSender });
+    expect(provider.getTransactionCount).toHaveBeenCalledWith({ address: altSender });
+  });
+
+  it('uses hints.nonce without calling getTransactionCount', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = makeDummyQuote();
+    const payload = await client.signablePayload(quote, { nonce: 99 });
+    expect(payload.payload.tx.nonce).toBe(99);
+    expect(provider.getTransactionCount).not.toHaveBeenCalled();
+  });
+
+  it('uses hints.maxFeePerGas without calling estimateFeesPerGas', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = makeDummyQuote();
+    const payload = await client.signablePayload(quote, {
+      maxFeePerGas:         50n,
+      maxPriorityFeePerGas: 5n,
+    });
+    expect(payload.payload.tx.maxFeePerGas).toBe(50n);
+    expect(payload.payload.tx.maxPriorityFeePerGas).toBe(5n);
+    expect(provider.estimateFeesPerGas).not.toHaveBeenCalled();
+  });
+
+  it('uses hints.gasLimit over quote.gasEstimate', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = makeDummyQuote(); // gasEstimate = 150000n
+    const payload = await client.signablePayload(quote, { gasLimit: 200000n });
+    expect(payload.payload.tx.gas).toBe(200000n);
+  });
+
+  it('calls provider.call when hints.simulate is true', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = makeDummyQuote();
+    await client.signablePayload(quote, { simulate: true });
+    expect(provider.call).toHaveBeenCalledOnce();
+  });
+
+  it('throws SIMULATE_FAILED when provider.call throws during simulation', async () => {
+    const provider = makeMockProvider();
+    provider.call.mockRejectedValueOnce(new Error('execution reverted'));
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = makeDummyQuote();
+    await expect(client.signablePayload(quote, { simulate: true })).rejects.toThrow(FyndError);
+    try {
+      await client.signablePayload(quote, { simulate: true });
+    } catch (e) {
+      expect(e instanceof FyndError && e.code).toBe('SIMULATE_FAILED');
+    }
+  });
+});
+
+describe('FyndClient.execute — standard path', () => {
+  it('calls sendRawTransaction and returns receipt with settle()', async () => {
+    const provider = makeMockProvider();
+    provider.sendRawTransaction.mockResolvedValueOnce('0xhash123' as Hex);
+    const receipt: MinimalReceipt = {
+      transactionHash: '0xhash123' as Hex,
+      gasUsed:         150000n,
+      effectiveGasPrice: 20n,
+      logs:            [],
+    };
+    provider.getTransactionReceipt.mockResolvedValueOnce(receipt);
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    const executionReceipt = await client.execute(signedOrder);
+    expect(provider.sendRawTransaction).toHaveBeenCalledOnce();
+
+    const settled = await executionReceipt.settle();
+    expect(settled.txHash).toBe('0xhash123');
+    expect(settled.gasCost).toBe(3000000n); // 150000 * 20
+  });
+
+  it('throws CONFIG when provider not set', async () => {
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+    });
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    await expect(client.execute(signedOrder)).rejects.toThrow(FyndError);
+  });
+});
+
+describe('FyndClient.execute — dry-run path', () => {
+  it('calls provider.call and estimateGas, not sendRawTransaction', async () => {
+    const provider = makeMockProvider();
+    // Return 32 bytes of return data (1000 in big-endian uint256)
+    // 64 hex chars total: 61 zeros + '3e8' (0x3e8 = 1000)
+    const returnHex = ('0x' + '0'.repeat(61) + '3e8') as Hex;  // 0x3e8 = 1000
+    provider.call.mockResolvedValueOnce({ data: returnHex as Hex });
+    provider.estimateGas.mockResolvedValueOnce(100000n);
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    const executionReceipt = await client.execute(signedOrder, { dryRun: true });
+    expect(provider.sendRawTransaction).not.toHaveBeenCalled();
+    expect(provider.call).toHaveBeenCalledOnce();
+    expect(provider.estimateGas).toHaveBeenCalledOnce();
+
+    const settled = await executionReceipt.settle();
+    expect(settled.txHash).toBeUndefined();
+    expect(settled.gasCost).toBe(100000n * 20000000000n); // gasUsed * maxFeePerGas
+  });
+
+  it('settle() resolves immediately for dry-run', async () => {
+    const provider = makeMockProvider();
+    provider.call.mockResolvedValueOnce({ data: undefined });
+    provider.estimateGas.mockResolvedValueOnce(50000n);
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    const executionReceipt = await client.execute(signedOrder, { dryRun: true });
+    // Should resolve without any polling
+    const settled = await executionReceipt.settle();
+    expect(provider.getTransactionReceipt).not.toHaveBeenCalled();
+    expect(settled.settledAmount).toBeUndefined();
+  });
+
+  it('settledAmount decoded from 32-byte return data', async () => {
+    const provider = makeMockProvider();
+    // 32 bytes = 64 hex chars: represent value 0x123 = 291
+    // Pad to exactly 64 hex chars: 61 zeros + '123'
+    const returnHex = ('0x' + '0'.repeat(61) + '123') as Hex;
+    provider.call.mockResolvedValueOnce({ data: returnHex });
+    provider.estimateGas.mockResolvedValueOnce(50000n);
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    const receipt = await client.execute(signedOrder, { dryRun: true });
+    const settled = await receipt.settle();
+    expect(settled.settledAmount).toBe(0x123n);
+  });
+
+  it('settledAmount is undefined when return data is absent', async () => {
+    const provider = makeMockProvider();
+    provider.call.mockResolvedValueOnce({ data: undefined });
+    provider.estimateGas.mockResolvedValueOnce(50000n);
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    const receipt = await client.execute(signedOrder, { dryRun: true });
+    const settled = await receipt.settle();
+    expect(settled.settledAmount).toBeUndefined();
+  });
+
+  it('throws SIMULATE_FAILED when provider.call throws during dry-run', async () => {
+    const provider = makeMockProvider();
+    provider.call.mockRejectedValueOnce(new Error('execution reverted'));
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    await expect(client.execute(signedOrder, { dryRun: true })).rejects.toThrow(FyndError);
+    try {
+      await client.execute(signedOrder, { dryRun: true });
+    } catch (e) {
+      expect(e instanceof FyndError && e.code).toBe('SIMULATE_FAILED');
+    }
+  });
+
+  it('uses maxFeePerGas for dry-run gasCost calculation', async () => {
+    const provider = makeMockProvider();
+    provider.call.mockResolvedValueOnce({ data: undefined });
+    provider.estimateGas.mockResolvedValueOnce(200000n);
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const quote = makeDummyQuote();
+    // maxFeePerGas is set in signablePayload; here we create a signed order directly
+    const signedOrder = makeSignedOrder(quote, { maxFeePerGas: 30n });
+    const receipt = await client.execute(signedOrder, { dryRun: true });
+    const settled = await receipt.settle();
+    expect(settled.gasCost).toBe(200000n * 30n); // gasUsed * maxFeePerGas
+  });
+});
+
+// Transfer log decoding — tested indirectly via execute settle()
+describe('Transfer log decoding via settle()', () => {
+  const ERC20_TOPIC = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' as Hex;
+  const ERC6909_TOPIC = '0x1b3d7edb2e9c0b0e7c525b20aaaef0f5940d2ed71663c7d39266ecafac728859' as Hex;
+
+  function padAddress(addr: string): Hex {
+    return `0x${'0'.repeat(24)}${addr.slice(2)}` as Hex;
+  }
+
+  function makeReceiptWithLogs(logs: MinimalReceipt['logs']): MinimalReceipt {
+    return {
+      transactionHash: '0xtxhash' as Hex,
+      gasUsed:         100000n,
+      effectiveGasPrice: 10n,
+      logs,
+    };
+  }
+
+  async function executeAndSettle(
+    quote: ReturnType<typeof makeDummyQuote>,
+    receipt: MinimalReceipt,
+  ) {
+    const provider = makeMockProvider();
+    provider.sendRawTransaction.mockResolvedValueOnce('0xtxhash' as Hex);
+    provider.getTransactionReceipt.mockResolvedValueOnce(receipt);
+
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      routerAddress: ROUTER,
+      sender:        SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(quote);
+    const executionReceipt = await client.execute(signedOrder);
+    return executionReceipt.settle();
+  }
+
+  it('ERC-20: matching log returns correct amount', async () => {
+    const amount = 3500000000n;
+    const amountHex = amount.toString(16).padStart(64, '0');
+    const log = {
+      address: TOKEN_OUT,
+      topics: [ERC20_TOPIC, padAddress(SENDER), padAddress(SENDER)] as Hex[],
+      data:   `0x${amountHex}` as Hex,
+    };
+    const settled = await executeAndSettle(makeDummyQuote(), makeReceiptWithLogs([log]));
+    expect(settled.settledAmount).toBe(amount);
+  });
+
+  it('ERC-20: wrong token address returns undefined', async () => {
+    const wrongToken = '0x0000000000000000000000000000000000000001' as Address;
+    const log = {
+      address: wrongToken,
+      topics: [ERC20_TOPIC, padAddress(SENDER), padAddress(SENDER)] as Hex[],
+      data:   `0x${'0'.repeat(63)}1` as Hex,
+    };
+    const settled = await executeAndSettle(makeDummyQuote(), makeReceiptWithLogs([log]));
+    expect(settled.settledAmount).toBeUndefined();
+  });
+
+  it('ERC-20: wrong receiver returns undefined', async () => {
+    const wrongReceiver = '0x9999999999999999999999999999999999999999' as Address;
+    const log = {
+      address: TOKEN_OUT,
+      topics: [ERC20_TOPIC, padAddress(SENDER), padAddress(wrongReceiver)] as Hex[],
+      data:   `0x${'0'.repeat(63)}1` as Hex,
+    };
+    const settled = await executeAndSettle(makeDummyQuote(), makeReceiptWithLogs([log]));
+    expect(settled.settledAmount).toBeUndefined();
+  });
+
+  it('ERC-6909: matching log returns correct amount at bytes 32..64', async () => {
+    const amount = 12345n;
+    const amountHex = amount.toString(16).padStart(64, '0');
+    // data: caller[32 bytes] + amount[32 bytes]
+    const callerHex = '0'.repeat(64);
+    const log = {
+      address: TOKEN_OUT,
+      topics: [ERC6909_TOPIC, padAddress(SENDER), padAddress(SENDER)] as Hex[],
+      data:   `0x${callerHex}${amountHex}` as Hex,
+    };
+    const settled = await executeAndSettle(makeDummyQuote(), makeReceiptWithLogs([log]));
+    expect(settled.settledAmount).toBe(amount);
+  });
+
+  it('multiple matching logs: amounts are summed', async () => {
+    const amountHex1 = (1000n).toString(16).padStart(64, '0');
+    const amountHex2 = (2000n).toString(16).padStart(64, '0');
+    const logs = [
+      {
+        address: TOKEN_OUT,
+        topics: [ERC20_TOPIC, padAddress(SENDER), padAddress(SENDER)] as Hex[],
+        data:   `0x${amountHex1}` as Hex,
+      },
+      {
+        address: TOKEN_OUT,
+        topics: [ERC20_TOPIC, padAddress(SENDER), padAddress(SENDER)] as Hex[],
+        data:   `0x${amountHex2}` as Hex,
+      },
+    ];
+    const settled = await executeAndSettle(makeDummyQuote(), makeReceiptWithLogs(logs));
+    expect(settled.settledAmount).toBe(3000n);
+  });
+
+  it('empty logs returns undefined', async () => {
+    const settled = await executeAndSettle(makeDummyQuote(), makeReceiptWithLogs([]));
+    expect(settled.settledAmount).toBeUndefined();
+  });
+});
+
+// ---- helpers ----
+
+function makeDummyQuote(overrides?: Partial<{ gasEstimate: bigint }>) {
+  return {
+    orderId:     'test-order',
+    status:      'success' as const,
+    backend:     'fynd' as const,
+    amountIn:    1000n,
+    amountOut:   3500n,
+    gasEstimate: overrides?.gasEstimate ?? 150000n,
+    block: { hash: '0xabc', number: 100, timestamp: 1000 },
+    tokenOut: TOKEN_OUT,
+    receiver: SENDER,
+  };
+}
+
+function makeSignedOrder(
+  quote: ReturnType<typeof makeDummyQuote>,
+  txOverrides?: { maxFeePerGas?: bigint },
+) {
+  const tx = {
+    chainId:              1,
+    nonce:                0,
+    maxFeePerGas:         txOverrides?.maxFeePerGas ?? 20000000000n,
+    maxPriorityFeePerGas: 2000000000n,
+    gas:                  quote.gasEstimate,
+    to:                   ROUTER,
+    value:                0n,
+    data:                 '0x' as Hex,
+  };
+  const payload = { kind: 'fynd' as const, payload: { quote, tx } };
+  // A valid 65-byte hex signature (r[32]+s[32]+v[1])
+  const sig = `0x${'ab'.repeat(32)}${'cd'.repeat(32)}00` as `0x${string}`;
+  return { payload, signature: sig };
+}

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -206,7 +206,13 @@ export class FyndClient {
     // signature is '0x' + 130 hex chars (65 bytes)
     const r = `0x${signature.slice(2, 66)}` as Hex;
     const s = `0x${signature.slice(66, 130)}` as Hex;
-    const yParity = parseInt(signature.slice(130, 132), 16) as 0 | 1;
+    const vByte = parseInt(signature.slice(130, 132), 16);
+    // Normalize: legacy v=27/28 → yParity 0/1; EIP-1559 v=0/1 pass through
+    const vNormalized = vByte === 27 ? 0 : vByte === 28 ? 1 : vByte;
+    if (vNormalized !== 0 && vNormalized !== 1) {
+      throw FyndError.config(`invalid signature v byte: ${vByte}`);
+    }
+    const yParity: 0 | 1 = vNormalized;
 
     const rawTx = serializeTransaction(
       {

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -1,0 +1,332 @@
+import { keccak256, serializeTransaction, toHex } from 'viem';
+import { createFyndClient, type FyndClient as AutogenClient } from "@fynd/autogen";
+import type { components } from "@fynd/autogen";
+import { FyndError } from "./error.js";
+import * as mapping from "./mapping.js";
+import type {
+  Eip1559Transaction,
+  ExecutionReceipt,
+  FyndPayload,
+  SettledOrder,
+  SignablePayload,
+  SignedOrder,
+} from "./signing.js";
+import type { Address, Hex, HealthStatus, Quote, QuoteParams } from "./types.js";
+
+type WireErrorResponse = components["schemas"]["ErrorResponse"];
+
+// ERC-20 Transfer(address,address,uint256)
+const ERC20_TRANSFER_TOPIC = keccak256(toHex('Transfer(address,address,uint256)'));
+// ERC-6909 Transfer(address,address,address,uint256,uint256)
+const ERC6909_TRANSFER_TOPIC = keccak256(toHex('Transfer(address,address,address,uint256,uint256)'));
+
+export interface MinimalReceipt {
+  transactionHash: Hex;
+  gasUsed: bigint;
+  effectiveGasPrice: bigint;
+  logs: Array<{ address: Address; topics: readonly Hex[]; data: Hex }>;
+}
+
+export interface EthProvider {
+  getTransactionCount(args: { address: Address }): Promise<number>;
+  estimateFeesPerGas(): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }>;
+  call(tx: Eip1559Transaction): Promise<{ data?: Hex }>;
+  estimateGas(tx: Eip1559Transaction): Promise<bigint>;
+  sendRawTransaction(rawTx: Hex): Promise<Hex>;
+  getTransactionReceipt(args: { hash: Hex }): Promise<MinimalReceipt | null>;
+}
+
+export interface RetryConfig {
+  maxAttempts?: number;      // default: 3
+  initialBackoffMs?: number; // default: 100
+  maxBackoffMs?: number;     // default: 2_000
+}
+
+export interface SigningHints {
+  sender?: Address;
+  nonce?: number;
+  maxFeePerGas?: bigint;
+  maxPriorityFeePerGas?: bigint;
+  gasLimit?: bigint;
+  simulate?: boolean;
+}
+
+export interface ExecutionOptions {
+  dryRun?: boolean;
+}
+
+export interface FyndClientOptions {
+  baseUrl: string;
+  chainId: number;
+  routerAddress: Address;
+  sender?: Address;
+  timeoutMs?: number;    // default: 30_000
+  retry?: RetryConfig;
+  provider?: EthProvider;
+  submitProvider?: EthProvider;
+}
+
+export class FyndClient {
+  private readonly http: AutogenClient;
+  private readonly options: FyndClientOptions;
+
+  constructor(options: FyndClientOptions) {
+    this.http = createFyndClient(options.baseUrl);
+    this.options = options;
+  }
+
+  async quote(params: QuoteParams): Promise<Quote> {
+    const tokenOut = params.order.tokenOut;
+    const receiver = params.order.receiver ?? params.order.sender;
+
+    const retry = this.options.retry ?? {};
+    const maxAttempts = retry.maxAttempts ?? 3;
+    const initialBackoffMs = retry.initialBackoffMs ?? 100;
+    const maxBackoffMs = retry.maxBackoffMs ?? 2_000;
+
+    const body = mapping.toWireRequest({ ...params, order: { ...params.order, receiver } });
+
+    let delay = initialBackoffMs;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        return await this.doQuote(body, tokenOut, receiver);
+      } catch (e) {
+        if (e instanceof FyndError && e.isRetryable() && attempt < maxAttempts) {
+          const jittered = delay * (0.75 + Math.random() * 0.5);
+          await sleep(jittered);
+          delay = Math.min(delay * 2, maxBackoffMs);
+        } else {
+          throw e;
+        }
+      }
+    }
+    // Unreachable but satisfies TypeScript exhaustiveness
+    throw FyndError.config("retry loop exhausted without result");
+  }
+
+  private async doQuote(
+    body: components["schemas"]["SolutionRequest"],
+    tokenOut: Address,
+    receiver: Address,
+  ): Promise<Quote> {
+    const timeoutMs = this.options.timeoutMs ?? 30_000;
+    const { data, error } = await this.http.POST("/v1/solve", {
+      body,
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (error !== undefined) {
+      // openapi-fetch does not yet union error shapes per status code; cast is required here
+      throw FyndError.fromWireError(error as WireErrorResponse);
+    }
+    if (data === undefined) {
+      throw FyndError.config("server returned no data for successful response");
+    }
+    return mapping.fromWireQuote(data, tokenOut, receiver);
+  }
+
+  async health(): Promise<HealthStatus> {
+    const { data, error } = await this.http.GET("/v1/health");
+    if (error !== undefined) {
+      throw FyndError.fromWireError(error as WireErrorResponse);
+    }
+    if (data === undefined) {
+      throw FyndError.config("server returned no data for health response");
+    }
+    return mapping.fromWireHealth(data);
+  }
+
+  async signablePayload(quote: Quote, hints?: SigningHints): Promise<SignablePayload> {
+    if (quote.backend !== 'fynd') {
+      throw new Error('not implemented: Turbine backend signing');
+    }
+    return this.fyndSignablePayload(quote, hints ?? {});
+  }
+
+  private async fyndSignablePayload(quote: Quote, hints: SigningHints): Promise<SignablePayload> {
+    const senderOpt = hints.sender ?? (this.options.sender ? this.options.sender : undefined);
+    if (senderOpt === undefined) {
+      throw FyndError.config(
+        "sender is required: set FyndClientOptions.sender or SigningHints.sender"
+      );
+    }
+    const sender: Address = senderOpt;
+
+    const provider = this.options.provider;
+    if (provider === undefined) {
+      throw FyndError.config("provider is required for signablePayload");
+    }
+
+    const nonce = hints.nonce !== undefined
+      ? hints.nonce
+      : await provider.getTransactionCount({ address: sender });
+
+    const { maxFeePerGas, maxPriorityFeePerGas } =
+      hints.maxFeePerGas !== undefined && hints.maxPriorityFeePerGas !== undefined
+        ? { maxFeePerGas: hints.maxFeePerGas, maxPriorityFeePerGas: hints.maxPriorityFeePerGas }
+        : await provider.estimateFeesPerGas();
+
+    const gas = hints.gasLimit ?? quote.gasEstimate;
+
+    const tx: Eip1559Transaction = {
+      chainId:              this.options.chainId,
+      nonce,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      gas,
+      to:    this.options.routerAddress,
+      value: 0n,
+      data:  '0x',
+    };
+
+    if (hints.simulate === true) {
+      await provider.call(tx).catch((err: unknown) => {
+        throw FyndError.simulateFailed(`transaction simulation failed: ${String(err)}`);
+      });
+    }
+
+    const payload: FyndPayload = { quote, tx };
+    return { kind: 'fynd', payload };
+  }
+
+  async execute(order: SignedOrder, options?: ExecutionOptions): Promise<ExecutionReceipt> {
+    const { payload, signature } = order;
+    const tx = payload.payload.tx;
+    const quote = payload.payload.quote;
+
+    if (options?.dryRun === true) {
+      return this.dryRunExecute(tx, quote);
+    }
+
+    const provider = this.options.submitProvider ?? this.options.provider;
+    if (provider === undefined) {
+      throw FyndError.config("provider is required for execute");
+    }
+
+    // Parse r, s, yParity from the 65-byte hex signature: r[32] + s[32] + v[1]
+    // signature is '0x' + 130 hex chars (65 bytes)
+    const r = `0x${signature.slice(2, 66)}` as Hex;
+    const s = `0x${signature.slice(66, 130)}` as Hex;
+    const yParity = parseInt(signature.slice(130, 132), 16) as 0 | 1;
+
+    const rawTx = serializeTransaction(
+      {
+        type:                 'eip1559',
+        chainId:              tx.chainId,
+        nonce:                tx.nonce,
+        maxFeePerGas:         tx.maxFeePerGas,
+        maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+        gas:                  tx.gas,
+        to:                   tx.to,
+        value:                tx.value,
+        data:                 tx.data,
+      },
+      { r, s, yParity },
+    ) as Hex;
+
+    const txHash = await provider.sendRawTransaction(rawTx);
+    const tokenOut = quote.tokenOut;
+    const receiver = quote.receiver;
+
+    return {
+      settle: async (): Promise<SettledOrder> => {
+        for (;;) {
+          const receipt = await provider.getTransactionReceipt({ hash: txHash });
+          if (receipt !== null) {
+            const settledAmount = computeSettledAmount(receipt, tokenOut, receiver);
+            const gasCost = receipt.gasUsed * receipt.effectiveGasPrice;
+            // exactOptionalPropertyTypes: spread optional fields only when defined
+            return {
+              txHash,
+              gasCost,
+              ...(settledAmount !== undefined ? { settledAmount } : {}),
+            };
+          }
+          await sleep(2_000);
+        }
+      },
+    };
+  }
+
+  private async dryRunExecute(tx: Eip1559Transaction, quote: Quote): Promise<ExecutionReceipt> {
+    const provider = this.options.provider;
+    if (provider === undefined) {
+      throw FyndError.config("provider is required for dry-run execute");
+    }
+
+    const callResult = await provider.call(tx).catch((err: unknown) => {
+      throw FyndError.simulateFailed(`dry run simulation failed: ${String(err)}`);
+    });
+    const gasUsed = await provider.estimateGas(tx).catch((err: unknown) => {
+      throw FyndError.simulateFailed(`dry run gas estimation failed: ${String(err)}`);
+    });
+
+    // Parse first 32 bytes of return data as uint256 settled amount.
+    // Hex string: '0x' + 64 hex chars = 66 chars total for 32 bytes.
+    const returnData = callResult.data;
+    const settledAmount =
+      returnData !== undefined && returnData.length >= 66
+        ? BigInt(`0x${returnData.slice(2, 66)}`)
+        : undefined;
+
+    const gasCost = gasUsed * tx.maxFeePerGas;
+
+    // No txHash for dry-run
+    void quote;
+
+    return {
+      settle: async (): Promise<SettledOrder> => ({
+        gasCost,
+        // exactOptionalPropertyTypes: spread optional fields only when defined
+        ...(settledAmount !== undefined ? { settledAmount } : {}),
+      }),
+    };
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function computeSettledAmount(
+  receipt: MinimalReceipt,
+  tokenOut: Address,
+  receiver: Address,
+): bigint | undefined {
+  let total = 0n;
+  let found = false;
+
+  for (const log of receipt.logs) {
+    if (log.address.toLowerCase() !== tokenOut.toLowerCase()) continue;
+    if (log.topics.length === 0) continue;
+
+    const topic0 = log.topics[0];
+    if (topic0 === undefined) continue;
+
+    if (topic0 === ERC20_TRANSFER_TOPIC && log.topics.length >= 3) {
+      // topics[2] = to address (padded to 32 bytes, address in last 20 bytes)
+      const toTopic = log.topics[2];
+      if (toTopic === undefined) continue;
+      const toAddr = `0x${toTopic.slice(-40)}` as Address;
+      if (toAddr.toLowerCase() === receiver.toLowerCase()) {
+        // data = uint256 amount (32 bytes = 64 hex chars after '0x')
+        const amount = BigInt(`0x${log.data.slice(2, 66)}`);
+        total += amount;
+        found = true;
+      }
+    } else if (topic0 === ERC6909_TRANSFER_TOPIC && log.topics.length >= 3) {
+      // topics[2] = to address
+      const toTopic = log.topics[2];
+      if (toTopic === undefined) continue;
+      const toAddr = `0x${toTopic.slice(-40)}` as Address;
+      if (toAddr.toLowerCase() === receiver.toLowerCase()) {
+        // data layout: caller[32 bytes] + amount[32 bytes]
+        // amount starts at byte offset 32 → hex positions 2+64=66 to 66+64=130
+        const amount = BigInt(`0x${log.data.slice(66, 130)}`);
+        total += amount;
+        found = true;
+      }
+    }
+  }
+
+  return found ? total : undefined;
+}

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -105,12 +105,12 @@ export class FyndClient {
   }
 
   private async doQuote(
-    body: components["schemas"]["SolutionRequest"],
+    body: components["schemas"]["QuoteRequest"],
     tokenOut: Address,
     receiver: Address,
   ): Promise<Quote> {
     const timeoutMs = this.options.timeoutMs ?? 30_000;
-    const { data, error } = await this.http.POST("/v1/solve", {
+    const { data, error } = await this.http.POST("/v1/quote", {
       body,
       signal: AbortSignal.timeout(timeoutMs),
     });

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -143,7 +143,7 @@ export class FyndClient {
   }
 
   private async fyndSignablePayload(quote: Quote, hints: SigningHints): Promise<SignablePayload> {
-    const senderOpt = hints.sender ?? (this.options.sender ? this.options.sender : undefined);
+    const senderOpt = hints.sender ?? this.options.sender;
     if (senderOpt === undefined) {
       throw FyndError.config(
         "sender is required: set FyndClientOptions.sender or SigningHints.sender"

--- a/clients/typescript/client/src/error.test.ts
+++ b/clients/typescript/client/src/error.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { FyndError } from './error.js';
+import type { ErrorCode } from './error.js';
+
+describe('FyndError.isRetryable', () => {
+  const retryableCodes: ErrorCode[] = [
+    'TIMEOUT',
+    'QUEUE_FULL',
+    'SERVICE_OVERLOADED',
+    'STALE_DATA',
+    'NOT_READY',
+    'HTTP',
+  ];
+
+  const nonRetryableCodes: ErrorCode[] = [
+    'BAD_REQUEST',
+    'NO_ROUTE_FOUND',
+    'INSUFFICIENT_LIQUIDITY',
+    'INVALID_ORDER',
+    'INTERNAL_ERROR',
+    'ALGORITHM_ERROR',
+    'DESERIALIZE',
+    'CONFIG',
+    'SIMULATE_FAILED',
+  ];
+
+  for (const code of retryableCodes) {
+    it(`returns true for ${String(code)}`, () => {
+      const err = new FyndError('test', code);
+      expect(err.isRetryable()).toBe(true);
+    });
+  }
+
+  for (const code of nonRetryableCodes) {
+    it(`returns false for ${String(code)}`, () => {
+      const err = new FyndError('test', code);
+      expect(err.isRetryable()).toBe(false);
+    });
+  }
+
+  it('returns false for UNKNOWN code object', () => {
+    const err = new FyndError('test', { kind: 'UNKNOWN', raw: 'WHATEVER' });
+    expect(err.isRetryable()).toBe(false);
+  });
+});
+
+describe('FyndError.fromWireError', () => {
+  it('maps BAD_REQUEST correctly', () => {
+    const err = FyndError.fromWireError({ code: 'BAD_REQUEST', error: 'bad input' });
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.isRetryable()).toBe(false);
+    expect(err.message).toBe('bad input');
+  });
+
+  it('maps NO_ROUTE_FOUND correctly', () => {
+    const err = FyndError.fromWireError({ code: 'NO_ROUTE_FOUND', error: 'no route' });
+    expect(err.code).toBe('NO_ROUTE_FOUND');
+    expect(err.isRetryable()).toBe(false);
+  });
+
+  it('maps INSUFFICIENT_LIQUIDITY correctly', () => {
+    const err = FyndError.fromWireError({ code: 'INSUFFICIENT_LIQUIDITY', error: 'low liquidity' });
+    expect(err.code).toBe('INSUFFICIENT_LIQUIDITY');
+    expect(err.isRetryable()).toBe(false);
+  });
+
+  it('maps TIMEOUT as retryable', () => {
+    const err = FyndError.fromWireError({ code: 'TIMEOUT', error: 'timed out' });
+    expect(err.code).toBe('TIMEOUT');
+    expect(err.isRetryable()).toBe(true);
+  });
+
+  it('maps QUEUE_FULL as retryable', () => {
+    const err = FyndError.fromWireError({ code: 'QUEUE_FULL', error: 'queue full' });
+    expect(err.code).toBe('QUEUE_FULL');
+    expect(err.isRetryable()).toBe(true);
+  });
+
+  it('maps SERVICE_OVERLOADED as retryable', () => {
+    const err = FyndError.fromWireError({ code: 'SERVICE_OVERLOADED', error: 'overloaded' });
+    expect(err.code).toBe('SERVICE_OVERLOADED');
+    expect(err.isRetryable()).toBe(true);
+  });
+
+  it('maps STALE_DATA as retryable', () => {
+    const err = FyndError.fromWireError({ code: 'STALE_DATA', error: 'stale' });
+    expect(err.code).toBe('STALE_DATA');
+    expect(err.isRetryable()).toBe(true);
+  });
+
+  it('maps INVALID_ORDER correctly', () => {
+    const err = FyndError.fromWireError({ code: 'INVALID_ORDER', error: 'invalid' });
+    expect(err.code).toBe('INVALID_ORDER');
+    expect(err.isRetryable()).toBe(false);
+  });
+
+  it('maps INTERNAL_ERROR correctly', () => {
+    const err = FyndError.fromWireError({ code: 'INTERNAL_ERROR', error: 'internal' });
+    expect(err.code).toBe('INTERNAL_ERROR');
+    expect(err.isRetryable()).toBe(false);
+  });
+
+  it('maps NOT_READY as retryable', () => {
+    const err = FyndError.fromWireError({ code: 'NOT_READY', error: 'not ready' });
+    expect(err.code).toBe('NOT_READY');
+    expect(err.isRetryable()).toBe(true);
+  });
+
+  it('maps ALGORITHM_ERROR correctly', () => {
+    const err = FyndError.fromWireError({ code: 'ALGORITHM_ERROR', error: 'algo error' });
+    expect(err.code).toBe('ALGORITHM_ERROR');
+    expect(err.isRetryable()).toBe(false);
+  });
+
+  it('maps unknown code to UNKNOWN object', () => {
+    const err = FyndError.fromWireError({ code: 'SOME_NEW_CODE', error: 'unknown' });
+    expect(err.code).toEqual({ kind: 'UNKNOWN', raw: 'SOME_NEW_CODE' });
+    expect(err.isRetryable()).toBe(false);
+  });
+
+  it('propagates details', () => {
+    const details = { field: 'amount', reason: 'negative' };
+    const err = FyndError.fromWireError({ code: 'BAD_REQUEST', error: 'bad', details });
+    expect(err.details).toEqual(details);
+  });
+});
+
+describe('FyndError.config', () => {
+  it('creates a CONFIG error that is not retryable', () => {
+    const err = FyndError.config('provider not set');
+    expect(err.code).toBe('CONFIG');
+    expect(err.isRetryable()).toBe(false);
+    expect(err.message).toBe('provider not set');
+    expect(err.name).toBe('FyndError');
+  });
+});
+
+describe('FyndError.simulateFailed', () => {
+  it('creates a SIMULATE_FAILED error that is not retryable', () => {
+    const err = FyndError.simulateFailed('revert: ERC20: insufficient balance');
+    expect(err.code).toBe('SIMULATE_FAILED');
+    expect(err.isRetryable()).toBe(false);
+    expect(err.message).toBe('revert: ERC20: insufficient balance');
+  });
+});
+
+describe('FyndError basic properties', () => {
+  it('is an instance of Error', () => {
+    const err = new FyndError('msg', 'CONFIG');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(FyndError);
+  });
+
+  it('has name FyndError', () => {
+    const err = new FyndError('msg', 'HTTP');
+    expect(err.name).toBe('FyndError');
+  });
+
+  it('has no details when not provided', () => {
+    const err = new FyndError('msg', 'CONFIG');
+    expect(err.details).toBeUndefined();
+  });
+});

--- a/clients/typescript/client/src/error.ts
+++ b/clients/typescript/client/src/error.ts
@@ -1,0 +1,80 @@
+import type { components } from "@fynd/autogen";
+
+type WireErrorResponse = components["schemas"]["ErrorResponse"];
+
+// Server-side codes — kept in sync with fynd-rpc/src/api/error.rs
+export type ServerErrorCode =
+  | 'BAD_REQUEST'
+  | 'NO_ROUTE_FOUND'
+  | 'INSUFFICIENT_LIQUIDITY'
+  | 'TIMEOUT'
+  | 'QUEUE_FULL'
+  | 'SERVICE_OVERLOADED'
+  | 'STALE_DATA'
+  | 'INVALID_ORDER'
+  | 'INTERNAL_ERROR'
+  | 'NOT_READY'
+  | 'ALGORITHM_ERROR'
+  | { kind: 'UNKNOWN'; raw: string };
+
+export type ClientErrorCode = 'HTTP' | 'DESERIALIZE' | 'CONFIG' | 'SIMULATE_FAILED';
+export type ErrorCode = ServerErrorCode | ClientErrorCode;
+
+const KNOWN_SERVER_CODES = new Set([
+  'BAD_REQUEST',
+  'NO_ROUTE_FOUND',
+  'INSUFFICIENT_LIQUIDITY',
+  'TIMEOUT',
+  'QUEUE_FULL',
+  'SERVICE_OVERLOADED',
+  'STALE_DATA',
+  'INVALID_ORDER',
+  'INTERNAL_ERROR',
+  'NOT_READY',
+  'ALGORITHM_ERROR',
+]);
+
+const RETRYABLE_CODES = new Set<string>([
+  'TIMEOUT',
+  'QUEUE_FULL',
+  'SERVICE_OVERLOADED',
+  'STALE_DATA',
+  'NOT_READY',
+  'HTTP',
+]);
+
+export class FyndError extends Error {
+  readonly code: ErrorCode;
+  readonly details?: unknown;
+
+  constructor(message: string, code: ErrorCode, details?: unknown) {
+    super(message);
+    this.name = 'FyndError';
+    this.code = code;
+    if (details !== undefined) {
+      this.details = details;
+    }
+  }
+
+  isRetryable(): boolean {
+    if (typeof this.code === 'string') {
+      return RETRYABLE_CODES.has(this.code);
+    }
+    return false;
+  }
+
+  static fromWireError(wire: WireErrorResponse): FyndError {
+    const code: ErrorCode = KNOWN_SERVER_CODES.has(wire.code)
+      ? (wire.code as ServerErrorCode)
+      : { kind: 'UNKNOWN', raw: wire.code };
+    return new FyndError(wire.error, code, wire.details);
+  }
+
+  static config(message: string): FyndError {
+    return new FyndError(message, 'CONFIG');
+  }
+
+  static simulateFailed(reason: string): FyndError {
+    return new FyndError(reason, 'SIMULATE_FAILED');
+  }
+}

--- a/clients/typescript/client/src/index.ts
+++ b/clients/typescript/client/src/index.ts
@@ -1,0 +1,36 @@
+export type {
+  Address,
+  BackendKind,
+  BlockInfo,
+  Hex,
+  HealthStatus,
+  Order,
+  OrderSide,
+  Quote,
+  QuoteOptions,
+  QuoteParams,
+  Route,
+  SolutionStatus,
+  Swap,
+} from "./types.js";
+export { FyndError } from "./error.js";
+export type { ClientErrorCode, ErrorCode, ServerErrorCode } from "./error.js";
+export type {
+  Eip1559Transaction,
+  ExecutionReceipt,
+  FyndPayload,
+  PrimitiveSignature,
+  SettledOrder,
+  SignablePayload,
+  SignedOrder,
+} from "./signing.js";
+export { assembleSignedOrder, signingHash } from "./signing.js";
+export { FyndClient } from "./client.js";
+export type {
+  EthProvider,
+  ExecutionOptions,
+  FyndClientOptions,
+  MinimalReceipt,
+  RetryConfig,
+  SigningHints,
+} from "./client.js";

--- a/clients/typescript/client/src/mapping.test.ts
+++ b/clients/typescript/client/src/mapping.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import { toWireRequest, fromWireQuote, fromWireHealth } from './mapping.js';
+import { FyndError } from './error.js';
+import type { QuoteParams } from './types.js';
+import type { components } from '@fynd/autogen';
+
+type WireSolution = components["schemas"]["Solution"];
+
+const SENDER = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const;
+const TOKEN_IN = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as const;
+const TOKEN_OUT = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as const;
+const RECEIVER = '0x1234512345123451234512345123451234512345' as const;
+
+const baseParams: QuoteParams = {
+  order: {
+    tokenIn:  TOKEN_IN,
+    tokenOut: TOKEN_OUT,
+    amount:   1000n,
+    side:     'sell',
+    sender:   SENDER,
+  },
+};
+
+const baseWireSolution: WireSolution = {
+  orders: [
+    {
+      order_id:           'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      status:             'success',
+      amount_in:          '1000000000000000000',
+      amount_out:         '3500000000',
+      amount_out_net_gas: '3498000000',
+      gas_estimate:       '150000',
+      block: {
+        hash:      '0xabcdef1234',
+        number:    21000000,
+        timestamp: 1730000000,
+      },
+    },
+  ],
+  total_gas_estimate: '150000',
+  solve_time_ms:      12,
+};
+
+describe('toWireRequest', () => {
+  it('converts a basic sell order', () => {
+    const wire = toWireRequest(baseParams);
+    expect(wire.orders).toHaveLength(1);
+    const order = wire.orders[0];
+    expect(order?.token_in).toBe(TOKEN_IN);
+    expect(order?.token_out).toBe(TOKEN_OUT);
+    expect(order?.amount).toBe('1000');
+    expect(order?.side).toBe('sell');
+    expect(order?.sender).toBe(SENDER);
+  });
+
+  it('omits receiver key when order.receiver is undefined', () => {
+    const wire = toWireRequest(baseParams);
+    expect(wire.orders[0]).not.toHaveProperty('receiver');
+  });
+
+  it('includes receiver key when order.receiver is set', () => {
+    const params: QuoteParams = {
+      order: { ...baseParams.order, receiver: RECEIVER },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.orders[0]?.receiver).toBe(RECEIVER);
+  });
+
+  it('omits options when not provided', () => {
+    const wire = toWireRequest(baseParams);
+    expect(wire).not.toHaveProperty('options');
+  });
+
+  it('converts maxGas bigint to string', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: { maxGas: 500000n },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.options?.max_gas).toBe('500000');
+  });
+
+  it('converts all options when fully specified', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: {
+        timeoutMs:    2000,
+        minResponses: 2,
+        maxGas:       500000n,
+      },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.options?.timeout_ms).toBe(2000);
+    expect(wire.options?.min_responses).toBe(2);
+    expect(wire.options?.max_gas).toBe('500000');
+  });
+
+  it('omits individual option fields when not provided', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: { timeoutMs: 1000 },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.options).toBeDefined();
+    expect(wire.options).not.toHaveProperty('min_responses');
+    expect(wire.options).not.toHaveProperty('max_gas');
+  });
+});
+
+describe('fromWireQuote', () => {
+  it('maps all fields correctly on happy path', () => {
+    const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, SENDER);
+    expect(quote.orderId).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+    expect(quote.status).toBe('success');
+    expect(quote.backend).toBe('fynd');
+    expect(quote.amountIn).toBe(1000000000000000000n);
+    expect(quote.amountOut).toBe(3500000000n);
+    expect(quote.gasEstimate).toBe(150000n);
+    expect(quote.tokenOut).toBe(TOKEN_OUT);
+    expect(quote.receiver).toBe(SENDER);
+  });
+
+  it('converts amount strings to bigint', () => {
+    const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, SENDER);
+    expect(typeof quote.amountIn).toBe('bigint');
+    expect(typeof quote.amountOut).toBe('bigint');
+    expect(typeof quote.gasEstimate).toBe('bigint');
+    expect(quote.amountIn).toBe(1000000000000000000n);
+  });
+
+  it('maps block info correctly', () => {
+    const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, SENDER);
+    expect(quote.block.hash).toBe('0xabcdef1234');
+    expect(quote.block.number).toBe(21000000);
+    expect(quote.block.timestamp).toBe(1730000000);
+  });
+
+  it('throws FyndError.CONFIG when orders array is empty', () => {
+    const wire: WireSolution = { ...baseWireSolution, orders: [] };
+    expect(() => fromWireQuote(wire, TOKEN_OUT, SENDER)).toThrow(FyndError);
+    try {
+      fromWireQuote(wire, TOKEN_OUT, SENDER);
+    } catch (e) {
+      expect(e instanceof FyndError && e.code).toBe('CONFIG');
+    }
+  });
+
+  it('route is undefined when wire route is null', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [{ ...baseWireSolution.orders[0]!, route: null }],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.route).toBeUndefined();
+  });
+
+  it('maps route swaps when route is present', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [
+        {
+          ...baseWireSolution.orders[0]!,
+          route: {
+            swaps: [
+              {
+                component_id: '0xpool',
+                protocol:     'uniswap_v2',
+                token_in:     TOKEN_IN,
+                token_out:    TOKEN_OUT,
+                amount_in:    '1000',
+                amount_out:   '3500',
+                gas_estimate: '80000',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.route).toBeDefined();
+    expect(quote.route?.swaps).toHaveLength(1);
+    const swap = quote.route?.swaps[0];
+    expect(swap?.poolId).toBe('0xpool');
+    expect(swap?.protocol).toBe('uniswap_v2');
+    expect(swap?.amountIn).toBe(1000n);
+    expect(swap?.amountOut).toBe(3500n);
+    expect(swap?.gasEstimate).toBe(80000n);
+  });
+
+  it('maps component_id to poolId', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [
+        {
+          ...baseWireSolution.orders[0]!,
+          route: {
+            swaps: [
+              {
+                component_id: '0xpool123',
+                protocol:     'uniswap_v3',
+                token_in:     TOKEN_IN,
+                token_out:    TOKEN_OUT,
+                amount_in:    '100',
+                amount_out:   '200',
+                gas_estimate: '50000',
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.route?.swaps[0]?.poolId).toBe('0xpool123');
+  });
+
+  it('priceImpactBps is undefined when wire value is null', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [{ ...baseWireSolution.orders[0]!, price_impact_bps: null }],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.priceImpactBps).toBeUndefined();
+  });
+
+  it('priceImpactBps is set when wire value is present', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [{ ...baseWireSolution.orders[0]!, price_impact_bps: 15 }],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.priceImpactBps).toBe(15);
+  });
+
+  it('propagates tokenOut and receiver from caller args', () => {
+    const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, RECEIVER);
+    expect(quote.tokenOut).toBe(TOKEN_OUT);
+    expect(quote.receiver).toBe(RECEIVER);
+  });
+});
+
+describe('fromWireHealth', () => {
+  it('maps all fields to camelCase', () => {
+    const health = fromWireHealth({
+      healthy:          true,
+      last_update_ms:   1250,
+      num_solver_pools: 2,
+    });
+    expect(health.healthy).toBe(true);
+    expect(health.lastUpdateMs).toBe(1250);
+    expect(health.numSolverPools).toBe(2);
+  });
+
+  it('maps healthy=false correctly', () => {
+    const health = fromWireHealth({
+      healthy:          false,
+      last_update_ms:   5000,
+      num_solver_pools: 0,
+    });
+    expect(health.healthy).toBe(false);
+    expect(health.lastUpdateMs).toBe(5000);
+    expect(health.numSolverPools).toBe(0);
+  });
+});

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -11,9 +11,9 @@ import type {
 } from "./types.js";
 
 type WireOrder           = components["schemas"]["Order"];
-type WireSolution        = components["schemas"]["Solution"];
-type WireSolutionRequest = components["schemas"]["SolutionRequest"];
-type WireSolutionOptions = components["schemas"]["SolutionOptions"];
+type WireSolution        = components["schemas"]["Quote"];
+type WireSolutionRequest = components["schemas"]["QuoteRequest"];
+type WireSolutionOptions = components["schemas"]["QuoteOptions"];
 type WireHealthStatus    = components["schemas"]["HealthStatus"];
 type WireRoute           = components["schemas"]["Route"];
 type WireSwap            = components["schemas"]["Swap"];
@@ -65,7 +65,7 @@ export function fromWireQuote(
   return {
     orderId:         orderSolution.order_id,
     status:          orderSolution.status,
-    backend:         'fynd',  // WireOrderSolution has no backend field; hardcoded per design
+    backend:         'fynd',  // WireOrderQuote has no backend field; hardcoded per design
     amountIn:        BigInt(orderSolution.amount_in),
     amountOut:       BigInt(orderSolution.amount_out),
     gasEstimate:     BigInt(orderSolution.gas_estimate),

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -1,0 +1,111 @@
+import type { components } from "@fynd/autogen";
+import { FyndError } from "./error.js";
+import type {
+  Address,
+  BlockInfo,
+  HealthStatus,
+  Quote,
+  QuoteParams,
+  Route,
+  Swap,
+} from "./types.js";
+
+type WireOrder           = components["schemas"]["Order"];
+type WireSolution        = components["schemas"]["Solution"];
+type WireSolutionRequest = components["schemas"]["SolutionRequest"];
+type WireSolutionOptions = components["schemas"]["SolutionOptions"];
+type WireHealthStatus    = components["schemas"]["HealthStatus"];
+type WireRoute           = components["schemas"]["Route"];
+type WireSwap            = components["schemas"]["Swap"];
+type WireBlockInfo       = components["schemas"]["BlockInfo"];
+
+
+export function toWireRequest(params: QuoteParams): WireSolutionRequest {
+  const wireOrder: WireOrder = {
+    token_in:  params.order.tokenIn,
+    token_out: params.order.tokenOut,
+    amount:    params.order.amount.toString(),
+    side:      'sell',
+    sender:    params.order.sender,
+    // exactOptionalPropertyTypes: must omit undefined keys entirely
+    ...(params.order.receiver !== undefined ? { receiver: params.order.receiver } : {}),
+  };
+  const wireOptions: WireSolutionOptions | undefined = params.options !== undefined
+    ? {
+        ...(params.options.timeoutMs !== undefined
+          ? { timeout_ms: params.options.timeoutMs }
+          : {}),
+        ...(params.options.minResponses !== undefined
+          ? { min_responses: params.options.minResponses }
+          : {}),
+        ...(params.options.maxGas !== undefined
+          ? { max_gas: params.options.maxGas.toString() }
+          : {}),
+      }
+    : undefined;
+  return {
+    orders: [wireOrder],
+    ...(wireOptions !== undefined ? { options: wireOptions } : {}),
+  };
+}
+
+export function fromWireQuote(
+  wire: WireSolution,
+  tokenOut: Address,
+  receiver: Address,
+): Quote {
+  const orderSolution = wire.orders[0];
+  if (orderSolution === undefined) {
+    throw FyndError.config("server returned empty orders array");
+  }
+  const route = orderSolution.route !== null && orderSolution.route !== undefined
+    ? fromWireRoute(orderSolution.route)
+    : undefined;
+  const priceImpactBps = orderSolution.price_impact_bps ?? undefined;
+  return {
+    orderId:         orderSolution.order_id,
+    status:          orderSolution.status,
+    backend:         'fynd',  // WireOrderSolution has no backend field; hardcoded per design
+    amountIn:        BigInt(orderSolution.amount_in),
+    amountOut:       BigInt(orderSolution.amount_out),
+    gasEstimate:     BigInt(orderSolution.gas_estimate),
+    block:           fromWireBlockInfo(orderSolution.block),
+    tokenOut,
+    receiver,
+    // exactOptionalPropertyTypes: spread optional fields only when defined
+    ...(route !== undefined ? { route } : {}),
+    ...(priceImpactBps !== undefined ? { priceImpactBps } : {}),
+  };
+}
+
+function fromWireRoute(wire: WireRoute): Route {
+  return { swaps: wire.swaps.map(fromWireSwap) };
+}
+
+function fromWireSwap(wire: WireSwap): Swap {
+  return {
+    poolId:      wire.component_id,
+    protocol:    wire.protocol,
+    tokenIn:     wire.token_in as Address,
+    tokenOut:    wire.token_out as Address,
+    amountIn:    BigInt(wire.amount_in),
+    amountOut:   BigInt(wire.amount_out),
+    gasEstimate: BigInt(wire.gas_estimate),
+  };
+}
+
+function fromWireBlockInfo(wire: WireBlockInfo): BlockInfo {
+  return {
+    number:    wire.number,
+    hash:      wire.hash,
+    timestamp: wire.timestamp,
+  };
+}
+
+export function fromWireHealth(wire: WireHealthStatus): HealthStatus {
+  return {
+    healthy:        wire.healthy,
+    lastUpdateMs:   wire.last_update_ms,
+    numSolverPools: wire.num_solver_pools,
+  };
+}

--- a/clients/typescript/client/src/signing.test.ts
+++ b/clients/typescript/client/src/signing.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { assembleSignedOrder, signingHash } from './signing.js';
+import type { SignablePayload, PrimitiveSignature } from './signing.js';
+import type { Quote } from './types.js';
+
+const TOKEN_OUT = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as const;
+const SENDER    = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const;
+const ROUTER    = '0x1111111111111111111111111111111111111111' as const;
+
+const baseQuote: Quote = {
+  orderId:     'test-order-id',
+  status:      'success',
+  backend:     'fynd',
+  amountIn:    1000000000000000000n,
+  amountOut:   3500000000n,
+  gasEstimate: 150000n,
+  block: {
+    hash:      '0xabcdef',
+    number:    21000000,
+    timestamp: 1730000000,
+  },
+  tokenOut: TOKEN_OUT,
+  receiver: SENDER,
+};
+
+const basePayload: SignablePayload = {
+  kind: 'fynd',
+  payload: {
+    quote: baseQuote,
+    tx: {
+      chainId:              1,
+      nonce:                42,
+      maxFeePerGas:         20000000000n,
+      maxPriorityFeePerGas: 2000000000n,
+      gas:                  150000n,
+      to:                   ROUTER,
+      value:                0n,
+      data:                 '0x',
+    },
+  },
+};
+
+describe('assembleSignedOrder', () => {
+  it('wraps payload and signature without modification', () => {
+    const sig = ('0x' + 'a'.repeat(64) + 'b'.repeat(64) + '00') as PrimitiveSignature;
+    const order = assembleSignedOrder(basePayload, sig);
+    expect(order.payload).toBe(basePayload);
+    expect(order.signature).toBe(sig);
+  });
+
+  it('is a pure function — no I/O', () => {
+    const sig: PrimitiveSignature = `0x${'ff'.repeat(65)}`;
+    const order = assembleSignedOrder(basePayload, sig);
+    expect(order).toEqual({ payload: basePayload, signature: sig });
+  });
+});
+
+describe('signingHash', () => {
+  it('returns a 0x-prefixed hex string', () => {
+    const hash = signingHash(basePayload);
+    expect(hash).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for the same payload', () => {
+    const hash1 = signingHash(basePayload);
+    const hash2 = signingHash(basePayload);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('differs when nonce changes', () => {
+    const payload1 = basePayload;
+    const payload2: SignablePayload = {
+      ...basePayload,
+      payload: { ...basePayload.payload, tx: { ...basePayload.payload.tx, nonce: 43 } },
+    };
+    expect(signingHash(payload1)).not.toBe(signingHash(payload2));
+  });
+
+  it('differs when chainId changes', () => {
+    const payload1 = basePayload;
+    const payload2: SignablePayload = {
+      ...basePayload,
+      payload: { ...basePayload.payload, tx: { ...basePayload.payload.tx, chainId: 137 } },
+    };
+    expect(signingHash(payload1)).not.toBe(signingHash(payload2));
+  });
+
+  it('returns known hash for fixture transaction', async () => {
+    // Cross-checked: keccak256(serializeTransaction({ type: 'eip1559', chainId: 1, nonce: 42,
+    //   maxFeePerGas: 20000000000n, maxPriorityFeePerGas: 2000000000n, gas: 150000n,
+    //   to: '0x1111...', value: 0n, data: '0x' }))
+    const hash = signingHash(basePayload);
+    // Verify format only — exact hash is viem-internal
+    expect(hash.startsWith('0x')).toBe(true);
+    expect(hash.length).toBe(66);
+
+    // Verify a known hash by computing it independently
+    const { keccak256, serializeTransaction } = await import('viem');
+    const tx = basePayload.payload.tx;
+    const expected = keccak256(
+      serializeTransaction({
+        type: 'eip1559',
+        chainId: tx.chainId,
+        nonce: tx.nonce,
+        maxFeePerGas: tx.maxFeePerGas,
+        maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+        gas: tx.gas,
+        to: tx.to,
+        value: tx.value,
+        data: tx.data,
+      }),
+    );
+    expect(hash).toBe(expected);
+  });
+
+  it('includes all transaction fields in hash', () => {
+    // Changing value should change hash
+    const withValue: SignablePayload = {
+      ...basePayload,
+      payload: {
+        ...basePayload.payload,
+        tx: { ...basePayload.payload.tx, value: 1n },
+      },
+    };
+    expect(signingHash(basePayload)).not.toBe(signingHash(withValue));
+  });
+});

--- a/clients/typescript/client/src/signing.ts
+++ b/clients/typescript/client/src/signing.ts
@@ -1,0 +1,69 @@
+import { keccak256, serializeTransaction } from 'viem';
+import type { Address, Hex, Quote } from './types.js';
+
+export interface Eip1559Transaction {
+  chainId: number;
+  nonce: number;
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+  gas: bigint;
+  to: Address;
+  value: bigint;
+  data: Hex;
+}
+
+export interface FyndPayload {
+  quote: Quote;   // carries tokenOut and receiver for settlement
+  tx: Eip1559Transaction;
+}
+
+export type SignablePayload = { kind: 'fynd'; payload: FyndPayload };
+export type PrimitiveSignature = `0x${string}`;
+
+export interface SignedOrder {
+  payload: SignablePayload;
+  signature: PrimitiveSignature;
+}
+
+export interface SettledOrder {
+  txHash?: Hex;          // absent for dry-run
+  settledAmount?: bigint;
+  gasCost: bigint;
+}
+
+export interface ExecutionReceipt {
+  settle(): Promise<SettledOrder>;
+}
+
+/**
+ * Computes the EIP-1559 signing hash for a signable payload.
+ *
+ * Equivalent to keccak256 of the unsigned serialized EIP-1559 transaction,
+ * which is the hash the signer must sign.
+ */
+export function signingHash(payload: SignablePayload): Hex {
+  const tx = payload.payload.tx;
+  const serialized = serializeTransaction({
+    type: 'eip1559',
+    chainId: tx.chainId,
+    nonce: tx.nonce,
+    maxFeePerGas: tx.maxFeePerGas,
+    maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+    gas: tx.gas,
+    to: tx.to,
+    value: tx.value,
+    data: tx.data,
+  });
+  return keccak256(serialized);
+}
+
+/**
+ * Wraps a payload and signature into a SignedOrder without any I/O.
+ * Mirrors Rust's SignedOrder::assemble.
+ */
+export function assembleSignedOrder(
+  payload: SignablePayload,
+  signature: PrimitiveSignature,
+): SignedOrder {
+  return { payload, signature };
+}

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -1,4 +1,4 @@
-// Must stay in sync with components["schemas"]["SolutionStatus"] from @fynd/autogen.
+// Must stay in sync with components["schemas"]["QuoteStatus"] from @fynd/autogen.
 export type SolutionStatus =
   | 'success'
   | 'no_route_found'

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -1,0 +1,74 @@
+// Must stay in sync with components["schemas"]["SolutionStatus"] from @fynd/autogen.
+export type SolutionStatus =
+  | 'success'
+  | 'no_route_found'
+  | 'insufficient_liquidity'
+  | 'timeout'
+  | 'not_ready';
+
+export type BackendKind = 'fynd' | 'turbine';
+
+export type Address = `0x${string}`;
+export type Hex = `0x${string}`;
+
+export type OrderSide = 'sell';
+
+export interface Order {
+  tokenIn: Address;
+  tokenOut: Address;
+  amount: bigint;
+  side: OrderSide;
+  sender: Address;
+  receiver?: Address;
+}
+
+export interface QuoteOptions {
+  timeoutMs?: number;
+  minResponses?: number;
+  maxGas?: bigint;
+}
+
+export interface QuoteParams {
+  order: Order;
+  options?: QuoteOptions;
+}
+
+export interface BlockInfo {
+  number: number;
+  hash: string;
+  timestamp: number;
+}
+
+export interface Swap {
+  poolId: string;       // wire: component_id
+  protocol: string;
+  tokenIn: Address;
+  tokenOut: Address;
+  amountIn: bigint;
+  amountOut: bigint;
+  gasEstimate: bigint;
+}
+
+export interface Route {
+  swaps: Swap[];
+}
+
+export interface Quote {
+  orderId: string;
+  status: SolutionStatus;
+  backend: BackendKind;
+  route?: Route;
+  amountIn: bigint;
+  amountOut: bigint;
+  gasEstimate: bigint;
+  priceImpactBps?: number;
+  block: BlockInfo;
+  tokenOut: Address;    // from original Order; used by execute() for Transfer log parsing
+  receiver: Address;    // from original Order; defaults to sender if Order.receiver was absent
+}
+
+export interface HealthStatus {
+  healthy: boolean;
+  lastUpdateMs: number;
+  numSolverPools: number;
+}

--- a/clients/typescript/client/tsconfig.json
+++ b/clients/typescript/client/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
@@ -15,7 +15,10 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": "./src",
+    // viem/ox ship CJS-style _types dirs that TS 1479/1541 with node16 — skipLibCheck
+    // is required until those packages fix their declarations.
     "skipLibCheck": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/clients/typescript/client/tsconfig.json
+++ b/clients/typescript/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/clients/typescript/pnpm-lock.yaml
+++ b/clients/typescript/pnpm-lock.yaml
@@ -1,0 +1,1273 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  autogen:
+    dependencies:
+      openapi-fetch:
+        specifier: 0.17.0
+        version: 0.17.0
+    devDependencies:
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+
+  client:
+    dependencies:
+      '@fynd/autogen':
+        specifier: workspace:*
+        version: link:../autogen
+      viem:
+        specifier: 2.46.3
+        version: 2.46.3(typescript@5.8.2)
+    devDependencies:
+      oxlint:
+        specifier: 1.51.0
+        version: 1.51.0
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18
+
+packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.1':
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@oxlint/binding-android-arm-eabi@1.51.0':
+    resolution: {integrity: sha512-jJYIqbx4sX+suIxWstc4P7SzhEwb4ArWA2KVrmEuu9vH2i0qM6QIHz/ehmbGE4/2fZbpuMuBzTl7UkfNoqiSgw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.51.0':
+    resolution: {integrity: sha512-GtXyBCcH4ti98YdiMNCrpBNGitx87EjEWxevnyhcBK12k/Vu4EzSB45rzSC4fGFUD6sQgeaxItRCEEWeVwPafw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.51.0':
+    resolution: {integrity: sha512-3QJbeYaMHn6Bh2XeBXuITSsbnIctyTjvHf5nRjKYrT9pPeErNIpp5VDEeAXC0CZSwSVTsc8WOSDwgrAI24JolQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.51.0':
+    resolution: {integrity: sha512-NzErhMaTEN1cY0E8C5APy74lw5VwsNfJfVPBMWPVQLqAbO0k4FFLjvHURvkUL+Y18Wu+8Vs1kbqPh2hjXYA4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.51.0':
+    resolution: {integrity: sha512-msAIh3vPAoKoHlOE/oe6Q5C/n9umypv/k81lED82ibrJotn+3YG2Qp1kiR8o/Dg5iOEU97c6tl0utxcyFenpFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.51.0':
+    resolution: {integrity: sha512-CqQPcvqYyMe9ZBot2stjGogEzk1z8gGAngIX7srSzrzexmXixwVxBdFZyxTVM0CjGfDeV+Ru0w25/WNjlMM2Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.51.0':
+    resolution: {integrity: sha512-dstrlYQgZMnyOssxSbolGCge/sDbko12N/35RBNuqLpoPbft2aeBidBAb0dvQlyBd9RJ6u8D4o4Eh8Un6iTgyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.51.0':
+    resolution: {integrity: sha512-QEjUpXO7d35rP1/raLGGbAsBLLGZIzV3ZbeSjqWlD3oRnxpRIZ6iL4o51XQHkconn3uKssc+1VKdtHJ81BBhDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-musl@1.51.0':
+    resolution: {integrity: sha512-YSJua5irtG4DoMAjUapDTPhkQLHhBIY0G9JqlZS6/SZPzqDkPku/1GdWs0D6h/wyx0Iz31lNCfIaWKBQhzP0wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.51.0':
+    resolution: {integrity: sha512-7L4Wj2IEUNDETKssB9IDYt16T6WlF+X2jgC/hBq3diGHda9vJLpAgb09+D3quFq7TdkFtI7hwz/jmuQmQFPc1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.51.0':
+    resolution: {integrity: sha512-cBUHqtOXy76G41lOB401qpFoKx1xq17qYkhWrLSM7eEjiHM9sOtYqpr6ZdqCnN9s6ZpzudX4EkeHOFH2E9q0vA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-riscv64-musl@1.51.0':
+    resolution: {integrity: sha512-WKbg8CysgZcHfZX0ixQFBRSBvFZUHa3SBnEjHY2FVYt2nbNJEjzTxA3ZR5wMU0NOCNKIAFUFvAh5/XJKPRJuJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxlint/binding-linux-s390x-gnu@1.51.0':
+    resolution: {integrity: sha512-N1QRUvJTxqXNSu35YOufdjsAVmKVx5bkrggOWAhTWBc3J4qjcBwr1IfyLh/6YCg8sYRSR1GraldS9jUgJL/U4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-gnu@1.51.0':
+    resolution: {integrity: sha512-e0Mz0DizsCoqNIjeOg6OUKe8JKJWZ5zZlwsd05Bmr51Jo3AOL4UJnPvwKumr4BBtBrDZkCmOLhCvDGm95nJM2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-linux-x64-musl@1.51.0':
+    resolution: {integrity: sha512-wD8HGTWhYBKXvRDvoBVB1y+fEYV01samhWQSy1Zkxq2vpezvMnjaFKRuiP6tBNITLGuffbNDEXOwcAhJ3gI5Ug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint/binding-openharmony-arm64@1.51.0':
+    resolution: {integrity: sha512-5NSwQ2hDEJ0GPXqikjWtwzgAQCsS7P9aLMNenjjKa+gknN3lTCwwwERsT6lKXSirfU3jLjexA2XQvQALh5h27w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.51.0':
+    resolution: {integrity: sha512-JEZyah1M0RHMw8d+jjSSJmSmO8sABA1J1RtrHYujGPeCkYg1NeH0TGuClpe2h5QtioRTaF57y/TZfn/2IFV6fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.51.0':
+    resolution: {integrity: sha512-q3cEoKH6kwjz/WRyHwSf0nlD2F5Qw536kCXvmlSu+kaShzgrA0ojmh45CA81qL+7udfCaZL2SdKCZlLiGBVFlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.51.0':
+    resolution: {integrity: sha512-Q14+fOGb9T28nWF/0EUsYqERiRA7cl1oy4TJrGmLaqhm+aO2cV+JttboHI3CbdeMCAyDI1+NoSlrM7Melhp/cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    resolution: {integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    resolution: {integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    resolution: {integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    resolution: {integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    resolution: {integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    resolution: {integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    resolution: {integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    resolution: {integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    resolution: {integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip32@1.7.0':
+    resolution: {integrity: sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  abitype@1.2.3:
+    resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  isows@1.0.7:
+    resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
+    peerDependencies:
+      ws: '*'
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
+
+  ox@0.12.4:
+    resolution: {integrity: sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  oxlint@1.51.0:
+    resolution: {integrity: sha512-g6DNPaV9/WI9MoX2XllafxQuxwY1TV++j7hP8fTJByVBuCoVtm3dy9f/2vtH/HU40JztcgWF4G7ua+gkainklQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.15.0'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  viem@2.46.3:
+    resolution: {integrity: sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/curves@1.9.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
+  '@noble/hashes@1.8.0': {}
+
+  '@oxlint/binding-android-arm-eabi@1.51.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.51.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.51.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.51.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.51.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.51.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.51.0':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.59.0':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.59.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.59.0':
+    optional: true
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip32@1.7.0':
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1)':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
+  abitype@1.2.3(typescript@5.8.2):
+    optionalDependencies:
+      typescript: 5.8.2
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  eventemitter3@5.0.1: {}
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  isows@1.0.7(ws@8.18.3):
+    dependencies:
+      ws: 8.18.3
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.11: {}
+
+  obug@2.1.1: {}
+
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
+  openapi-typescript-helpers@0.1.0: {}
+
+  ox@0.12.4(typescript@5.8.2):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.8.2)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - zod
+
+  oxlint@1.51.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.51.0
+      '@oxlint/binding-android-arm64': 1.51.0
+      '@oxlint/binding-darwin-arm64': 1.51.0
+      '@oxlint/binding-darwin-x64': 1.51.0
+      '@oxlint/binding-freebsd-x64': 1.51.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.51.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.51.0
+      '@oxlint/binding-linux-arm64-gnu': 1.51.0
+      '@oxlint/binding-linux-arm64-musl': 1.51.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.51.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.51.0
+      '@oxlint/binding-linux-riscv64-musl': 1.51.0
+      '@oxlint/binding-linux-s390x-gnu': 1.51.0
+      '@oxlint/binding-linux-x64-gnu': 1.51.0
+      '@oxlint/binding-linux-x64-musl': 1.51.0
+      '@oxlint/binding-openharmony-arm64': 1.51.0
+      '@oxlint/binding-win32-arm64-msvc': 1.51.0
+      '@oxlint/binding-win32-ia32-msvc': 1.51.0
+      '@oxlint/binding-win32-x64-msvc': 1.51.0
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.59.0:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.59.0
+      '@rollup/rollup-android-arm64': 4.59.0
+      '@rollup/rollup-darwin-arm64': 4.59.0
+      '@rollup/rollup-darwin-x64': 4.59.0
+      '@rollup/rollup-freebsd-arm64': 4.59.0
+      '@rollup/rollup-freebsd-x64': 4.59.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.59.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.59.0
+      '@rollup/rollup-linux-arm64-gnu': 4.59.0
+      '@rollup/rollup-linux-arm64-musl': 4.59.0
+      '@rollup/rollup-linux-loong64-gnu': 4.59.0
+      '@rollup/rollup-linux-loong64-musl': 4.59.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.59.0
+      '@rollup/rollup-linux-ppc64-musl': 4.59.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.59.0
+      '@rollup/rollup-linux-riscv64-musl': 4.59.0
+      '@rollup/rollup-linux-s390x-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-gnu': 4.59.0
+      '@rollup/rollup-linux-x64-musl': 4.59.0
+      '@rollup/rollup-openbsd-x64': 4.59.0
+      '@rollup/rollup-openharmony-arm64': 4.59.0
+      '@rollup/rollup-win32-arm64-msvc': 4.59.0
+      '@rollup/rollup-win32-ia32-msvc': 4.59.0
+      '@rollup/rollup-win32-x64-gnu': 4.59.0
+      '@rollup/rollup-win32-x64-msvc': 4.59.0
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  tinyrainbow@3.0.3: {}
+
+  typescript@5.8.2: {}
+
+  viem@2.46.3(typescript@5.8.2):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.8.2)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.12.4(typescript@5.8.2)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  vite@7.3.1:
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.0.18:
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1)
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.18.3: {}

--- a/clients/typescript/pnpm-workspace.yaml
+++ b/clients/typescript/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - autogen
+  - client


### PR DESCRIPTION
## Summary

- Adds `@fynd/client` — a TypeScript client for the Fynd DEX router, mirroring the Rust client (`feat/eng-5593-rust-client`)
- All wire types sourced from `@fynd/autogen` (no hand-rolled OpenAPI types)
- Integrates into the existing `clients/typescript` pnpm workspace

## What's included

**Source (`clients/typescript/client/src/`):**
- `types.ts` — client-facing types: `Order`, `Quote`, `Swap`, `Route`, `BlockInfo`, `HealthStatus`
- `error.ts` — `FyndError` with `ServerErrorCode`/`ClientErrorCode`, `isRetryable`, factory methods
- `signing.ts` — `signingHash`, `assembleSignedOrder`, `ExecutionReceipt`, `SettledOrder`
- `mapping.ts` — wire↔client conversions, `exactOptionalPropertyTypes`-compliant
- `client.ts` — `FyndClient` with `quote` (retry + ±25% jitter), `health`, `signablePayload`, `execute` (standard + dry-run), ERC-20/ERC-6909 Transfer log decoding

**Tests:** 94 tests across `error.test.ts`, `mapping.test.ts`, `signing.test.ts`, `client.test.ts`

**CI:** `check_ts_client` job added — runs `tsc --noEmit`, `oxlint`, and `vitest run`

## Relates to

[ENG-5595](https://propeller-heads.atlassian.net/browse/ENG-5595)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-5595]: https://propeller-heads.atlassian.net/browse/ENG-5595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ