### PR TITLE
feat(rpc): add GET /v1/prices endpoint for derived market data

### DIFF
--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -42,77 +42,6 @@
         }
       }
     },
-    "/v1/prices": {
-      "get": {
-        "tags": [
-          "prices"
-        ],
-        "summary": "GET /v1/prices - Return derived token prices and optional market data.",
-        "description": "By default returns token gas prices only. Use `include` query parameter\nto add spot prices and/or pool depths.\n\n# Query Parameters\n\n- `include` - Comma-separated list: `depths`, `spot_prices`\n- `limit` - Max entries for spot_prices / pool_depths (default: 1000)",
-        "operationId": "get_prices",
-        "parameters": [
-          {
-            "name": "include",
-            "in": "query",
-            "description": "Comma-separated list of additional data to include.\nValid values: `depths`, `spot_prices`.",
-            "required": false,
-            "schema": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "example": "depths,spot_prices"
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum number of spot_prices and pool_depths entries (default: 1000).",
-            "required": false,
-            "schema": {
-              "type": [
-                "integer",
-                "null"
-              ],
-              "minimum": 0
-            },
-            "example": 1000
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Prices returned",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PricesResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid query parameter",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Data not yet available",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/quote": {
       "post": {
         "tags": [
@@ -498,85 +427,6 @@
           }
         }
       },
-      "PoolDepthEntry": {
-        "type": "object",
-        "description": "A single directional pool depth.",
-        "required": [
-          "component_id",
-          "token_in",
-          "token_out",
-          "depth"
-        ],
-        "properties": {
-          "component_id": {
-            "$ref": "#/components/schemas/String",
-            "description": "Pool / component identifier."
-          },
-          "depth": {
-            "type": "string",
-            "description": "Maximum input amount before hitting the slippage threshold (decimal string)."
-          },
-          "token_in": {
-            "type": "string",
-            "description": "Input token address.",
-            "example": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
-          },
-          "token_out": {
-            "type": "string",
-            "description": "Output token address.",
-            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-          }
-        }
-      },
-      "PricesResponse": {
-        "type": "object",
-        "description": "Top-level response for GET /v1/prices.",
-        "required": [
-          "prices",
-          "gas_token",
-          "last_block"
-        ],
-        "properties": {
-          "gas_token": {
-            "type": "string",
-            "description": "The gas token address (e.g. WETH).",
-            "example": "0x0000000000000000000000000000000000000000"
-          },
-          "last_block": {
-            "type": "integer",
-            "format": "int64",
-            "description": "Block number at which prices were last computed.",
-            "minimum": 0
-          },
-          "pool_depths": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/PoolDepthEntry"
-            },
-            "description": "Pool depths per pool direction (only if requested via `include=depths`)."
-          },
-          "prices": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/TokenPriceEntry"
-            },
-            "description": "Token gas prices relative to the native gas token."
-          },
-          "spot_prices": {
-            "type": [
-              "array",
-              "null"
-            ],
-            "items": {
-              "$ref": "#/components/schemas/SpotPriceEntry"
-            },
-            "description": "Spot prices per pool direction (only if requested via `include=spot_prices`)."
-          }
-        }
-      },
       "Quote": {
         "type": "object",
         "description": "Complete solution for a [`QuoteRequest`].\n\nContains a solution for each order in the request, along with aggregate\ngas estimates and timing information.",
@@ -696,40 +546,6 @@
           }
         }
       },
-      "SpotPriceEntry": {
-        "type": "object",
-        "description": "A single directional spot price within a pool.",
-        "required": [
-          "component_id",
-          "token_in",
-          "token_out",
-          "price"
-        ],
-        "properties": {
-          "component_id": {
-            "$ref": "#/components/schemas/String",
-            "description": "Pool / component identifier."
-          },
-          "price": {
-            "type": "number",
-            "format": "double",
-            "description": "Spot price (1 token_in = price token_out)."
-          },
-          "token_in": {
-            "type": "string",
-            "description": "Input token address.",
-            "example": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
-          },
-          "token_out": {
-            "type": "string",
-            "description": "Output token address.",
-            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-          }
-        }
-      },
-      "String": {
-        "type": "string"
-      },
       "Swap": {
         "type": "object",
         "description": "A single swap within a route.\n\nRepresents an atomic swap on a specific liquidity pool (component).",
@@ -783,26 +599,6 @@
           "token_out": {
             "type": "string",
             "description": "Output token address.",
-            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-          }
-        }
-      },
-      "TokenPriceEntry": {
-        "type": "object",
-        "description": "A single token's gas price.",
-        "required": [
-          "token",
-          "price"
-        ],
-        "properties": {
-          "price": {
-            "type": "number",
-            "format": "double",
-            "description": "Price relative to gas token as a float."
-          },
-          "token": {
-            "type": "string",
-            "description": "Token address.",
             "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
           }
         }

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.3.1"
+    "version": "0.4.0"
   },
   "paths": {
     "/v1/health": {
@@ -35,6 +35,77 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HealthStatus"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/prices": {
+      "get": {
+        "tags": [
+          "prices"
+        ],
+        "summary": "GET /v1/prices - Return derived token prices and optional market data.",
+        "description": "By default returns token gas prices only. Use `include` query parameter\nto add spot prices and/or pool depths.\n\n# Query Parameters\n\n- `include` - Comma-separated list: `depths`, `spot_prices`\n- `limit` - Max entries for spot_prices / pool_depths (default: 1000)",
+        "operationId": "get_prices",
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Comma-separated list of additional data to include.\nValid values: `depths`, `spot_prices`.",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "example": "depths,spot_prices"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of spot_prices and pool_depths entries (default: 1000).",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 0
+            },
+            "example": 1000
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Prices returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PricesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Data not yet available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
                 }
               }
             }
@@ -427,6 +498,85 @@
           }
         }
       },
+      "PoolDepthEntry": {
+        "type": "object",
+        "description": "A single directional pool depth.",
+        "required": [
+          "component_id",
+          "token_in",
+          "token_out",
+          "depth"
+        ],
+        "properties": {
+          "component_id": {
+            "$ref": "#/components/schemas/String",
+            "description": "Pool / component identifier."
+          },
+          "depth": {
+            "type": "string",
+            "description": "Maximum input amount before hitting the slippage threshold (decimal string)."
+          },
+          "token_in": {
+            "type": "string",
+            "description": "Input token address.",
+            "example": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          },
+          "token_out": {
+            "type": "string",
+            "description": "Output token address.",
+            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          }
+        }
+      },
+      "PricesResponse": {
+        "type": "object",
+        "description": "Top-level response for GET /v1/prices.",
+        "required": [
+          "prices",
+          "gas_token",
+          "last_block"
+        ],
+        "properties": {
+          "gas_token": {
+            "type": "string",
+            "description": "The gas token address (e.g. WETH).",
+            "example": "0x0000000000000000000000000000000000000000"
+          },
+          "last_block": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Block number at which prices were last computed.",
+            "minimum": 0
+          },
+          "pool_depths": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/PoolDepthEntry"
+            },
+            "description": "Pool depths per pool direction (only if requested via `include=depths`)."
+          },
+          "prices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TokenPriceEntry"
+            },
+            "description": "Token gas prices relative to the native gas token."
+          },
+          "spot_prices": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/SpotPriceEntry"
+            },
+            "description": "Spot prices per pool direction (only if requested via `include=spot_prices`)."
+          }
+        }
+      },
       "Quote": {
         "type": "object",
         "description": "Complete solution for a [`QuoteRequest`].\n\nContains a solution for each order in the request, along with aggregate\ngas estimates and timing information.",
@@ -546,6 +696,40 @@
           }
         }
       },
+      "SpotPriceEntry": {
+        "type": "object",
+        "description": "A single directional spot price within a pool.",
+        "required": [
+          "component_id",
+          "token_in",
+          "token_out",
+          "price"
+        ],
+        "properties": {
+          "component_id": {
+            "$ref": "#/components/schemas/String",
+            "description": "Pool / component identifier."
+          },
+          "price": {
+            "type": "number",
+            "format": "double",
+            "description": "Spot price (1 token_in = price token_out)."
+          },
+          "token_in": {
+            "type": "string",
+            "description": "Input token address.",
+            "example": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+          },
+          "token_out": {
+            "type": "string",
+            "description": "Output token address.",
+            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          }
+        }
+      },
+      "String": {
+        "type": "string"
+      },
       "Swap": {
         "type": "object",
         "description": "A single swap within a route.\n\nRepresents an atomic swap on a specific liquidity pool (component).",
@@ -599,6 +783,26 @@
           "token_out": {
             "type": "string",
             "description": "Output token address.",
+            "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+          }
+        }
+      },
+      "TokenPriceEntry": {
+        "type": "object",
+        "description": "A single token's gas price.",
+        "required": [
+          "token",
+          "price"
+        ],
+        "properties": {
+          "price": {
+            "type": "number",
+            "format": "double",
+            "description": "Price relative to gas token as a float."
+          },
+          "token": {
+            "type": "string",
+            "description": "Token address.",
             "example": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
           }
         }

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.4.0"
+    "version": "0.5.0"
   },
   "paths": {
     "/v1/health": {

--- a/fynd-rpc/Cargo.toml
+++ b/fynd-rpc/Cargo.toml
@@ -29,5 +29,8 @@ metrics.workspace = true
 hex = "0.4"
 tycho-execution.workspace = true
 
+[features]
+experimental = []
+
 [dev-dependencies]
 rstest.workspace = true

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -1,25 +1,26 @@
 //! HTTP request handlers for the solver API.
 
 use actix_web::{web, HttpResponse};
-use tracing::{info, instrument, warn};
+use tracing::{info, instrument};
+#[cfg(feature = "experimental")]
+use tracing::warn;
 
 use super::{dto, ApiError, AppState};
-use crate::api::{
-    error::ErrorResponse,
-    prices::{
-        price_to_f64, IncludeField, PoolDepthEntry, PricesQuery, PricesResponse, SpotPriceEntry,
-        TokenPriceEntry,
-    },
+use crate::api::error::ErrorResponse;
+#[cfg(feature = "experimental")]
+use crate::api::prices::{
+    price_to_f64, IncludeField, PoolDepthEntry, PricesQuery, PricesResponse, SpotPriceEntry,
+    TokenPriceEntry,
 };
 
 /// Configures API routes under /v1 namespace.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
-    cfg.service(
-        web::scope("/v1")
-            .route("/quote", web::post().to(quote))
-            .route("/health", web::get().to(health))
-            .route("/prices", web::get().to(get_prices)),
-    );
+    let scope = web::scope("/v1")
+        .route("/quote", web::post().to(quote))
+        .route("/health", web::get().to(health));
+    #[cfg(feature = "experimental")]
+    let scope = scope.route("/prices", web::get().to(get_prices));
+    cfg.service(scope);
 }
 
 /// POST /v1/quote - Request a quote.
@@ -114,9 +115,11 @@ pub async fn health(state: web::Data<AppState>) -> HttpResponse {
     }
 }
 
+#[cfg(feature = "experimental")]
 /// Default limit for spot_prices and pool_depths entries.
 const DEFAULT_PRICES_LIMIT: usize = 1000;
 
+#[cfg(feature = "experimental")]
 /// GET /v1/prices - Return derived token prices and optional market data.
 ///
 /// By default returns token gas prices only. Use `include` query parameter

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -1,9 +1,9 @@
 //! HTTP request handlers for the solver API.
 
 use actix_web::{web, HttpResponse};
-use tracing::{info, instrument};
 #[cfg(feature = "experimental")]
 use tracing::warn;
+use tracing::{info, instrument};
 
 use super::{dto, ApiError, AppState};
 use crate::api::error::ErrorResponse;

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -1,17 +1,24 @@
 //! HTTP request handlers for the solver API.
 
 use actix_web::{web, HttpResponse};
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use super::{dto, ApiError, AppState};
-use crate::api::error::ErrorResponse;
+use crate::api::{
+    error::ErrorResponse,
+    prices::{
+        IncludeField, PoolDepthEntry, PricesQuery, PricesResponse, SpotPriceEntry,
+        TokenPriceEntry, price_to_f64,
+    },
+};
 
 /// Configures API routes under /v1 namespace.
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/v1")
             .route("/quote", web::post().to(quote))
-            .route("/health", web::get().to(health)),
+            .route("/health", web::get().to(health))
+            .route("/prices", web::get().to(get_prices)),
     );
 }
 
@@ -105,6 +112,136 @@ pub async fn health(state: web::Data<AppState>) -> HttpResponse {
     } else {
         HttpResponse::ServiceUnavailable().json(status)
     }
+}
+
+/// Default limit for spot_prices and pool_depths entries.
+const DEFAULT_PRICES_LIMIT: usize = 1000;
+
+/// GET /v1/prices - Return derived token prices and optional market data.
+///
+/// By default returns token gas prices only. Use `include` query parameter
+/// to add spot prices and/or pool depths.
+///
+/// # Query Parameters
+///
+/// - `include` - Comma-separated list: `depths`, `spot_prices`
+/// - `limit` - Max entries for spot_prices / pool_depths (default: 1000)
+#[utoipa::path(
+    get,
+    path = "/v1/prices",
+    tag = "prices",
+    params(PricesQuery),
+    responses(
+        (status = 200, description = "Prices returned", body = PricesResponse),
+        (status = 400, description = "Invalid query parameter", body = ErrorResponse),
+        (status = 503, description = "Data not yet available", body = ErrorResponse),
+    )
+)]
+#[instrument(skip(state))]
+pub async fn get_prices(
+    state: web::Data<AppState>,
+    query: web::Query<PricesQuery>,
+) -> Result<HttpResponse, ApiError> {
+    // Parse include fields (reject unknowns with 400)
+    let include_fields = match &query.include {
+        Some(raw) => IncludeField::parse_include(raw)
+            .map_err(ApiError::BadRequest)?,
+        None => vec![],
+    };
+    let limit = query.limit.unwrap_or(DEFAULT_PRICES_LIMIT);
+    let want_depths = include_fields.contains(&IncludeField::Depths);
+    let want_spot = include_fields.contains(&IncludeField::SpotPrices);
+
+    // Acquire read lock, check staleness first (avoid cloning if 503), then clone
+    let store = state.derived_data.read().await;
+    let last_block = store
+        .last_block()
+        .ok_or(ApiError::StaleData { age_ms: u64::MAX })?;
+    let token_prices = store.token_prices().cloned();
+    let spot_prices_data = if want_spot { store.spot_prices().cloned() } else { None };
+    let pool_depths_data = if want_depths { store.pool_depths().cloned() } else { None };
+    drop(store);
+
+    // Convert token gas prices
+    let mut prices = Vec::new();
+    if let Some(token_prices) = &token_prices {
+        for (address, price) in token_prices {
+            match price_to_f64(&price.numerator, &price.denominator) {
+                Some(f) => {
+                    prices.push(TokenPriceEntry {
+                        token: address.clone(),
+                        price: f,
+                    });
+                }
+                None => {
+                    warn!(
+                        token = %address,
+                        "skipping token with unconvertible price (zero denom or overflow)"
+                    );
+                }
+            }
+        }
+    }
+    // Convert spot prices if requested (sorted for deterministic limit)
+    let spot_prices = if want_spot {
+        let mut entries: Vec<SpotPriceEntry> = spot_prices_data
+            .into_iter()
+            .flatten()
+            .map(|((component_id, token_in, token_out), price)| SpotPriceEntry {
+                component_id,
+                token_in,
+                token_out,
+                price,
+            })
+            .collect();
+        entries.sort_by(|a, b| {
+            (&a.component_id, &a.token_in, &a.token_out)
+                .cmp(&(&b.component_id, &b.token_in, &b.token_out))
+        });
+        entries.truncate(limit);
+        Some(entries)
+    } else {
+        None
+    };
+
+    // Convert pool depths if requested (sorted for deterministic limit)
+    let pool_depths = if want_depths {
+        let mut entries: Vec<PoolDepthEntry> = pool_depths_data
+            .into_iter()
+            .flatten()
+            .map(|((component_id, token_in, token_out), depth)| PoolDepthEntry {
+                component_id,
+                token_in,
+                token_out,
+                depth: depth.to_string(),
+            })
+            .collect();
+        entries.sort_by(|a, b| {
+            (&a.component_id, &a.token_in, &a.token_out)
+                .cmp(&(&b.component_id, &b.token_in, &b.token_out))
+        });
+        entries.truncate(limit);
+        Some(entries)
+    } else {
+        None
+    };
+
+    let response = PricesResponse {
+        prices,
+        gas_token: state.gas_token.clone(),
+        last_block,
+        spot_prices,
+        pool_depths,
+    };
+
+    info!(
+        num_tokens = response.prices.len(),
+        has_spot = response.spot_prices.is_some(),
+        has_depths = response.pool_depths.is_some(),
+        "prices response"
+    );
+
+    Ok(HttpResponse::Ok().json(response))
 }
 
 #[cfg(test)]

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -7,8 +7,8 @@ use super::{dto, ApiError, AppState};
 use crate::api::{
     error::ErrorResponse,
     prices::{
-        IncludeField, PoolDepthEntry, PricesQuery, PricesResponse, SpotPriceEntry,
-        TokenPriceEntry, price_to_f64,
+        price_to_f64, IncludeField, PoolDepthEntry, PricesQuery, PricesResponse, SpotPriceEntry,
+        TokenPriceEntry,
     },
 };
 
@@ -144,11 +144,12 @@ pub async fn get_prices(
 ) -> Result<HttpResponse, ApiError> {
     // Parse include fields (reject unknowns with 400)
     let include_fields = match &query.include {
-        Some(raw) => IncludeField::parse_include(raw)
-            .map_err(ApiError::BadRequest)?,
+        Some(raw) => IncludeField::parse_include(raw).map_err(ApiError::BadRequest)?,
         None => vec![],
     };
-    let limit = query.limit.unwrap_or(DEFAULT_PRICES_LIMIT);
+    let limit = query
+        .limit
+        .unwrap_or(DEFAULT_PRICES_LIMIT);
     let want_depths = include_fields.contains(&IncludeField::Depths);
     let want_spot = include_fields.contains(&IncludeField::SpotPrices);
 
@@ -168,10 +169,7 @@ pub async fn get_prices(
         for (address, price) in token_prices {
             match price_to_f64(&price.numerator, &price.denominator) {
                 Some(f) => {
-                    prices.push(TokenPriceEntry {
-                        token: address.clone(),
-                        price: f,
-                    });
+                    prices.push(TokenPriceEntry { token: address.clone(), price: f });
                 }
                 None => {
                     warn!(
@@ -195,8 +193,11 @@ pub async fn get_prices(
             })
             .collect();
         entries.sort_by(|a, b| {
-            (&a.component_id, &a.token_in, &a.token_out)
-                .cmp(&(&b.component_id, &b.token_in, &b.token_out))
+            (&a.component_id, &a.token_in, &a.token_out).cmp(&(
+                &b.component_id,
+                &b.token_in,
+                &b.token_out,
+            ))
         });
         entries.truncate(limit);
         Some(entries)
@@ -217,8 +218,11 @@ pub async fn get_prices(
             })
             .collect();
         entries.sort_by(|a, b| {
-            (&a.component_id, &a.token_in, &a.token_out)
-                .cmp(&(&b.component_id, &b.token_in, &b.token_out))
+            (&a.component_id, &a.token_in, &a.token_out).cmp(&(
+                &b.component_id,
+                &b.token_in,
+                &b.token_out,
+            ))
         });
         entries.truncate(limit);
         Some(entries)

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -7,6 +7,7 @@
 pub mod dto;
 pub mod error;
 pub mod handlers;
+pub mod prices;
 
 use std::{
     sync::Arc,
@@ -16,16 +17,23 @@ use std::{
 use actix_web::web;
 pub use dto::HealthStatus;
 pub use error::ApiError;
-use fynd_core::{feed::market_data::SharedMarketDataRef, order_manager::OrderManager};
+use fynd_core::{
+    derived::SharedDerivedDataRef, feed::market_data::SharedMarketDataRef,
+    order_manager::OrderManager,
+};
 use handlers::configure_routes;
+use tycho_simulation::tycho_common::models::Address;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::api::error::ErrorResponse;
+use crate::api::{
+    error::ErrorResponse,
+    prices::{PoolDepthEntry, PricesResponse, SpotPriceEntry, TokenPriceEntry},
+};
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(handlers::quote, handlers::health),
+    paths(handlers::quote, handlers::health, handlers::get_prices),
     components(schemas(
         dto::QuoteRequest,
         dto::Order,
@@ -39,6 +47,10 @@ use crate::api::error::ErrorResponse;
         dto::BlockInfo,
         HealthStatus,
         ErrorResponse,
+        PricesResponse,
+        TokenPriceEntry,
+        SpotPriceEntry,
+        PoolDepthEntry,
     ))
 )]
 pub struct ApiDoc;
@@ -83,12 +95,26 @@ pub struct AppState {
     pub order_manager: Arc<OrderManager>,
     /// Health tracker for monitoring data freshness.
     pub health_tracker: HealthTracker,
+    /// Shared derived data (token prices, spot prices, pool depths).
+    pub derived_data: SharedDerivedDataRef,
+    /// Gas token address for this chain (e.g. WETH).
+    pub gas_token: Address,
 }
 
 impl AppState {
     /// Creates new application state.
-    pub fn new(order_manager: OrderManager, health_tracker: HealthTracker) -> Self {
-        Self { order_manager: Arc::new(order_manager), health_tracker }
+    pub fn new(
+        order_manager: OrderManager,
+        health_tracker: HealthTracker,
+        derived_data: SharedDerivedDataRef,
+        gas_token: Address,
+    ) -> Self {
+        Self {
+            order_manager: Arc::new(order_manager),
+            health_tracker,
+            derived_data,
+            gas_token,
+        }
     }
 }
 

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -109,12 +109,7 @@ impl AppState {
         derived_data: SharedDerivedDataRef,
         gas_token: Address,
     ) -> Self {
-        Self {
-            order_manager: Arc::new(order_manager),
-            health_tracker,
-            derived_data,
-            gas_token,
-        }
+        Self { order_manager: Arc::new(order_manager), health_tracker, derived_data, gas_token }
     }
 }
 

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -7,6 +7,7 @@
 pub mod dto;
 pub mod error;
 pub mod handlers;
+#[cfg(feature = "experimental")]
 pub mod prices;
 
 use std::{
@@ -17,23 +18,23 @@ use std::{
 use actix_web::web;
 pub use dto::HealthStatus;
 pub use error::ApiError;
-use fynd_core::{
-    derived::SharedDerivedDataRef, feed::market_data::SharedMarketDataRef,
-    order_manager::OrderManager,
-};
+#[cfg(feature = "experimental")]
+use fynd_core::derived::SharedDerivedDataRef;
+use fynd_core::{feed::market_data::SharedMarketDataRef, order_manager::OrderManager};
 use handlers::configure_routes;
+#[cfg(feature = "experimental")]
 use tycho_simulation::tycho_common::models::Address;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use crate::api::{
-    error::ErrorResponse,
-    prices::{PoolDepthEntry, PricesResponse, SpotPriceEntry, TokenPriceEntry},
-};
+use crate::api::error::ErrorResponse;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(handlers::quote, handlers::health, handlers::get_prices),
+    paths(
+        handlers::quote,
+        handlers::health,
+    ),
     components(schemas(
         dto::QuoteRequest,
         dto::Order,
@@ -47,13 +48,22 @@ use crate::api::{
         dto::BlockInfo,
         HealthStatus,
         ErrorResponse,
-        PricesResponse,
-        TokenPriceEntry,
-        SpotPriceEntry,
-        PoolDepthEntry,
     ))
 )]
 pub struct ApiDoc;
+
+#[cfg(feature = "experimental")]
+#[derive(OpenApi)]
+#[openapi(
+    paths(handlers::get_prices),
+    components(schemas(
+        prices::PricesResponse,
+        prices::TokenPriceEntry,
+        prices::SpotPriceEntry,
+        prices::PoolDepthEntry,
+    ))
+)]
+pub struct ExperimentalApiDoc;
 
 /// Simple tracker for service health metrics.
 ///
@@ -96,8 +106,10 @@ pub struct AppState {
     /// Health tracker for monitoring data freshness.
     pub health_tracker: HealthTracker,
     /// Shared derived data (token prices, spot prices, pool depths).
+    #[cfg(feature = "experimental")]
     pub derived_data: SharedDerivedDataRef,
     /// Gas token address for this chain (e.g. WETH).
+    #[cfg(feature = "experimental")]
     pub gas_token: Address,
 }
 
@@ -106,16 +118,30 @@ impl AppState {
     pub fn new(
         order_manager: OrderManager,
         health_tracker: HealthTracker,
-        derived_data: SharedDerivedDataRef,
-        gas_token: Address,
+        #[cfg(feature = "experimental")] derived_data: SharedDerivedDataRef,
+        #[cfg(feature = "experimental")] gas_token: Address,
     ) -> Self {
-        Self { order_manager: Arc::new(order_manager), health_tracker, derived_data, gas_token }
+        Self {
+            order_manager: Arc::new(order_manager),
+            health_tracker,
+            #[cfg(feature = "experimental")]
+            derived_data,
+            #[cfg(feature = "experimental")]
+            gas_token,
+        }
     }
 }
 
 /// Configures the Actix Web application with routes and state.
 pub fn configure_app(cfg: &mut web::ServiceConfig, state: AppState) {
+    #[allow(unused_mut)]
+    let mut openapi = ApiDoc::openapi();
+    #[cfg(feature = "experimental")]
+    {
+        let experimental = ExperimentalApiDoc::openapi();
+        openapi.merge(experimental);
+    }
     cfg.app_data(web::Data::new(state))
         .configure(configure_routes)
-        .service(SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", ApiDoc::openapi()));
+        .service(SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", openapi));
 }

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -31,10 +31,7 @@ use crate::api::error::ErrorResponse;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(
-        handlers::quote,
-        handlers::health,
-    ),
+    paths(handlers::quote, handlers::health,),
     components(schemas(
         dto::QuoteRequest,
         dto::Order,

--- a/fynd-rpc/src/api/prices.rs
+++ b/fynd-rpc/src/api/prices.rs
@@ -1,0 +1,216 @@
+//! Types and helpers for the GET /v1/prices endpoint.
+
+use std::fmt;
+
+use fynd_core::types::ComponentId;
+use serde::{Deserialize, Serialize};
+use tycho_simulation::tycho_common::models::Address;
+use utoipa::{IntoParams, ToSchema};
+
+/// Query parameters for GET /v1/prices.
+#[derive(Debug, Default, Deserialize, IntoParams)]
+pub struct PricesQuery {
+    /// Comma-separated list of additional data to include.
+    /// Valid values: `depths`, `spot_prices`.
+    #[param(example = "depths,spot_prices")]
+    pub include: Option<String>,
+    /// Maximum number of spot_prices and pool_depths entries (default: 1000).
+    #[param(example = 1000)]
+    pub limit: Option<usize>,
+}
+
+/// Parsed variant of the `include` query parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IncludeField {
+    Depths,
+    SpotPrices,
+}
+
+impl IncludeField {
+    /// Parses a comma-separated include string into validated fields.
+    ///
+    /// Returns an error with the first unrecognised value.
+    pub fn parse_include(raw: &str) -> Result<Vec<Self>, String> {
+        let mut fields = Vec::new();
+        for part in raw.split(',') {
+            let trimmed = part.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match trimmed {
+                "depths" => fields.push(Self::Depths),
+                "spot_prices" => fields.push(Self::SpotPrices),
+                other => {
+                    return Err(format!(
+                        "unknown include field '{}'. Valid values: depths, spot_prices",
+                        other,
+                    ));
+                }
+            }
+        }
+        Ok(fields)
+    }
+}
+
+impl fmt::Display for IncludeField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Depths => write!(f, "depths"),
+            Self::SpotPrices => write!(f, "spot_prices"),
+        }
+    }
+}
+
+/// Top-level response for GET /v1/prices.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PricesResponse {
+    /// Token gas prices relative to the native gas token.
+    pub prices: Vec<TokenPriceEntry>,
+    /// The gas token address (e.g. WETH).
+    #[schema(value_type = String, example = "0x0000000000000000000000000000000000000000")]
+    pub gas_token: Address,
+    /// Block number at which prices were last computed.
+    pub last_block: u64,
+    /// Spot prices per pool direction (only if requested via `include=spot_prices`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spot_prices: Option<Vec<SpotPriceEntry>>,
+    /// Pool depths per pool direction (only if requested via `include=depths`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pool_depths: Option<Vec<PoolDepthEntry>>,
+}
+
+/// A single token's gas price.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TokenPriceEntry {
+    /// Token address.
+    #[schema(value_type = String, example = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")]
+    pub token: Address,
+    /// Price relative to gas token as a float.
+    pub price: f64,
+}
+
+/// A single directional spot price within a pool.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SpotPriceEntry {
+    /// Pool / component identifier.
+    pub component_id: ComponentId,
+    /// Input token address.
+    #[schema(value_type = String, example = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
+    pub token_in: Address,
+    /// Output token address.
+    #[schema(value_type = String, example = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")]
+    pub token_out: Address,
+    /// Spot price (1 token_in = price token_out).
+    pub price: f64,
+}
+
+/// A single directional pool depth.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PoolDepthEntry {
+    /// Pool / component identifier.
+    pub component_id: ComponentId,
+    /// Input token address.
+    #[schema(value_type = String, example = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
+    pub token_in: Address,
+    /// Output token address.
+    #[schema(value_type = String, example = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")]
+    pub token_out: Address,
+    /// Maximum input amount before hitting the slippage threshold (decimal string).
+    pub depth: String,
+}
+
+/// Convert a `tycho_core::Price { numerator, denominator }` to f64.
+///
+/// Returns `None` if the denominator is zero or if either value overflows f64.
+/// Note: f64 prices are approximate and suitable for TVL calculations,
+/// not for execution-critical amounts.
+pub fn price_to_f64(
+    numerator: &num_bigint::BigUint,
+    denominator: &num_bigint::BigUint,
+) -> Option<f64> {
+    use num_traits::{ToPrimitive, Zero};
+
+    if denominator.is_zero() {
+        return None;
+    }
+    let n = numerator.to_f64()?;
+    let d = denominator.to_f64()?;
+    Some(n / d)
+}
+
+#[cfg(test)]
+mod tests {
+    use num_bigint::BigUint;
+
+    use super::*;
+
+    // ---- IncludeField parsing ----
+
+    #[test]
+    fn parse_include_empty() {
+        assert_eq!(IncludeField::parse_include("").unwrap(), vec![]);
+    }
+
+    #[test]
+    fn parse_include_depths() {
+        let fields = IncludeField::parse_include("depths").unwrap();
+        assert_eq!(fields, vec![IncludeField::Depths]);
+    }
+
+    #[test]
+    fn parse_include_spot_prices() {
+        let fields = IncludeField::parse_include("spot_prices").unwrap();
+        assert_eq!(fields, vec![IncludeField::SpotPrices]);
+    }
+
+    #[test]
+    fn parse_include_both() {
+        let fields = IncludeField::parse_include("depths,spot_prices").unwrap();
+        assert_eq!(fields, vec![IncludeField::Depths, IncludeField::SpotPrices]);
+    }
+
+    #[test]
+    fn parse_include_with_whitespace() {
+        let fields = IncludeField::parse_include(" depths , spot_prices ").unwrap();
+        assert_eq!(fields, vec![IncludeField::Depths, IncludeField::SpotPrices]);
+    }
+
+    #[test]
+    fn parse_include_unknown_rejects() {
+        let err = IncludeField::parse_include("depths,foobar").unwrap_err();
+        assert!(err.contains("foobar"));
+    }
+
+    // ---- Price to f64 conversion ----
+
+    #[test]
+    fn price_to_f64_normal() {
+        let n = BigUint::from(3u64);
+        let d = BigUint::from(10u64);
+        let result = price_to_f64(&n, &d).unwrap();
+        assert!((result - 0.3).abs() < 1e-10);
+    }
+
+    #[test]
+    fn price_to_f64_zero_denominator() {
+        let n = BigUint::from(1u64);
+        let d = BigUint::from(0u64);
+        assert!(price_to_f64(&n, &d).is_none());
+    }
+
+    #[test]
+    fn price_to_f64_large_values() {
+        let n = BigUint::from(10u64).pow(18);
+        let d = BigUint::from(10u64).pow(18);
+        let result = price_to_f64(&n, &d).unwrap();
+        assert!((result - 1.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn price_to_f64_small_fraction() {
+        let n = BigUint::from(1u64);
+        let d = BigUint::from(10u64).pow(6);
+        let result = price_to_f64(&n, &d).unwrap();
+        assert!((result - 1e-6).abs() < 1e-15);
+    }
+}

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -272,8 +272,14 @@ impl FyndBuilder {
             .with_min_responses(self.order_manager_min_responses);
         let order_manager = OrderManager::new(solver_pool_handles, order_manager_config);
 
-        let app_state =
-            AppState::new(order_manager, health_tracker, Arc::clone(&derived_data), gas_token);
+        let app_state = AppState::new(
+            order_manager,
+            health_tracker,
+            #[cfg(feature = "experimental")]
+            Arc::clone(&derived_data),
+            #[cfg(feature = "experimental")]
+            gas_token,
+        );
 
         let server = HttpServer::new(move || {
             App::new()

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -272,12 +272,8 @@ impl FyndBuilder {
             .with_min_responses(self.order_manager_min_responses);
         let order_manager = OrderManager::new(solver_pool_handles, order_manager_config);
 
-        let app_state = AppState::new(
-            order_manager,
-            health_tracker,
-            Arc::clone(&derived_data),
-            gas_token,
-        );
+        let app_state =
+            AppState::new(order_manager, health_tracker, Arc::clone(&derived_data), gas_token);
 
         let server = HttpServer::new(move || {
             App::new()

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -192,7 +192,7 @@ impl FyndBuilder {
         // Computation manager for derived data (token prices, pool depths)
         let gas_token = native_token(&self.chain).context("gas token not configured for chain")?;
         let computation_config = ComputationManagerConfig::new()
-            .with_gas_token(gas_token)
+            .with_gas_token(gas_token.clone())
             .with_depth_slippage_threshold(defaults::DEPTH_SLIPPAGE_THRESHOLD);
         let (computation_manager, _derived_event_rx) =
             ComputationManager::new(computation_config, Arc::clone(&market_data))
@@ -272,7 +272,12 @@ impl FyndBuilder {
             .with_min_responses(self.order_manager_min_responses);
         let order_manager = OrderManager::new(solver_pool_handles, order_manager_config);
 
-        let app_state = AppState::new(order_manager, health_tracker);
+        let app_state = AppState::new(
+            order_manager,
+            health_tracker,
+            Arc::clone(&derived_data),
+            gas_token,
+        );
 
         let server = HttpServer::new(move || {
             App::new()


### PR DESCRIPTION
## Summary

- Adds `GET /v1/prices` endpoint that returns derived token gas prices, with optional spot prices and pool depths via `include` query parameter
- **Feature-gated behind `experimental`** (off by default). Enable with `--features experimental` to opt in.
- Extends `AppState` with `derived_data` (SharedDerivedDataRef) and `gas_token` (Address), both gated behind the same feature flag
- Wires the existing `ComputationManager` store into the HTTP layer

## Details

By default returns token prices only. Callers opt into additional data:

- `GET /v1/prices` returns token gas prices
- `GET /v1/prices?include=spot_prices` adds spot prices
- `GET /v1/prices?include=depths` adds pool depths
- `GET /v1/prices?include=depths,spot_prices&limit=500` returns everything, capped

Key design decisions:
- RwLock read acquired, staleness checked first, data cloned, lock dropped before serialization
- Spot prices and pool depths sorted by `(component_id, token_in, token_out)` for deterministic limit truncation
- Unknown `include` values return 400; no derived data yet returns 503
- `Price` (BigUint fraction) converted to f64 with zero-denom/overflow guard

### Feature gate

The entire endpoint is behind `#[cfg(feature = "experimental")]`:
- `prices` module, route registration, handler, and OpenAPI schemas
- `AppState.derived_data` and `AppState.gas_token` fields
- Separate `ExperimentalApiDoc` merged into OpenAPI spec only when enabled
- The checked-in `openapi.json` reflects the default (non-experimental) build

## Test plan

- [x] `cargo check` passes without the feature
- [x] `cargo check --features experimental` passes
- [x] `cargo clippy -p fynd-rpc -- -D warnings` zero warnings (both configs)
- [x] `cargo test -p fynd-rpc --features experimental` 12/12 pass (10 new: 6 include-parsing, 4 price-conversion)
- [ ] Manual test against running instance with `curl /v1/prices?include=depths,spot_prices`