### PR TITLE
feat: Don't allow intermediate cyclical swaps

### DIFF
--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -182,9 +182,20 @@ impl MostLiquidAlgorithm {
 
             for edge in graph.edges(current_node) {
                 let next_node = edge.target();
+                let next_addr = &graph[next_node];
+
+                // Skip paths that revisit a token already in the path.
+                // Exception: when source == destination, the destination may
+                // appear at the end (forming a first == last cycle, e.g.
+                // USDC → WETH → USDC). All other intermediate cycles (e.g.
+                // USDC → WETH → WBTC → WETH) are not supported by Tycho execution.
+                let is_valid_cycle = next_node == to_idx && from_idx == to_idx;
+                if !is_valid_cycle && current_path.tokens.contains(&next_addr) {
+                    continue;
+                }
 
                 let mut new_path = current_path.clone();
-                new_path.add_hop(&graph[current_node], edge.weight(), &graph[next_node]);
+                new_path.add_hop(&graph[current_node], edge.weight(), next_addr);
 
                 if next_node == to_idx && new_path.len() >= min_hops {
                     paths.push(new_path.clone());
@@ -850,23 +861,17 @@ mod tests {
     }
 
     #[test]
-    fn test_find_paths_revisit_destination() {
+    fn test_find_paths_no_intermediate_cycles() {
         let (a, b, _, _) = addrs();
         let m = linear_graph();
         let g = m.graph();
 
-        // A->B with max_hops=3: finds 1-hop path plus 3-hop revisit paths
+        // A->B with max_hops=3: only the direct 1-hop path is valid.
+        // Revisit paths like A->B->C->B or A->B->B->B are pruned because
+        // they create intermediate cycles unsupported by Tycho execution
+        // (only first == last cycles are allowed, i.e. from == to).
         let p = MostLiquidAlgorithm::find_paths(g, &a, &b, 1, 3).unwrap();
-
-        // Check all expected paths are found (order-independent)
-        assert_eq!(
-            all_ids(p),
-            HashSet::from([
-                vec!["ab"],             // 1-hop direct
-                vec!["ab", "ab", "ab"], // 3-hop: revisit via self
-                vec!["ab", "bc", "bc"], // 3-hop: A->B->C->B
-            ])
-        );
+        assert_eq!(all_ids(p), HashSet::from([vec!["ab"]]));
     }
 
     #[test]
@@ -931,17 +936,29 @@ mod tests {
 
     #[test]
     fn test_find_paths_bfs_ordering() {
-        let (a, b, _, _) = addrs();
-        let m = linear_graph();
+        // Build a graph with 1-hop, 2-hop, and 3-hop paths to E:
+        //   A --[ae]--> E                          (1-hop)
+        //   A --[ab]--> B --[be]--> E              (2-hop)
+        //   A --[ac]--> C --[cd]--> D --[de]--> E  (3-hop)
+        let (a, b, c, d) = addrs();
+        let e = addr(0x0E);
+        let mut m = PetgraphStableDiGraphManager::<DepthAndPrice>::new();
+        let mut t = HashMap::new();
+        t.insert("ae".into(), vec![a.clone(), e.clone()]);
+        t.insert("ab".into(), vec![a.clone(), b.clone()]);
+        t.insert("be".into(), vec![b, e.clone()]);
+        t.insert("ac".into(), vec![a.clone(), c.clone()]);
+        t.insert("cd".into(), vec![c, d.clone()]);
+        t.insert("de".into(), vec![d, e.clone()]);
+        m.initialize_graph(&t);
         let g = m.graph();
 
-        // BFS ensures shorter paths come first: 1-hop before 3-hop
-        let p = MostLiquidAlgorithm::find_paths(g, &a, &b, 1, 3).unwrap();
+        let p = MostLiquidAlgorithm::find_paths(g, &a, &e, 1, 3).unwrap();
 
-        // Verify BFS property: paths are ordered by hop count
+        // BFS guarantees paths are ordered by hop count
         assert_eq!(p.len(), 3, "Expected 3 paths total");
         assert_eq!(p[0].len(), 1, "First path should be 1-hop");
-        assert_eq!(p[1].len(), 3, "Second path should be 3-hop");
+        assert_eq!(p[1].len(), 2, "Second path should be 2-hop");
         assert_eq!(p[2].len(), 3, "Third path should be 3-hop");
     }
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -185,12 +185,12 @@ impl MostLiquidAlgorithm {
                 let next_addr = &graph[next_node];
 
                 // Skip paths that revisit a token already in the path.
-                // Exception: when source == destination, the destination may
-                // appear at the end (forming a first == last cycle, e.g.
-                // USDC → WETH → USDC). All other intermediate cycles (e.g.
-                // USDC → WETH → WBTC → WETH) are not supported by Tycho execution.
-                let is_valid_cycle = next_node == to_idx && from_idx == to_idx;
-                if !is_valid_cycle && current_path.tokens.contains(&next_addr) {
+                // Exception: when source == destination, the destination may appear at the end
+                // (forming a first == last cycle, e.g. USDC → WETH → USDC). All other intermediate
+                // cycles (e.g. USDC → WETH → WBTC → WETH) are not supported by Tycho execution.
+                let already_visited = current_path.tokens.contains(&next_addr);
+                let is_closing_circular_route = from_idx == to_idx && next_node == to_idx;
+                if already_visited && !is_closing_circular_route {
                     continue;
                 }
 

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -14,7 +14,7 @@
 //! - [`Route`] - Sequence of swaps to execute
 //! - [`Swap`] - A single swap on a specific protocol
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
@@ -875,6 +875,8 @@ impl Route {
     /// Returns an error if:
     /// - The route has no swaps
     /// - Consecutive swaps are not connected (output token != next input token)
+    /// - A token appears more than once in the path unless it is both the first and last token
+    ///   (Tycho execution only supports this type of cycle)
     pub fn validate(&self) -> Result<(), RouteValidationError> {
         if self.swaps.is_empty() {
             return Err(RouteValidationError::EmptyRoute);
@@ -889,6 +891,28 @@ impl Route {
             }
         }
 
+        // Collect every token in the path:
+        // A token may only repeat if it is both the first and last in the path.
+        let first_token = &self.swaps[0].token_in;
+        let last_token = &self.swaps[self.swaps.len() - 1].token_out;
+
+        let mut seen = HashSet::new();
+        seen.insert(first_token.clone());
+        let last_idx = self.swaps.len() - 1;
+        for (i, swap) in self.swaps.iter().enumerate() {
+            if !seen.insert(swap.token_out.clone()) {
+                // Duplicate token — only allowed if it's the last token
+                // matching the first (simple round-trip cycle).
+                if !(i == last_idx && swap.token_out == *first_token) {
+                    return Err(RouteValidationError::UnsupportedCycle {
+                        token: swap.token_out.clone(),
+                        first: first_token.clone(),
+                        last: last_token.clone(),
+                    });
+                }
+            }
+        }
+
         Ok(())
     }
 }
@@ -900,6 +924,11 @@ pub enum RouteValidationError {
     EmptyRoute,
     #[error("swaps are not connected: {first_out} != {second_in}")]
     DisconnectedSwaps { first_out: Address, second_in: Address },
+    #[error(
+        "unsupported cycle: token {token} appears more than once in route \
+         {first} -> ... -> {last} (only first == last cycles are supported)"
+    )]
+    UnsupportedCycle { token: Address, first: Address, last: Address },
 }
 
 /// A single swap within a route.
@@ -1230,8 +1259,19 @@ mod tests {
     #[rstest]
     #[case::valid_single(vec![(0x01, 0x02)], true, None)]
     #[case::valid_connected(vec![(0x01, 0x02), (0x02, 0x03)], true, None)]
+    #[case::valid_first_last_cycle(vec![(0x01, 0x02), (0x02, 0x01)], true, None)]
     #[case::empty(vec![], false, Some("EmptyRoute"))]
     #[case::disconnected(vec![(0x01, 0x02), (0x03, 0x04)], false, Some("DisconnectedSwaps"))]
+    #[case::unsupported_intermediate_cycle(
+        vec![(0x01, 0x02), (0x02, 0x03), (0x03, 0x02)],
+        false,
+        Some("UnsupportedCycle")
+    )]
+    #[case::unsupported_mid_path_cycle(
+        vec![(0x01, 0x02), (0x02, 0x01), (0x01, 0x03)],
+        false,
+        Some("UnsupportedCycle")
+    )]
     fn test_route_validation(
         #[case] swaps: Vec<(u8, u8)>,
         #[case] should_pass: bool,
@@ -1247,6 +1287,9 @@ mod tests {
                 "EmptyRoute" => assert!(matches!(err, RouteValidationError::EmptyRoute)),
                 "DisconnectedSwaps" => {
                     assert!(matches!(err, RouteValidationError::DisconnectedSwaps { .. }))
+                }
+                "UnsupportedCycle" => {
+                    assert!(matches!(err, RouteValidationError::UnsupportedCycle { .. }))
                 }
                 _ => panic!("Unknown error type"),
             }


### PR DESCRIPTION
Only allow if the first token == last token, because tycho-execution limits this.

Allowed: A -> B -> C -> A
Forbidden: A -> B -> A -> C

Fix — two layers of defense:

1. quote.rs — Route validation
- Added cycle detection: rejects any route where a token appears more than once — unless it's the last token matching the first
- Added UnsupportedCycle variant to RouteValidationError with a clear error message.
2. most_liquid.rs — BFS path pruning (find_paths())
- During BFS exploration, skip edges that would revisit a token already in the path, unless the cycle is valid
- This prevents wasting computation on paths that would fail validation anyway.
- Updated test_find_paths_revisit_destination → test_find_paths_no_intermediate_cycles to verify that revisit paths like A→B→C→B are now pruned.
- Updated test_find_paths_bfs_ordering. After pruning duplicate steps, it wasn't testing much anymore, since going from a-b on a linear graph would only have one possible path.

Before change, running with `--protocols uniswap_v2,uniswap_v3,uniswap_v4`:
```
Round-trip times (client → server → client):
  Min:     2435ms
  Mean:    2652ms
  Median:  2526ms
  Std Dev: 490.63ms
  P95:     2917ms
  P99:     5004ms
  Max:     5004ms

Round-trip Distribution:
   2400-2449 ms [   3] ███
   2450-2499 ms [  24] ████████████████████████
   2500-2549 ms [  42] ██████████████████████████████████████████
   2550-2599 ms [   8] ████████
   2600-2649 ms [   5] █████
   2650-2699 ms [   3] ███
   2700-2749 ms [   3] ███
   2750-2799 ms [   3] ███
   2800-2849 ms [   2] ██
   2850-2899 ms [   2] ██
   2900-2949 ms [   1] █
   ... (empty)
   5000-5049 ms [   4] ████

Server solve times (OrderManager timing):
  Min:     2434ms
  Mean:    2650ms
  Median:  2525ms
  Std Dev: 490.54ms
  P95:     2915ms
  P99:     5003ms
  Max:     5003ms

Solve time Distribution:
   2400-2449 ms [   3] ███
   2450-2499 ms [  26] ██████████████████████████
   2500-2549 ms [  40] ████████████████████████████████████████
   2550-2599 ms [   8] ████████
   2600-2649 ms [   5] █████
   2650-2699 ms [   3] ███
   2700-2749 ms [   3] ███
   2750-2799 ms [   3] ███
   2800-2849 ms [   2] ██
   2850-2899 ms [   2] ██
   2900-2949 ms [   1] █
   ... (empty)
   5000-5049 ms [   4] ████

Overhead (round-trip - solve time):
  Min:     1ms
  Mean:    1ms
  Median:  1ms
  Std Dev: 0.52ms
  P95:     2ms
  P99:     3ms
  Max:     3ms

```

After change:
```
Round-trip times (client → server → client):
  Min:     292ms
  Mean:    310ms
  Median:  306ms
  Std Dev: 19.93ms
  P95:     356ms
  P99:     409ms
  Max:     409ms

Round-trip Distribution:
    250-299  ms [  31] ████████████████████████
    300-349  ms [  64] ██████████████████████████████████████████████████
    350-399  ms [   4] ███
    400-449  ms [   1] █

Server solve times (OrderManager timing):
  Min:     291ms
  Mean:    308ms
  Median:  305ms
  Std Dev: 19.87ms
  P95:     355ms
  P99:     408ms
  Max:     408ms

Solve time Distribution:
    250-299  ms [  35] █████████████████████████████
    300-349  ms [  60] ██████████████████████████████████████████████████
    350-399  ms [   4] ███
    400-449  ms [   1] █

Overhead (round-trip - solve time):
  Min:     1ms
  Mean:    1ms
  Median:  1ms
  Std Dev: 0.37ms
  P95:     2ms
  P99:     3ms
  Max:     3ms

Overhead Distribution:
      0-9    ms [ 100] ██████████████████████████████████████████████████
```