### PR TITLE
feat(ts-client): use transaction calldata from order quote

### DIFF
--- a/clients/typescript/client/src/client.test.ts
+++ b/clients/typescript/client/src/client.test.ts
@@ -28,10 +28,9 @@ function makeClientWithHttpMock(
   opts?: Partial<FyndClientOptions>,
 ): FyndClient {
   const client = new FyndClient({
-    baseUrl:       'http://localhost:8080',
-    chainId:       1,
-    routerAddress: ROUTER,
-    sender:        SENDER,
+    baseUrl:  'http://localhost:8080',
+    chainId:  1,
+    sender:   SENDER,
     ...opts,
   });
 

--- a/clients/typescript/client/src/client.test.ts
+++ b/clients/typescript/client/src/client.test.ts
@@ -68,7 +68,8 @@ const wireSolution = {
       gas_estimate:       '150000',
       route:              null,
       price_impact_bps:   null,
-      block: { hash: '0xabc', number: 100, timestamp: 1000000 },
+      block:              { hash: '0xabc', number: 100, timestamp: 1000000 },
+      transaction:        { to: ROUTER, value: '0', data: '0x' },
     },
   ],
   total_gas_estimate: '150000',
@@ -146,7 +147,6 @@ describe('FyndClient.quote — retry path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       retry:         { maxAttempts: 3, initialBackoffMs: 1, maxBackoffMs: 10 },
     });
@@ -179,7 +179,6 @@ describe('FyndClient.quote — retry path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       retry:         { maxAttempts: 3, initialBackoffMs: 1 },
     });
@@ -210,7 +209,6 @@ describe('FyndClient.quote — retry path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       retry:         { maxAttempts: 2, initialBackoffMs: 1, maxBackoffMs: 5 },
     });
@@ -266,7 +264,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -280,7 +277,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
     });
     const quote = { ...makeDummyQuote() };
@@ -297,7 +293,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       provider,
       // no sender
     });
@@ -310,21 +305,37 @@ describe('FyndClient.signablePayload', () => {
     }
   });
 
-  it('builds transaction with correct to and value', async () => {
+  it('builds transaction with correct to and value from quote.transaction', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
     const quote = makeDummyQuote();
     const payload = await client.signablePayload(quote);
     expect(payload.kind).toBe('fynd');
-    expect(payload.payload.tx.to).toBe(ROUTER);
-    expect(payload.payload.tx.value).toBe(0n);
-    expect(payload.payload.tx.data).toBe('0x');
+    expect(payload.payload.tx.to).toBe(quote.transaction?.to);
+    expect(payload.payload.tx.value).toBe(quote.transaction?.value);
+    expect(payload.payload.tx.data).toBe(quote.transaction?.data);
+  });
+
+  it('throws CONFIG error when quote.transaction is undefined', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl:       'http://localhost:8080',
+      chainId:       1,
+      sender:        SENDER,
+      provider,
+    });
+    const quote = { ...makeDummyQuote(), transaction: undefined };
+    await expect(client.signablePayload(quote)).rejects.toThrow(FyndError);
+    try {
+      await client.signablePayload(quote);
+    } catch (e) {
+      expect(e instanceof FyndError && e.code).toBe('CONFIG');
+    }
   });
 
   it('uses hints.sender over options.sender', async () => {
@@ -333,7 +344,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -347,7 +357,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -362,7 +371,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -381,7 +389,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -395,7 +402,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -410,7 +416,6 @@ describe('FyndClient.signablePayload', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -439,7 +444,6 @@ describe('FyndClient.execute — standard path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -457,7 +461,6 @@ describe('FyndClient.execute — standard path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
     });
     const signedOrder = makeSignedOrder(makeDummyQuote());
@@ -477,7 +480,6 @@ describe('FyndClient.execute — dry-run path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -501,7 +503,6 @@ describe('FyndClient.execute — dry-run path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -525,7 +526,6 @@ describe('FyndClient.execute — dry-run path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -544,7 +544,6 @@ describe('FyndClient.execute — dry-run path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -562,7 +561,6 @@ describe('FyndClient.execute — dry-run path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -584,7 +582,6 @@ describe('FyndClient.execute — dry-run path', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -627,7 +624,6 @@ describe('Transfer log decoding via settle()', () => {
     const client = new FyndClient({
       baseUrl:       'http://localhost:8080',
       chainId:       1,
-      routerAddress: ROUTER,
       sender:        SENDER,
       provider,
     });
@@ -720,9 +716,10 @@ function makeDummyQuote(overrides?: Partial<{ gasEstimate: bigint }>) {
     amountIn:    1000n,
     amountOut:   3500n,
     gasEstimate: overrides?.gasEstimate ?? 150000n,
-    block: { hash: '0xabc', number: 100, timestamp: 1000 },
-    tokenOut: TOKEN_OUT,
-    receiver: SENDER,
+    block:       { hash: '0xabc', number: 100, timestamp: 1000 },
+    tokenOut:    TOKEN_OUT,
+    receiver:    SENDER,
+    transaction: { to: ROUTER, value: 0n, data: '0x' as Hex },
   };
 }
 

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -58,7 +58,6 @@ export interface ExecutionOptions {
 export interface FyndClientOptions {
   baseUrl: string;
   chainId: number;
-  routerAddress: Address;
   sender?: Address;
   timeoutMs?: number;    // default: 30_000
   retry?: RetryConfig;
@@ -167,15 +166,21 @@ export class FyndClient {
 
     const gas = hints.gasLimit ?? quote.gasEstimate;
 
+    if (quote.transaction === undefined) {
+      throw FyndError.config(
+        "quote has no transaction: request a quote with EncodingOptions to get calldata from the server"
+      );
+    }
+
     const tx: Eip1559Transaction = {
       chainId:              this.options.chainId,
       nonce,
       maxFeePerGas,
       maxPriorityFeePerGas,
       gas,
-      to:    this.options.routerAddress,
-      value: 0n,
-      data:  '0x',
+      to:    quote.transaction.to,
+      value: quote.transaction.value,
+      data:  quote.transaction.data,
     };
 
     if (hints.simulate === true) {

--- a/clients/typescript/client/src/index.ts
+++ b/clients/typescript/client/src/index.ts
@@ -2,16 +2,21 @@ export type {
   Address,
   BackendKind,
   BlockInfo,
+  EncodingOptions,
   Hex,
   HealthStatus,
   Order,
   OrderSide,
+  PermitDetails,
+  PermitSingle,
   Quote,
   QuoteOptions,
   QuoteParams,
   Route,
   SolutionStatus,
   Swap,
+  Transaction,
+  UserTransferType,
 } from "./types.js";
 export { FyndError } from "./error.js";
 export type { ClientErrorCode, ErrorCode, ServerErrorCode } from "./error.js";

--- a/clients/typescript/client/src/mapping.test.ts
+++ b/clients/typescript/client/src/mapping.test.ts
@@ -2,9 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { toWireRequest, fromWireQuote, fromWireHealth } from './mapping.js';
 import { FyndError } from './error.js';
 import type { QuoteParams } from './types.js';
+import type { Address, Hex } from './types.js';
 import type { components } from '@fynd/autogen';
 
-type WireSolution = components["schemas"]["Solution"];
+type WireSolution = components["schemas"]["Quote"];
 
 const SENDER = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as const;
 const TOKEN_IN = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as const;
@@ -104,6 +105,76 @@ describe('toWireRequest', () => {
     expect(wire.options).toBeDefined();
     expect(wire.options).not.toHaveProperty('min_responses');
     expect(wire.options).not.toHaveProperty('max_gas');
+  });
+
+  it('serializes encodingOptions.slippage and transfer_type', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: {
+        encodingOptions: { slippage: 0.005, transferType: 'transfer_from' },
+      },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.options?.encoding_options?.slippage).toBe(0.005);
+    expect(wire.options?.encoding_options?.transfer_type).toBe('transfer_from');
+    expect(wire.options?.encoding_options).not.toHaveProperty('permit');
+    expect(wire.options?.encoding_options).not.toHaveProperty('permit2_signature');
+  });
+
+  it('omits transfer_type key when not set (exactOptionalPropertyTypes)', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: { encodingOptions: { slippage: 0.001 } },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.options?.encoding_options).not.toHaveProperty('transfer_type');
+  });
+
+  it('serializes encodingOptions with permit and permit2Signature using snake_case wire fields', () => {
+    const SPENDER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address;
+    const TOKEN   = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as Address;
+    const SIG     = '0xdeadbeef' as Hex;
+    const params: QuoteParams = {
+      ...baseParams,
+      options: {
+        encodingOptions: {
+          slippage:        0.003,
+          transferType:    'transfer_from_permit2',
+          permit2Signature: SIG,
+          permit: {
+            spender:     SPENDER,
+            sigDeadline: 1893456000n,
+            details: {
+              token:      TOKEN,
+              amount:     1000000000000000000n,
+              expiration: 1893456000n,
+              nonce:      0n,
+            },
+          },
+        },
+      },
+    };
+    const wire = toWireRequest(params);
+    const enc = wire.options?.encoding_options;
+    expect(enc?.transfer_type).toBe('transfer_from_permit2');
+    expect(enc?.permit2_signature).toBe(SIG);
+    // PermitSingle wire fields
+    expect(enc?.permit?.spender).toBe(SPENDER);
+    expect(enc?.permit?.sig_deadline).toBe('1893456000');
+    // PermitDetails wire fields
+    expect(enc?.permit?.details.token).toBe(TOKEN);
+    expect(enc?.permit?.details.amount).toBe('1000000000000000000');
+    expect(enc?.permit?.details.expiration).toBe('1893456000');
+    expect(enc?.permit?.details.nonce).toBe('0');
+  });
+
+  it('serializes UserTransferType "none" correctly', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: { encodingOptions: { slippage: 0.0, transferType: 'none' } },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.options?.encoding_options?.transfer_type).toBe('none');
   });
 });
 
@@ -235,6 +306,57 @@ describe('fromWireQuote', () => {
     const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, RECEIVER);
     expect(quote.tokenOut).toBe(TOKEN_OUT);
     expect(quote.receiver).toBe(RECEIVER);
+  });
+
+  it('transaction is undefined when wire transaction is null', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [{ ...baseWireSolution.orders[0]!, transaction: null }],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.transaction).toBeUndefined();
+  });
+
+  it('transaction is undefined when wire transaction is absent', () => {
+    // baseWireSolution.orders[0] has no transaction field
+    const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, SENDER);
+    expect(quote.transaction).toBeUndefined();
+  });
+
+  it('maps transaction fields: to as Address, value as bigint, data as Hex', () => {
+    const ROUTER = '0x1111111111111111111111111111111111111111' as Address;
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [
+        {
+          ...baseWireSolution.orders[0]!,
+          transaction: { to: ROUTER, value: '12345', data: '0xdeadbeef' },
+        },
+      ],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.transaction).toBeDefined();
+    expect(quote.transaction?.to).toBe(ROUTER);
+    expect(quote.transaction?.value).toBe(12345n);
+    expect(quote.transaction?.data).toBe('0xdeadbeef');
+  });
+
+  it('transaction.value of "0" maps to 0n', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [
+        {
+          ...baseWireSolution.orders[0]!,
+          transaction: {
+            to:    '0x1111111111111111111111111111111111111111',
+            value: '0',
+            data:  '0x',
+          },
+        },
+      ],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.transaction?.value).toBe(0n);
   });
 });
 

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -3,11 +3,13 @@ import { FyndError } from "./error.js";
 import type {
   Address,
   BlockInfo,
+  EncodingOptions,
   HealthStatus,
   Quote,
   QuoteParams,
   Route,
   Swap,
+  Transaction,
 } from "./types.js";
 
 type WireOrder           = components["schemas"]["Order"];
@@ -18,6 +20,10 @@ type WireHealthStatus    = components["schemas"]["HealthStatus"];
 type WireRoute           = components["schemas"]["Route"];
 type WireSwap            = components["schemas"]["Swap"];
 type WireBlockInfo       = components["schemas"]["BlockInfo"];
+type WireTransaction     = components["schemas"]["Transaction"];
+type WireEncodingOptions = components["schemas"]["EncodingOptions"];
+type WirePermitSingle    = components["schemas"]["PermitSingle"];
+type WirePermitDetails   = components["schemas"]["PermitDetails"];
 
 
 export function toWireRequest(params: QuoteParams): WireSolutionRequest {
@@ -41,6 +47,9 @@ export function toWireRequest(params: QuoteParams): WireSolutionRequest {
         ...(params.options.maxGas !== undefined
           ? { max_gas: params.options.maxGas.toString() }
           : {}),
+        ...(params.options.encodingOptions !== undefined
+          ? { encoding_options: toWireEncodingOptions(params.options.encodingOptions) }
+          : {}),
       }
     : undefined;
   return {
@@ -62,6 +71,9 @@ export function fromWireQuote(
     ? fromWireRoute(orderSolution.route)
     : undefined;
   const priceImpactBps = orderSolution.price_impact_bps ?? undefined;
+  const transaction = orderSolution.transaction != null
+    ? fromWireTransaction(orderSolution.transaction)
+    : undefined;
   return {
     orderId:         orderSolution.order_id,
     status:          orderSolution.status,
@@ -75,6 +87,7 @@ export function fromWireQuote(
     // exactOptionalPropertyTypes: spread optional fields only when defined
     ...(route !== undefined ? { route } : {}),
     ...(priceImpactBps !== undefined ? { priceImpactBps } : {}),
+    ...(transaction !== undefined ? { transaction } : {}),
   };
 }
 
@@ -99,6 +112,40 @@ function fromWireBlockInfo(wire: WireBlockInfo): BlockInfo {
     number:    wire.number,
     hash:      wire.hash,
     timestamp: wire.timestamp,
+  };
+}
+
+function fromWireTransaction(wire: WireTransaction): Transaction {
+  return {
+    to:    wire.to as Address,
+    value: BigInt(wire.value),
+    data:  wire.data as `0x${string}`,
+  };
+}
+
+function toWireEncodingOptions(opts: EncodingOptions): WireEncodingOptions {
+  const permit: WirePermitSingle | undefined = opts.permit !== undefined
+    ? toWirePermitSingle(opts.permit)
+    : undefined;
+  return {
+    slippage: opts.slippage,
+    ...(opts.transferType !== undefined ? { transfer_type: opts.transferType } : {}),
+    ...(permit !== undefined ? { permit } : {}),
+    ...(opts.permit2Signature !== undefined ? { permit2_signature: opts.permit2Signature } : {}),
+  };
+}
+
+function toWirePermitSingle(permit: import("./types.js").PermitSingle): WirePermitSingle {
+  const details: WirePermitDetails = {
+    token:      permit.details.token,
+    amount:     permit.details.amount.toString(),
+    expiration: permit.details.expiration.toString(),
+    nonce:      permit.details.nonce.toString(),
+  };
+  return {
+    details,
+    spender:      permit.spender,
+    sig_deadline: permit.sigDeadline.toString(),
   };
 }
 

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -22,10 +22,39 @@ export interface Order {
   receiver?: Address;
 }
 
+export type UserTransferType = 'transfer_from' | 'transfer_from_permit2' | 'none';
+
+export interface PermitDetails {
+  token: Address;
+  amount: bigint;
+  expiration: bigint;
+  nonce: bigint;
+}
+
+export interface PermitSingle {
+  details: PermitDetails;
+  spender: Address;
+  sigDeadline: bigint;
+}
+
+export interface EncodingOptions {
+  slippage: number;
+  transferType?: UserTransferType;
+  permit?: PermitSingle;
+  permit2Signature?: Hex;
+}
+
+export interface Transaction {
+  to: Address;
+  value: bigint;
+  data: Hex;
+}
+
 export interface QuoteOptions {
   timeoutMs?: number;
   minResponses?: number;
   maxGas?: bigint;
+  encodingOptions?: EncodingOptions;
 }
 
 export interface QuoteParams {
@@ -65,6 +94,7 @@ export interface Quote {
   block: BlockInfo;
   tokenOut: Address;    // from original Order; used by execute() for Transfer log parsing
   receiver: Address;    // from original Order; defaults to sender if Order.receiver was absent
+  transaction?: Transaction;  // present when EncodingOptions was set in the quote request
 }
 
 export interface HealthStatus {


### PR DESCRIPTION
## Summary

TypeScript client mirror of the Rust PR #90 changes: delegate transaction encoding to the server instead of using a hardcoded router address and empty calldata.

- Remove `routerAddress` from `FyndClientOptions`
- Add `EncodingOptions` to `QuoteOptions` so callers can request encoded calldata (slippage, transfer type, optional Permit2)
- Add `Transaction` to `Quote` — populated by the server when `EncodingOptions` is set in the request
- `fyndSignablePayload()` reads `to`/`value`/`data` from `quote.transaction`; throws `CONFIG` error when absent (quote requested without `EncodingOptions`)
- Export new public types: `EncodingOptions`, `PermitDetails`, `PermitSingle`, `Transaction`, `UserTransferType`
- Fix stale `WireSolution` type alias in `mapping.test.ts` (`schemas["Solution"]` → `schemas["Quote"]`)
- Add mapping tests for `EncodingOptions` serialization and `Transaction` deserialization (103 tests total)

## Test plan

- [ ] `pnpm test` — 103 tests pass
- [ ] `pnpm exec tsc --noEmit` — no type errors
- [ ] `pnpm exec oxlint src` — no lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)