### PR TITLE
fix(ci): strip info.version from openapi drift check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,10 +82,15 @@ jobs:
           cache-on-failure: true
       - name: Check OpenAPI spec is up to date
         run: |
-          cargo run --locked -- openapi > /tmp/openapi.json
-          if ! diff -q clients/openapi.json /tmp/openapi.json > /dev/null 2>&1; then
+          # Strip info.version before diffing: the release bot bumps Cargo.toml and commits it
+          # to main, which changes the generated spec's version field. Regenerating and committing
+          # openapi.json as part of the release would require a second post-release commit, so we
+          # accept version drift here and only check that the API surface itself hasn't changed.
+          cargo run --locked -- openapi | jq 'del(.info.version)' > /tmp/openapi.json
+          jq 'del(.info.version)' clients/openapi.json > /tmp/openapi_committed.json
+          if ! diff -q /tmp/openapi_committed.json /tmp/openapi.json > /dev/null 2>&1; then
             echo "clients/openapi.json is out of date. Run 'cargo run -- openapi > clients/openapi.json' and commit."
-            diff clients/openapi.json /tmp/openapi.json
+            diff /tmp/openapi_committed.json /tmp/openapi.json
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- The release bot bumps `Cargo.toml` and commits it to `main`, which changes the `info.version` field in the generated OpenAPI spec
- This caused `openapi_drift` to fail on every branch created after a release, even with no real API changes
- Strip `info.version` from both sides before diffing so only actual API surface changes are caught

## Test plan

- [ ] Verify CI passes on this PR
- [ ] After next release, confirm a new branch no longer fails `openapi_drift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)