### PR TITLE
feat: include derived data in readiness in health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,12 @@ Submit one or more swap orders and receive optimal routes.
 
 ### GET /v1/health
 
-Returns service health status. HTTP 200 if healthy, 503 if stale.
+Returns service health status. HTTP 200 if healthy, 503 if unhealthy.
+
+The service is healthy when market data is fresh (< 60s old) **and** derived data has 
+been computed at least once. The `derived_data_ready` field indicates overall readiness, 
+not per-block freshness — algorithms that require fresh derived data will wait for 
+recomputation before solving.
 
 ## Configuration
 

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -189,7 +189,7 @@ impl From<dto::BlockInfo> for BlockInfo {
 
 impl From<dto::HealthStatus> for HealthStatus {
     fn from(dh: dto::HealthStatus) -> Self {
-        HealthStatus::new(dh.healthy, dh.last_update_ms, dh.num_solver_pools)
+        HealthStatus::new(dh.healthy, dh.last_update_ms, dh.num_solver_pools, dh.derived_data_ready)
     }
 }
 

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -445,6 +445,7 @@ pub struct HealthStatus {
     healthy: bool,
     last_update_ms: u64,
     num_solver_pools: usize,
+    derived_data_ready: bool,
 }
 
 impl HealthStatus {
@@ -463,8 +464,22 @@ impl HealthStatus {
         self.num_solver_pools
     }
 
-    pub(crate) fn new(healthy: bool, last_update_ms: u64, num_solver_pools: usize) -> Self {
-        Self { healthy, last_update_ms, num_solver_pools }
+    /// Whether derived data has been computed at least once.
+    ///
+    /// This indicates overall readiness, not per-block freshness. Some algorithms
+    /// require fresh derived data for each block — they are ready to receive orders
+    /// but will wait for recomputation before solving.
+    pub fn derived_data_ready(&self) -> bool {
+        self.derived_data_ready
+    }
+
+    pub(crate) fn new(
+        healthy: bool,
+        last_update_ms: u64,
+        num_solver_pools: usize,
+        derived_data_ready: bool,
+    ) -> Self {
+        Self { healthy, last_update_ms, num_solver_pools, derived_data_ready }
     }
 }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,7 +142,7 @@ Actix Web HTTP handlers. Validates requests, delegates to OrderManager, returns 
 **Endpoints:**
 
 - `POST /v1/quote` -- Submit quote requests
-- `GET /v1/health` -- Health check (data freshness + pool count)
+- `GET /v1/health` -- Health check (data freshness, derived data readiness, pool count)
 - `GET /metrics` -- Prometheus metrics (separate server, port 9898)
 
 ---

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -388,6 +388,14 @@ pub struct HealthStatus {
     /// Number of active solver pools.
     #[cfg_attr(feature = "openapi", schema(example = 2))]
     pub num_solver_pools: usize,
+    /// Whether derived data has been computed at least once.
+    ///
+    /// This indicates overall readiness, not per-block freshness. Some algorithms
+    /// require fresh derived data for each block — they are ready to receive orders
+    /// but will wait for recomputation before solving.
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(example = true))]
+    pub derived_data_ready: bool,
 }
 
 /// Error response body.

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -100,12 +100,18 @@ pub async fn quote(
 )]
 pub async fn health(state: web::Data<AppState>) -> HttpResponse {
     let age_ms = state.health_tracker.age_ms().await;
-    let is_healthy = age_ms < 60_000; // Healthy if data less than 60s old
+    let data_fresh = age_ms < 60_000; // Healthy if data less than 60s old
+    let derived_data_ready = state
+        .health_tracker
+        .derived_data_ready()
+        .await;
+    let is_healthy = data_fresh && derived_data_ready;
 
     let status = dto::HealthStatus {
         healthy: is_healthy,
         last_update_ms: age_ms,
         num_solver_pools: state.order_manager.num_pools(),
+        derived_data_ready,
     };
 
     if is_healthy {

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -18,9 +18,10 @@ use std::{
 use actix_web::web;
 pub use dto::HealthStatus;
 pub use error::ApiError;
-#[cfg(feature = "experimental")]
-use fynd_core::derived::SharedDerivedDataRef;
-use fynd_core::{feed::market_data::SharedMarketDataRef, order_manager::OrderManager};
+use fynd_core::{
+    derived::SharedDerivedDataRef, feed::market_data::SharedMarketDataRef,
+    order_manager::OrderManager,
+};
 use handlers::configure_routes;
 #[cfg(feature = "experimental")]
 use tycho_simulation::tycho_common::models::Address;
@@ -64,17 +65,18 @@ pub struct ExperimentalApiDoc;
 
 /// Simple tracker for service health metrics.
 ///
-/// Reads the last update timestamp from SharedMarketData to determine
-/// how fresh the market data is.
+/// Reads the last update timestamp from SharedMarketData to determine how fresh the market data is,
+/// and checks derived data overall readiness.
 #[derive(Clone)]
 pub struct HealthTracker {
     market_data: SharedMarketDataRef,
+    derived_data: SharedDerivedDataRef,
 }
 
 impl HealthTracker {
     /// Creates a new health tracker.
-    pub fn new(market_data: SharedMarketDataRef) -> Self {
-        Self { market_data }
+    pub fn new(market_data: SharedMarketDataRef, derived_data: SharedDerivedDataRef) -> Self {
+        Self { market_data, derived_data }
     }
 
     /// Returns milliseconds since the last market data update.
@@ -92,6 +94,19 @@ impl HealthTracker {
             }
             None => u64::MAX, // Never updated
         }
+    }
+
+    /// Returns whether derived data has been computed at least once.
+    ///
+    /// This checks overall readiness (has any computation cycle completed), not per-block
+    /// freshness. Algorithms that require fresh derived data are ready to receive orders but
+    /// will wait for per-block recomputation before solving.
+    pub async fn derived_data_ready(&self) -> bool {
+        self.derived_data
+            .read()
+            .await
+            .last_block()
+            .is_some()
     }
 }
 

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -162,7 +162,6 @@ impl FyndBuilder {
 
         // Shared state
         let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
-        let health_tracker = HealthTracker::new(Arc::clone(&market_data));
 
         // Tycho feed
         let tycho_feed_config = TychoFeedConfig::new(
@@ -198,6 +197,8 @@ impl FyndBuilder {
             ComputationManager::new(computation_config, Arc::clone(&market_data))
                 .map_err(|e| anyhow::anyhow!("failed to create computation manager: {}", e))?;
         let derived_data: SharedDerivedDataRef = computation_manager.store();
+        let health_tracker =
+            HealthTracker::new(Arc::clone(&market_data), Arc::clone(&derived_data));
         let computation_event_rx = tycho_feed.subscribe();
         let (computation_shutdown_tx, computation_shutdown_rx) = tokio::sync::broadcast::channel(1);
 


### PR DESCRIPTION
## Summary

  The health endpoint only checked market data freshness, so it could report healthy while workers failed with "timeout waiting for derived data: missing {"token_prices"}". Now the service is reported as unhealthy until at least one derived data computation cycle completes.

  - Adds derived_data_ready field to HealthStatus response (serde(default) for backward compat)
  - Health returns 503 if market data is stale or derived data hasn't been computed yet
  - derived_data_ready reflects overall readiness, not per-block freshness — algorithms requiring fresh data will wait for recomputation before solving