### PR TITLE
fix: quote endpoint, block hash encoding, and quote example

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,7 +89,7 @@ jobs:
           cargo run --locked -- openapi | jq 'del(.info.version)' > /tmp/openapi.json
           jq 'del(.info.version)' clients/openapi.json > /tmp/openapi_committed.json
           if ! diff -q /tmp/openapi_committed.json /tmp/openapi.json > /dev/null 2>&1; then
-            echo "clients/openapi.json is out of date. Run 'cargo run -- openapi > clients/openapi.json' and commit."
+            echo "clients/openapi.json is out of date. Run './scripts/update-openapi.sh' and commit the changed files."
             diff /tmp/openapi_committed.json /tmp/openapi.json
             exit 1
           fi
@@ -109,8 +109,7 @@ jobs:
       - name: Check autogen schema is up to date
         run: |
           if ! diff -q clients/typescript/autogen/src/schema.d.ts /tmp/schema.d.ts > /dev/null 2>&1; then
-            echo "clients/typescript/autogen/src/schema.d.ts is out of date."
-            echo "Regenerate by running: openapi-typescript clients/openapi.json -o clients/typescript/autogen/src/schema.d.ts"
+            echo "clients/typescript/autogen/src/schema.d.ts is out of date. Run './scripts/update-openapi.sh' and commit the changed files."
             diff clients/typescript/autogen/src/schema.d.ts /tmp/schema.d.ts
             exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "alloy",
  "bytes",
  "fynd-rpc-types",
+ "hex",
  "num-bigint",
  "num-traits",
  "reqwest",

--- a/clients/README.md
+++ b/clients/README.md
@@ -12,24 +12,31 @@ clients/
     autogen/                # Auto-generated TypeScript types + fetch client
 ```
 
-## Regenerating clients/openapi.json
+## Regenerating derived artefacts
 
-`clients/openapi.json` is generated from the Rust source via the `openapi` subcommand. It must be kept in
-sync with the code — CI will fail if it drifts.
+`clients/openapi.json` and `clients/typescript/autogen/src/schema.d.ts` are both generated files
+committed to source control. CI drift checks verify they match the binary output on every PR.
 
-After changing any HTTP handler, request/response type, or route:
-
-```bash
-cargo run --locked -- openapi > clients/openapi.json
-```
-
-## Regenerating the TypeScript autogen schema
-
-`clients/typescript/autogen/src/schema.d.ts` is generated from `clients/openapi.json` using
-[openapi-typescript](https://openapi-ts.dev/). Regenerate it after updating `clients/openapi.json`:
+After changing any HTTP handler, request/response type, or route, run:
 
 ```bash
-npx openapi-typescript@7.13.0 clients/openapi.json -o clients/typescript/autogen/src/schema.d.ts
+./scripts/update-openapi.sh
 ```
 
-Both files are committed to source control. CI drift checks verify they match the binary output on every PR.
+This rebuilds the server binary, exports `clients/openapi.json`, then regenerates the TypeScript schema
+in one step. Commit both files afterwards.
+
+### What the script does
+
+| Step | Command |
+|------|---------|
+| Export OpenAPI spec | `cargo run -- openapi > clients/openapi.json` |
+| Regenerate TS schema | `npx openapi-typescript clients/openapi.json -o clients/typescript/autogen/src/schema.d.ts` |
+
+## Adding a new client
+
+1. Create your client under `clients/<language>/`.
+2. If your client has generated artefacts (types, SDKs) derived from `clients/openapi.json`, add the
+   regeneration command to `scripts/update-openapi.sh` so a single script keeps everything in sync.
+3. Add a CI drift check (similar to the existing `TypeScript Autogen Drift Check`) that fails if the
+   committed artefact diverges from the generated output.

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -41,3 +41,4 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 wiremock = "0.6"
 serde_json = { workspace = true }
+hex = { workspace = true }

--- a/clients/rust/examples/quote.rs
+++ b/clients/rust/examples/quote.rs
@@ -57,14 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -----------------------------------------------------------------------
     let quote = client
         .quote(QuoteParams::new(
-            Order::new(
-                addr(WETH),
-                addr(USDC),
-                one_ether(),
-                OrderSide::Sell,
-                addr(VITALIK),
-                None,
-            ),
+            Order::new(addr(WETH), addr(USDC), one_ether(), OrderSide::Sell, addr(VITALIK), None),
             QuoteOptions::default(),
         ))
         .await?;
@@ -76,11 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  amount_out:    {}", quote.amount_out());
     println!("  gas_estimate:  {}", quote.gas_estimate());
     println!("  solve_time_ms: {}", quote.solve_time_ms());
-    println!(
-        "  block:         #{} ({})",
-        quote.block().number(),
-        quote.block().hash()
-    );
+    println!("  block:         #{} ({})", quote.block().number(), quote.block().hash());
     if let Some(route) = quote.route() {
         for (i, swap) in route.swaps().iter().enumerate() {
             println!(
@@ -107,14 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -----------------------------------------------------------------------
     let quote2 = client
         .quote(QuoteParams::new(
-            Order::new(
-                addr(USDC),
-                addr(USDT),
-                one_usdc(),
-                OrderSide::Sell,
-                addr(VITALIK),
-                None,
-            ),
+            Order::new(addr(USDC), addr(USDT), one_usdc(), OrderSide::Sell, addr(VITALIK), None),
             QuoteOptions::default(),
         ))
         .await?;
@@ -125,11 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  amount_in:     {}", quote2.amount_in());
     println!("  amount_out:    {}", quote2.amount_out());
     println!("  gas_estimate:  {}", quote2.gas_estimate());
-    println!(
-        "  block:         #{} ({})",
-        quote2.block().number(),
-        quote2.block().hash()
-    );
+    println!("  block:         #{} ({})", quote2.block().number(), quote2.block().hash());
     println!();
 
     assert_eq!(quote2.status(), QuoteStatus::Success, "expected a successful USDC→USDT quote");

--- a/clients/rust/examples/quote.rs
+++ b/clients/rust/examples/quote.rs
@@ -1,0 +1,139 @@
+//! Example: request quotes from a local Fynd instance.
+//!
+//! Runs a health check and two quote requests against the server at
+//! `http://localhost:3000`. Only quote retrieval is exercised; no transactions
+//! are formed.
+//!
+//! ```
+//! cargo run --example quote
+//! ```
+
+use bytes::Bytes;
+use fynd_client::{FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams, QuoteStatus};
+use num_bigint::BigUint;
+
+const FYND_URL: &str = "http://localhost:3000";
+
+// Mainnet token addresses.
+const WETH: &str = "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const USDC: &str = "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const USDT: &str = "dAC17F958D2ee523a2206206994597C13D831ec7";
+
+// A well-known Ethereum address used as the sender/receiver.
+const VITALIK: &str = "d8dA6BF26964aF9D7eEd9e03E53415D37aA96045";
+
+fn addr(hex: &str) -> Bytes {
+    Bytes::from(hex::decode(hex).expect("valid hex address"))
+}
+
+fn one_ether() -> BigUint {
+    BigUint::from(1_000_000_000_000_000_000u64)
+}
+
+fn one_usdc() -> BigUint {
+    // USDC has 6 decimals.
+    BigUint::from(1_000_000u64)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = FyndClientBuilder::new(FYND_URL, FYND_URL)
+        .build_quote_only()
+        .expect("valid URL");
+
+    // -----------------------------------------------------------------------
+    // Health check
+    // -----------------------------------------------------------------------
+    let health = client.health().await?;
+    println!("=== Health ===");
+    println!("  healthy:            {}", health.healthy());
+    println!("  last_update_ms:     {}", health.last_update_ms());
+    println!("  num_solver_pools:   {}", health.num_solver_pools());
+    println!("  derived_data_ready: {}", health.derived_data_ready());
+    println!();
+
+    // -----------------------------------------------------------------------
+    // Quote 1: sell 1 WETH for USDC
+    // -----------------------------------------------------------------------
+    let quote = client
+        .quote(QuoteParams::new(
+            Order::new(
+                addr(WETH),
+                addr(USDC),
+                one_ether(),
+                OrderSide::Sell,
+                addr(VITALIK),
+                None,
+            ),
+            QuoteOptions::default(),
+        ))
+        .await?;
+
+    println!("=== Quote: 1 WETH → USDC ===");
+    println!("  order_id:      {}", quote.order_id());
+    println!("  status:        {:?}", quote.status());
+    println!("  amount_in:     {}", quote.amount_in());
+    println!("  amount_out:    {}", quote.amount_out());
+    println!("  gas_estimate:  {}", quote.gas_estimate());
+    println!("  solve_time_ms: {}", quote.solve_time_ms());
+    println!(
+        "  block:         #{} ({})",
+        quote.block().number(),
+        quote.block().hash()
+    );
+    if let Some(route) = quote.route() {
+        for (i, swap) in route.swaps().iter().enumerate() {
+            println!(
+                "  swap[{i}]: {} {} → {} (pool {})",
+                swap.protocol(),
+                swap.amount_in(),
+                swap.amount_out(),
+                swap.component_id(),
+            );
+        }
+    }
+    println!();
+
+    assert_eq!(quote.status(), QuoteStatus::Success, "expected a successful WETH→USDC quote");
+    assert!(quote.amount_out() > &BigUint::from(0u32), "amount_out must be non-zero");
+    assert!(
+        !quote.block().hash().contains('"'),
+        "block hash must not contain literal quote characters"
+    );
+
+    // -----------------------------------------------------------------------
+    // Quote 2: sell 1 USDC for USDT (stablecoin pair, small amount)
+    // -----------------------------------------------------------------------
+    let quote2 = client
+        .quote(QuoteParams::new(
+            Order::new(
+                addr(USDC),
+                addr(USDT),
+                one_usdc(),
+                OrderSide::Sell,
+                addr(VITALIK),
+                None,
+            ),
+            QuoteOptions::default(),
+        ))
+        .await?;
+
+    println!("=== Quote: 1 USDC → USDT ===");
+    println!("  order_id:      {}", quote2.order_id());
+    println!("  status:        {:?}", quote2.status());
+    println!("  amount_in:     {}", quote2.amount_in());
+    println!("  amount_out:    {}", quote2.amount_out());
+    println!("  gas_estimate:  {}", quote2.gas_estimate());
+    println!(
+        "  block:         #{} ({})",
+        quote2.block().number(),
+        quote2.block().hash()
+    );
+    println!();
+
+    assert_eq!(quote2.status(), QuoteStatus::Success, "expected a successful USDC→USDT quote");
+    assert!(quote2.amount_out() > &BigUint::from(0u32), "amount_out must be non-zero");
+
+    println!("All assertions passed.");
+    Ok(())
+}

--- a/clients/rust/examples/quote.rs
+++ b/clients/rust/examples/quote.rs
@@ -97,8 +97,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(quote.status(), QuoteStatus::Success, "expected a successful WETH→USDC quote");
     assert!(quote.amount_out() > &BigUint::from(0u32), "amount_out must be non-zero");
     assert!(
-        !quote.block().hash().contains('"'),
-        "block hash must not contain literal quote characters"
+        quote.block().hash().starts_with("0x"),
+        "block hash must be a 0x-prefixed hex string, got: {}",
+        quote.block().hash()
     );
 
     // -----------------------------------------------------------------------

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -171,7 +171,7 @@ where
                 .ok_or(SolveError::NotReady("No block info".to_string()))?;
             BlockInfo::new(
                 last_block.number(),
-                format!("{:?}", last_block.hash()),
+                last_block.hash().to_string(),
                 last_block.timestamp(),
             )
         };

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -749,4 +749,3 @@ mod conversions {
         }
     }
 }
-

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -297,10 +297,14 @@ pub struct BlockInfo {
     #[cfg_attr(feature = "openapi", schema(example = 21000000))]
     pub number: u64,
     /// Block hash as a hex string.
+    ///
+    /// Uses a custom deserializer to strip any spurious surrounding quotes that
+    /// the server may emit (e.g. `"\"0x...\""`  →  `"0x..."`).
     #[cfg_attr(
         feature = "openapi",
         schema(example = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd")
     )]
+    #[serde(deserialize_with = "deserialize_unquoted_string")]
     pub hash: String,
     /// Block timestamp in Unix seconds.
     #[cfg_attr(feature = "openapi", schema(example = 1730000000))]
@@ -453,6 +457,23 @@ where
 // ============================================================================
 // PRIVATE HELPERS
 // ============================================================================
+
+/// Deserializes a string, stripping one layer of surrounding `"` quotes when present.
+///
+/// The Fynd server currently double-encodes `BlockInfo.hash`, emitting
+/// `"hash":"\"0x...\"` instead of `"hash":"0x..."`. This deserializer accepts
+/// both forms so the client is robust to either encoding.
+fn deserialize_unquoted_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+        Ok(s[1..s.len() - 1].to_string())
+    } else {
+        Ok(s)
+    }
+}
 
 /// Generates a unique order ID using UUID v4.
 fn generate_order_id() -> String {
@@ -747,5 +768,24 @@ mod conversions {
                 assert_eq!(QuoteStatus::from(core), expected);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_info_hash_strips_surrounding_quotes() {
+        let json = r#"{"number":1,"hash":"\"0xdeadbeef\"","timestamp":0}"#;
+        let block: BlockInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(block.hash, "0xdeadbeef");
+    }
+
+    #[test]
+    fn block_info_hash_plain_string_unchanged() {
+        let json = r#"{"number":1,"hash":"0xdeadbeef","timestamp":0}"#;
+        let block: BlockInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(block.hash, "0xdeadbeef");
     }
 }

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -297,14 +297,10 @@ pub struct BlockInfo {
     #[cfg_attr(feature = "openapi", schema(example = 21000000))]
     pub number: u64,
     /// Block hash as a hex string.
-    ///
-    /// Uses a custom deserializer to strip any spurious surrounding quotes that
-    /// the server may emit (e.g. `"\"0x...\""`  →  `"0x..."`).
     #[cfg_attr(
         feature = "openapi",
         schema(example = "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd")
     )]
-    #[serde(deserialize_with = "deserialize_unquoted_string")]
     pub hash: String,
     /// Block timestamp in Unix seconds.
     #[cfg_attr(feature = "openapi", schema(example = 1730000000))]
@@ -457,23 +453,6 @@ where
 // ============================================================================
 // PRIVATE HELPERS
 // ============================================================================
-
-/// Deserializes a string, stripping one layer of surrounding `"` quotes when present.
-///
-/// The Fynd server currently double-encodes `BlockInfo.hash`, emitting
-/// `"hash":"\"0x...\"` instead of `"hash":"0x..."`. This deserializer accepts
-/// both forms so the client is robust to either encoding.
-fn deserialize_unquoted_string<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let s = String::deserialize(deserializer)?;
-    if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
-        Ok(s[1..s.len() - 1].to_string())
-    } else {
-        Ok(s)
-    }
-}
 
 /// Generates a unique order ID using UUID v4.
 fn generate_order_id() -> String {
@@ -771,21 +750,3 @@ mod conversions {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn block_info_hash_strips_surrounding_quotes() {
-        let json = r#"{"number":1,"hash":"\"0xdeadbeef\"","timestamp":0}"#;
-        let block: BlockInfo = serde_json::from_str(json).unwrap();
-        assert_eq!(block.hash, "0xdeadbeef");
-    }
-
-    #[test]
-    fn block_info_hash_plain_string_unchanged() {
-        let json = r#"{"number":1,"hash":"0xdeadbeef","timestamp":0}"#;
-        let block: BlockInfo = serde_json::from_str(json).unwrap();
-        assert_eq!(block.hash, "0xdeadbeef");
-    }
-}

--- a/scripts/update-openapi.sh
+++ b/scripts/update-openapi.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Regenerate the OpenAPI spec and all derived artefacts from the current server code.
+#
+# Run this after any change to fynd-rpc-types or fynd-rpc that affects the API
+# surface (new fields, new endpoints, changed types):
+#
+#   ./scripts/update-openapi.sh
+#
+# What it does:
+#   1. Builds the server binary and exports the OpenAPI spec to clients/openapi.json
+#   2. Regenerates clients/typescript/autogen/src/schema.d.ts via openapi-typescript
+#
+# Requirements:
+#   - Rust toolchain (cargo)
+#   - openapi-typescript (npx will download it on first use)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OPENAPI_JSON="$REPO_ROOT/clients/openapi.json"
+TS_SCHEMA="$REPO_ROOT/clients/typescript/autogen/src/schema.d.ts"
+
+echo "==> Generating OpenAPI spec..."
+cargo run --manifest-path "$REPO_ROOT/Cargo.toml" -- openapi 2>/dev/null >"$OPENAPI_JSON"
+echo "    Written: $OPENAPI_JSON"
+
+echo "==> Regenerating TypeScript schema..."
+npx --yes openapi-typescript "$OPENAPI_JSON" -o "$TS_SCHEMA"
+echo "    Written: $TS_SCHEMA"
+
+echo "Done. Commit both files if they changed."


### PR DESCRIPTION
## Summary

- Fixes the Rust client sending requests to `/v1/solve` instead of `/v1/quote`
- Fixes block hash being double-encoded (`"\"0x...\""`) due to `{:?}` debug formatting of a `&str` in `worker.rs`
- Adds a `quote` example that runs health check and two quote requests against a live Fynd instance

## Changes

**`fynd-core/src/worker_pool/worker.rs`**
`format!("{:?}", last_block.hash())` used the `Debug` formatter on a `&str`, which wraps the value in double-quotes. Replaced with `last_block.hash().to_string()`.

**`clients/rust/src/client.rs` + `tests/integration.rs`**
All `/v1/solve` references updated to `/v1/quote` to match the actual server route.

**`clients/rust/examples/quote.rs`**
New example: connects to `localhost:3000` via `build_quote_only`, checks health, fetches WETH→USDC and USDC→USDT quotes, and asserts status and amounts.

## Test plan

- [ ] `cargo test -p fynd-client` — all integration tests pass
- [ ] `cargo test -p fynd-core` — passes
- [ ] `cargo run --example quote -p fynd-client` against a local Fynd instance — all assertions pass