### PR TITLE
feat: allow external algorithms in WorkerPoolBuilder

### DIFF
--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -1,0 +1,302 @@
+//! Custom algorithm example for fynd-core
+//!
+//! Demonstrates how to implement the [`Algorithm`] trait for a custom type and plug it
+//! into a [`WorkerPoolBuilder`] via [`WorkerPoolBuilder::with_algorithm`], without
+//! modifying fynd-core itself.
+//!
+//! [`MyAlgorithm`] here is a thin wrapper around [`MostLiquidAlgorithm`]. In a real
+//! integration you would replace the delegation with your own routing logic.
+//!
+//! # Prerequisites
+//!
+//! ```bash
+//! export TYCHO_API_KEY="your-api-key"
+//! export RPC_URL="https://eth.llamarpc.com"
+//! export TYCHO_URL="tycho-beta.propellerheads.xyz"  # Optional
+//! cargo run --package fynd-core --example custom_algorithm
+//! ```
+
+use std::{
+    env,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use fynd_core::{
+    derived::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef},
+    feed::{
+        gas::GasPriceFetcher,
+        market_data::{SharedMarketData, SharedMarketDataRef},
+        tycho_feed::TychoFeed,
+        TychoFeedConfig,
+    },
+    types::{constants::native_token, RouteResult},
+    Algorithm, AlgorithmConfig, AlgorithmError, ComputationRequirements, MostLiquidAlgorithm,
+    Order, OrderManager, OrderManagerConfig, OrderSide, QuoteRequest, SolverPoolHandle,
+    WorkerPoolBuilder,
+};
+use num_bigint::BigUint;
+use tokio::sync::RwLock;
+use tycho_simulation::{
+    evm::tycho_models::Chain, tycho_core::Bytes, tycho_ethereum::rpc::EthereumRpcClient,
+};
+
+// =============================================================================
+// Custom algorithm implementation
+// =============================================================================
+
+/// A custom algorithm that wraps [`MostLiquidAlgorithm`].
+///
+/// Replace the delegation in [`Algorithm::find_best_route`] with your own routing
+/// logic to use a fully custom algorithm.
+struct MyAlgorithm {
+    inner: MostLiquidAlgorithm,
+}
+
+impl MyAlgorithm {
+    fn new(config: AlgorithmConfig) -> Self {
+        let inner =
+            MostLiquidAlgorithm::with_config(config).expect("invalid algorithm configuration");
+        Self { inner }
+    }
+}
+
+impl Algorithm for MyAlgorithm {
+    // Reuse the built-in graph type and manager so the worker infrastructure
+    // (graph initialisation, event handling, edge weight updates) works unchanged.
+    type GraphType = <MostLiquidAlgorithm as Algorithm>::GraphType;
+    type GraphManager = <MostLiquidAlgorithm as Algorithm>::GraphManager;
+
+    fn name(&self) -> &str {
+        "my_custom_algo"
+    }
+
+    async fn find_best_route(
+        &self,
+        graph: &Self::GraphType,
+        market: SharedMarketDataRef,
+        derived: Option<SharedDerivedDataRef>,
+        order: &fynd_core::Order,
+    ) -> Result<RouteResult, AlgorithmError> {
+        // Delegate to the inner algorithm.  Replace this with custom logic.
+        self.inner
+            .find_best_route(graph, market, derived, order)
+            .await
+    }
+
+    fn computation_requirements(&self) -> ComputationRequirements {
+        self.inner.computation_requirements()
+    }
+
+    fn timeout(&self) -> Duration {
+        self.inner.timeout()
+    }
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Configuration from environment
+    let tycho_url =
+        env::var("TYCHO_URL").unwrap_or_else(|_| "tycho-beta.propellerheads.xyz".to_string());
+    let tycho_api_key = env::var("TYCHO_API_KEY").ok();
+    let rpc_url = env::var("RPC_URL").expect("RPC_URL env var not set");
+    let chain = Chain::Ethereum;
+
+    // 2. Market data and Tycho feed
+    let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
+
+    let tycho_feed_config = TychoFeedConfig::new(
+        tycho_url,
+        chain,
+        tycho_api_key,
+        true,
+        vec!["uniswap_v2".to_string(), "uniswap_v3".to_string()],
+        10.0,
+    )
+    .min_token_quality(100);
+
+    // 3. Gas price fetcher
+    let ethereum_client = EthereumRpcClient::new(rpc_url.as_str())
+        .map_err(|e| format!("failed to create ethereum client: {}", e))?;
+
+    let (mut gas_price_fetcher, gas_price_worker_signal_tx) =
+        GasPriceFetcher::new(ethereum_client, Arc::clone(&market_data));
+
+    let mut tycho_feed = TychoFeed::new(tycho_feed_config, Arc::clone(&market_data));
+    tycho_feed = tycho_feed.with_gas_price_worker_signal_tx(gas_price_worker_signal_tx);
+
+    // 4. Derived data computation manager
+    let gas_token = native_token(&chain).expect("gas token not configured for chain");
+    let computation_config = ComputationManagerConfig::new()
+        .with_gas_token(gas_token)
+        .with_depth_slippage_threshold(0.01);
+
+    let (computation_manager, _derived_event_rx) =
+        ComputationManager::new(computation_config, Arc::clone(&market_data))
+            .map_err(|e| format!("failed to create computation manager: {}", e))?;
+
+    let derived_data = computation_manager.store();
+    let derived_event_tx = computation_manager.event_sender();
+
+    // 5. Event subscriptions
+    let computation_event_rx = tycho_feed.subscribe();
+    let pool_event_rx = tycho_feed.subscribe();
+    let (computation_shutdown_tx, computation_shutdown_rx) = tokio::sync::broadcast::channel(1);
+
+    // 6. Worker pool using the custom algorithm via with_algorithm()
+    //
+    // Key difference from solve_order.rs: instead of .algorithm("most_liquid"),
+    // we call .with_algorithm() with a factory closure that constructs MyAlgorithm.
+    let algorithm_config = AlgorithmConfig::new(1, 2, Duration::from_millis(5000), None)?;
+
+    let (worker_pool, task_handle) = WorkerPoolBuilder::new()
+        .name("custom-solver".to_string())
+        .with_algorithm("my_custom_algo", MyAlgorithm::new)
+        .algorithm_config(algorithm_config)
+        .num_workers(2)
+        .task_queue_capacity(100)
+        .build(
+            Arc::clone(&market_data),
+            derived_data,
+            pool_event_rx,
+            derived_event_tx.subscribe(),
+        )?;
+
+    println!("Worker pool algorithm: {}", worker_pool.algorithm());
+
+    // 7. OrderManager
+    let order_manager = OrderManager::new(
+        vec![SolverPoolHandle::new("custom-solver", task_handle)],
+        OrderManagerConfig::default().with_timeout(Duration::from_secs(10)),
+    );
+
+    // 8. Background tasks
+    let feed_handle = tokio::spawn(async move {
+        if let Err(e) = tycho_feed.run().await {
+            eprintln!("Tycho feed error: {:?}", e);
+        }
+    });
+    let _gas_price_worker_handle = tokio::spawn(async move {
+        if let Err(e) = gas_price_fetcher.run().await {
+            eprintln!("Gas price fetcher error: {}", e);
+        }
+    });
+    let _computation_handle = tokio::spawn(async move {
+        computation_manager
+            .run(computation_event_rx, computation_shutdown_rx)
+            .await;
+    });
+
+    // 9. Wait for market data
+    print!("Loading market data...");
+    std::io::Write::flush(&mut std::io::stdout())?;
+
+    for attempt in 1..=10 {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let market = market_data.read().await;
+        let age_ms = match market.last_updated() {
+            Some(block_info) => {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                now.saturating_sub(block_info.timestamp())
+                    .saturating_mul(1000)
+            }
+            None => u64::MAX,
+        };
+        drop(market);
+        if age_ms < 60_000 {
+            break;
+        }
+        if attempt == 10 {
+            eprintln!("\nWarning: market data may be stale");
+        }
+    }
+
+    // Wait for derived data computations to complete
+    tokio::time::sleep(Duration::from_secs(60)).await;
+    println!(" done");
+
+    // 10. Solve an order: Sell 1000 USDC for WBTC
+    let usdc_addr = Bytes::from_str("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")?;
+    let wbtc_addr = Bytes::from_str("0x2260fac5e5542a773aa44fbcfedf7c193bc2c599")?;
+
+    let order = Order::new(
+        usdc_addr,
+        wbtc_addr,
+        BigUint::from(1_000_000_000u128),
+        OrderSide::Sell,
+        "0x0000000000000000000000000000000000000000".parse()?,
+    )
+    .with_id("custom-algo-order".to_string());
+
+    print!("Solving: 1000 USDC → WBTC with MyAlgorithm...");
+    std::io::Write::flush(&mut std::io::stdout())?;
+
+    let request = QuoteRequest::new(vec![order], Default::default());
+    let solution = order_manager.quote(request).await?;
+    println!(" done ({}ms)\n", solution.solve_time_ms());
+
+    // 11. Display results
+    let order_quote = &solution.orders()[0];
+    if let Some(route) = order_quote.route() {
+        let market = market_data.read().await;
+        let final_swap = route.swaps().last().unwrap();
+        let final_token_out = market
+            .get_token(final_swap.token_out())
+            .unwrap();
+        let final_amount_out = final_swap
+            .amount_out()
+            .to_string()
+            .parse::<f64>()
+            .unwrap_or(0.0) /
+            10f64.powi(final_token_out.decimals as i32);
+        println!("Result: {:.2} {}", final_amount_out, final_token_out.symbol);
+        println!("Gas:    {}\n", route.total_gas());
+        println!("Route ({} hops):", route.swaps().len());
+        for (i, swap) in route.swaps().iter().enumerate() {
+            let token_in = market
+                .get_token(swap.token_in())
+                .unwrap();
+            let token_out = market
+                .get_token(swap.token_out())
+                .unwrap();
+
+            let amount_in_f64 = swap
+                .amount_in()
+                .to_string()
+                .parse::<f64>()
+                .unwrap_or(0.0) /
+                10f64.powi(token_in.decimals as i32);
+            let amount_out_f64 = swap
+                .amount_out()
+                .to_string()
+                .parse::<f64>()
+                .unwrap_or(0.0) /
+                10f64.powi(token_out.decimals as i32);
+            println!(
+                "  {}. {:.6} {} → {:.6} {} ({})",
+                i + 1,
+                amount_in_f64,
+                token_in.symbol,
+                amount_out_f64,
+                token_out.symbol,
+                swap.protocol()
+            );
+        }
+    } else {
+        println!("No route found (status: {:?})", order_quote.status());
+    }
+
+    let _ = computation_shutdown_tx.send(());
+    worker_pool.shutdown();
+    feed_handle.abort();
+
+    Ok(())
+}

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -31,6 +31,8 @@ pub mod worker_pool;
 
 // Re-export commonly used types for convenience
 pub use algorithm::{Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgorithm};
+// Required for implementing the Algorithm trait externally
+pub use derived::computation::ComputationRequirements;
 pub use order_manager::{config::OrderManagerConfig, OrderManager, SolverPoolHandle};
 pub use types::{
     BlockInfo, ComponentId, EncodingOptions, Order, OrderQuote, OrderSide, OrderValidationError,

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -15,20 +15,22 @@ use crate::{
     feed::{events::MarketEvent, market_data::SharedMarketDataRef},
     types::internal::SolveTask,
     worker_pool::{
-        registry::{spawn_workers, SpawnWorkersParams, UnknownAlgorithmError, DEFAULT_ALGORITHM},
+        registry::{
+            spawn_workers_generic, AlgorithmSpawner, SpawnWorkersParams, UnknownAlgorithmError,
+            DEFAULT_ALGORITHM,
+        },
         task_queue::{TaskQueue, TaskQueueConfig, TaskQueueHandle},
     },
 };
 
 /// Configuration for the worker pool.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct WorkerPoolConfig {
     /// Human-readable name for this pool (used in logging/metrics).
     /// Can differ from algorithm to distinguish pools with same algorithm but different configs.
     name: String,
-    /// Algorithm name for this pool (e.g., "most_liquid").
-    /// Use `worker_pool::list_algorithms()` to see available options.
-    algorithm: String,
+    /// How to spawn workers — either a built-in registry lookup or a custom factory.
+    pub(crate) spawner: AlgorithmSpawner,
     /// Number of worker threads.
     num_workers: usize,
     /// Configuration for the algorithm used by each worker.
@@ -37,11 +39,18 @@ pub struct WorkerPoolConfig {
     task_queue_capacity: usize,
 }
 
+impl WorkerPoolConfig {
+    /// Returns the algorithm name for this pool.
+    pub fn algorithm_name(&self) -> &str {
+        self.spawner.algorithm_name()
+    }
+}
+
 impl Default for WorkerPoolConfig {
     fn default() -> Self {
         Self {
             name: DEFAULT_ALGORITHM.to_string(),
-            algorithm: DEFAULT_ALGORITHM.to_string(),
+            spawner: AlgorithmSpawner::Registry { algorithm: DEFAULT_ALGORITHM.to_string() },
             num_workers: num_cpus::get(),
             algorithm_config: AlgorithmConfig::default(),
             task_queue_capacity: 1000,
@@ -89,11 +98,14 @@ impl WorkerPool {
     ) -> Result<Self, UnknownAlgorithmError> {
         let (shutdown_tx, _) = broadcast::channel(1);
         let name = config.name.clone();
-        let algorithm = config.algorithm.clone();
+        let algorithm = config
+            .spawner
+            .algorithm_name()
+            .to_string();
 
-        // Spawn workers via the algorithm registry
+        // Spawn workers
         let params = SpawnWorkersParams {
-            algorithm: config.algorithm,
+            algorithm: algorithm.clone(),
             num_workers: config.num_workers,
             algorithm_config: config.algorithm_config,
             task_rx,
@@ -103,7 +115,7 @@ impl WorkerPool {
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
         };
-        let workers = spawn_workers(params)?;
+        let workers = config.spawner.spawn(params)?;
 
         info!(
             name = %name,
@@ -169,11 +181,36 @@ impl WorkerPoolBuilder {
         self
     }
 
-    /// Sets the algorithm by name.
+    /// Sets the algorithm by name (built-in registry lookup).
     ///
-    /// Use `worker_pool::list_algorithms()` to see available options.
+    /// Available built-in algorithms: `"most_liquid"`.
     pub fn algorithm(mut self, algorithm: impl Into<String>) -> Self {
-        self.config.algorithm = algorithm.into();
+        self.config.spawner = AlgorithmSpawner::Registry { algorithm: algorithm.into() };
+        self
+    }
+
+    /// Sets a custom algorithm implementation via a factory closure.
+    ///
+    /// The `factory` is called once per worker thread to create an algorithm instance.
+    /// This bypasses the built-in registry, so any type implementing [`Algorithm`] can be used.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// builder.with_algorithm("my_algo", |config| MyAlgorithm::new(config))
+    /// ```
+    pub fn with_algorithm<A, F>(mut self, name: impl Into<String>, factory: F) -> Self
+    where
+        A: crate::algorithm::Algorithm + 'static,
+        A::GraphManager: crate::feed::events::MarketEventHandler
+            + crate::graph::EdgeWeightUpdaterWithDerived
+            + 'static,
+        F: Fn(AlgorithmConfig) -> A + Clone + Send + Sync + 'static,
+    {
+        let name = name.into();
+        let spawner =
+            Box::new(move |params: SpawnWorkersParams| spawn_workers_generic(params, &factory));
+        self.config.spawner = AlgorithmSpawner::Custom { algorithm: name, spawner };
         self
     }
 

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -12,7 +12,11 @@ use tracing::{error, info};
 use crate::{
     algorithm::AlgorithmConfig,
     derived::{events::DerivedDataEvent, SharedDerivedDataRef},
-    feed::{events::MarketEvent, market_data::SharedMarketDataRef},
+    feed::{
+        events::{MarketEvent, MarketEventHandler},
+        market_data::SharedMarketDataRef,
+    },
+    graph::EdgeWeightUpdaterWithDerived,
     types::internal::SolveTask,
     worker_pool::{
         registry::{
@@ -30,7 +34,7 @@ pub struct WorkerPoolConfig {
     /// Can differ from algorithm to distinguish pools with same algorithm but different configs.
     name: String,
     /// How to spawn workers — either a built-in registry lookup or a custom factory.
-    pub(crate) spawner: AlgorithmSpawner,
+    spawner: AlgorithmSpawner,
     /// Number of worker threads.
     num_workers: usize,
     /// Configuration for the algorithm used by each worker.
@@ -202,9 +206,7 @@ impl WorkerPoolBuilder {
     pub fn with_algorithm<A, F>(mut self, name: impl Into<String>, factory: F) -> Self
     where
         A: crate::algorithm::Algorithm + 'static,
-        A::GraphManager: crate::feed::events::MarketEventHandler
-            + crate::graph::EdgeWeightUpdaterWithDerived
-            + 'static,
+        A::GraphManager: MarketEventHandler + EdgeWeightUpdaterWithDerived + 'static,
         F: Fn(AlgorithmConfig) -> A + Clone + Send + Sync + 'static,
     {
         let name = name.into();

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -1,12 +1,13 @@
 //! Worker pool registry for spawning workers with different algorithms.
 //!
 //! This module provides a registry pattern for algorithms, allowing worker pools
-//! to be created by algorithm name (string).
+//! to be created by algorithm name (string), or with a custom algorithm factory
+//! via [`AlgorithmSpawner`].
 //!
-//! # Adding a New Algorithm
+//! # Adding a New Built-in Algorithm
 //!
 //! 1. Implement the `Algorithm` trait for your algorithm
-//! 2. Add a match arm in `spawn_workers` that creates your algorithm
+//! 2. Add a match arm in `AlgorithmSpawner::spawn` that creates your algorithm
 //! 3. Add the algorithm name to `AVAILABLE_ALGORITHMS`
 
 use std::{
@@ -25,7 +26,7 @@ use crate::{
     worker_pool::worker::SolverWorker,
 };
 
-/// List of available algorithm names.
+/// List of available built-in algorithm names (for registry-based dispatch).
 pub(crate) const AVAILABLE_ALGORITHMS: &[&str] = &["most_liquid"];
 
 /// Default algorithm to use if none specified.
@@ -33,7 +34,7 @@ pub(crate) const DEFAULT_ALGORITHM: &str = "most_liquid";
 
 /// Parameters for spawning workers.
 pub(crate) struct SpawnWorkersParams {
-    /// Algorithm name (e.g., "most_liquid").
+    /// Algorithm name (e.g., "most_liquid") — used for thread naming and logging.
     pub algorithm: String,
     /// Number of worker threads to spawn.
     pub num_workers: usize,
@@ -61,21 +62,55 @@ pub struct UnknownAlgorithmError {
     pub name: String,
 }
 
-/// Spawns worker threads for the specified algorithm.
+/// Determines how a worker pool spawns its workers.
 ///
-/// This is the core registry dispatch function. It matches on the algorithm name
-/// and creates the appropriate algorithm instance and workers.
-///
-/// # Returns
-///
-/// Vector of join handles for the spawned worker threads, or an error if the
-/// algorithm is not registered.
-pub(crate) fn spawn_workers(
-    params: SpawnWorkersParams,
-) -> Result<Vec<JoinHandle<()>>, UnknownAlgorithmError> {
-    match params.algorithm.as_str() {
-        "most_liquid" => Ok(spawn_most_liquid_workers(params)),
-        _ => Err(UnknownAlgorithmError { name: params.algorithm }),
+/// - `Registry`: looks up a built-in algorithm by name.
+/// - `Custom`: uses a caller-supplied factory closure, bypassing the registry.
+pub(crate) enum AlgorithmSpawner {
+    /// Spawn workers using a built-in algorithm looked up by name.
+    Registry { algorithm: String },
+    /// Spawn workers using a custom factory function (type-erased).
+    Custom {
+        algorithm: String,
+        spawner: Box<dyn Fn(SpawnWorkersParams) -> Vec<JoinHandle<()>> + Send + Sync>,
+    },
+}
+
+impl std::fmt::Debug for AlgorithmSpawner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Registry { algorithm } => f
+                .debug_struct("Registry")
+                .field("algorithm", algorithm)
+                .finish(),
+            Self::Custom { algorithm, .. } => f
+                .debug_struct("Custom")
+                .field("algorithm", algorithm)
+                .finish(),
+        }
+    }
+}
+
+impl AlgorithmSpawner {
+    /// Spawns workers, dispatching to the registry or custom spawner as appropriate.
+    pub(crate) fn spawn(
+        self,
+        params: SpawnWorkersParams,
+    ) -> Result<Vec<JoinHandle<()>>, UnknownAlgorithmError> {
+        match self {
+            Self::Registry { algorithm } => match algorithm.as_str() {
+                "most_liquid" => Ok(spawn_most_liquid_workers(params)),
+                _ => Err(UnknownAlgorithmError { name: algorithm }),
+            },
+            Self::Custom { spawner, .. } => Ok(spawner(params)),
+        }
+    }
+
+    /// Returns the algorithm name associated with this spawner.
+    pub(crate) fn algorithm_name(&self) -> &str {
+        match self {
+            Self::Registry { algorithm } | Self::Custom { algorithm, .. } => algorithm,
+        }
     }
 }
 
@@ -86,17 +121,18 @@ pub(crate) fn spawn_workers(
 /// - Setting up tokio runtimes
 /// - Initializing graphs and running worker loops
 ///
-/// The `create_algorithm` closure is called once per worker to create the
-/// algorithm-specific instance.
-fn spawn_workers_generic<A, F>(
+/// The `factory` closure is called once per worker to create the algorithm instance.
+/// It is borrowed rather than consumed, so callers (including type-erased spawner closures)
+/// can call this function without giving up ownership of the factory.
+pub(crate) fn spawn_workers_generic<A, F>(
     params: SpawnWorkersParams,
-    create_algorithm: F,
+    factory: &F,
 ) -> Vec<JoinHandle<()>>
 where
     A: crate::algorithm::Algorithm + 'static,
     A::GraphManager:
         crate::feed::events::MarketEventHandler + crate::graph::EdgeWeightUpdaterWithDerived,
-    F: Fn(&AlgorithmConfig) -> A + Send + Sync + Clone + 'static,
+    F: Fn(AlgorithmConfig) -> A + Clone + Send + Sync + 'static,
 {
     let mut workers = Vec::with_capacity(params.num_workers);
 
@@ -109,7 +145,7 @@ where
         let algorithm_config = params.algorithm_config.clone();
         let shutdown_rx = params.shutdown_tx.subscribe();
         let algorithm_name = params.algorithm.clone();
-        let create_algorithm = create_algorithm.clone();
+        let factory = factory.clone();
 
         let handle = thread::Builder::new()
             .name(format!("{}-worker-{}", algorithm_name, worker_id))
@@ -120,7 +156,7 @@ where
                     .expect("failed to create tokio runtime");
 
                 rt.block_on(async move {
-                    let algorithm = create_algorithm(&algorithm_config);
+                    let algorithm = factory(algorithm_config);
 
                     let mut worker =
                         SolverWorker::new(market_data, derived_data, algorithm, worker_id);
@@ -139,7 +175,7 @@ where
     info!(
         algorithm = %params.algorithm,
         num_workers = params.num_workers,
-        "spawned workers via registry"
+        "spawned workers"
     );
 
     workers
@@ -147,10 +183,11 @@ where
 
 /// Spawns workers for the MostLiquid algorithm.
 fn spawn_most_liquid_workers(params: SpawnWorkersParams) -> Vec<JoinHandle<()>> {
-    spawn_workers_generic(params, |config| {
-        MostLiquidAlgorithm::with_config(config.clone())
+    let factory = |config: AlgorithmConfig| {
+        MostLiquidAlgorithm::with_config(config)
             .expect("invalid worker configuration for MostLiquidAlgorithm")
-    })
+    };
+    spawn_workers_generic(params, &factory)
 }
 
 #[cfg(test)]
@@ -162,18 +199,16 @@ mod tests {
     use super::*;
     use crate::{derived::DerivedData, feed::market_data::SharedMarketData};
 
-    #[test]
-    fn test_spawn_workers_unknown_algorithm_returns_error() {
-        let (task_tx, task_rx) = async_channel::bounded(10);
+    fn make_params(algorithm: &str, num_workers: usize) -> SpawnWorkersParams {
+        let (_task_tx, task_rx) = async_channel::bounded(10);
         let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
         let derived_data = Arc::new(RwLock::new(DerivedData::new()));
-        let (event_tx, event_rx) = broadcast::channel(10);
+        let (_event_tx, event_rx) = broadcast::channel(10);
         let (_derived_event_tx, derived_event_rx) = broadcast::channel(10);
         let (shutdown_tx, _) = broadcast::channel(1);
-
-        let params = SpawnWorkersParams {
-            algorithm: "unknown_algorithm".to_string(),
-            num_workers: 1,
+        SpawnWorkersParams {
+            algorithm: algorithm.to_string(),
+            num_workers,
             algorithm_config: AlgorithmConfig::default(),
             task_rx,
             market_data,
@@ -181,31 +216,32 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx,
-        };
+        }
+    }
 
-        let result = spawn_workers(params);
+    #[test]
+    fn test_registry_unknown_algorithm_returns_error() {
+        let params = make_params("unknown_algorithm", 1);
+        let result =
+            AlgorithmSpawner::Registry { algorithm: "unknown_algorithm".to_string() }.spawn(params);
+
         assert!(result.is_err());
-
         let err = result.unwrap_err();
         assert_eq!(err.name, "unknown_algorithm");
         assert!(err
             .to_string()
             .contains("unknown_algorithm"));
-        assert!(err.to_string().contains("most_liquid")); // Should list available algorithms
-
-        // Cleanup
-        drop(task_tx);
-        drop(event_tx);
+        assert!(err.to_string().contains("most_liquid"));
     }
 
     #[test]
-    fn test_spawn_workers_creates_correct_number_of_workers() {
+    fn test_registry_spawns_correct_number_of_workers() {
+        let (shutdown_tx, _) = broadcast::channel(1);
         let (_task_tx, task_rx) = async_channel::bounded(10);
         let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
         let derived_data = Arc::new(RwLock::new(DerivedData::new()));
         let (event_tx, event_rx) = broadcast::channel(10);
         let (_derived_event_tx, derived_event_rx) = broadcast::channel(10);
-        let (shutdown_tx, _) = broadcast::channel(1);
 
         let params = SpawnWorkersParams {
             algorithm: "most_liquid".to_string(),
@@ -219,10 +255,10 @@ mod tests {
             shutdown_tx: shutdown_tx.clone(),
         };
 
-        let result = spawn_workers(params);
-        assert!(result.is_ok());
-
-        let workers = result.unwrap();
+        let workers =
+            AlgorithmSpawner::Registry { algorithm: "most_liquid".to_string() }.spawn(params);
+        assert!(workers.is_ok());
+        let workers = workers.unwrap();
         assert_eq!(workers.len(), 3);
 
         // Shutdown workers gracefully
@@ -233,5 +269,61 @@ mod tests {
             // Give workers time to shutdown, then check they finished
             let _ = handle.join();
         }
+    }
+
+    #[test]
+    fn test_custom_spawner_bypasses_registry_for_unknown_names() {
+        // "my_custom_algo" is not registered — the registry would reject it.
+        // The Custom spawner bypasses the registry and uses the factory directly.
+        let (shutdown_tx, _) = broadcast::channel(1);
+        let (_task_tx, task_rx) = async_channel::bounded(10);
+        let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
+        let derived_data = Arc::new(RwLock::new(DerivedData::new()));
+        let (event_tx, _) = broadcast::channel::<MarketEvent>(10);
+        let (derived_event_tx, _) = broadcast::channel(10);
+
+        let registry_err = AlgorithmSpawner::Registry { algorithm: "my_custom_algo".to_string() }
+            .spawn(SpawnWorkersParams {
+                algorithm: "my_custom_algo".to_string(),
+                num_workers: 1,
+                algorithm_config: AlgorithmConfig::default(),
+                task_rx: task_rx.clone(),
+                market_data: Arc::clone(&market_data),
+                derived_data: Arc::clone(&derived_data),
+                event_rx: event_tx.subscribe(),
+                derived_event_rx: derived_event_tx.subscribe(),
+                shutdown_tx: shutdown_tx.clone(),
+            });
+        assert!(registry_err.is_err());
+
+        // Using MostLiquid anyway for simplicity - not to have to define a new algorithm from
+        // scratch
+        let spawner: Box<dyn Fn(SpawnWorkersParams) -> Vec<JoinHandle<()>> + Send + Sync> =
+            Box::new(|p| {
+                let factory = |config: AlgorithmConfig| {
+                    MostLiquidAlgorithm::with_config(config)
+                        .expect("invalid config in test custom spawner")
+                };
+                spawn_workers_generic(p, &factory)
+            });
+
+        let workers = AlgorithmSpawner::Custom { algorithm: "my_custom_algo".to_string(), spawner }
+            .spawn(SpawnWorkersParams {
+                algorithm: "my_custom_algo".to_string(),
+                num_workers: 2,
+                algorithm_config: AlgorithmConfig::new(1, 2, Duration::from_millis(50), None)
+                    .unwrap(),
+                task_rx,
+                market_data,
+                derived_data,
+                event_rx: event_tx.subscribe(),
+                derived_event_rx: derived_event_tx.subscribe(),
+                shutdown_tx: shutdown_tx.clone(),
+            });
+
+        assert!(workers.is_ok());
+        assert_eq!(workers.unwrap().len(), 2);
+
+        let _ = shutdown_tx.send(());
     }
 }


### PR DESCRIPTION
Add WorkerPoolBuilder::with_algorithm() so callers can pass any Algorithm implementation directly without modifying the registry.

- Add AlgorithmSpawner enum (Registry | Custom) to registry.rs, replacing the spawn_workers free function; Custom stores a type-erased factory closure that bypasses the string-based registry
- WorkerPoolConfig.algorithm: String -> pub(crate) spawner: AlgorithmSpawner; add algorithm_name() public accessor; remove Clone (boxed closures are not Clone)
- WorkerPoolBuilder gains with_algorithm<A, F>() alongside the existing algorithm() method; existing .algorithm("most_liquid") call sites are unchanged
- spawn_workers_generic now takes factory: &F (borrow not consume) so the type- erased spawner closure can call it without giving up ownership of the factory
- Export ComputationRequirements from lib.rs so external Algorithm implementors can satisfy the trait return type
- Add examples/custom_algorithm.rs showing a delegating MyAlgorithm using with_algorithm("my_custom_algo", MyAlgorithm::new)

🤖 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>