### PR TITLE
feat: update fynd defaults to match fynd-basic plan

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -239,7 +239,8 @@ Provides `extract_subset()` for creating filtered snapshots that algorithms can 
 **Location:** `fynd-core/src/feed/tycho_feed.rs`
 
 Background task that connects to Tycho's WebSocket API, processes component/state updates, updates SharedMarketData, and
-broadcasts `MarketEvent`s. Applies TVL filtering with hysteresis, blacklisting, and token quality filtering.
+broadcasts `MarketEvent`s. Applies TVL filtering with hysteresis (components are added at `min_tvl` and removed at
+`min_tvl / tvl_buffer_ratio`), token recency filtering (`traded_n_days_ago`), blacklisting, and token quality filtering.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,9 +46,8 @@ Fynd puts you in control:
 ### Supported Chains
 
 * Ethereum Mainnet
-* **Coming soon:**
-  * Base&#x20;
-  * Unichain
+* Base
+* Unichain
 
 ### Supported Protocols
 

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -49,21 +49,30 @@ export RUST_LOG=info
 
 ### 3. Run
 
+All on-chain protocols are fetched from Tycho RPC by default, so `--protocols` is optional. The `--tycho-url` also defaults to the Fynd endpoint for the selected chain.
+
 ```bash
-cargo run --release -- \
-  --tycho-url tycho-beta.propellerheads.xyz \
-  --protocols uniswap_v2,uniswap_v3,uniswap_v3,vm:curve \
-  --min-tvl 50
+cargo run --release -- serve
+```
+
+To run on a different chain, use `--chain`:
+
+```bash
+cargo run --release -- serve --chain base
 ```
 
 `--rpc-url` defaults to the public endpoint `https://eth.llamarpc.com`. For production, pass a dedicated endpoint:
 
 ```bash
-cargo run --release -- \
-  --tycho-url tycho-beta.propellerheads.xyz \
-  --rpc-url https://your-rpc-provider.com/v1/your_key \
-  --protocols uniswap_v2,uniswap_v3,uniswap_v3,vm:curve \
-  --min-tvl 50
+cargo run --release -- serve \
+  --rpc-url https://your-rpc-provider.com/v1/your_key
+```
+
+You can also specify protocols explicitly:
+
+```bash
+cargo run --release -- serve \
+  --protocols uniswap_v2,uniswap_v3,vm:curve
 ```
 
 See the full [list of available protocols](https://docs.propellerheads.xyz/tycho/for-solvers/supported-protocols).
@@ -81,11 +90,17 @@ orders.
 
 #### 3.1 Including RFQ Protocols
 
-Include RFQ (Request-for-Quote) protocols alongside on-chain protocols:
+Include RFQ (Request-for-Quote) protocols alongside on-chain protocols. Use the `all_onchain` keyword to combine auto-fetched on-chain protocols with specific RFQ protocols:
 
 ```bash
-cargo run --release -- \
-  --tycho-url tycho-beta.propellerheads.xyz \
+cargo run --release -- serve \
+  --protocols all_onchain,rfq:bebop
+```
+
+Or specify both on-chain and RFQ protocols explicitly:
+
+```bash
+cargo run --release -- serve \
   --protocols uniswap_v2,uniswap_v3,rfq:bebop
 ```
 
@@ -152,9 +167,9 @@ Tune Fynd with the following flags:
 
 #### Optional
 
-<table><thead><tr><th width="246.9140625">Flag</th><th>Env Var</th><th>Default</th><th>Description</th></tr></thead><tbody><tr><td><code>--rpc-url</code></td><td><code>RPC_URL</code></td><td><code>https://eth.llamarpc.com</code></td><td>Ethereum RPC endpoint. Use a dedicated endpoint in production.</td></tr><tr><td><code>--tycho-url</code></td><td><code>TYCHO_URL</code></td><td><code>localhost:4242</code></td><td>Tycho WebSocket URL</td></tr><tr><td><code>--chain</code></td><td>--</td><td><code>Ethereum</code></td><td>Target chain</td></tr><tr><td><code>-p, --protocols</code></td><td>--</td><td><em>(all)</em></td><td>Protocols to index (comma-separated)</td></tr><tr><td><code>--http-port</code></td><td><code>HTTP_PORT</code></td><td><code>3000</code></td><td>API port</td></tr><tr><td><code>--min-tvl</code></td><td>--</td><td><code>10.0</code></td><td>Minimum pool TVL in native token (ETH)</td></tr><tr><td><code>--tvl-buffer-multiplier</code></td><td>--</td><td><code>1.1</code></td><td>Hysteresis buffer for TVL filtering</td></tr><tr><td><code>--order-manager-timeout-ms</code></td><td>--</td><td><code>100</code></td><td>Default solve timeout (ms)</td></tr><tr><td><code>--order-manager-min-responses</code></td><td>--</td><td><code>0</code></td><td>Early return threshold (0 = wait for all pools)</td></tr><tr><td><code>-w, --worker-pools-config</code></td><td><code>WORKER_POOLS_CONFIG</code></td><td><code>worker_pools.toml</code></td><td>Worker pools config file path</td></tr><tr><td><code>--blacklist-config</code></td><td><code>BLACKLIST_CONFIG</code></td><td><code>blacklist.toml</code></td><td>Blacklist config file path</td></tr><tr><td><code>--disable-tls</code></td><td>--</td><td><code>false</code></td><td>Disable TLS for Tycho connection</td></tr><tr><td><code>--min-token-quality</code></td><td>--</td><td><code>100</code></td><td>Minimum <a href="https://docs.propellerheads.xyz/tycho/overview/concepts#token">token quality</a> filter</td></tr><tr><td><code>--gas-refresh-interval-secs</code></td><td>--</td><td><code>30</code></td><td>Gas price refresh interval</td></tr><tr><td><code>--reconnect-delay-secs</code></td><td>--</td><td><code>5</code></td><td>Reconnect delay on connection failure</td></tr></tbody></table>
+<table><thead><tr><th width="246.9140625">Flag</th><th>Env Var</th><th>Default</th><th>Description</th></tr></thead><tbody><tr><td><code>--rpc-url</code></td><td><code>RPC_URL</code></td><td><code>https://eth.llamarpc.com</code></td><td>Ethereum RPC endpoint. Use a dedicated endpoint in production.</td></tr><tr><td><code>--tycho-url</code></td><td><code>TYCHO_URL</code></td><td><em>(chain-specific)</em></td><td>Tycho WebSocket URL. Defaults to the Fynd endpoint for the selected chain (e.g. <code>tycho-fynd-ethereum.propellerheads.xyz</code>).</td></tr><tr><td><code>--chain</code></td><td>--</td><td><code>Ethereum</code></td><td>Target chain</td></tr><tr><td><code>-p, --protocols</code></td><td>--</td><td><em>(all on-chain)</em></td><td>Protocols to index (comma-separated). If omitted, all on-chain protocols are fetched from Tycho RPC. Use <code>all_onchain</code> to combine auto-fetched protocols with explicit entries (e.g. <code>all_onchain,rfq:bebop</code>).</td></tr><tr><td><code>--http-port</code></td><td><code>HTTP_PORT</code></td><td><code>3000</code></td><td>API port</td></tr><tr><td><code>--min-tvl</code></td><td>--</td><td><code>10.0</code></td><td>Minimum pool TVL in native token (ETH)</td></tr><tr><td><code>--tvl-buffer-ratio</code></td><td>--</td><td><code>1.1</code></td><td>Hysteresis buffer for TVL filtering. Components are added when TVL >= <code>min_tvl</code> and removed when TVL drops below <code>min_tvl / tvl_buffer_ratio</code>.</td></tr><tr><td><code>--traded-n-days-ago</code></td><td>--</td><td><code>3</code></td><td>Only include tokens traded within this many days.</td></tr><tr><td><code>--order-manager-timeout-ms</code></td><td>--</td><td><code>100</code></td><td>Default solve timeout (ms)</td></tr><tr><td><code>--order-manager-min-responses</code></td><td>--</td><td><code>0</code></td><td>Early return threshold (0 = wait for all pools)</td></tr><tr><td><code>-w, --worker-pools-config</code></td><td><code>WORKER_POOLS_CONFIG</code></td><td><code>worker_pools.toml</code></td><td>Worker pools config file path</td></tr><tr><td><code>--blacklist-config</code></td><td><code>BLACKLIST_CONFIG</code></td><td><code>blacklist.toml</code></td><td>Blacklist config file path</td></tr><tr><td><code>--disable-tls</code></td><td>--</td><td><code>false</code></td><td>Disable TLS for Tycho connection</td></tr><tr><td><code>--min-token-quality</code></td><td>--</td><td><code>100</code></td><td>Minimum <a href="https://docs.propellerheads.xyz/tycho/overview/concepts#token">token quality</a> filter</td></tr><tr><td><code>--gas-refresh-interval-secs</code></td><td>--</td><td><code>30</code></td><td>Gas price refresh interval</td></tr><tr><td><code>--reconnect-delay-secs</code></td><td>--</td><td><code>5</code></td><td>Reconnect delay on connection failure</td></tr></tbody></table>
 
-Run `cargo run --release -- --help` for the full list.
+Run `cargo run --release -- serve --help` for the full list.
 
 #### 5.1 - Worker pools file (`worker_pools.toml`)
 
@@ -203,9 +218,7 @@ Both pools solve every incoming order in parallel. Fynd picks the best result ac
 To use a custom config file:
 
 ```bash
-cargo run --release -- \
-  --tycho-url tycho-beta.propellerheads.xyz \
-  -w my_worker_pools.toml
+cargo run --release -- serve -w my_worker_pools.toml
 ```
 
 #### 5.1 Blacklist (`blacklist.toml`)
@@ -228,16 +241,16 @@ Control log verbosity with `RUST_LOG`:
 
 ```bash
 # Minimal output
-RUST_LOG=warn cargo run --release -- ...
+RUST_LOG=warn cargo run --release -- serve ...
 
 # Default (recommended)
-RUST_LOG=info cargo run --release -- ...
+RUST_LOG=info cargo run --release -- serve ...
 
 # Debug solver internals
-RUST_LOG=info,tycho_solver=debug cargo run --release -- ...
+RUST_LOG=info,tycho_solver=debug cargo run --release -- serve ...
 
 # Trace-level (very verbose, not recommended)
-RUST_LOG=info,tycho_solver=trace cargo run --release -- ...
+RUST_LOG=info,tycho_solver=trace cargo run --release -- serve ...
 ```
 
 #### Prometheus Metrics

--- a/docs/get-started/quickstart/executing-the-solutions.md
+++ b/docs/get-started/quickstart/executing-the-solutions.md
@@ -36,14 +36,10 @@ description: >-
 In one terminal:
 
 ```bash
-export TYCHO_URL=tycho-beta.propellerheads.xyz
 export TYCHO_API_KEY=your_api_key
 export RPC_URL=https://your-rpc-provider.com/v1/your_key
 
-RUST_LOG=info cargo run --release -- \
-  --tycho-url tycho-beta.propellerheads.xyz \
-  --protocols uniswap_v2,uniswap_v3,uniswap_v3,vm:curve \
-  --min-tvl 50
+RUST_LOG=info cargo run --release -- serve
 ```
 
 Wait for it to be ready: [#id-3.1-check-solver-health](./#id-3.1-check-solver-health "mention")
@@ -124,7 +120,7 @@ cargo run --example tutorial -- \
 | `--sell-token`    | USDC address          | Token address to sell                                                |
 | `--buy-token`     | WETH address          | Token address to buy                                                 |
 | `--sell-amount`   | 10.0                  | Amount to sell (human readable)                                      |
-| `--chain`         | ethereum              | Blockchain (currently only ethereum is available)                    |
+| `--chain`         | ethereum              | Blockchain (ethereum, base, unichain)                                |
 | `--solver-url`    | http://localhost:3000 | Solver API URL                                                       |
 | `--tvl-threshold` | 10.0                  | Min pool TVL in ETH                                                  |
 | `--simulate-only` | false                 | Only simulate, don't prompt for execution                            |

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -29,13 +29,12 @@ pub struct TychoFeedConfig {
     pub(crate) min_tvl: f64,
     /// Minimum token quality filter.
     pub(crate) min_token_quality: i32,
-    /// Multiplier used to define the upper bound of the TVL filter.
-    /// The upper bound is calculated as `min_tvl * tvl_buffer_multiplier`.
-    /// Only components with TVL above this upper bound will be added to the market data.
-    /// This approach helps to reduce fluctuations caused by components hovering around a single
-    /// threshold.
+    /// Ratio used to define the lower bound of the TVL filter for hysteresis.
+    /// The lower bound is calculated as `min_tvl / tvl_buffer_ratio`.
+    /// Components are added when TVL >= `min_tvl` and removed when TVL drops below
+    /// `min_tvl / tvl_buffer_ratio`.
     /// Default is 1.1 (10% buffer).
-    pub(crate) tvl_buffer_multiplier: f64,
+    pub(crate) tvl_buffer_ratio: f64,
     /// Gas price refresh interval.
     /// Default is 30 seconds.
     pub(crate) gas_refresh_interval: Duration,
@@ -66,15 +65,15 @@ impl TychoFeedConfig {
             min_tvl,
             min_token_quality: 100,
             traded_n_days_ago: None,
-            tvl_buffer_multiplier: 1.1,
+            tvl_buffer_ratio: 1.1,
             gas_refresh_interval: Duration::from_secs(30),
             reconnect_delay: Duration::from_secs(5),
             blacklisted_components: HashSet::new(),
         }
     }
 
-    pub fn tvl_buffer_multiplier(mut self, tvl_buffer_multiplier: f64) -> Self {
-        self.tvl_buffer_multiplier = tvl_buffer_multiplier;
+    pub fn tvl_buffer_ratio(mut self, tvl_buffer_ratio: f64) -> Self {
+        self.tvl_buffer_ratio = tvl_buffer_ratio;
         self
     }
 

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -42,6 +42,8 @@ pub struct TychoFeedConfig {
     /// Reconnect delay on connection failure.
     /// Default is 5 seconds.
     pub(crate) reconnect_delay: Duration,
+    /// Only include tokens traded within this many days.
+    pub(crate) traded_n_days_ago: Option<u64>,
     /// Component IDs to exclude from routing.
     pub(crate) blacklisted_components: HashSet<String>,
 }
@@ -63,6 +65,7 @@ impl TychoFeedConfig {
             protocols,
             min_tvl,
             min_token_quality: 100,
+            traded_n_days_ago: None,
             tvl_buffer_multiplier: 1.1,
             gas_refresh_interval: Duration::from_secs(30),
             reconnect_delay: Duration::from_secs(5),
@@ -87,6 +90,11 @@ impl TychoFeedConfig {
 
     pub fn min_token_quality(mut self, min_token_quality: i32) -> Self {
         self.min_token_quality = min_token_quality;
+        self
+    }
+
+    pub fn traded_n_days_ago(mut self, days: u64) -> Self {
+        self.traded_n_days_ago = Some(days);
         self
     }
 

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -131,8 +131,8 @@ impl TychoFeed {
                     ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
                         .skip_state_decode_failures(true),
                     ComponentFilter::with_tvl_range(
+                        self.config.min_tvl / self.config.tvl_buffer_multiplier,
                         self.config.min_tvl,
-                        self.config.min_tvl * self.config.tvl_buffer_multiplier,
                     ),
                     &self.config.protocols,
                 )?

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -112,7 +112,7 @@ impl TychoFeed {
             true,
             self.config.chain,
             Some(self.config.min_token_quality),
-            None,
+            self.config.traded_n_days_ago,
         )
         .await
         .map_err(|e| DataFeedError::StreamError(e.to_string()))?;

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -131,7 +131,7 @@ impl TychoFeed {
                     ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
                         .skip_state_decode_failures(true),
                     ComponentFilter::with_tvl_range(
-                        self.config.min_tvl / self.config.tvl_buffer_multiplier,
+                        self.config.min_tvl / self.config.tvl_buffer_ratio,
                         self.config.min_tvl,
                     ),
                     &self.config.protocols,

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -43,6 +43,7 @@ pub struct FyndBuilder {
     protocols: Vec<String>,
     min_tvl: f64,
     min_token_quality: i32,
+    traded_n_days_ago: u64,
     tvl_buffer_multiplier: f64,
     gas_refresh_interval: Duration,
     reconnect_delay: Duration,
@@ -75,6 +76,7 @@ impl FyndBuilder {
             protocols,
             min_tvl: defaults::MIN_TVL,
             min_token_quality: defaults::MIN_TOKEN_QUALITY,
+            traded_n_days_ago: defaults::TRADED_N_DAYS_AGO,
             tvl_buffer_multiplier: defaults::TVL_BUFFER_MULTIPLIER,
             gas_refresh_interval: Duration::from_secs(defaults::GAS_REFRESH_INTERVAL_SECS),
             reconnect_delay: Duration::from_secs(defaults::RECONNECT_DELAY_SECS),
@@ -106,6 +108,12 @@ impl FyndBuilder {
     /// Sets the minimum token quality filter.
     pub fn min_token_quality(mut self, min_token_quality: i32) -> Self {
         self.min_token_quality = min_token_quality;
+        self
+    }
+
+    /// Sets the traded_n_days_ago filter (default: 3).
+    pub fn traded_n_days_ago(mut self, days: u64) -> Self {
+        self.traded_n_days_ago = days;
         self
     }
 
@@ -187,6 +195,7 @@ impl FyndBuilder {
         .gas_refresh_interval(self.gas_refresh_interval)
         .reconnect_delay(self.reconnect_delay)
         .min_token_quality(self.min_token_quality)
+        .traded_n_days_ago(self.traded_n_days_ago)
         .blacklisted_components(self.blacklist.components);
 
         let ethereum_client = EthereumRpcClient::new(self.rpc_url.as_str())

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -44,7 +44,7 @@ pub struct FyndBuilder {
     min_tvl: f64,
     min_token_quality: i32,
     traded_n_days_ago: u64,
-    tvl_buffer_multiplier: f64,
+    tvl_buffer_ratio: f64,
     gas_refresh_interval: Duration,
     reconnect_delay: Duration,
     order_manager_timeout: Duration,
@@ -77,7 +77,7 @@ impl FyndBuilder {
             min_tvl: defaults::MIN_TVL,
             min_token_quality: defaults::MIN_TOKEN_QUALITY,
             traded_n_days_ago: defaults::TRADED_N_DAYS_AGO,
-            tvl_buffer_multiplier: defaults::TVL_BUFFER_MULTIPLIER,
+            tvl_buffer_ratio: defaults::TVL_BUFFER_RATIO,
             gas_refresh_interval: Duration::from_secs(defaults::GAS_REFRESH_INTERVAL_SECS),
             reconnect_delay: Duration::from_secs(defaults::RECONNECT_DELAY_SECS),
             order_manager_timeout: Duration::from_millis(defaults::ORDER_MANAGER_TIMEOUT_MS),
@@ -117,9 +117,9 @@ impl FyndBuilder {
         self
     }
 
-    /// Sets the TVL buffer multiplier (default: 1.1).
-    pub fn tvl_buffer_multiplier(mut self, multiplier: f64) -> Self {
-        self.tvl_buffer_multiplier = multiplier;
+    /// Sets the TVL buffer ratio (default: 1.1).
+    pub fn tvl_buffer_ratio(mut self, multiplier: f64) -> Self {
+        self.tvl_buffer_ratio = multiplier;
         self
     }
 
@@ -191,7 +191,7 @@ impl FyndBuilder {
             self.protocols.clone(),
             self.min_tvl,
         )
-        .tvl_buffer_multiplier(self.tvl_buffer_multiplier)
+        .tvl_buffer_ratio(self.tvl_buffer_ratio)
         .gas_refresh_interval(self.gas_refresh_interval)
         .reconnect_delay(self.reconnect_delay)
         .min_token_quality(self.min_token_quality)

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -170,4 +170,14 @@ pub mod defaults {
     pub const POOL_MIN_HOPS: usize = 1;
     pub const POOL_MAX_HOPS: usize = 3;
     pub const POOL_TIMEOUT_MS: u64 = 100;
+
+    /// Returns the default Tycho Fynd endpoint URL for the given chain.
+    pub fn default_tycho_url(chain: &str) -> &str {
+        match chain.to_lowercase().as_str() {
+            "ethereum" => "tycho-fynd-ethereum.propellerheads.xyz",
+            "base" => "tycho-fynd-base.propellerheads.xyz",
+            "unichain" => "tycho-fynd-unichain.propellerheads.xyz",
+            _ => "localhost:4242",
+        }
+    }
 }

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -152,7 +152,7 @@ pub mod defaults {
     pub const MIN_TVL: f64 = 10.0;
     pub const MIN_TOKEN_QUALITY: i32 = 100;
     pub const TRADED_N_DAYS_AGO: u64 = 3;
-    pub const TVL_BUFFER_MULTIPLIER: f64 = 1.1;
+    pub const TVL_BUFFER_RATIO: f64 = 1.1;
     pub const RECONNECT_DELAY_SECS: u64 = 5;
 
     // Gas

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -172,12 +172,17 @@ pub mod defaults {
     pub const POOL_TIMEOUT_MS: u64 = 100;
 
     /// Returns the default Tycho Fynd endpoint URL for the given chain.
-    pub fn default_tycho_url(chain: &str) -> &str {
+    ///
+    /// Returns an error if the chain is not recognized.
+    pub fn default_tycho_url(chain: &str) -> Result<&str, String> {
         match chain.to_lowercase().as_str() {
-            "ethereum" => "tycho-fynd-ethereum.propellerheads.xyz",
-            "base" => "tycho-fynd-base.propellerheads.xyz",
-            "unichain" => "tycho-fynd-unichain.propellerheads.xyz",
-            _ => "localhost:4242",
+            "ethereum" => Ok("tycho-fynd-ethereum.propellerheads.xyz"),
+            "base" => Ok("tycho-fynd-base.propellerheads.xyz"),
+            "unichain" => Ok("tycho-fynd-unichain.propellerheads.xyz"),
+            other => Err(format!(
+                "no default Tycho URL for chain '{}'. Please provide --tycho-url explicitly.",
+                other
+            )),
         }
     }
 }

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -151,6 +151,7 @@ pub mod defaults {
     // Tycho stream
     pub const MIN_TVL: f64 = 10.0;
     pub const MIN_TOKEN_QUALITY: i32 = 100;
+    pub const TRADED_N_DAYS_AGO: u64 = 3;
     pub const TVL_BUFFER_MULTIPLIER: f64 = 1.1;
     pub const RECONNECT_DELAY_SECS: u64 = 5;
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,10 @@ pub struct ServeArgs {
     #[arg(long, default_value_t = defaults::MIN_TOKEN_QUALITY)]
     pub min_token_quality: i32,
 
+    /// Only include tokens traded within this many days.
+    #[arg(long, default_value_t = defaults::TRADED_N_DAYS_AGO)]
+    pub traded_n_days_ago: u64,
+
     /// Gas price refresh interval in seconds
     #[arg(long, default_value_t = defaults::GAS_REFRESH_INTERVAL_SECS)]
     pub gas_refresh_interval_secs: u64,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,9 +37,9 @@ pub struct ServeArgs {
     #[arg(long, default_value_t = defaults::HTTP_PORT, env)]
     pub http_port: u16,
 
-    /// Tycho WebSocket URL (default: tycho-beta.propellerheads.xyz)
-    #[arg(long, default_value = "localhost:4242", env)]
-    pub tycho_url: String,
+    /// Tycho WebSocket URL. Defaults to the Fynd endpoint for the selected chain.
+    #[arg(long, env)]
+    pub tycho_url: Option<String>,
 
     /// Tycho API key
     #[arg(long, env)]
@@ -143,7 +143,7 @@ mod cli_tests {
         assert_eq!(args.http_port, 8080);
         assert_eq!(args.tycho_api_key, Some("test-key".to_string()));
         assert_eq!(args.rpc_url, Some("https://rpc.example.com".to_string()));
-        assert_eq!(args.tycho_url, "wss://custom.tycho.url");
+        assert_eq!(args.tycho_url, Some("wss://custom.tycho.url".to_string()));
         assert_eq!(args.protocols, vec!["uniswap_v2", "uniswap_v3"]);
         assert_eq!(args.min_tvl, 20.0);
         assert_eq!(args.worker_pools_config, PathBuf::from("new_worker_pools.toml"));
@@ -163,7 +163,7 @@ mod cli_tests {
         assert_eq!(args.http_port, 3000);
         assert_eq!(args.tycho_api_key, None);
         assert_eq!(args.rpc_url, None);
-        assert_eq!(args.tycho_url, "localhost:4242");
+        assert_eq!(args.tycho_url, None);
         assert!(args.protocols.is_empty());
         assert_eq!(args.min_tvl, 10.0);
         assert_eq!(args.tvl_buffer_ratio, 1.1);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,13 +65,12 @@ pub struct ServeArgs {
     #[arg(long, default_value_t = defaults::MIN_TVL)]
     pub min_tvl: f64,
 
-    /// TVL buffer multiplier.
+    /// TVL buffer ratio.
     /// Used to avoid fluctuations caused by components hovering around a single threshold.
-    /// Default is 1.1 (10% buffer). For example, if the minimum TVL is 10 ETH, then components
-    /// that drop below 10 ETH will be removed from the market data and components that exceed 11
-    /// ETH will be added.
-    #[arg(long, default_value_t = defaults::TVL_BUFFER_MULTIPLIER)]
-    pub tvl_buffer_multiplier: f64,
+    /// Default is 1.1 (10% buffer). For example, if the minimum TVL is 10 ETH, components are
+    /// added when TVL >= 10 ETH and removed when TVL drops below 10 / 1.1 ≈ 9.09 ETH.
+    #[arg(long, default_value_t = defaults::TVL_BUFFER_RATIO)]
+    pub tvl_buffer_ratio: f64,
 
     /// Minimum token quality filter.
     #[arg(long, default_value_t = defaults::MIN_TOKEN_QUALITY)]
@@ -167,7 +166,7 @@ mod cli_tests {
         assert_eq!(args.tycho_url, "localhost:4242");
         assert!(args.protocols.is_empty());
         assert_eq!(args.min_tvl, 10.0);
-        assert_eq!(args.tvl_buffer_multiplier, 1.1);
+        assert_eq!(args.tvl_buffer_ratio, 1.1);
         assert_eq!(args.gas_refresh_interval_secs, 30);
         assert_eq!(args.reconnect_delay_secs, 5);
         assert_eq!(args.order_manager_timeout_ms, 100);

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,7 +197,8 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
     let tycho_url = match &args.tycho_url {
         Some(url) => url.clone(),
         None => {
-            let default = defaults::default_tycho_url(&args.chain);
+            let default = defaults::default_tycho_url(&args.chain)
+                .map_err(SolverError::SetupError)?;
             info!(
                 "No --tycho-url provided. Using default for {}: {}",
                 args.chain, default

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,6 +247,7 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
             .http_port(args.http_port)
             .min_tvl(args.min_tvl)
             .min_token_quality(args.min_token_quality)
+            .traded_n_days_ago(args.traded_n_days_ago)
             .tvl_buffer_multiplier(args.tvl_buffer_multiplier)
             .gas_refresh_interval(Duration::from_secs(args.gas_refresh_interval_secs))
             .reconnect_delay(Duration::from_secs(args.reconnect_delay_secs))

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,7 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
             .http_host(args.http_host.clone())
             .http_port(args.http_port)
             .min_tvl(args.min_tvl)
+            .min_token_quality(args.min_token_quality)
             .tvl_buffer_multiplier(args.tvl_buffer_multiplier)
             .gas_refresh_interval(Duration::from_secs(args.gas_refresh_interval_secs))
             .reconnect_delay(Duration::from_secs(args.reconnect_delay_secs))

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,6 +193,19 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
     let chain = parse_chain(&args.chain)
         .map_err(|e| SolverError::SetupError(format!("failed to parse chain: {}", e)))?;
 
+    // Resolve Tycho URL, falling back to chain-specific Fynd endpoint
+    let tycho_url = match &args.tycho_url {
+        Some(url) => url.clone(),
+        None => {
+            let default = defaults::default_tycho_url(&args.chain);
+            info!(
+                "No --tycho-url provided. Using default for {}: {}",
+                args.chain, default
+            );
+            default.to_string()
+        }
+    };
+
     // Resolve RPC URL, falling back to public endpoint with a warning
     let rpc_url = match &args.rpc_url {
         Some(url) => url.clone(),
@@ -213,7 +226,7 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
             .any(|p| p == "all_onchain");
     let protocols = if needs_fetch {
         let mut fetched = fetch_protocol_systems(
-            &args.tycho_url,
+            &tycho_url,
             args.tycho_api_key.as_deref(),
             !args.disable_tls,
             chain,
@@ -242,7 +255,7 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
 
     // Build solver with all fields from CLI
     let mut builder =
-        FyndBuilder::new(chain, pools_config.pools, args.tycho_url.clone(), rpc_url, protocols)
+        FyndBuilder::new(chain, pools_config.pools, tycho_url, rpc_url, protocols)
             .http_host(args.http_host.clone())
             .http_port(args.http_port)
             .min_tvl(args.min_tvl)

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,7 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::Fynd, 
             .min_tvl(args.min_tvl)
             .min_token_quality(args.min_token_quality)
             .traded_n_days_ago(args.traded_n_days_ago)
-            .tvl_buffer_multiplier(args.tvl_buffer_multiplier)
+            .tvl_buffer_ratio(args.tvl_buffer_ratio)
             .gas_refresh_interval(Duration::from_secs(args.gas_refresh_interval_secs))
             .reconnect_delay(Duration::from_secs(args.reconnect_delay_secs))
             .order_manager_timeout(Duration::from_millis(args.order_manager_timeout_ms))


### PR DESCRIPTION
## Summary

Rebased on top of #88 — protocol defaults are now handled by the RPC-based fetch from that PR (no hardcoding).

- **fix: connect min_token_quality CLI arg to builder** — the `--min-token-quality` flag was accepted but silently ignored
- **feat: add traded_n_days_ago parameter** — new `--traded-n-days-ago` flag (default: 3) passed through CLI → builder → feed → `load_all_tokens`
- **fix: apply TVL buffer as lower bound for hysteresis** — the buffer ratio now defines the remove threshold (`min_tvl / ratio`), so `min_tvl` is correctly sent as `tvl_gt` to the indexer
- **refactor: rename tvl_buffer_multiplier to tvl_buffer_ratio** — better reflects its role as a hysteresis ratio
- **feat: add chain-specific defaults for tycho_url** — `--tycho-url` is now optional; defaults resolve per chain to the fynd indexer endpoints (e.g. `tycho-fynd-ethereum.propellerheads.xyz`)

With these changes, a user with a fynd-basic plan key can run `fynd serve --tycho-api-key <key>` with no extra args and get a working solver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)