### PR TITLE
feat: Add encoding to examples

### DIFF
--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -33,9 +33,9 @@ use fynd_core::{
         TychoFeedConfig,
     },
     types::{constants::native_token, RouteResult},
-    Algorithm, AlgorithmConfig, AlgorithmError, ComputationRequirements, MostLiquidAlgorithm,
-    Order, OrderManager, OrderManagerConfig, OrderSide, QuoteRequest, SolverPoolHandle,
-    WorkerPoolBuilder,
+    Algorithm, AlgorithmConfig, AlgorithmError, ComputationRequirements, EncodingOptions,
+    MostLiquidAlgorithm, Order, OrderManager, OrderManagerConfig, OrderSide, QuoteOptions,
+    QuoteRequest, SolverPoolHandle, WorkerPoolBuilder,
 };
 use num_bigint::BigUint;
 use tokio::sync::RwLock;
@@ -246,7 +246,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     print!("Solving: 1000 USDC → WBTC with MyAlgorithm...");
     std::io::Write::flush(&mut std::io::stdout())?;
 
-    let request = QuoteRequest::new(vec![order], Default::default());
+    let options = QuoteOptions::default().with_encoding_options(EncodingOptions::new(0.01));
+    let request = QuoteRequest::new(vec![order], options);
     let solution = order_manager.quote(request).await?;
     println!(" done ({}ms)\n", solution.solve_time_ms());
 
@@ -296,6 +297,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 token_out.symbol,
                 swap.protocol()
             );
+        }
+        if let Some(tx) = order_quote.transaction() {
+            let calldata: String = tx
+                .data()
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("\nEncoded tx: to={}, calldata=0x{}", tx.to(), calldata);
         }
     } else {
         println!("No route found (status: {:?})", order_quote.status());

--- a/fynd-core/examples/solve_order.rs
+++ b/fynd-core/examples/solve_order.rs
@@ -26,7 +26,8 @@ use fynd_core::{
         gas::GasPriceFetcher, market_data::SharedMarketData, tycho_feed::TychoFeed, TychoFeedConfig,
     },
     types::{constants::native_token, Order, OrderSide},
-    OrderManager, OrderManagerConfig, QuoteRequest, SolverPoolHandle, WorkerPoolBuilder,
+    EncodingOptions, OrderManager, OrderManagerConfig, QuoteOptions, QuoteRequest,
+    SolverPoolHandle, WorkerPoolBuilder,
 };
 use num_bigint::BigUint;
 use tokio::sync::RwLock;
@@ -184,7 +185,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     print!("Solving: 1000 USDC → WBTC...");
     std::io::Write::flush(&mut std::io::stdout())?;
 
-    let request = QuoteRequest::new(vec![order], Default::default());
+    let options = QuoteOptions::default().with_encoding_options(EncodingOptions::new(0.01));
+    let request = QuoteRequest::new(vec![order], options);
     let solution = order_manager.quote(request).await?;
 
     println!(" done ({}ms)\n", solution.solve_time_ms());
@@ -240,6 +242,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 token_out.symbol,
                 swap.protocol()
             );
+        }
+        if let Some(tx) = order_quote.transaction() {
+            let calldata: String = tx
+                .data()
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect();
+            println!("\nEncoded tx: to={}, calldata=0x{}", tx.to(), calldata);
         }
     } else {
         println!("No route found (status: {:?})", order_quote.status());


### PR DESCRIPTION
From our call today: In the tutorial we should be using the fynd rpc types for now, until the fynd client fully supports encoding/executing/simulating a transaction on-chain. A few objects were still using the fynd core types - updated those in this PR too.

Tutorial output:
```
========== Quote ==========
Status: Success
Swap: 1000.000000 USDC -> 0.481474 WETH
Price: 0.000481 WETH per USDC
Gas estimate: 120000

Route (1 hops):
  1. USDC -> WETH via uniswap_v2 (pool: 0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc)

Encoded transaction (from server):
  To: 0xfd0b31d2e955fa55e3fa641fe90e08b677188d35
  Value: 0
  Data: 0x5c4b639c000000000000000000000000000000000000000000000000000000003b9aca00000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc200000000000000000000000000000000000000000000000006a5fcb9f3f7a376000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000052ae04ca7e9ed79cbd988f6c536ce11c621166f41ba0b86991c6218b36c1d19d4a2e9eb0ce3606eb48b4e16d0168e52d35cacd2c6185b44281ec28c9dc000000000000000000000000000000000000000001000000000000000000000000000000

Solve time: 87ms
Total gas: 120000
============================

```

Also updated fynd-core examples to use encoding.