### PR TITLE
feat: default to all protocol systems when --protocols is omitted

### DIFF
--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, env, time::Duration};
 
-use tracing::info;
+use tracing::{info, warn};
 use tycho_simulation::{
     evm::{
         engine_db::tycho_db::PreCachedDB,
@@ -130,7 +130,7 @@ pub(crate) fn register_exchanges(
                 continue;
             }
             _ => {
-                return Err(DataFeedError::Config(format!("Unknown protocol: {}", protocol)));
+                warn!("Skipping unknown protocol: {}", protocol);
             }
         }
     }
@@ -172,7 +172,7 @@ pub(crate) fn register_rfq(
                     .add_client::<HashflowState>("hashflow", Box::new(hashflow_client));
             }
             p if p.starts_with("rfq:") => {
-                return Err(DataFeedError::Config(format!("Unknown RFQ protocol: {}", p)));
+                warn!("Skipping unknown RFQ protocol: {}", p);
             }
             _ => {}
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -54,7 +54,9 @@ pub struct ServeArgs {
     pub rpc_url: Option<String>,
 
     /// List of protocols to index (comma-separated, e.g., uniswap_v2,uniswap_v3).
-    /// If omitted, all supported protocols are fetched from Tycho RPC.
+    /// If omitted, all on-chain protocols are fetched from Tycho RPC.
+    /// Use "all_onchain" to fetch all on-chain protocols and combine with explicit entries,
+    /// e.g., --protocols all_onchain,rfq:bebop.
     #[arg(short, long, value_delimiter = ',', value_name = "PROTO1,PROTO2")]
     pub protocols: Vec<String>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,7 +53,8 @@ pub struct ServeArgs {
     #[arg(long, env)]
     pub rpc_url: Option<String>,
 
-    /// List of protocols to index (comma-separated, e.g., uniswap_v2,uniswap_v3)
+    /// List of protocols to index (comma-separated, e.g., uniswap_v2,uniswap_v3).
+    /// If omitted, all supported protocols are fetched from Tycho RPC.
     #[arg(short, long, value_delimiter = ',', value_name = "PROTO1,PROTO2")]
     pub protocols: Vec<String>,
 
@@ -147,8 +148,7 @@ mod cli_tests {
     fn test_arg_parsing_defaults() {
         // Clear ambient env var so the test is deterministic
         std::env::remove_var("RPC_URL");
-        let cli = Cli::try_parse_from(vec!["fynd", "serve", "--protocols", "uniswap_v2"])
-            .expect("parse errored");
+        let cli = Cli::try_parse_from(vec!["fynd", "serve"]).expect("parse errored");
 
         let Commands::Serve(args) = cli.command else {
             panic!("expected Serve command");
@@ -159,7 +159,7 @@ mod cli_tests {
         assert_eq!(args.tycho_api_key, None);
         assert_eq!(args.rpc_url, None);
         assert_eq!(args.tycho_url, "localhost:4242");
-        assert_eq!(args.protocols, vec!["uniswap_v2"]);
+        assert!(args.protocols.is_empty());
         assert_eq!(args.min_tvl, 10.0);
         assert_eq!(args.tvl_buffer_multiplier, 1.1);
         assert_eq!(args.gas_refresh_interval_secs, 30);
@@ -170,15 +170,8 @@ mod cli_tests {
 
     #[test]
     fn test_arg_parsing_default_worker_pools() {
-        let cli = Cli::try_parse_from(vec![
-            "fynd",
-            "serve",
-            "--tycho-api-key",
-            "test-key",
-            "--protocols",
-            "uniswap_v2",
-        ])
-        .expect("parse errored");
+        let cli = Cli::try_parse_from(vec!["fynd", "serve", "--tycho-api-key", "test-key"])
+            .expect("parse errored");
 
         let Commands::Serve(args) = cli.command else {
             panic!("expected Serve command");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,12 @@
 //! # Usage
 //!
 //! ```bash
-//! # All supported protocols are fetched from Tycho RPC by default:
+//! # All on-chain protocols are fetched from Tycho RPC by default:
 //! fynd serve --tycho-url tycho-beta.propellerheads.xyz
+//!
+//! # Combine all on-chain protocols with specific RFQ protocols:
+//! fynd serve --tycho-url tycho-beta.propellerheads.xyz \
+//!            --protocols all_onchain,rfq:bebop
 //!
 //! # Or specify protocols explicitly:
 //! fynd serve --tycho-url tycho-beta.propellerheads.xyz \
@@ -202,16 +206,27 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
         }
     };
 
-    // Resolve protocols: use CLI args, or fetch all supported from Tycho RPC
-    let protocols = if args.protocols.is_empty() {
-        fetch_protocol_systems(
+    // Resolve protocols: fetch from Tycho RPC if omitted or if "all_onchain" is used
+    let needs_fetch = args.protocols.is_empty() ||
+        args.protocols
+            .iter()
+            .any(|p| p == "all_onchain");
+    let protocols = if needs_fetch {
+        let mut fetched = fetch_protocol_systems(
             &args.tycho_url,
             args.tycho_api_key.as_deref(),
             !args.disable_tls,
             chain,
         )
         .await
-        .map_err(|e| SolverError::SetupError(format!("failed to fetch protocol systems: {}", e)))?
+        .map_err(|e| SolverError::SetupError(format!("failed to fetch protocol systems: {}", e)))?;
+        // Append any explicit protocols (e.g. rfq:bebop) alongside all_onchain
+        for p in &args.protocols {
+            if p != "all_onchain" && !fetched.contains(p) {
+                fetched.push(p.clone());
+            }
+        }
+        fetched
     } else {
         args.protocols.clone()
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,10 @@
 //! # Usage
 //!
 //! ```bash
+//! # All supported protocols are fetched from Tycho RPC by default:
+//! fynd serve --tycho-url tycho-beta.propellerheads.xyz
+//!
+//! # Or specify protocols explicitly:
 //! fynd serve --tycho-url tycho-beta.propellerheads.xyz \
 //!            --protocols uniswap_v2,uniswap_v3
 //! ```
@@ -15,8 +19,7 @@
 //!
 //! ```bash
 //! fynd serve --tycho-url tycho-beta.propellerheads.xyz \
-//!            --rpc-url https://your-rpc-provider.com/v1/your_key \
-//!            --protocols uniswap_v2,uniswap_v3
+//!            --rpc-url https://your-rpc-provider.com/v1/your_key
 //! ```
 //!
 //! See `fynd --help` for all available options.
@@ -30,6 +33,10 @@ use fynd_rpc::{
     builder::{parse_chain, FyndBuilder},
     config::{defaults, BlacklistConfig, WorkerPoolsConfig},
 };
+use tycho_simulation::{
+    tycho_client::rpc::{HttpRPCClient, HttpRPCClientOptions, RPCClient},
+    tycho_common::models::Chain,
+};
 
 mod cli;
 use cli::{Cli, Commands};
@@ -42,7 +49,7 @@ use tokio::{
     select,
     signal::unix::{signal, SignalKind},
 };
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 fn main() -> Result<(), anyhow::Error> {
@@ -195,22 +202,40 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
         }
     };
 
+    // Resolve protocols: use CLI args, or fetch all supported from Tycho RPC
+    let protocols = if args.protocols.is_empty() {
+        fetch_protocol_systems(
+            &args.tycho_url,
+            args.tycho_api_key.as_deref(),
+            !args.disable_tls,
+            chain,
+        )
+        .await
+        .map_err(|e| SolverError::SetupError(format!("failed to fetch protocol systems: {}", e)))?
+    } else {
+        args.protocols.clone()
+    };
+
+    if protocols.is_empty() {
+        return Err(SolverError::SetupError(
+            "no supported protocols found. Provide --protocols or check Tycho connectivity."
+                .to_string(),
+        ));
+    }
+
+    info!(?protocols, "starting with {} protocol(s)", protocols.len());
+
     // Build solver with all fields from CLI
-    let mut builder = FyndBuilder::new(
-        chain,
-        pools_config.pools,
-        args.tycho_url.clone(),
-        rpc_url,
-        args.protocols.clone(),
-    )
-    .http_host(args.http_host.clone())
-    .http_port(args.http_port)
-    .min_tvl(args.min_tvl)
-    .tvl_buffer_multiplier(args.tvl_buffer_multiplier)
-    .gas_refresh_interval(Duration::from_secs(args.gas_refresh_interval_secs))
-    .reconnect_delay(Duration::from_secs(args.reconnect_delay_secs))
-    .worker_router_timeout(Duration::from_millis(args.worker_router_timeout_ms))
-    .worker_router_min_responses(args.worker_router_min_responses);
+    let mut builder =
+        FyndBuilder::new(chain, pools_config.pools, args.tycho_url.clone(), rpc_url, protocols)
+            .http_host(args.http_host.clone())
+            .http_port(args.http_port)
+            .min_tvl(args.min_tvl)
+            .tvl_buffer_multiplier(args.tvl_buffer_multiplier)
+            .gas_refresh_interval(Duration::from_secs(args.gas_refresh_interval_secs))
+            .reconnect_delay(Duration::from_secs(args.reconnect_delay_secs))
+            .worker_router_timeout(Duration::from_millis(args.worker_router_timeout_ms))
+            .worker_router_min_responses(args.worker_router_min_responses);
 
     if args.disable_tls {
         builder = builder.disable_tls();
@@ -291,4 +316,44 @@ async fn run_solver(args: cli::ServeArgs) -> Result<(), SolverError> {
         let _ = provider.shutdown();
     }
     Ok(())
+}
+
+/// Fetches all available protocol systems from Tycho RPC.
+async fn fetch_protocol_systems(
+    tycho_url: &str,
+    auth_key: Option<&str>,
+    use_tls: bool,
+    chain: Chain,
+) -> Result<Vec<String>, anyhow::Error> {
+    use tycho_simulation::tycho_common::dto::{PaginationParams, ProtocolSystemsRequestBody};
+
+    info!("Fetching available protocol systems from Tycho RPC...");
+
+    let rpc_url =
+        if use_tls { format!("https://{tycho_url}") } else { format!("http://{tycho_url}") };
+    let rpc_options = HttpRPCClientOptions::new().with_auth_key(auth_key.map(|s| s.to_string()));
+    let rpc_client = HttpRPCClient::new(&rpc_url, rpc_options)?;
+
+    const PAGE_SIZE: i64 = 100;
+    let mut all_protocols = Vec::new();
+    let mut page = 0;
+
+    loop {
+        let request = ProtocolSystemsRequestBody {
+            chain: chain.into(),
+            pagination: PaginationParams { page, page_size: PAGE_SIZE },
+        };
+        let response = rpc_client
+            .get_protocol_systems(&request)
+            .await?;
+        let count = response.protocol_systems.len();
+        all_protocols.extend(response.protocol_systems);
+        if (count as i64) < PAGE_SIZE {
+            break;
+        }
+        page += 1;
+    }
+
+    debug!("Fetched {} protocol system(s) from Tycho RPC", all_protocols.len());
+    Ok(all_protocols)
 }


### PR DESCRIPTION
Fetch available onchain protocols from Tycho RPC at startup when no --protocols flag is provided or "all_onchain" keyword is used. The protocol registry now warns and skips unknown protocols instead of erroring, removing hardcoded protocol lists.