### PR TITLE
feat(most_liquid): optimise solving speed by capping number of routes simulated

### DIFF
--- a/fynd-core/examples/solve_order.rs
+++ b/fynd-core/examples/solve_order.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (computation_shutdown_tx, computation_shutdown_rx) = tokio::sync::broadcast::channel(1);
 
     // 6. Worker pool with most_liquid algorithm
-    let algorithm_config = AlgorithmConfig::new(1, 2, Duration::from_millis(5000))?;
+    let algorithm_config = AlgorithmConfig::new(1, 2, Duration::from_millis(5000), None)?;
 
     let (worker_pool, task_handle) = WorkerPoolBuilder::new()
         .name("solver".to_string())

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -73,7 +73,6 @@ impl AlgorithmConfig {
         }
         Ok(Self { min_hops, max_hops, timeout, max_routes })
     }
-
 }
 
 impl Default for AlgorithmConfig {

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -38,6 +38,8 @@ pub struct AlgorithmConfig {
     pub max_hops: usize,
     /// Timeout for solving.
     pub timeout: Duration,
+    /// Maximum number of paths to simulate. `None` means no cap.
+    pub max_routes: Option<usize>,
 }
 
 impl AlgorithmConfig {
@@ -52,6 +54,7 @@ impl AlgorithmConfig {
         min_hops: usize,
         max_hops: usize,
         timeout: Duration,
+        max_routes: Option<usize>,
     ) -> Result<Self, AlgorithmError> {
         if min_hops == 0 {
             return Err(AlgorithmError::InvalidConfiguration {
@@ -63,29 +66,20 @@ impl AlgorithmConfig {
                 reason: format!("min_hops ({}) cannot exceed max_hops ({})", min_hops, max_hops),
             });
         }
-        Ok(Self { min_hops, max_hops, timeout })
+        if max_routes == Some(0) {
+            return Err(AlgorithmError::InvalidConfiguration {
+                reason: "max_routes must be at least 1".to_string(),
+            });
+        }
+        Ok(Self { min_hops, max_hops, timeout, max_routes })
     }
 
-    /// Returns the minimum number of hops to search.
-    pub(crate) fn min_hops(&self) -> usize {
-        self.min_hops
-    }
-
-    /// Returns the maximum number of hops to search.
-    pub(crate) fn max_hops(&self) -> usize {
-        self.max_hops
-    }
-
-    /// Returns the timeout for solving.
-    pub(crate) fn timeout(&self) -> Duration {
-        self.timeout
-    }
 }
 
 impl Default for AlgorithmConfig {
     fn default() -> Self {
         // Default values are valid, so we can unwrap safely
-        Self::new(1, 3, Duration::from_millis(100)).unwrap()
+        Self::new(1, 3, Duration::from_millis(100), None).unwrap()
     }
 }
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -36,6 +36,7 @@ pub struct MostLiquidAlgorithm {
     min_hops: usize,
     max_hops: usize,
     timeout: Duration,
+    max_routes: Option<usize>,
 }
 
 /// Algorithm-specific edge data for liquidity-based routing.
@@ -112,15 +113,16 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
 impl MostLiquidAlgorithm {
     /// Creates a new MostLiquidAlgorithm with default settings.
     pub fn new() -> Self {
-        Self { min_hops: 1, max_hops: 3, timeout: Duration::from_millis(500) }
+        Self { min_hops: 1, max_hops: 3, timeout: Duration::from_millis(500), max_routes: None }
     }
 
     /// Creates a new MostLiquidAlgorithm with custom settings.
     pub fn with_config(config: AlgorithmConfig) -> Result<Self, AlgorithmError> {
         Ok(Self {
-            min_hops: config.min_hops(),
-            max_hops: config.max_hops(),
-            timeout: config.timeout(),
+            min_hops: config.min_hops,
+            max_hops: config.max_hops,
+            timeout: config.timeout,
+            max_routes: config.max_routes,
         })
     }
 
@@ -472,6 +474,10 @@ impl Algorithm for MostLiquidAlgorithm {
                 .partial_cmp(a_score)
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
+
+        if let Some(max_routes) = self.max_routes {
+            scored_paths.truncate(max_routes);
+        }
 
         let paths_to_simulate = scored_paths.len();
         let scoring_failures = paths_candidates - paths_to_simulate;
@@ -1120,7 +1126,7 @@ mod tests {
             setup_market(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(1, 1, Duration::from_millis(100)).unwrap(),
+            AlgorithmConfig::new(1, 1, Duration::from_millis(100), None).unwrap(),
         )
         .unwrap();
         let order = order(&token_a, &token_b, ONE_ETH, OrderSide::Sell);
@@ -1156,7 +1162,7 @@ mod tests {
         ]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(1, 1, Duration::from_millis(100)).unwrap(),
+            AlgorithmConfig::new(1, 1, Duration::from_millis(100), None).unwrap(),
         )
         .unwrap();
         let order = order(&token_a, &token_b, 1000, OrderSide::Sell);
@@ -1206,7 +1212,7 @@ mod tests {
         ]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(1, 2, Duration::from_millis(100)).unwrap(),
+            AlgorithmConfig::new(1, 2, Duration::from_millis(100), None).unwrap(),
         )
         .unwrap();
         let order = order(&token_a, &token_c, ONE_ETH, OrderSide::Sell);
@@ -1276,7 +1282,7 @@ mod tests {
 
         // Use max_hops=1 to focus only on direct 1-hop paths
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(1, 1, Duration::from_millis(100)).unwrap(),
+            AlgorithmConfig::new(1, 1, Duration::from_millis(100), None).unwrap(),
         )
         .unwrap();
         let order = order(&token_a, &token_b, ONE_ETH, OrderSide::Sell);
@@ -1458,7 +1464,7 @@ mod tests {
 
         // Use min_hops=2 to require at least 2 hops (circular)
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(2, 2, Duration::from_millis(100)).unwrap(),
+            AlgorithmConfig::new(2, 2, Duration::from_millis(100), None).unwrap(),
         )
         .unwrap();
 
@@ -1504,7 +1510,7 @@ mod tests {
 
         // min_hops=2 should skip the 1-hop direct path
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(2, 3, Duration::from_millis(100)).unwrap(),
+            AlgorithmConfig::new(2, 3, Duration::from_millis(100), None).unwrap(),
         )
         .unwrap();
         let order = order(&token_a, &token_b, 100, OrderSide::Sell);
@@ -1539,7 +1545,7 @@ mod tests {
 
         // max_hops=1 cannot reach C from A (needs 2 hops)
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(1, 1, Duration::from_millis(100)).unwrap(),
+            AlgorithmConfig::new(1, 1, Duration::from_millis(100), None).unwrap(),
         )
         .unwrap();
         let order = order(&token_a, &token_c, 100, OrderSide::Sell);
@@ -1572,7 +1578,7 @@ mod tests {
 
         // timeout=0ms should timeout after processing some paths
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(1, 1, Duration::from_millis(0)).unwrap(),
+            AlgorithmConfig::new(1, 1, Duration::from_millis(0), None).unwrap(),
         )
         .unwrap();
         let order = order(&token_a, &token_b, 100, OrderSide::Sell);
@@ -1613,7 +1619,8 @@ mod tests {
         use crate::algorithm::Algorithm;
 
         let algorithm = MostLiquidAlgorithm::with_config(
-            AlgorithmConfig::new(min_hops, max_hops, Duration::from_millis(timeout_ms)).unwrap(),
+            AlgorithmConfig::new(min_hops, max_hops, Duration::from_millis(timeout_ms), None)
+                .unwrap(),
         )
         .unwrap();
 
@@ -1635,9 +1642,90 @@ mod tests {
 
     // ==================== Configuration Validation Tests ====================
 
+    #[tokio::test]
+    async fn find_best_route_respects_max_routes_cap() {
+        // 4 parallel pools. Score = spot_price * min_depth.
+        // In tests, depth comes from get_limits().0 (sell_limit), which is
+        // liquidity / (spot_price * (1 - fee)). With fee=0: depth = liquidity / spot_price.
+        // We vary liquidity to create a clear score ranking:
+        //   pool4 (score = 1.0 * 4M/1.0 = 4M)
+        //   pool3 (score = 2.0 * 3M/2.0 = 3M)
+        //   pool2 (score = 3.0 * 2M/3.0 = 2M)
+        //   pool1 (score = 4.0 * 1M/4.0 = 1M)
+        //
+        // With max_routes=2, only pool4 and pool3 are simulated.
+        // pool1 has the best simulation output (4x) but the lowest score,
+        // so it's excluded by the cap.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+
+        let (market, manager) = setup_market(vec![
+            ("pool1", &token_a, &token_b, MockProtocolSim::new(4.0).with_liquidity(1_000_000)),
+            ("pool2", &token_a, &token_b, MockProtocolSim::new(3.0).with_liquidity(2_000_000)),
+            ("pool3", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(3_000_000)),
+            ("pool4", &token_a, &token_b, MockProtocolSim::new(1.0).with_liquidity(4_000_000)),
+        ]);
+
+        // Cap at 2: only the two highest-scored paths are simulated
+        let algorithm = MostLiquidAlgorithm::with_config(
+            AlgorithmConfig::new(1, 1, Duration::from_millis(100), Some(2)).unwrap(),
+        )
+        .unwrap();
+        let order = order(&token_a, &token_b, 1000, OrderSide::Sell);
+        let result = algorithm
+            .find_best_route(manager.graph(), market, None, &order)
+            .await
+            .unwrap();
+
+        // pool1 has the best simulation output (4x) but lowest score, so it's
+        // excluded by the cap. Among the top-2 scored (pool4=4M, pool3=3M),
+        // pool3 gives the best simulation output (2x vs 1x).
+        assert_eq!(result.route.swaps.len(), 1);
+        assert_eq!(result.route.swaps[0].component_id, "pool3");
+        assert_eq!(result.route.swaps[0].amount_out, BigUint::from(2000u64));
+    }
+
+    #[tokio::test]
+    async fn find_best_route_no_cap_when_max_routes_is_none() {
+        // Same setup but no cap — pool1 (best output) should win.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+
+        let (market, manager) = setup_market(vec![
+            ("pool1", &token_a, &token_b, MockProtocolSim::new(4.0).with_liquidity(1_000_000)),
+            ("pool2", &token_a, &token_b, MockProtocolSim::new(3.0).with_liquidity(2_000_000)),
+            ("pool3", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(3_000_000)),
+            ("pool4", &token_a, &token_b, MockProtocolSim::new(1.0).with_liquidity(4_000_000)),
+        ]);
+
+        let algorithm = MostLiquidAlgorithm::with_config(
+            AlgorithmConfig::new(1, 1, Duration::from_millis(100), None).unwrap(),
+        )
+        .unwrap();
+        let order = order(&token_a, &token_b, 1000, OrderSide::Sell);
+        let result = algorithm
+            .find_best_route(manager.graph(), market, None, &order)
+            .await
+            .unwrap();
+
+        // All 4 paths simulated, pool1 wins with best output (4x)
+        assert_eq!(result.route.swaps.len(), 1);
+        assert_eq!(result.route.swaps[0].component_id, "pool1");
+        assert_eq!(result.route.swaps[0].amount_out, BigUint::from(4000u64));
+    }
+
+    #[test]
+    fn algorithm_config_rejects_zero_max_routes() {
+        let result = AlgorithmConfig::new(1, 3, Duration::from_millis(100), Some(0));
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::InvalidConfiguration { reason }) if reason.contains("max_routes must be at least 1")
+        ));
+    }
+
     #[test]
     fn algorithm_config_rejects_zero_min_hops() {
-        let result = AlgorithmConfig::new(0, 3, Duration::from_millis(100));
+        let result = AlgorithmConfig::new(0, 3, Duration::from_millis(100), None);
         assert!(matches!(
             result,
             Err(AlgorithmError::InvalidConfiguration { reason }) if reason.contains("min_hops must be at least 1")
@@ -1646,7 +1734,7 @@ mod tests {
 
     #[test]
     fn algorithm_config_rejects_min_greater_than_max() {
-        let result = AlgorithmConfig::new(5, 3, Duration::from_millis(100));
+        let result = AlgorithmConfig::new(5, 3, Duration::from_millis(100), None);
         assert!(matches!(
             result,
             Err(AlgorithmError::InvalidConfiguration { reason }) if reason.contains("cannot exceed")

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -693,7 +693,7 @@ mod tests {
     // ==================== try_score_path Tests ====================
 
     #[test]
-    fn try_score_path_calculates_correctly() {
+    fn test_try_score_path_calculates_correctly() {
         let (a, b, c, _) = addrs();
         let mut m = linear_graph();
 
@@ -716,13 +716,13 @@ mod tests {
     }
 
     #[test]
-    fn try_score_path_empty_returns_none() {
+    fn test_try_score_path_empty_returns_none() {
         let path: Path<DepthAndPrice> = Path::new();
         assert_eq!(MostLiquidAlgorithm::try_score_path(&path), None);
     }
 
     #[test]
-    fn try_score_path_missing_weight_returns_none() {
+    fn test_try_score_path_missing_weight_returns_none() {
         let (a, b, _, _) = addrs();
         let m = linear_graph();
         let graph = m.graph();
@@ -732,7 +732,7 @@ mod tests {
     }
 
     #[test]
-    fn try_score_path_circular_route() {
+    fn test_try_score_path_circular_route() {
         // Test scoring a circular path A -> B -> A
         let (a, b, _, _) = addrs();
         let mut m = linear_graph();
@@ -775,7 +775,7 @@ mod tests {
     }
 
     #[test]
-    fn find_paths_linear_forward_and_reverse() {
+    fn test_find_paths_linear_forward_and_reverse() {
         let (a, b, c, d) = addrs();
         let m = linear_graph();
         let g = m.graph();
@@ -796,7 +796,7 @@ mod tests {
     }
 
     #[test]
-    fn find_paths_respects_hop_bounds() {
+    fn test_find_paths_respects_hop_bounds() {
         let (a, _, c, d) = addrs();
         let m = linear_graph();
         let g = m.graph();
@@ -813,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    fn find_paths_parallel_pools() {
+    fn test_find_paths_parallel_pools() {
         let (a, b, c, _) = addrs();
         let m = parallel_graph();
         let g = m.graph();
@@ -838,7 +838,7 @@ mod tests {
     }
 
     #[test]
-    fn find_paths_diamond_multiple_routes() {
+    fn test_find_paths_diamond_multiple_routes() {
         let (a, _, _, d) = addrs();
         let m = diamond_graph();
         let g = m.graph();
@@ -849,7 +849,7 @@ mod tests {
     }
 
     #[test]
-    fn find_paths_revisit_destination() {
+    fn test_find_paths_revisit_destination() {
         let (a, b, _, _) = addrs();
         let m = linear_graph();
         let g = m.graph();
@@ -869,7 +869,7 @@ mod tests {
     }
 
     #[test]
-    fn find_paths_cyclic_same_source_dest() {
+    fn test_find_paths_cyclic_same_source_dest() {
         let (a, _, _, _) = addrs();
         // Use parallel_graph with 3 A<->B pools to verify all combinations
         let m = parallel_graph();
@@ -897,7 +897,7 @@ mod tests {
     #[rstest]
     #[case::source_not_in_graph(false, true)]
     #[case::dest_not_in_graph(true, false)]
-    fn find_paths_token_not_in_graph(#[case] from_exists: bool, #[case] to_exists: bool) {
+    fn test_find_paths_token_not_in_graph(#[case] from_exists: bool, #[case] to_exists: bool) {
         // Graph contains tokens A (0x0A) and B (0x0B) from linear_graph fixture
         let (a, b, _, _) = addrs();
         let non_existent = addr(0x99);
@@ -915,7 +915,7 @@ mod tests {
     #[rstest]
     #[case::min_greater_than_max(3, 1)]
     #[case::min_hops_zero(0, 1)]
-    fn find_paths_invalid_configuration(#[case] min_hops: usize, #[case] max_hops: usize) {
+    fn test_find_paths_invalid_configuration(#[case] min_hops: usize, #[case] max_hops: usize) {
         let (a, b, _, _) = addrs();
         let m = linear_graph();
         let g = m.graph();
@@ -929,7 +929,7 @@ mod tests {
     }
 
     #[test]
-    fn find_paths_bfs_ordering() {
+    fn test_find_paths_bfs_ordering() {
         let (a, b, _, _) = addrs();
         let m = linear_graph();
         let g = m.graph();
@@ -952,7 +952,7 @@ mod tests {
     // downcasts to EVMPoolState<PreCachedDB>, or integration tests with real VM pools.
 
     #[test]
-    fn simulate_path_single_hop() {
+    fn test_simulate_path_single_hop() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
@@ -984,7 +984,7 @@ mod tests {
     }
 
     #[test]
-    fn simulate_path_multi_hop_chains_amounts() {
+    fn test_simulate_path_multi_hop_chains_amounts() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
@@ -1021,7 +1021,7 @@ mod tests {
     }
 
     #[test]
-    fn simulate_path_same_pool_twice_uses_updated_state() {
+    fn test_simulate_path_same_pool_twice_uses_updated_state() {
         // Route: A -> B -> A through the same pool
         // First swap uses multiplier=2, second should use multiplier=3 (updated state)
         let token_a = token(0x01, "A");
@@ -1061,7 +1061,7 @@ mod tests {
     }
 
     #[test]
-    fn simulate_path_missing_token_returns_data_not_found() {
+    fn test_simulate_path_missing_token_returns_data_not_found() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
@@ -1089,7 +1089,7 @@ mod tests {
     }
 
     #[test]
-    fn simulate_path_missing_component_returns_data_not_found() {
+    fn test_simulate_path_missing_component_returns_data_not_found() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let (market, manager) =
@@ -1118,7 +1118,7 @@ mod tests {
     // ==================== find_best_route Tests ====================
 
     #[tokio::test]
-    async fn find_best_route_single_path() {
+    async fn test_find_best_route_single_path() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
@@ -1141,7 +1141,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_ranks_by_net_amount_out() {
+    async fn test_find_best_route_ranks_by_net_amount_out() {
         // Tests that route selection is based on net_amount_out (output - gas cost),
         // not just gross output. Three parallel pools with different spot_price/gas combos:
         //
@@ -1183,7 +1183,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_no_path_returns_error() {
+    async fn test_find_best_route_no_path_returns_error() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C"); // Disconnected
@@ -1201,7 +1201,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_multi_hop() {
+    async fn test_find_best_route_multi_hop() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
@@ -1231,7 +1231,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_skips_paths_without_edge_weights() {
+    async fn test_find_best_route_skips_paths_without_edge_weights() {
         // Pool1 has edge weights (scoreable), Pool2 doesn't (filtered out during scoring)
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1299,7 +1299,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_no_scorable_paths() {
+    async fn test_find_best_route_no_scorable_paths() {
         // All paths exist but none have edge weights (can't be scored)
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1344,7 +1344,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_gas_exceeds_output_returns_negative_net() {
+    async fn test_find_best_route_gas_exceeds_output_returns_negative_net() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
@@ -1387,7 +1387,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_insufficient_liquidity() {
+    async fn test_find_best_route_insufficient_liquidity() {
         // Pool has limited liquidity (1000 wei) but we try to swap ONE_ETH
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1409,7 +1409,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_missing_gas_price_returns_error() {
+    async fn test_find_best_route_missing_gas_price_returns_error() {
         // Test that missing gas price returns DataNotFound error, not InsufficientLiquidity
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1453,7 +1453,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_circular_arbitrage() {
+    async fn test_find_best_route_circular_arbitrage() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
@@ -1494,7 +1494,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_respects_min_hops() {
+    async fn test_find_best_route_respects_min_hops() {
         // Setup: A->B (1-hop) and A->C->B (2-hop)
         // With min_hops=2, should only return the 2-hop path
         let token_a = token(0x01, "A");
@@ -1531,7 +1531,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_respects_max_hops() {
+    async fn test_find_best_route_respects_max_hops() {
         // Setup: Only path is A->B->C (2 hops)
         // With max_hops=1, should return NoPath error
         let token_a = token(0x01, "A");
@@ -1560,7 +1560,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_timeout_returns_best_so_far() {
+    async fn test_find_best_route_timeout_returns_best_so_far() {
         // Setup: Many parallel paths to process
         // With very short timeout, should return the best route found before timeout
         // or Timeout error if no route was completed
@@ -1611,7 +1611,7 @@ mod tests {
     #[case::multi_hop_min(2, 5, 200)]
     #[case::zero_timeout(1, 3, 0)]
     #[case::large_values(10, 100, 10000)]
-    fn algorithm_config_getters(
+    fn test_algorithm_config_getters(
         #[case] min_hops: usize,
         #[case] max_hops: usize,
         #[case] timeout_ms: u64,
@@ -1630,7 +1630,7 @@ mod tests {
     }
 
     #[test]
-    fn algorithm_default_config() {
+    fn test_algorithm_default_config() {
         use crate::algorithm::Algorithm;
 
         let algorithm = MostLiquidAlgorithm::new();
@@ -1643,7 +1643,7 @@ mod tests {
     // ==================== Configuration Validation Tests ====================
 
     #[tokio::test]
-    async fn find_best_route_respects_max_routes_cap() {
+    async fn test_find_best_route_respects_max_routes_cap() {
         // 4 parallel pools. Score = spot_price * min_depth.
         // In tests, depth comes from get_limits().0 (sell_limit), which is
         // liquidity / (spot_price * (1 - fee)). With fee=0: depth = liquidity / spot_price.
@@ -1686,7 +1686,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_best_route_no_cap_when_max_routes_is_none() {
+    async fn test_find_best_route_no_cap_when_max_routes_is_none() {
         // Same setup but no cap — pool1 (best output) should win.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1715,7 +1715,7 @@ mod tests {
     }
 
     #[test]
-    fn algorithm_config_rejects_zero_max_routes() {
+    fn test_algorithm_config_rejects_zero_max_routes() {
         let result = AlgorithmConfig::new(1, 3, Duration::from_millis(100), Some(0));
         assert!(matches!(
             result,
@@ -1724,7 +1724,7 @@ mod tests {
     }
 
     #[test]
-    fn algorithm_config_rejects_zero_min_hops() {
+    fn test_algorithm_config_rejects_zero_min_hops() {
         let result = AlgorithmConfig::new(0, 3, Duration::from_millis(100), None);
         assert!(matches!(
             result,
@@ -1733,7 +1733,7 @@ mod tests {
     }
 
     #[test]
-    fn algorithm_config_rejects_min_greater_than_max() {
+    fn test_algorithm_config_rejects_min_greater_than_max() {
         let result = AlgorithmConfig::new(5, 3, Duration::from_millis(100), None);
         assert!(matches!(
             result,

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -210,7 +210,7 @@ mod tests {
         let params = SpawnWorkersParams {
             algorithm: "most_liquid".to_string(),
             num_workers: 3,
-            algorithm_config: AlgorithmConfig::new(1, 2, Duration::from_millis(50)).unwrap(),
+            algorithm_config: AlgorithmConfig::new(1, 2, Duration::from_millis(50), None).unwrap(),
             task_rx,
             market_data,
             derived_data,

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -217,6 +217,7 @@ impl FyndBuilder {
                 pool_cfg.min_hops,
                 pool_cfg.max_hops,
                 Duration::from_millis(pool_cfg.timeout_ms),
+                pool_cfg.max_routes,
             )
             .context(format!("invalid algorithm configuration for pool '{}'", pool_name))?;
 

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -24,16 +24,16 @@ pub struct PoolConfig {
     #[serde(default = "num_cpus::get")]
     pub num_workers: usize,
     /// Task queue capacity for this pool
-    #[serde(default = "usize_val::<1000>")]
+    #[serde(default = "usize_val::<{ defaults::POOL_TASK_QUEUE_CAPACITY }>")]
     pub task_queue_capacity: usize,
     /// Minimum hops to search (must be >= 1)
-    #[serde(default = "usize_val::<1>")]
+    #[serde(default = "usize_val::<{ defaults::POOL_MIN_HOPS }>")]
     pub min_hops: usize,
     /// Maximum hops to search
-    #[serde(default = "usize_val::<3>")]
+    #[serde(default = "usize_val::<{ defaults::POOL_MAX_HOPS }>")]
     pub max_hops: usize,
     /// Timeout for solving in milliseconds
-    #[serde(default = "u64_val::<100>")]
+    #[serde(default = "u64_val::<{ defaults::POOL_TIMEOUT_MS }>")]
     pub timeout_ms: u64,
     /// Maximum number of paths to simulate per solve. Omit to simulate all scored paths.
     #[serde(default)]
@@ -109,10 +109,10 @@ mod tests {
         let pool = &config.pools["basic"];
         assert_eq!(pool.algorithm, "most_liquid");
         assert_eq!(pool.num_workers, num_cpus::get());
-        assert_eq!(pool.task_queue_capacity, 1000);
-        assert_eq!(pool.min_hops, 1);
-        assert_eq!(pool.max_hops, 3);
-        assert_eq!(pool.timeout_ms, 100);
+        assert_eq!(pool.task_queue_capacity, defaults::POOL_TASK_QUEUE_CAPACITY);
+        assert_eq!(pool.min_hops, defaults::POOL_MIN_HOPS);
+        assert_eq!(pool.max_hops, defaults::POOL_MAX_HOPS);
+        assert_eq!(pool.timeout_ms, defaults::POOL_TIMEOUT_MS);
         assert_eq!(pool.max_routes, None);
     }
 
@@ -140,17 +140,30 @@ mod tests {
     }
 }
 
-// Solver defaults
 pub mod defaults {
+    // HTTP server
     pub const HTTP_HOST: &str = "0.0.0.0";
     pub const HTTP_PORT: u16 = 3000;
+
+    // Tycho stream
     pub const MIN_TVL: f64 = 10.0;
     pub const MIN_TOKEN_QUALITY: i32 = 100;
     pub const TVL_BUFFER_MULTIPLIER: f64 = 1.1;
-    pub const GAS_REFRESH_INTERVAL_SECS: u64 = 30;
     pub const RECONNECT_DELAY_SECS: u64 = 5;
+
+    // Gas
+    pub const GAS_REFRESH_INTERVAL_SECS: u64 = 30;
+
+    // Order manager
     pub const ORDER_MANAGER_TIMEOUT_MS: u64 = 100;
     pub const ORDER_MANAGER_MIN_RESPONSES: usize = 0;
-    /// Slippage threshold for pool depth computation (1%)
+
+    // Derived data
     pub const DEPTH_SLIPPAGE_THRESHOLD: f64 = 0.01;
+
+    // Worker pool config
+    pub const POOL_TASK_QUEUE_CAPACITY: usize = 1000;
+    pub const POOL_MIN_HOPS: usize = 1;
+    pub const POOL_MAX_HOPS: usize = 3;
+    pub const POOL_TIMEOUT_MS: u64 = 100;
 }

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -100,7 +100,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pool_config_minimal_uses_defaults() {
+    fn test_pool_config_minimal_uses_defaults() {
         let toml = r#"
             [pools.basic]
             algorithm = "most_liquid"
@@ -117,7 +117,7 @@ mod tests {
     }
 
     #[test]
-    fn pool_config_all_fields_explicit() {
+    fn test_pool_config_all_fields_explicit() {
         let toml = r#"
             [pools.custom]
             algorithm = "most_liquid"

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -35,6 +35,9 @@ pub struct PoolConfig {
     /// Timeout for solving in milliseconds
     #[serde(default = "u64_val::<100>")]
     pub timeout_ms: u64,
+    /// Maximum number of paths to simulate per solve. Omit to simulate all scored paths.
+    #[serde(default)]
+    pub max_routes: Option<usize>,
 }
 
 impl WorkerPoolsConfig {
@@ -90,6 +93,51 @@ fn usize_val<const V: usize>() -> usize {
 
 fn u64_val<const V: u64>() -> u64 {
     V
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pool_config_minimal_uses_defaults() {
+        let toml = r#"
+            [pools.basic]
+            algorithm = "most_liquid"
+        "#;
+        let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
+        let pool = &config.pools["basic"];
+        assert_eq!(pool.algorithm, "most_liquid");
+        assert_eq!(pool.num_workers, num_cpus::get());
+        assert_eq!(pool.task_queue_capacity, 1000);
+        assert_eq!(pool.min_hops, 1);
+        assert_eq!(pool.max_hops, 3);
+        assert_eq!(pool.timeout_ms, 100);
+        assert_eq!(pool.max_routes, None);
+    }
+
+    #[test]
+    fn pool_config_all_fields_explicit() {
+        let toml = r#"
+            [pools.custom]
+            algorithm = "most_liquid"
+            num_workers = 8
+            task_queue_capacity = 500
+            min_hops = 2
+            max_hops = 4
+            timeout_ms = 200
+            max_routes = 50
+        "#;
+        let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
+        let pool = &config.pools["custom"];
+        assert_eq!(pool.algorithm, "most_liquid");
+        assert_eq!(pool.num_workers, 8);
+        assert_eq!(pool.task_queue_capacity, 500);
+        assert_eq!(pool.min_hops, 2);
+        assert_eq!(pool.max_hops, 4);
+        assert_eq!(pool.timeout_ms, 200);
+        assert_eq!(pool.max_routes, Some(50));
+    }
 }
 
 // Solver defaults

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -7,6 +7,7 @@ num_workers = 5
 task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 100
+max_routes = 50
 
 [pools.most_liquid_3_hops]
 algorithm = "most_liquid"


### PR DESCRIPTION
## Summary

  - Add max_routes: Option<usize> to AlgorithmConfig and PoolConfig, allowing algorithms to cap how many paths are simulated per solve.
  - When max_routes is omitted from config, all scored paths are simulated (no behavior change).
  - Refactor: remove redundant accessor methods on AlgorithmConfig (fields are already pub). Organize defaults module into labeled sections.

  Resolves https://propeller-heads.atlassian.net/browse/ENG-5577