### PR TITLE
feat(ts-client): add Permit2 support and encoding options

### DIFF
--- a/clients/typescript/client/src/client.test.ts
+++ b/clients/typescript/client/src/client.test.ts
@@ -486,6 +486,25 @@ describe('FyndClient.execute — standard path', () => {
     const signedOrder = makeSignedOrder(makeDummyQuote());
     await expect(client.execute(signedOrder)).rejects.toThrow(FyndError);
   });
+
+  it('settle() throws SETTLE_TIMEOUT when receipt never arrives', async () => {
+    const provider = makeMockProvider();
+    provider.sendRawTransaction.mockResolvedValueOnce('0xhash123' as Hex);
+    provider.getTransactionReceipt.mockResolvedValue(null);
+
+    const client = new FyndClient({
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
+      provider,
+    });
+
+    const signedOrder = makeSignedOrder(makeDummyQuote());
+    const executionReceipt = await client.execute(signedOrder);
+    await expect(executionReceipt.settle({ timeoutMs: 0 })).rejects.toThrow(
+      expect.objectContaining({ code: 'SETTLE_TIMEOUT' }),
+    );
+  });
 });
 
 describe('FyndClient.execute — dry-run path', () => {

--- a/clients/typescript/client/src/client.test.ts
+++ b/clients/typescript/client/src/client.test.ts
@@ -28,10 +28,9 @@ function makeClientWithHttpMock(
   opts?: Partial<FyndClientOptions>,
 ): FyndClient {
   const client = new FyndClient({
-    baseUrl:       'http://localhost:8080',
-    chainId:       1,
-    routerAddress: ROUTER,
-    sender:        SENDER,
+    baseUrl: 'http://localhost:8080',
+    chainId: 1,
+    sender:  SENDER,
     ...opts,
   });
 
@@ -144,11 +143,10 @@ describe('FyndClient.quote — error path', () => {
 describe('FyndClient.quote — retry path', () => {
   it('retries on QUEUE_FULL and succeeds on second attempt', async () => {
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
-      retry:         { maxAttempts: 3, initialBackoffMs: 1, maxBackoffMs: 10 },
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
+      retry:   { maxAttempts: 3, initialBackoffMs: 1, maxBackoffMs: 10 },
     });
 
     let callCount = 0;
@@ -177,11 +175,10 @@ describe('FyndClient.quote — retry path', () => {
 
   it('does not retry on non-retryable errors', async () => {
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
-      retry:         { maxAttempts: 3, initialBackoffMs: 1 },
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
+      retry:   { maxAttempts: 3, initialBackoffMs: 1 },
     });
 
     let callCount = 0;
@@ -208,11 +205,10 @@ describe('FyndClient.quote — retry path', () => {
 
   it('exhausts all retries and throws on all-retryable failure', async () => {
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
-      retry:         { maxAttempts: 2, initialBackoffMs: 1, maxBackoffMs: 5 },
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
+      retry:   { maxAttempts: 2, initialBackoffMs: 1, maxBackoffMs: 5 },
     });
 
     let callCount = 0;
@@ -264,10 +260,9 @@ describe('FyndClient.signablePayload', () => {
   it('throws for turbine backend (not yet implemented)', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const turbineQuote = { ...makeDummyQuote(), backend: 'turbine' as const };
@@ -278,10 +273,9 @@ describe('FyndClient.signablePayload', () => {
 
   it('throws CONFIG error when provider is not set', async () => {
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
     });
     const quote = { ...makeDummyQuote() };
     await expect(client.signablePayload(quote)).rejects.toThrow(FyndError);
@@ -295,9 +289,8 @@ describe('FyndClient.signablePayload', () => {
   it('throws CONFIG error when no sender configured', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
       provider,
       // no sender
     });
@@ -310,13 +303,12 @@ describe('FyndClient.signablePayload', () => {
     }
   });
 
-  it('builds transaction with correct to and value', async () => {
+  it('builds transaction with correct to, value, and data from quote.transaction', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const quote = makeDummyQuote();
@@ -327,14 +319,52 @@ describe('FyndClient.signablePayload', () => {
     expect(payload.payload.tx.data).toBe('0x');
   });
 
+  it('builds transaction with calldata from quote.transaction', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
+      provider,
+    });
+    const quote = {
+      ...makeDummyQuote(),
+      transaction: {
+        to: '0x2222222222222222222222222222222222222222' as Address,
+        value: 42n,
+        data: '0xdeadbeef' as Hex,
+      },
+    };
+    const payload = await client.signablePayload(quote);
+    expect(payload.payload.tx.to).toBe('0x2222222222222222222222222222222222222222');
+    expect(payload.payload.tx.value).toBe(42n);
+    expect(payload.payload.tx.data).toBe('0xdeadbeef');
+  });
+
+  it('throws CONFIG error when quote has no transaction', async () => {
+    const provider = makeMockProvider();
+    const client = new FyndClient({
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
+      provider,
+    });
+    const { transaction: _, ...quoteWithoutTx } = makeDummyQuote();
+    await expect(client.signablePayload(quoteWithoutTx)).rejects.toThrow(FyndError);
+    try {
+      await client.signablePayload(quoteWithoutTx);
+    } catch (e) {
+      expect(e instanceof FyndError && e.code).toBe('CONFIG');
+    }
+  });
+
   it('uses hints.sender over options.sender', async () => {
     const provider = makeMockProvider();
     const altSender = '0x9999999999999999999999999999999999999999' as Address;
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const quote = makeDummyQuote();
@@ -345,10 +375,9 @@ describe('FyndClient.signablePayload', () => {
   it('uses hints.nonce without calling getTransactionCount', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const quote = makeDummyQuote();
@@ -360,10 +389,9 @@ describe('FyndClient.signablePayload', () => {
   it('uses hints.maxFeePerGas without calling estimateFeesPerGas', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const quote = makeDummyQuote();
@@ -379,10 +407,9 @@ describe('FyndClient.signablePayload', () => {
   it('uses hints.gasLimit over quote.gasEstimate', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const quote = makeDummyQuote(); // gasEstimate = 150000n
@@ -393,10 +420,9 @@ describe('FyndClient.signablePayload', () => {
   it('calls provider.call when hints.simulate is true', async () => {
     const provider = makeMockProvider();
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const quote = makeDummyQuote();
@@ -408,10 +434,9 @@ describe('FyndClient.signablePayload', () => {
     const provider = makeMockProvider();
     provider.call.mockRejectedValueOnce(new Error('execution reverted'));
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
     const quote = makeDummyQuote();
@@ -437,10 +462,9 @@ describe('FyndClient.execute — standard path', () => {
     provider.getTransactionReceipt.mockResolvedValueOnce(receipt);
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -455,10 +479,9 @@ describe('FyndClient.execute — standard path', () => {
 
   it('throws CONFIG when provider not set', async () => {
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
     });
     const signedOrder = makeSignedOrder(makeDummyQuote());
     await expect(client.execute(signedOrder)).rejects.toThrow(FyndError);
@@ -475,10 +498,9 @@ describe('FyndClient.execute — dry-run path', () => {
     provider.estimateGas.mockResolvedValueOnce(100000n);
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -499,10 +521,9 @@ describe('FyndClient.execute — dry-run path', () => {
     provider.estimateGas.mockResolvedValueOnce(50000n);
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -523,10 +544,9 @@ describe('FyndClient.execute — dry-run path', () => {
     provider.estimateGas.mockResolvedValueOnce(50000n);
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -542,10 +562,9 @@ describe('FyndClient.execute — dry-run path', () => {
     provider.estimateGas.mockResolvedValueOnce(50000n);
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -560,10 +579,9 @@ describe('FyndClient.execute — dry-run path', () => {
     provider.call.mockRejectedValueOnce(new Error('execution reverted'));
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -582,10 +600,9 @@ describe('FyndClient.execute — dry-run path', () => {
     provider.estimateGas.mockResolvedValueOnce(200000n);
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -625,10 +642,9 @@ describe('Transfer log decoding via settle()', () => {
     provider.getTransactionReceipt.mockResolvedValueOnce(receipt);
 
     const client = new FyndClient({
-      baseUrl:       'http://localhost:8080',
-      chainId:       1,
-      routerAddress: ROUTER,
-      sender:        SENDER,
+      baseUrl: 'http://localhost:8080',
+      chainId: 1,
+      sender:  SENDER,
       provider,
     });
 
@@ -723,6 +739,11 @@ function makeDummyQuote(overrides?: Partial<{ gasEstimate: bigint }>) {
     block: { hash: '0xabc', number: 100, timestamp: 1000 },
     tokenOut: TOKEN_OUT,
     receiver: SENDER,
+    transaction: {
+      to: ROUTER,
+      value: 0n,
+      data: '0x' as Hex,
+    },
   };
 }
 

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -22,6 +22,7 @@ const ERC20_TRANSFER_TOPIC = keccak256(toHex('Transfer(address,address,uint256)'
 // ERC-6909 Transfer(address,address,address,uint256,uint256)
 const ERC6909_TRANSFER_TOPIC = keccak256(toHex('Transfer(address,address,address,uint256,uint256)'));
 
+/** Minimal transaction receipt, compatible with viem and ethers receipts. */
 export interface MinimalReceipt {
   transactionHash: Hex;
   gasUsed: bigint;
@@ -29,6 +30,11 @@ export interface MinimalReceipt {
   logs: Array<{ address: Address; topics: readonly Hex[]; data: Hex }>;
 }
 
+/**
+ * Blockchain provider interface used by {@link FyndClient} for signing and execution.
+ *
+ * Use {@link viemProvider} to create one from a viem `PublicClient`.
+ */
 export interface EthProvider {
   getTransactionCount(args: { address: Address }): Promise<number>;
   estimateFeesPerGas(): Promise<{ maxFeePerGas: bigint; maxPriorityFeePerGas: bigint }>;
@@ -38,35 +44,61 @@ export interface EthProvider {
   getTransactionReceipt(args: { hash: Hex }): Promise<MinimalReceipt | null>;
 }
 
+/** Configuration for exponential backoff retry on transient quote errors. */
 export interface RetryConfig {
-  maxAttempts?: number;      // default: 3
-  initialBackoffMs?: number; // default: 100
-  maxBackoffMs?: number;     // default: 2_000
+  /** Maximum number of attempts (default: 3). */
+  maxAttempts?: number;
+  /** Initial backoff delay in milliseconds (default: 100). */
+  initialBackoffMs?: number;
+  /** Maximum backoff delay in milliseconds (default: 2000). */
+  maxBackoffMs?: number;
 }
 
+/** Overrides for transaction parameters when building a signable payload. */
 export interface SigningHints {
+  /** Override the sender address (defaults to {@link FyndClientOptions.sender}). */
   sender?: Address;
+  /** Override the nonce (defaults to on-chain pending nonce). */
   nonce?: number;
+  /** Override `maxFeePerGas` (defaults to provider estimate). */
   maxFeePerGas?: bigint;
+  /** Override `maxPriorityFeePerGas` (defaults to provider estimate). */
   maxPriorityFeePerGas?: bigint;
+  /** Override gas limit (defaults to `quote.gasEstimate`). */
   gasLimit?: bigint;
+  /** When `true`, simulate the transaction via `eth_call` before returning. */
   simulate?: boolean;
 }
 
+/** Options for {@link FyndClient.execute}. */
 export interface ExecutionOptions {
+  /** When `true`, simulate execution without broadcasting a transaction. */
   dryRun?: boolean;
 }
 
+/** Configuration for constructing a {@link FyndClient}. */
 export interface FyndClientOptions {
+  /** Base URL of the Fynd API (e.g. `"https://api.fynd.exchange"`). */
   baseUrl: string;
+  /** EVM chain ID for transaction signing. */
   chainId: number;
+  /** Default sender address, used when {@link SigningHints.sender} is not set. */
   sender?: Address;
-  timeoutMs?: number;    // default: 30_000
+  /** HTTP request timeout in milliseconds (default: 30000). */
+  timeoutMs?: number;
   retry?: RetryConfig;
+  /** Provider for reading chain state and simulating transactions. */
   provider?: EthProvider;
+  /** Separate provider for broadcasting transactions; falls back to `provider`. */
   submitProvider?: EthProvider;
 }
 
+/**
+ * Client for the Fynd swap routing API.
+ *
+ * Provides methods to request quotes, build signable payloads, and execute
+ * signed swap transactions on-chain.
+ */
 export class FyndClient {
   private readonly http: AutogenClient;
   private readonly options: FyndClientOptions;
@@ -76,6 +108,11 @@ export class FyndClient {
     this.options = options;
   }
 
+  /**
+   * Requests a swap quote from the solver with automatic retry on transient errors.
+   *
+   * @throws {FyndError} With a server or client error code on failure.
+   */
   async quote(params: QuoteParams): Promise<Quote> {
     const tokenOut = params.order.tokenOut;
     const receiver = params.order.receiver ?? params.order.sender;
@@ -125,6 +162,11 @@ export class FyndClient {
     return mapping.fromWireQuote(data, tokenOut, receiver);
   }
 
+  /**
+   * Returns the solver's health status.
+   *
+   * @throws {FyndError} If the server returns an error or is unreachable.
+   */
   async health(): Promise<HealthStatus> {
     const { data, error } = await this.http.GET("/v1/health");
     if (error !== undefined) {
@@ -136,6 +178,13 @@ export class FyndClient {
     return mapping.fromWireHealth(data);
   }
 
+  /**
+   * Builds an unsigned transaction payload from a quote, ready for wallet signing.
+   *
+   * @remarks Requires a `provider` and `sender` to be configured (via options or hints).
+   * @throws {FyndError} With code `CONFIG` if provider/sender is missing or quote has no transaction.
+   * @throws {FyndError} With code `SIMULATE_FAILED` if `hints.simulate` is `true` and the call reverts.
+   */
   async signablePayload(quote: Quote, hints?: SigningHints): Promise<SignablePayload> {
     if (quote.backend !== 'fynd') {
       throw new Error('not implemented: Turbine backend signing');
@@ -196,6 +245,14 @@ export class FyndClient {
     return { kind: 'fynd', payload };
   }
 
+  /**
+   * Broadcasts a signed order on-chain and returns a handle to await settlement.
+   *
+   * Call {@link ExecutionReceipt.settle} on the result to wait for confirmation.
+   *
+   * @throws {FyndError} With code `CONFIG` if no provider is configured or the signature is invalid.
+   * @throws {FyndError} With code `SIMULATE_FAILED` when `dryRun` is `true` and the simulation reverts.
+   */
   async execute(order: SignedOrder, options?: ExecutionOptions): Promise<ExecutionReceipt> {
     const { payload, signature } = order;
     const tx = payload.payload.tx;

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -98,6 +98,9 @@ export interface FyndClientOptions {
  *
  * Provides methods to request quotes, build signable payloads, and execute
  * signed swap transactions on-chain.
+ *
+ * Requires `provider` for building signable payloads and executing transactions.
+ * Optionally accepts a separate `submitProvider` for broadcasting (falls back to `provider`).
  */
 export class FyndClient {
   private readonly http: AutogenClient;
@@ -109,9 +112,18 @@ export class FyndClient {
   }
 
   /**
-   * Requests a swap quote from the solver with automatic retry on transient errors.
+   * Requests a swap quote from the solver.
    *
-   * @throws {FyndError} With a server or client error code on failure.
+   * Retries automatically on transient server errors (`TIMEOUT`, `QUEUE_FULL`,
+   * `SERVICE_OVERLOADED`, `STALE_DATA`, `NOT_READY`) using exponential backoff
+   * with jitter. Configure retry behavior via {@link FyndClientOptions.retry}
+   * (defaults: 3 attempts, 100ms initial backoff, 2s max backoff).
+   *
+   * Each request is subject to an HTTP timeout controlled by
+   * {@link FyndClientOptions.timeoutMs} (default: 30s).
+   *
+   * @throws {FyndError} With a server error code (`NO_ROUTE_FOUND`, `INSUFFICIENT_LIQUIDITY`, etc.) on non-retryable failures.
+   * @throws {FyndError} With code `HTTP` on network-level failures.
    */
   async quote(params: QuoteParams): Promise<Quote> {
     const tokenOut = params.order.tokenOut;
@@ -165,7 +177,10 @@ export class FyndClient {
   /**
    * Returns the solver's health status.
    *
-   * @throws {FyndError} If the server returns an error or is unreachable.
+   * Unlike {@link quote}, this method does not retry on transient errors.
+   *
+   * @throws {FyndError} With a server error code if the solver reports unhealthy.
+   * @throws {FyndError} With code `HTTP` on network-level failures.
    */
   async health(): Promise<HealthStatus> {
     const { data, error } = await this.http.GET("/v1/health");
@@ -179,11 +194,23 @@ export class FyndClient {
   }
 
   /**
-   * Builds an unsigned transaction payload from a quote, ready for wallet signing.
+   * Builds an unsigned EIP-1559 transaction payload from a quote, ready for wallet signing.
    *
-   * @remarks Requires a `provider` and `sender` to be configured (via options or hints).
-   * @throws {FyndError} With code `CONFIG` if provider/sender is missing or quote has no transaction.
-   * @throws {FyndError} With code `SIMULATE_FAILED` if `hints.simulate` is `true` and the call reverts.
+   * Fetches the sender's nonce and current gas fees from the provider unless
+   * overridden via {@link SigningHints}. The gas limit defaults to `quote.gasEstimate`.
+   *
+   * The quote must include a `transaction` field (returned when `encodingOptions`
+   * is set in the quote request). The `to`, `value`, and `data` fields are read
+   * from `quote.transaction`.
+   *
+   * When `hints.simulate` is `true`, the transaction is executed via `eth_call`
+   * before returning. This catches reverts early but adds one RPC round-trip.
+   *
+   * @param quote - A quote obtained from {@link quote}. Must have `transaction` populated.
+   * @param hints - Optional overrides for nonce, gas fees, gas limit, sender, and simulation.
+   * @throws {FyndError} With code `CONFIG` if `provider` or `sender` is not configured.
+   * @throws {FyndError} With code `CONFIG` if `quote.transaction` is absent (forgot `encodingOptions`).
+   * @throws {FyndError} With code `SIMULATE_FAILED` if `hints.simulate` is `true` and the `eth_call` reverts.
    */
   async signablePayload(quote: Quote, hints?: SigningHints): Promise<SignablePayload> {
     if (quote.backend !== 'fynd') {
@@ -248,9 +275,24 @@ export class FyndClient {
   /**
    * Broadcasts a signed order on-chain and returns a handle to await settlement.
    *
-   * Call {@link ExecutionReceipt.settle} on the result to wait for confirmation.
+   * Uses `submitProvider` if configured, otherwise falls back to `provider`.
+   * The signed transaction is serialized as an EIP-1559 envelope and sent via
+   * `eth_sendRawTransaction`.
    *
-   * @throws {FyndError} With code `CONFIG` if no provider is configured or the signature is invalid.
+   * Call {@link ExecutionReceipt.settle} on the returned handle to poll for
+   * the transaction receipt. Settlement polling has a default timeout of
+   * {@link DEFAULT_SETTLE_TIMEOUT_MS} (120s), configurable via {@link SettleOptions.timeoutMs}.
+   * The settled result includes `gasCost` (gasUsed * effectiveGasPrice) and
+   * `settledAmount` (parsed from ERC-20/ERC-6909 Transfer logs to the receiver).
+   *
+   * When `dryRun` is `true`, the transaction is simulated via `eth_call` and
+   * `eth_estimateGas` without broadcasting. The returned `settle()` resolves
+   * immediately with estimated gas cost and decoded return data.
+   *
+   * @param order - A signed order from {@link assembleSignedOrder}.
+   * @param options - Set `dryRun: true` to simulate without broadcasting.
+   * @throws {FyndError} With code `CONFIG` if no provider is configured.
+   * @throws {FyndError} With code `CONFIG` if the signature has an invalid v byte.
    * @throws {FyndError} With code `SIMULATE_FAILED` when `dryRun` is `true` and the simulation reverts.
    */
   async execute(order: SignedOrder, options?: ExecutionOptions): Promise<ExecutionReceipt> {

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -3,13 +3,15 @@ import { createFyndClient, type FyndClient as AutogenClient } from "@fynd/autoge
 import type { components } from "@fynd/autogen";
 import { FyndError } from "./error.js";
 import * as mapping from "./mapping.js";
-import type {
-  Eip1559Transaction,
-  ExecutionReceipt,
-  FyndPayload,
-  SettledOrder,
-  SignablePayload,
-  SignedOrder,
+import {
+  DEFAULT_SETTLE_TIMEOUT_MS,
+  type Eip1559Transaction,
+  type ExecutionReceipt,
+  type FyndPayload,
+  type SettledOrder,
+  type SettleOptions,
+  type SignablePayload,
+  type SignedOrder,
 } from "./signing.js";
 import type { Address, Hex, HealthStatus, Quote, QuoteParams } from "./types.js";
 
@@ -240,7 +242,9 @@ export class FyndClient {
     const receiver = quote.receiver;
 
     return {
-      settle: async (): Promise<SettledOrder> => {
+      settle: async (options?: SettleOptions): Promise<SettledOrder> => {
+        const timeout = options?.timeoutMs ?? DEFAULT_SETTLE_TIMEOUT_MS;
+        const deadline = Date.now() + timeout;
         for (;;) {
           const receipt = await provider.getTransactionReceipt({ hash: txHash });
           if (receipt !== null) {
@@ -252,6 +256,11 @@ export class FyndClient {
               gasCost,
               ...(settledAmount !== undefined ? { settledAmount } : {}),
             };
+          }
+          if (Date.now() >= deadline) {
+            throw FyndError.timeout(
+              `transaction ${txHash} did not settle within ${timeout}ms`,
+            );
           }
           await sleep(2_000);
         }

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -58,7 +58,6 @@ export interface ExecutionOptions {
 export interface FyndClientOptions {
   baseUrl: string;
   chainId: number;
-  routerAddress: Address;
   sender?: Address;
   timeoutMs?: number;    // default: 30_000
   retry?: RetryConfig;
@@ -167,15 +166,22 @@ export class FyndClient {
 
     const gas = hints.gasLimit ?? quote.gasEstimate;
 
+    const txData = quote.transaction;
+    if (txData === undefined) {
+      throw FyndError.config(
+        "quote has no calldata; set encodingOptions in QuoteOptions"
+      );
+    }
+
     const tx: Eip1559Transaction = {
       chainId:              this.options.chainId,
       nonce,
       maxFeePerGas,
       maxPriorityFeePerGas,
       gas,
-      to:    this.options.routerAddress,
-      value: 0n,
-      data:  '0x',
+      to:    txData.to,
+      value: txData.value,
+      data:  txData.data,
     };
 
     if (hints.simulate === true) {

--- a/clients/typescript/client/src/error.ts
+++ b/clients/typescript/client/src/error.ts
@@ -17,7 +17,7 @@ export type ServerErrorCode =
   | 'ALGORITHM_ERROR'
   | { kind: 'UNKNOWN'; raw: string };
 
-export type ClientErrorCode = 'HTTP' | 'DESERIALIZE' | 'CONFIG' | 'SIMULATE_FAILED';
+export type ClientErrorCode = 'HTTP' | 'DESERIALIZE' | 'CONFIG' | 'SIMULATE_FAILED' | 'SETTLE_TIMEOUT';
 export type ErrorCode = ServerErrorCode | ClientErrorCode;
 
 const KNOWN_SERVER_CODES = new Set([
@@ -76,5 +76,9 @@ export class FyndError extends Error {
 
   static simulateFailed(reason: string): FyndError {
     return new FyndError(reason, 'SIMULATE_FAILED');
+  }
+
+  static timeout(message: string): FyndError {
+    return new FyndError(message, 'SETTLE_TIMEOUT');
   }
 }

--- a/clients/typescript/client/src/error.ts
+++ b/clients/typescript/client/src/error.ts
@@ -75,12 +75,19 @@ export class FyndError extends Error {
     return false;
   }
 
-  /** Creates a `FyndError` from a server error response. */
-  static fromWireError(wire: WireErrorResponse): FyndError {
-    const code: ErrorCode = KNOWN_SERVER_CODES.has(wire.code)
-      ? (wire.code as ServerErrorCode)
-      : { kind: 'UNKNOWN', raw: wire.code };
-    return new FyndError(wire.error, code, wire.details);
+  /** Creates a `FyndError` from a server error response or unstructured error. */
+  static fromWireError(wire: WireErrorResponse | unknown): FyndError {
+    const obj = wire as Record<string, unknown>;
+    const rawCode = obj['code'];
+    const rawError = obj['error'];
+    if (typeof rawCode !== 'string' || typeof rawError !== 'string') {
+      const message = typeof wire === 'string' ? wire : JSON.stringify(wire);
+      return new FyndError(message, 'HTTP');
+    }
+    const code: ErrorCode = KNOWN_SERVER_CODES.has(rawCode)
+      ? (rawCode as ServerErrorCode)
+      : { kind: 'UNKNOWN', raw: rawCode };
+    return new FyndError(rawError, code, obj['details']);
   }
 
   /** Creates a `CONFIG` error for invalid or missing client configuration. */

--- a/clients/typescript/client/src/error.ts
+++ b/clients/typescript/client/src/error.ts
@@ -2,7 +2,7 @@ import type { components } from "@fynd/autogen";
 
 type WireErrorResponse = components["schemas"]["ErrorResponse"];
 
-// Server-side codes — kept in sync with fynd-rpc/src/api/error.rs
+/** Error code returned by the Fynd server. Kept in sync with the server schema. */
 export type ServerErrorCode =
   | 'BAD_REQUEST'
   | 'NO_ROUTE_FOUND'
@@ -17,7 +17,10 @@ export type ServerErrorCode =
   | 'ALGORITHM_ERROR'
   | { kind: 'UNKNOWN'; raw: string };
 
+/** Error code originating from the client SDK itself. */
 export type ClientErrorCode = 'HTTP' | 'DESERIALIZE' | 'CONFIG' | 'SIMULATE_FAILED' | 'SETTLE_TIMEOUT';
+
+/** Union of all error codes, covering both server and client errors. */
 export type ErrorCode = ServerErrorCode | ClientErrorCode;
 
 const KNOWN_SERVER_CODES = new Set([
@@ -43,8 +46,16 @@ const RETRYABLE_CODES = new Set<string>([
   'HTTP',
 ]);
 
+/**
+ * Typed error thrown by all Fynd client operations.
+ *
+ * Use {@link FyndError.code} to programmatically handle specific failure modes,
+ * and {@link FyndError.isRetryable} to decide whether to retry.
+ */
 export class FyndError extends Error {
+  /** Machine-readable error code identifying the failure category. */
   readonly code: ErrorCode;
+  /** Optional structured details from the server error response. */
   readonly details?: unknown;
 
   constructor(message: string, code: ErrorCode, details?: unknown) {
@@ -56,6 +67,7 @@ export class FyndError extends Error {
     }
   }
 
+  /** Returns `true` if the error is transient and the operation can be retried. */
   isRetryable(): boolean {
     if (typeof this.code === 'string') {
       return RETRYABLE_CODES.has(this.code);
@@ -63,6 +75,7 @@ export class FyndError extends Error {
     return false;
   }
 
+  /** Creates a `FyndError` from a server error response. */
   static fromWireError(wire: WireErrorResponse): FyndError {
     const code: ErrorCode = KNOWN_SERVER_CODES.has(wire.code)
       ? (wire.code as ServerErrorCode)
@@ -70,14 +83,17 @@ export class FyndError extends Error {
     return new FyndError(wire.error, code, wire.details);
   }
 
+  /** Creates a `CONFIG` error for invalid or missing client configuration. */
   static config(message: string): FyndError {
     return new FyndError(message, 'CONFIG');
   }
 
+  /** Creates a `SIMULATE_FAILED` error when an on-chain simulation reverts. */
   static simulateFailed(reason: string): FyndError {
     return new FyndError(reason, 'SIMULATE_FAILED');
   }
 
+  /** Creates a `SETTLE_TIMEOUT` error when transaction confirmation takes too long. */
   static timeout(message: string): FyndError {
     return new FyndError(message, 'SETTLE_TIMEOUT');
   }

--- a/clients/typescript/client/src/index.ts
+++ b/clients/typescript/client/src/index.ts
@@ -2,16 +2,21 @@ export type {
   Address,
   BackendKind,
   BlockInfo,
+  EncodingOptions,
   Hex,
   HealthStatus,
   Order,
   OrderSide,
+  PermitDetails,
+  PermitSingle,
   Quote,
   QuoteOptions,
   QuoteParams,
   Route,
   SolutionStatus,
   Swap,
+  Transaction,
+  UserTransferType,
 } from "./types.js";
 export { FyndError } from "./error.js";
 export type { ClientErrorCode, ErrorCode, ServerErrorCode } from "./error.js";
@@ -25,6 +30,12 @@ export type {
   SignedOrder,
 } from "./signing.js";
 export { assembleSignedOrder, signingHash } from "./signing.js";
+export {
+  permit2SigningHash,
+  encodingOptions,
+  withPermit2,
+  withNoTransfer,
+} from "./permit2.js";
 export { FyndClient } from "./client.js";
 export type {
   EthProvider,

--- a/clients/typescript/client/src/index.ts
+++ b/clients/typescript/client/src/index.ts
@@ -45,3 +45,5 @@ export type {
   RetryConfig,
   SigningHints,
 } from "./client.js";
+export { viemProvider } from "./viem.js";
+export type { ViemPublicClient } from "./viem.js";

--- a/clients/typescript/client/src/index.ts
+++ b/clients/typescript/client/src/index.ts
@@ -26,10 +26,11 @@ export type {
   FyndPayload,
   PrimitiveSignature,
   SettledOrder,
+  SettleOptions,
   SignablePayload,
   SignedOrder,
 } from "./signing.js";
-export { assembleSignedOrder, signingHash } from "./signing.js";
+export { assembleSignedOrder, DEFAULT_SETTLE_TIMEOUT_MS, signingHash } from "./signing.js";
 export {
   permit2SigningHash,
   encodingOptions,

--- a/clients/typescript/client/src/mapping.test.ts
+++ b/clients/typescript/client/src/mapping.test.ts
@@ -113,7 +113,7 @@ describe('toWireRequest', () => {
     };
     const wire = toWireRequest(params);
     expect(wire.options?.encoding_options).toBeDefined();
-    expect(wire.options?.encoding_options?.slippage).toBe(0.005);
+    expect(wire.options?.encoding_options?.slippage).toBe("0.005");
     expect(wire.options?.encoding_options?.transfer_type).toBe('transfer_from');
   });
 

--- a/clients/typescript/client/src/mapping.test.ts
+++ b/clients/typescript/client/src/mapping.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { toWireRequest, fromWireQuote, fromWireHealth } from './mapping.js';
 import { FyndError } from './error.js';
-import type { QuoteParams } from './types.js';
+import type { Address, Hex, QuoteParams } from './types.js';
 import type { components } from '@fynd/autogen';
 
 type WireSolution = components["schemas"]["Solution"];
@@ -104,6 +104,52 @@ describe('toWireRequest', () => {
     expect(wire.options).toBeDefined();
     expect(wire.options).not.toHaveProperty('min_responses');
     expect(wire.options).not.toHaveProperty('max_gas');
+  });
+
+  it('serializes encodingOptions with slippage', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: { encodingOptions: { slippage: 0.005, transferType: 'transfer_from' } },
+    };
+    const wire = toWireRequest(params);
+    expect(wire.options?.encoding_options).toBeDefined();
+    expect(wire.options?.encoding_options?.slippage).toBe(0.005);
+    expect(wire.options?.encoding_options?.transfer_type).toBe('transfer_from');
+  });
+
+  it('serializes encodingOptions with permit2 fields', () => {
+    const params: QuoteParams = {
+      ...baseParams,
+      options: {
+        encodingOptions: {
+          slippage: 0.01,
+          transferType: 'transfer_from_permit2',
+          permit: {
+            details: {
+              token: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as Address,
+              amount: 1000n,
+              expiration: 1893456000n,
+              nonce: 0n,
+            },
+            spender: '0x1111111111111111111111111111111111111111' as Address,
+            sigDeadline: 1893456000n,
+          },
+          permit2Signature: `0x${'ab'.repeat(65)}` as Hex,
+        },
+      },
+    };
+    const wire = toWireRequest(params);
+    const enc = wire.options?.encoding_options;
+    expect(enc?.transfer_type).toBe('transfer_from_permit2');
+    expect(enc?.permit?.details.amount).toBe('1000');
+    expect(enc?.permit?.details.nonce).toBe('0');
+    expect(enc?.permit?.sig_deadline).toBe('1893456000');
+    expect(enc?.permit2_signature).toBe(`0x${'ab'.repeat(65)}`);
+  });
+
+  it('omits encoding_options when not provided', () => {
+    const wire = toWireRequest(baseParams);
+    expect(wire).not.toHaveProperty('options');
   });
 });
 
@@ -235,6 +281,41 @@ describe('fromWireQuote', () => {
     const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, RECEIVER);
     expect(quote.tokenOut).toBe(TOKEN_OUT);
     expect(quote.receiver).toBe(RECEIVER);
+  });
+
+  it('maps transaction field when present', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [
+        {
+          ...baseWireSolution.orders[0]!,
+          transaction: {
+            to: '0x1111111111111111111111111111111111111111',
+            value: '12345',
+            data: '0xdeadbeef',
+          },
+        },
+      ],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.transaction).toBeDefined();
+    expect(quote.transaction?.to).toBe('0x1111111111111111111111111111111111111111');
+    expect(quote.transaction?.value).toBe(12345n);
+    expect(quote.transaction?.data).toBe('0xdeadbeef');
+  });
+
+  it('transaction is undefined when wire value is null', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [{ ...baseWireSolution.orders[0]!, transaction: null }],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.transaction).toBeUndefined();
+  });
+
+  it('transaction is undefined when wire value is absent', () => {
+    const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, SENDER);
+    expect(quote.transaction).toBeUndefined();
   });
 });
 

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -121,7 +121,8 @@ function fromWireBlockInfo(wire: WireBlockInfo): BlockInfo {
 
 function toWireEncodingOptions(opts: EncodingOptions): WireEncodingOptions {
   return {
-    slippage: opts.slippage,
+    // Server deserializes slippage as a string despite OpenAPI declaring number.
+    slippage: opts.slippage.toString() as unknown as number,
     ...(opts.transferType !== undefined ? { transfer_type: opts.transferType } : {}),
     ...(opts.permit !== undefined ? { permit: toWirePermitSingle(opts.permit) } : {}),
     ...(opts.permit2Signature !== undefined

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -3,11 +3,16 @@ import { FyndError } from "./error.js";
 import type {
   Address,
   BlockInfo,
+  EncodingOptions,
   HealthStatus,
+  Hex,
+  PermitDetails,
+  PermitSingle,
   Quote,
   QuoteParams,
   Route,
   Swap,
+  Transaction,
 } from "./types.js";
 
 type WireOrder           = components["schemas"]["Order"];
@@ -18,6 +23,10 @@ type WireHealthStatus    = components["schemas"]["HealthStatus"];
 type WireRoute           = components["schemas"]["Route"];
 type WireSwap            = components["schemas"]["Swap"];
 type WireBlockInfo       = components["schemas"]["BlockInfo"];
+type WireEncodingOptions = components["schemas"]["EncodingOptions"];
+type WireTransaction     = components["schemas"]["Transaction"];
+type WirePermitSingle    = components["schemas"]["PermitSingle"];
+type WirePermitDetails   = components["schemas"]["PermitDetails"];
 
 
 export function toWireRequest(params: QuoteParams): WireSolutionRequest {
@@ -41,6 +50,9 @@ export function toWireRequest(params: QuoteParams): WireSolutionRequest {
         ...(params.options.maxGas !== undefined
           ? { max_gas: params.options.maxGas.toString() }
           : {}),
+        ...(params.options.encodingOptions !== undefined
+          ? { encoding_options: toWireEncodingOptions(params.options.encodingOptions) }
+          : {}),
       }
     : undefined;
   return {
@@ -61,6 +73,10 @@ export function fromWireQuote(
   const route = orderSolution.route !== null && orderSolution.route !== undefined
     ? fromWireRoute(orderSolution.route)
     : undefined;
+  const transaction = orderSolution.transaction !== null
+    && orderSolution.transaction !== undefined
+    ? fromWireTransaction(orderSolution.transaction)
+    : undefined;
   const priceImpactBps = orderSolution.price_impact_bps ?? undefined;
   return {
     orderId:         orderSolution.order_id,
@@ -74,6 +90,7 @@ export function fromWireQuote(
     receiver,
     // exactOptionalPropertyTypes: spread optional fields only when defined
     ...(route !== undefined ? { route } : {}),
+    ...(transaction !== undefined ? { transaction } : {}),
     ...(priceImpactBps !== undefined ? { priceImpactBps } : {}),
   };
 }
@@ -99,6 +116,42 @@ function fromWireBlockInfo(wire: WireBlockInfo): BlockInfo {
     number:    wire.number,
     hash:      wire.hash,
     timestamp: wire.timestamp,
+  };
+}
+
+function toWireEncodingOptions(opts: EncodingOptions): WireEncodingOptions {
+  return {
+    slippage: opts.slippage,
+    ...(opts.transferType !== undefined ? { transfer_type: opts.transferType } : {}),
+    ...(opts.permit !== undefined ? { permit: toWirePermitSingle(opts.permit) } : {}),
+    ...(opts.permit2Signature !== undefined
+      ? { permit2_signature: opts.permit2Signature }
+      : {}),
+  };
+}
+
+function toWirePermitSingle(permit: PermitSingle): WirePermitSingle {
+  return {
+    details: toWirePermitDetails(permit.details),
+    spender: permit.spender,
+    sig_deadline: permit.sigDeadline.toString(),
+  };
+}
+
+function toWirePermitDetails(d: PermitDetails): WirePermitDetails {
+  return {
+    token: d.token,
+    amount: d.amount.toString(),
+    expiration: d.expiration.toString(),
+    nonce: d.nonce.toString(),
+  };
+}
+
+function fromWireTransaction(wire: WireTransaction): Transaction {
+  return {
+    to:    wire.to as Address,
+    value: BigInt(wire.value),
+    data:  wire.data as Hex,
   };
 }
 

--- a/clients/typescript/client/src/permit2.test.ts
+++ b/clients/typescript/client/src/permit2.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  permit2SigningHash,
+  encodingOptions,
+  withPermit2,
+  withNoTransfer,
+} from './permit2.js';
+import { FyndError } from './error.js';
+import type { Address, Hex, PermitSingle } from './types.js';
+
+const PERMIT2_ADDRESS = '0x000000000022D473030F116dDEE9F6B43aC78BA3' as Address;
+const TOKEN = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2' as Address;
+const SPENDER = '0x1111111111111111111111111111111111111111' as Address;
+
+const basePermit: PermitSingle = {
+  details: {
+    token: TOKEN,
+    amount: 1000000000000000000n,
+    expiration: 1893456000n,
+    nonce: 0n,
+  },
+  spender: SPENDER,
+  sigDeadline: 1893456000n,
+};
+
+describe('permit2SigningHash', () => {
+  it('returns a 0x-prefixed 66-char hex string', () => {
+    const hash = permit2SigningHash(basePermit, 1, PERMIT2_ADDRESS);
+    expect(hash).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for same inputs', () => {
+    const hash1 = permit2SigningHash(basePermit, 1, PERMIT2_ADDRESS);
+    const hash2 = permit2SigningHash(basePermit, 1, PERMIT2_ADDRESS);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('differs when chainId changes', () => {
+    const hash1 = permit2SigningHash(basePermit, 1, PERMIT2_ADDRESS);
+    const hash137 = permit2SigningHash(basePermit, 137, PERMIT2_ADDRESS);
+    expect(hash1).not.toBe(hash137);
+  });
+
+  it('differs when nonce changes', () => {
+    const hash0 = permit2SigningHash(basePermit, 1, PERMIT2_ADDRESS);
+    const permit1: PermitSingle = {
+      ...basePermit,
+      details: { ...basePermit.details, nonce: 1n },
+    };
+    const hash1 = permit2SigningHash(permit1, 1, PERMIT2_ADDRESS);
+    expect(hash0).not.toBe(hash1);
+  });
+
+  it('differs when spender changes', () => {
+    const hash1 = permit2SigningHash(basePermit, 1, PERMIT2_ADDRESS);
+    const altPermit: PermitSingle = {
+      ...basePermit,
+      spender: '0x2222222222222222222222222222222222222222' as Address,
+    };
+    const hash2 = permit2SigningHash(altPermit, 1, PERMIT2_ADDRESS);
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('encodingOptions', () => {
+  it('returns default transfer type transfer_from', () => {
+    const opts = encodingOptions(0.005);
+    expect(opts.slippage).toBe(0.005);
+    expect(opts.transferType).toBe('transfer_from');
+    expect(opts.permit).toBeUndefined();
+    expect(opts.permit2Signature).toBeUndefined();
+  });
+});
+
+describe('withPermit2', () => {
+  it('sets transfer type and permit fields', () => {
+    const base = encodingOptions(0.01);
+    const sig = `0x${'ab'.repeat(65)}` as Hex;
+    const result = withPermit2(base, basePermit, sig);
+    expect(result.transferType).toBe('transfer_from_permit2');
+    expect(result.permit).toBe(basePermit);
+    expect(result.permit2Signature).toBe(sig);
+    expect(result.slippage).toBe(0.01);
+  });
+
+  it('throws on wrong signature length (too short)', () => {
+    const base = encodingOptions(0.01);
+    const shortSig = '0xabcd' as Hex;
+    expect(() => withPermit2(base, basePermit, shortSig)).toThrow(FyndError);
+  });
+
+  it('throws on wrong signature length (too long)', () => {
+    const base = encodingOptions(0.01);
+    const longSig = `0x${'ab'.repeat(66)}` as Hex;
+    expect(() => withPermit2(base, basePermit, longSig)).toThrow(FyndError);
+  });
+
+  it('accepts exactly 65 bytes (132 hex chars)', () => {
+    const base = encodingOptions(0.01);
+    const exactSig = `0x${'00'.repeat(65)}` as Hex;
+    const result = withPermit2(base, basePermit, exactSig);
+    expect(result.permit2Signature).toBe(exactSig);
+  });
+});
+
+describe('withNoTransfer', () => {
+  it('sets transfer type to none', () => {
+    const base = encodingOptions(0.01);
+    const result = withNoTransfer(base);
+    expect(result.transferType).toBe('none');
+    expect(result.slippage).toBe(0.01);
+  });
+});

--- a/clients/typescript/client/src/permit2.ts
+++ b/clients/typescript/client/src/permit2.ts
@@ -1,0 +1,93 @@
+import { hashTypedData } from 'viem';
+import { FyndError } from './error.js';
+import type { Address, EncodingOptions, Hex, PermitSingle } from './types.js';
+
+const PERMIT_DETAILS_TYPE = {
+  PermitDetails: [
+    { name: 'token', type: 'address' },
+    { name: 'amount', type: 'uint160' },
+    { name: 'expiration', type: 'uint48' },
+    { name: 'nonce', type: 'uint48' },
+  ],
+} as const;
+
+const PERMIT_SINGLE_TYPE = {
+  PermitSingle: [
+    { name: 'details', type: 'PermitDetails' },
+    { name: 'spender', type: 'address' },
+    { name: 'sigDeadline', type: 'uint256' },
+  ],
+  ...PERMIT_DETAILS_TYPE,
+} as const;
+
+/**
+ * Computes the EIP-712 signing hash for a Permit2 PermitSingle.
+ *
+ * Pass the returned hash to your signer's signMessage/signHash method,
+ * then supply the 65-byte signature to EncodingOptions.permit2Signature.
+ *
+ * The canonical Permit2 address across all chains is:
+ * 0x000000000022D473030F116dDEE9F6B43aC78BA3
+ */
+export function permit2SigningHash(
+  permit: PermitSingle,
+  chainId: number,
+  permit2Address: Address,
+): Hex {
+  return hashTypedData({
+    domain: {
+      name: 'Permit2',
+      chainId,
+      verifyingContract: permit2Address,
+    },
+    types: PERMIT_SINGLE_TYPE,
+    primaryType: 'PermitSingle',
+    message: {
+      details: {
+        token: permit.details.token,
+        amount: permit.details.amount,
+        expiration: Number(permit.details.expiration),
+        nonce: Number(permit.details.nonce),
+      },
+      spender: permit.spender,
+      sigDeadline: permit.sigDeadline,
+    },
+  });
+}
+
+/**
+ * Create encoding options with slippage tolerance.
+ * Default transfer type is 'transfer_from'.
+ */
+export function encodingOptions(slippage: number): EncodingOptions {
+  return { slippage, transferType: 'transfer_from' };
+}
+
+/**
+ * Add Permit2 authorization to encoding options.
+ * Validates that signature is exactly 65 bytes (130 hex chars + '0x' prefix).
+ */
+export function withPermit2(
+  opts: EncodingOptions,
+  permit: PermitSingle,
+  signature: Hex,
+): EncodingOptions {
+  if (signature.length !== 132) {
+    throw FyndError.config(
+      `Permit2 signature must be exactly 65 bytes (132 hex chars), got ${String(signature.length)} chars`
+    );
+  }
+  return {
+    ...opts,
+    transferType: 'transfer_from_permit2',
+    permit,
+    permit2Signature: signature,
+  };
+}
+
+/**
+ * Set transfer type to 'none' (funds already in router).
+ */
+export function withNoTransfer(opts: EncodingOptions): EncodingOptions {
+  return { ...opts, transferType: 'none' };
+}

--- a/clients/typescript/client/src/signing.test.ts
+++ b/clients/typescript/client/src/signing.test.ts
@@ -21,6 +21,11 @@ const baseQuote: Quote = {
   },
   tokenOut: TOKEN_OUT,
   receiver: SENDER,
+  transaction: {
+    to: ROUTER,
+    value: 0n,
+    data: '0x',
+  },
 };
 
 const basePayload: SignablePayload = {

--- a/clients/typescript/client/src/signing.ts
+++ b/clients/typescript/client/src/signing.ts
@@ -1,6 +1,7 @@
 import { keccak256, serializeTransaction } from 'viem';
 import type { Address, Hex, Quote } from './types.js';
 
+/** An unsigned EIP-1559 transaction ready for signing. */
 export interface Eip1559Transaction {
   chainId: number;
   nonce: number;
@@ -12,32 +13,49 @@ export interface Eip1559Transaction {
   data: Hex;
 }
 
+/** Internal payload pairing a quote with its unsigned transaction. */
 export interface FyndPayload {
-  quote: Quote;   // carries tokenOut and receiver for settlement
+  /** Original quote; carries `tokenOut` and `receiver` needed for settlement parsing. */
+  quote: Quote;
   tx: Eip1559Transaction;
 }
 
+/** Discriminated union of backend-specific payloads ready to be signed. */
 export type SignablePayload = { kind: 'fynd'; payload: FyndPayload };
+
+/** A 65-byte ECDSA signature encoded as a hex string. */
 export type PrimitiveSignature = `0x${string}`;
 
+/** A payload paired with its cryptographic signature, ready for on-chain submission. */
 export interface SignedOrder {
   payload: SignablePayload;
   signature: PrimitiveSignature;
 }
 
+/** Result of a settled (or dry-run) swap execution. */
 export interface SettledOrder {
-  txHash?: Hex;          // absent for dry-run
+  /** Transaction hash; absent for dry-run executions. */
+  txHash?: Hex;
+  /** Total output tokens received by the receiver, parsed from Transfer logs. */
   settledAmount?: bigint;
+  /** Gas cost in wei (gasUsed * effectiveGasPrice, or estimated for dry-run). */
   gasCost: bigint;
 }
 
+/** Options for waiting on transaction settlement. */
 export interface SettleOptions {
+  /** Maximum time to wait for confirmation in milliseconds. Defaults to {@link DEFAULT_SETTLE_TIMEOUT_MS}. */
   timeoutMs?: number;
 }
 
+/** Default timeout for {@link ExecutionReceipt.settle} (120 seconds). */
 export const DEFAULT_SETTLE_TIMEOUT_MS = 120_000;
 
+/** Handle returned by {@link FyndClient.execute} to await transaction settlement. */
 export interface ExecutionReceipt {
+  /** Polls for the transaction receipt and returns the settled result.
+   * @throws {FyndError} With code `SETTLE_TIMEOUT` if the transaction does not confirm in time.
+   */
   settle(options?: SettleOptions): Promise<SettledOrder>;
 }
 

--- a/clients/typescript/client/src/signing.ts
+++ b/clients/typescript/client/src/signing.ts
@@ -31,8 +31,14 @@ export interface SettledOrder {
   gasCost: bigint;
 }
 
+export interface SettleOptions {
+  timeoutMs?: number;
+}
+
+export const DEFAULT_SETTLE_TIMEOUT_MS = 120_000;
+
 export interface ExecutionReceipt {
-  settle(): Promise<SettledOrder>;
+  settle(options?: SettleOptions): Promise<SettledOrder>;
 }
 
 /**

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -1,4 +1,4 @@
-// Must stay in sync with components["schemas"]["QuoteStatus"] from @fynd/autogen.
+/** Outcome status of a quote request. Must stay in sync with the server schema. */
 export type SolutionStatus =
   | 'success'
   | 'no_route_found'
@@ -6,70 +6,105 @@ export type SolutionStatus =
   | 'timeout'
   | 'not_ready';
 
+/** Routing backend that produced a quote. */
 export type BackendKind = 'fynd' | 'turbine';
 
+/** EVM address as a hex string. */
 export type Address = `0x${string}`;
+/** Arbitrary hex-encoded bytes. */
 export type Hex = `0x${string}`;
 
+/** Order side. Currently only sell orders are supported. */
 export type OrderSide = 'sell';
 
+/** A swap order specifying input/output tokens, amount, and participants. */
 export interface Order {
+  /** Token to sell. */
   tokenIn: Address;
+  /** Token to receive. */
   tokenOut: Address;
+  /** Amount of `tokenIn` to sell (in token base units). */
   amount: bigint;
   side: OrderSide;
+  /** Address that holds the input tokens and sends the transaction. */
   sender: Address;
+  /** Address that receives output tokens. Defaults to `sender` if omitted. */
   receiver?: Address;
 }
 
+/** How the router pulls input tokens from the sender. */
 export type UserTransferType = 'transfer_from' | 'transfer_from_permit2' | 'none';
 
+/** Uniswap Permit2 allowance details for a single token. */
 export interface PermitDetails {
   token: Address;
+  /** Maximum transferable amount (uint160). */
   amount: bigint;
+  /** Unix timestamp after which the permit expires (uint48). */
   expiration: bigint;
+  /** Permit2 nonce for this token/spender pair (uint48). */
   nonce: bigint;
 }
 
+/** Uniswap Permit2 single-token permit, ready for EIP-712 signing. */
 export interface PermitSingle {
   details: PermitDetails;
+  /** Address authorized to spend tokens via Permit2. */
   spender: Address;
+  /** Unix timestamp after which the signature is invalid. */
   sigDeadline: bigint;
 }
 
+/** Controls how the solver encodes the settlement transaction. */
 export interface EncodingOptions {
+  /** Maximum acceptable slippage as a fraction (e.g. 0.01 for 1%). */
   slippage: number;
+  /** How tokens are transferred to the router. Defaults to `'transfer_from'`. */
   transferType?: UserTransferType;
+  /** Permit2 permit data; required when `transferType` is `'transfer_from_permit2'`. */
   permit?: PermitSingle;
+  /** 65-byte Permit2 signature over the permit; required with `permit`. */
   permit2Signature?: Hex;
 }
 
+/** An encoded on-chain transaction returned by the solver. */
 export interface Transaction {
   to: Address;
   value: bigint;
   data: Hex;
 }
 
+/** Optional parameters for a quote request. */
 export interface QuoteOptions {
+  /** Server-side solver timeout in milliseconds. */
   timeoutMs?: number;
+  /** Minimum number of solver responses to wait for before returning. */
   minResponses?: number;
+  /** Maximum gas the solution may consume. */
   maxGas?: bigint;
+  /** Encoding options; when set, the response includes a ready-to-sign transaction. */
   encodingOptions?: EncodingOptions;
 }
 
+/** Input parameters for {@link FyndClient.quote}. */
 export interface QuoteParams {
   order: Order;
   options?: QuoteOptions;
 }
 
+/** Block metadata at the time the quote was computed. */
 export interface BlockInfo {
   number: number;
   hash: string;
+  /** Unix timestamp of the block (seconds). */
   timestamp: number;
 }
 
+/** A single pool-level swap within a route. */
 export interface Swap {
-  poolId: string;       // wire: component_id
+  /** Unique pool identifier (wire name: `component_id`). */
+  poolId: string;
+  /** Protocol name (e.g. "uniswap_v3", "balancer_v2"). */
   protocol: string;
   tokenIn: Address;
   tokenOut: Address;
@@ -78,10 +113,12 @@ export interface Swap {
   gasEstimate: bigint;
 }
 
+/** An ordered sequence of swaps forming a complete routing path. */
 export interface Route {
   swaps: Swap[];
 }
 
+/** A solver quote containing the best route, amounts, and optional encoded transaction. */
 export interface Quote {
   orderId: string;
   status: SolutionStatus;
@@ -90,15 +127,22 @@ export interface Quote {
   amountIn: bigint;
   amountOut: bigint;
   gasEstimate: bigint;
+  /** Price impact in basis points (1 bp = 0.01%). */
   priceImpactBps?: number;
   block: BlockInfo;
-  tokenOut: Address;    // from original Order; used by execute() for Transfer log parsing
-  receiver: Address;    // from original Order; defaults to sender if Order.receiver was absent
+  /** Output token address from the original order; used internally for settlement parsing. */
+  tokenOut: Address;
+  /** Receiver address; defaults to sender if not specified in the original order. */
+  receiver: Address;
+  /** Encoded transaction; present only when `encodingOptions` was set in the quote request. */
   transaction?: Transaction;
 }
 
+/** Solver health status and readiness information. */
 export interface HealthStatus {
   healthy: boolean;
+  /** Milliseconds since the last state update. */
   lastUpdateMs: number;
+  /** Number of liquidity pools tracked by the solver. */
   numSolverPools: number;
 }

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -22,10 +22,39 @@ export interface Order {
   receiver?: Address;
 }
 
+export type UserTransferType = 'transfer_from' | 'transfer_from_permit2' | 'none';
+
+export interface PermitDetails {
+  token: Address;
+  amount: bigint;
+  expiration: bigint;
+  nonce: bigint;
+}
+
+export interface PermitSingle {
+  details: PermitDetails;
+  spender: Address;
+  sigDeadline: bigint;
+}
+
+export interface EncodingOptions {
+  slippage: number;
+  transferType?: UserTransferType;
+  permit?: PermitSingle;
+  permit2Signature?: Hex;
+}
+
+export interface Transaction {
+  to: Address;
+  value: bigint;
+  data: Hex;
+}
+
 export interface QuoteOptions {
   timeoutMs?: number;
   minResponses?: number;
   maxGas?: bigint;
+  encodingOptions?: EncodingOptions;
 }
 
 export interface QuoteParams {
@@ -65,6 +94,7 @@ export interface Quote {
   block: BlockInfo;
   tokenOut: Address;    // from original Order; used by execute() for Transfer log parsing
   receiver: Address;    // from original Order; defaults to sender if Order.receiver was absent
+  transaction?: Transaction;
 }
 
 export interface HealthStatus {

--- a/clients/typescript/client/src/viem.ts
+++ b/clients/typescript/client/src/viem.ts
@@ -1,0 +1,116 @@
+import type { Address, Hex } from './types.js';
+import type { EthProvider } from './client.js';
+
+/**
+ * Minimal subset of viem's PublicClient used by FyndClient.
+ *
+ * Declaring this interface avoids coupling to viem's full
+ * type surface while remaining structurally compatible.
+ */
+export interface ViemPublicClient {
+  getTransactionCount(
+    args: { address: Address },
+  ): Promise<number>;
+  estimateFeesPerGas(): Promise<{
+    maxFeePerGas: bigint | null;
+    maxPriorityFeePerGas: bigint | null;
+  }>;
+  call(
+    args: {
+      to: Address;
+      data: Hex;
+      value: bigint;
+      gas: bigint;
+      maxFeePerGas: bigint;
+      maxPriorityFeePerGas: bigint;
+    },
+  ): Promise<{ data?: Hex | undefined }>;
+  estimateGas(
+    args: {
+      account: Address;
+      to: Address;
+      data: Hex;
+      value: bigint;
+      maxFeePerGas: bigint;
+      maxPriorityFeePerGas: bigint;
+    },
+  ): Promise<bigint>;
+  sendRawTransaction(
+    args: { serializedTransaction: Hex },
+  ): Promise<Hex>;
+  getTransactionReceipt(
+    args: { hash: Hex },
+  ): Promise<{
+    transactionHash: Hex;
+    gasUsed: bigint;
+    effectiveGasPrice: bigint;
+    logs: ReadonlyArray<{
+      address: string;
+      topics: readonly string[];
+      data: string;
+    }>;
+  }>;
+}
+
+/**
+ * Wraps a viem PublicClient into an EthProvider for FyndClient.
+ *
+ * @param client - A viem PublicClient (from createPublicClient)
+ * @param sender - The sender address, used for estimateGas calls
+ */
+export function viemProvider(
+  client: ViemPublicClient,
+  sender: Address,
+): EthProvider {
+  return {
+    async getTransactionCount(args) {
+      return client.getTransactionCount(args);
+    },
+    async estimateFeesPerGas() {
+      const fees = await client.estimateFeesPerGas();
+      return {
+        maxFeePerGas: fees.maxFeePerGas ?? 0n,
+        maxPriorityFeePerGas: fees.maxPriorityFeePerGas ?? 0n,
+      };
+    },
+    async call(tx) {
+      const result = await client.call({
+        to: tx.to,
+        data: tx.data,
+        value: tx.value,
+        gas: tx.gas,
+        maxFeePerGas: tx.maxFeePerGas,
+        maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+      });
+      return result.data !== undefined ? { data: result.data } : {};
+    },
+    async estimateGas(tx) {
+      return client.estimateGas({
+        account: sender,
+        to: tx.to,
+        data: tx.data,
+        value: tx.value,
+        maxFeePerGas: tx.maxFeePerGas,
+        maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+      });
+    },
+    async sendRawTransaction(rawTx) {
+      return client.sendRawTransaction({
+        serializedTransaction: rawTx,
+      });
+    },
+    async getTransactionReceipt(args) {
+      const receipt = await client.getTransactionReceipt(args);
+      return {
+        transactionHash: receipt.transactionHash,
+        gasUsed: receipt.gasUsed,
+        effectiveGasPrice: receipt.effectiveGasPrice,
+        logs: receipt.logs.map((log) => ({
+          address: log.address as Address,
+          topics: log.topics as readonly Hex[],
+          data: log.data as Hex,
+        })),
+      };
+    },
+  };
+}

--- a/clients/typescript/client/src/viem.ts
+++ b/clients/typescript/client/src/viem.ts
@@ -2,10 +2,9 @@ import type { Address, Hex } from './types.js';
 import type { EthProvider } from './client.js';
 
 /**
- * Minimal subset of viem's PublicClient used by FyndClient.
+ * Minimal subset of viem's `PublicClient` used by {@link viemProvider}.
  *
- * Declaring this interface avoids coupling to viem's full
- * type surface while remaining structurally compatible.
+ * Any viem `PublicClient` created via `createPublicClient` satisfies this interface.
  */
 export interface ViemPublicClient {
   getTransactionCount(
@@ -53,10 +52,13 @@ export interface ViemPublicClient {
 }
 
 /**
- * Wraps a viem PublicClient into an EthProvider for FyndClient.
+ * Adapts a viem `PublicClient` into an {@link EthProvider} for use with {@link FyndClient}.
  *
- * @param client - A viem PublicClient (from createPublicClient)
- * @param sender - The sender address, used for estimateGas calls
+ * @example
+ * ```ts
+ * const provider = viemProvider(publicClient, senderAddress);
+ * const client = new FyndClient({ baseUrl, chainId, provider });
+ * ```
  */
 export function viemProvider(
   client: ViemPublicClient,

--- a/clients/typescript/client/src/viem.ts
+++ b/clients/typescript/client/src/viem.ts
@@ -102,7 +102,13 @@ export function viemProvider(
       });
     },
     async getTransactionReceipt(args) {
-      const receipt = await client.getTransactionReceipt(args);
+      let receipt;
+      try {
+        receipt = await client.getTransactionReceipt(args);
+      } catch {
+        // viem throws when the receipt is not yet available; settle() expects null.
+        return null;
+      }
       return {
         transactionHash: receipt.transactionHash,
         gasUsed: receipt.gasUsed,

--- a/clients/typescript/examples/tutorial/main.ts
+++ b/clients/typescript/examples/tutorial/main.ts
@@ -1,382 +1,136 @@
 // Tutorial: Quote, Sign & Execute Swaps with the Fynd TypeScript Client
 //
-// This example demonstrates how to:
-// 1. Create a FyndClient pointing at a running solver
-// 2. Get a swap quote with server-side encoding (encoding options)
-// 3. Sign the transaction with Permit2 authorization
-// 4. Simulate or execute the swap on-chain
-//
-// Prerequisites:
-//   - A running fynd solver (see the Rust tutorial README for setup)
-//   - Environment variables (see below)
-//
 // Environment variables:
 //   SOLVER_URL    - Solver API URL (default: http://localhost:3000)
-//   RPC_URL       - Ethereum RPC endpoint (required for simulation/execution)
-//   PRIVATE_KEY   - Wallet private key, hex without 0x prefix (required)
-//   CHAIN_ID      - Chain ID (default: 1 for Ethereum mainnet)
+//   RPC_URL       - Ethereum RPC endpoint (required)
+//   PRIVATE_KEY   - Wallet private key, hex (required)
+//   CHAIN_ID      - Chain ID (default: 1)
 
 import {
   type Address,
   type Hex,
-  type Quote,
   FyndClient,
   encodingOptions,
   withPermit2,
   permit2SigningHash,
   signingHash,
   assembleSignedOrder,
+  viemProvider,
 } from "@fynd/client";
-import {
-  createPublicClient,
-  createWalletClient,
-  http,
-  formatUnits,
-  parseUnits,
-} from "viem";
+import { createPublicClient, http, parseUnits } from "viem";
 import { privateKeyToAccount } from "viem/accounts";
 import { mainnet } from "viem/chains";
 
-// Well-known token addresses on Ethereum mainnet
 const USDC: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-
-// Canonical Permit2 address (same on all chains)
 const PERMIT2: Address = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 
-// Token metadata for display formatting
-const TOKEN_INFO: Record<string, { symbol: string; decimals: number }> = {
-  [USDC.toLowerCase()]: { symbol: "USDC", decimals: 6 },
-  [WETH.toLowerCase()]: { symbol: "WETH", decimals: 18 },
-};
-
-// ============================================================================
-// Configuration
-// ============================================================================
-
-interface Config {
-  solverUrl: string;
-  rpcUrl: string;
-  privateKey: Hex;
-  chainId: number;
-  sellToken: Address;
-  buyToken: Address;
-  sellAmount: string;
-  slippageBps: number;
-  simulateOnly: boolean;
-}
-
-function loadConfig(): Config {
-  const privateKey = process.env["PRIVATE_KEY"];
-  if (privateKey === undefined) {
-    throw new Error(
-      "PRIVATE_KEY environment variable is required. " +
-        "Set it to your wallet private key (hex, no 0x prefix)."
-    );
-  }
+async function main(): Promise<void> {
   const rpcUrl = process.env["RPC_URL"];
   if (rpcUrl === undefined) {
-    throw new Error(
-      "RPC_URL environment variable is required for simulation/execution."
-    );
+    throw new Error("RPC_URL environment variable is required.");
+  }
+  const rawKey = process.env["PRIVATE_KEY"];
+  if (rawKey === undefined) {
+    throw new Error("PRIVATE_KEY environment variable is required.");
   }
 
-  return {
-    solverUrl: process.env["SOLVER_URL"] ?? "http://localhost:3000",
-    rpcUrl,
-    privateKey: `0x${privateKey.replace(/^0x/, "")}` as Hex,
-    chainId: Number(process.env["CHAIN_ID"] ?? "1"),
-    sellToken: (process.env["SELL_TOKEN"] as Address | undefined) ?? USDC,
-    buyToken: (process.env["BUY_TOKEN"] as Address | undefined) ?? WETH,
-    sellAmount: process.env["SELL_AMOUNT"] ?? "100",
-    slippageBps: Number(process.env["SLIPPAGE_BPS"] ?? "50"),
-    simulateOnly: process.env["SIMULATE_ONLY"] === "true",
-  };
-}
-
-// ============================================================================
-// Display helpers
-// ============================================================================
-
-function tokenSymbol(address: Address): string {
-  return TOKEN_INFO[address.toLowerCase()]?.symbol ?? address.slice(0, 10);
-}
-
-function tokenDecimals(address: Address): number {
-  return TOKEN_INFO[address.toLowerCase()]?.decimals ?? 18;
-}
-
-function formatAmount(raw: bigint, address: Address): string {
-  return formatUnits(raw, tokenDecimals(address));
-}
-
-function displayQuote(
-  quote: Quote,
-  sellToken: Address,
-  buyToken: Address,
-): void {
-  console.log("\n========== Quote ==========");
-  console.log(`Status: ${quote.status}`);
-
-  if (quote.status !== "success") {
-    console.log("No route found.");
-    console.log("============================\n");
-    return;
-  }
-
-  const formattedIn = formatAmount(quote.amountIn, sellToken);
-  const formattedOut = formatAmount(quote.amountOut, buyToken);
-  console.log(
-    `Swap: ${formattedIn} ${tokenSymbol(sellToken)}` +
-      ` -> ${formattedOut} ${tokenSymbol(buyToken)}`
-  );
-
-  const decIn = Number(formattedIn);
-  const decOut = Number(formattedOut);
-  if (decIn > 0) {
-    const price = decOut / decIn;
-    console.log(
-      `Price: ${price.toFixed(6)} ${tokenSymbol(buyToken)}` +
-        ` per ${tokenSymbol(sellToken)}`
-    );
-  }
-
-  console.log(`Gas estimate: ${quote.gasEstimate}`);
-
-  if (quote.priceImpactBps !== undefined) {
-    console.log(`Price impact: ${(quote.priceImpactBps / 100).toFixed(2)}%`);
-  }
-
-  if (quote.route !== undefined) {
-    console.log(`\nRoute (${quote.route.swaps.length} hops):`);
-    for (const [i, swap] of quote.route.swaps.entries()) {
-      console.log(
-        `  ${i + 1}. ${tokenSymbol(swap.tokenIn)}` +
-          ` -> ${tokenSymbol(swap.tokenOut)}` +
-          ` via ${swap.protocol} (pool: ${swap.poolId})`
-      );
-    }
-  }
-
-  if (quote.transaction !== undefined) {
-    console.log(`\nTransaction encoded:`);
-    console.log(`  to: ${quote.transaction.to}`);
-    console.log(`  value: ${quote.transaction.value}`);
-    console.log(
-      `  data: ${quote.transaction.data.slice(0, 42)}...` +
-        ` (${(quote.transaction.data.length - 2) / 2} bytes)`
-    );
-  }
-
-  console.log("============================\n");
-}
-
-// ============================================================================
-// Main flow
-// ============================================================================
-
-async function main(): Promise<void> {
-  const config = loadConfig();
-
-  // Step 1: Set up viem account and providers
-  const account = privateKeyToAccount(config.privateKey);
-  console.log(`Wallet address: ${account.address}`);
+  const solverUrl = process.env["SOLVER_URL"] ?? "http://localhost:3000";
+  const chainId = Number(process.env["CHAIN_ID"] ?? "1");
+  const privateKey = `0x${rawKey.replace(/^0x/, "")}` as Hex;
+  const account = privateKeyToAccount(privateKey);
+  console.log(`Wallet: ${account.address}`);
 
   const publicClient = createPublicClient({
     chain: mainnet,
-    transport: http(config.rpcUrl),
+    transport: http(rpcUrl),
   });
 
-  const walletClient = createWalletClient({
-    account,
-    chain: mainnet,
-    transport: http(config.rpcUrl),
-  });
-
-  // Step 2: Create FyndClient with an EthProvider adapter for viem
+  // FyndClient accepts a viemProvider adapter — no manual wrapping needed.
   const fyndClient = new FyndClient({
-    baseUrl: config.solverUrl,
-    chainId: config.chainId,
+    baseUrl: solverUrl,
+    chainId,
     sender: account.address,
-    provider: {
-      async getTransactionCount({ address }) {
-        return publicClient.getTransactionCount({ address });
-      },
-      async estimateFeesPerGas() {
-        const fees = await publicClient.estimateFeesPerGas();
-        return {
-          maxFeePerGas: fees.maxFeePerGas ?? 0n,
-          maxPriorityFeePerGas: fees.maxPriorityFeePerGas ?? 0n,
-        };
-      },
-      async call(tx) {
-        const result = await publicClient.call({
-          to: tx.to,
-          data: tx.data,
-          value: tx.value,
-          gas: tx.gas,
-          maxFeePerGas: tx.maxFeePerGas,
-          maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
-        });
-        const hex = result.data as Hex | undefined;
-        return hex !== undefined ? { data: hex } : {};
-      },
-      async estimateGas(tx) {
-        return publicClient.estimateGas({
-          account: account.address,
-          to: tx.to,
-          data: tx.data,
-          value: tx.value,
-          maxFeePerGas: tx.maxFeePerGas,
-          maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
-        });
-      },
-      async sendRawTransaction(rawTx) {
-        return publicClient.sendRawTransaction({ serializedTransaction: rawTx });
-      },
-      async getTransactionReceipt({ hash }) {
-        const receipt = await publicClient.getTransactionReceipt({ hash });
-        return {
-          transactionHash: receipt.transactionHash,
-          gasUsed: receipt.gasUsed,
-          effectiveGasPrice: receipt.effectiveGasPrice,
-          logs: receipt.logs.map((log) => ({
-            address: log.address as Address,
-            topics: log.topics as readonly Hex[],
-            data: log.data as Hex,
-          })),
-        };
-      },
-    },
+    provider: viemProvider(publicClient, account.address),
   });
 
-  // Step 3: Check solver health
-  console.log(`\nChecking solver health at ${config.solverUrl}...`);
+  // Check solver health
   const health = await fyndClient.health();
   console.log(
-    `Solver healthy: ${String(health.healthy)},` +
-      ` last update: ${health.lastUpdateMs}ms ago,` +
-      ` ${health.numSolverPools} pools`
+    `Solver: healthy=${String(health.healthy)},` +
+      ` pools=${health.numSolverPools}`
   );
   if (!health.healthy) {
-    throw new Error("Solver is not healthy. Wait for market data to load.");
+    throw new Error("Solver is not healthy.");
   }
 
-  // Step 4: Build Permit2 encoding options with signature
-  //
-  // The solver needs the Permit2 permit + signature included in the
-  // encoding options so it can encode the calldata server-side.
-  // We construct the permit, sign it via EIP-712, and attach both to
-  // the quote request.
-  const sellDecimals = tokenDecimals(config.sellToken);
-  const amountIn = parseUnits(config.sellAmount, sellDecimals);
-  const slippage = config.slippageBps / 10_000;
-
-  // Read the Permit2 nonce for the sell token from on-chain.
-  // For simplicity we use nonce 0; a production app would read
-  // the current nonce from the Permit2 contract.
+  // Build Permit2 encoding options
+  const amountIn = parseUnits("100", 6); // 100 USDC
+  const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600);
   const permit = {
     details: {
-      token: config.sellToken,
+      token: USDC,
       amount: amountIn,
-      expiration: BigInt(Math.floor(Date.now() / 1000) + 3600),
+      expiration: deadline,
       nonce: 0n,
     },
     spender: "0x0000000000000000000000000000000000000000" as Address,
-    sigDeadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+    sigDeadline: deadline,
   };
 
-  // Sign the Permit2 message (EIP-712)
-  const permitHash = permit2SigningHash(permit, config.chainId, PERMIT2);
+  const permitHash = permit2SigningHash(permit, chainId, PERMIT2);
   const permitSig = await account.signMessage({
     message: { raw: permitHash },
   });
 
-  // Build encoding options: slippage + permit2
   const encOpts = withPermit2(
-    encodingOptions(slippage),
+    encodingOptions(50 / 10_000),
     permit,
     permitSig,
   );
 
-  // Step 5: Request a quote with encoding options
-  //
-  // When encoding options are provided, the solver returns a Transaction
-  // object with pre-built calldata. Without encoding options you only
-  // get the route/pricing.
-  console.log(
-    `\nGetting quote: ${config.sellAmount}` +
-      ` ${tokenSymbol(config.sellToken)}` +
-      ` -> ${tokenSymbol(config.buyToken)}`
-  );
-
+  // Request a quote with server-side encoding
+  console.log("\nQuoting 100 USDC -> WETH...");
   const quote = await fyndClient.quote({
     order: {
-      tokenIn: config.sellToken,
-      tokenOut: config.buyToken,
+      tokenIn: USDC,
+      tokenOut: WETH,
       amount: amountIn,
       side: "sell",
       sender: account.address,
     },
-    options: {
-      encodingOptions: encOpts,
-    },
+    options: { encodingOptions: encOpts },
   });
 
-  displayQuote(quote, config.sellToken, config.buyToken);
-
+  console.log(`Status: ${quote.status}`);
   if (quote.status !== "success") {
-    throw new Error(`Quote failed with status: ${quote.status}`);
+    throw new Error(`Quote failed: ${quote.status}`);
   }
+  console.log(`Amount out: ${quote.amountOut}`);
+  console.log(`Gas estimate: ${quote.gasEstimate}`);
+
   if (quote.transaction === undefined) {
-    throw new Error(
-      "Quote has no transaction data. " +
-        "Ensure encodingOptions were provided in the quote request."
-    );
+    throw new Error("No transaction data — ensure encodingOptions are set.");
   }
 
-  // Step 6: Build a signable payload (EIP-1559 transaction)
-  //
-  // signablePayload fills in nonce, gas fees, and gas limit from the
-  // provider, then wraps everything into a structure ready for signing.
-  console.log("Building signable payload...");
-  const payload = await fyndClient.signablePayload(quote, {
-    simulate: config.simulateOnly,
-  });
-
-  // Step 7: Sign the EIP-1559 transaction
+  // Build signable payload, sign, and assemble
+  const payload = await fyndClient.signablePayload(quote);
   const txHash = signingHash(payload);
-  const txSig = await account.signMessage({
-    message: { raw: txHash },
-  });
+  const txSig = await account.signMessage({ message: { raw: txHash } });
   const signedOrder = assembleSignedOrder(payload, txSig);
 
-  if (config.simulateOnly) {
-    console.log("\nSimulation passed (via signablePayload simulate hint).");
-    console.log("Set SIMULATE_ONLY=false to execute on-chain.");
-    return;
-  }
-
-  // Step 8: Execute the swap
-  //
-  // execute() serializes the signed EIP-1559 transaction and submits it
-  // via sendRawTransaction. The returned receipt has a settle() method
-  // that polls for confirmation.
+  // Execute on-chain
   console.log("\nSubmitting transaction...");
   const receipt = await fyndClient.execute(signedOrder);
-  console.log("Transaction submitted. Waiting for confirmation...");
-
   const settled = await receipt.settle();
-  console.log("\nSwap executed!");
+
+  console.log("Swap executed!");
   if (settled.txHash !== undefined) {
-    console.log(`  TX hash: ${settled.txHash}`);
+    console.log(`  TX: ${settled.txHash}`);
   }
   console.log(`  Gas cost: ${settled.gasCost} wei`);
   if (settled.settledAmount !== undefined) {
-    console.log(
-      `  Received: ${formatAmount(settled.settledAmount, config.buyToken)}` +
-        ` ${tokenSymbol(config.buyToken)}`
-    );
+    console.log(`  Received: ${settled.settledAmount}`);
   }
 }
 

--- a/clients/typescript/examples/tutorial/main.ts
+++ b/clients/typescript/examples/tutorial/main.ts
@@ -1,0 +1,386 @@
+// Tutorial: Quote, Sign & Execute Swaps with the Fynd TypeScript Client
+//
+// This example demonstrates how to:
+// 1. Create a FyndClient pointing at a running solver
+// 2. Get a swap quote with server-side encoding (encoding options)
+// 3. Sign the transaction with Permit2 authorization
+// 4. Simulate or execute the swap on-chain
+//
+// Prerequisites:
+//   - A running fynd solver (see the Rust tutorial README for setup)
+//   - Environment variables (see below)
+//
+// Environment variables:
+//   SOLVER_URL    - Solver API URL (default: http://localhost:3000)
+//   RPC_URL       - Ethereum RPC endpoint (required for simulation/execution)
+//   PRIVATE_KEY   - Wallet private key, hex without 0x prefix (required)
+//   CHAIN_ID      - Chain ID (default: 1 for Ethereum mainnet)
+
+import {
+  type Address,
+  type Hex,
+  type Quote,
+  FyndClient,
+  encodingOptions,
+  withPermit2,
+  permit2SigningHash,
+  signingHash,
+  assembleSignedOrder,
+} from "@fynd/client";
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  formatUnits,
+  parseUnits,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { mainnet } from "viem/chains";
+
+// Well-known token addresses on Ethereum mainnet
+const USDC: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const WETH: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+// Canonical Permit2 address (same on all chains)
+const PERMIT2: Address = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+
+// Token metadata for display formatting
+const TOKEN_INFO: Record<string, { symbol: string; decimals: number }> = {
+  [USDC.toLowerCase()]: { symbol: "USDC", decimals: 6 },
+  [WETH.toLowerCase()]: { symbol: "WETH", decimals: 18 },
+};
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+interface Config {
+  solverUrl: string;
+  rpcUrl: string;
+  privateKey: Hex;
+  chainId: number;
+  sellToken: Address;
+  buyToken: Address;
+  sellAmount: string;
+  slippageBps: number;
+  simulateOnly: boolean;
+}
+
+function loadConfig(): Config {
+  const privateKey = process.env["PRIVATE_KEY"];
+  if (privateKey === undefined) {
+    throw new Error(
+      "PRIVATE_KEY environment variable is required. " +
+        "Set it to your wallet private key (hex, no 0x prefix)."
+    );
+  }
+  const rpcUrl = process.env["RPC_URL"];
+  if (rpcUrl === undefined) {
+    throw new Error(
+      "RPC_URL environment variable is required for simulation/execution."
+    );
+  }
+
+  return {
+    solverUrl: process.env["SOLVER_URL"] ?? "http://localhost:3000",
+    rpcUrl,
+    privateKey: `0x${privateKey.replace(/^0x/, "")}` as Hex,
+    chainId: Number(process.env["CHAIN_ID"] ?? "1"),
+    sellToken: (process.env["SELL_TOKEN"] as Address | undefined) ?? USDC,
+    buyToken: (process.env["BUY_TOKEN"] as Address | undefined) ?? WETH,
+    sellAmount: process.env["SELL_AMOUNT"] ?? "100",
+    slippageBps: Number(process.env["SLIPPAGE_BPS"] ?? "50"),
+    simulateOnly: process.env["SIMULATE_ONLY"] === "true",
+  };
+}
+
+// ============================================================================
+// Display helpers
+// ============================================================================
+
+function tokenSymbol(address: Address): string {
+  return TOKEN_INFO[address.toLowerCase()]?.symbol ?? address.slice(0, 10);
+}
+
+function tokenDecimals(address: Address): number {
+  return TOKEN_INFO[address.toLowerCase()]?.decimals ?? 18;
+}
+
+function formatAmount(raw: bigint, address: Address): string {
+  return formatUnits(raw, tokenDecimals(address));
+}
+
+function displayQuote(
+  quote: Quote,
+  sellToken: Address,
+  buyToken: Address,
+): void {
+  console.log("\n========== Quote ==========");
+  console.log(`Status: ${quote.status}`);
+
+  if (quote.status !== "success") {
+    console.log("No route found.");
+    console.log("============================\n");
+    return;
+  }
+
+  const formattedIn = formatAmount(quote.amountIn, sellToken);
+  const formattedOut = formatAmount(quote.amountOut, buyToken);
+  console.log(
+    `Swap: ${formattedIn} ${tokenSymbol(sellToken)}` +
+      ` -> ${formattedOut} ${tokenSymbol(buyToken)}`
+  );
+
+  const decIn = Number(formattedIn);
+  const decOut = Number(formattedOut);
+  if (decIn > 0) {
+    const price = decOut / decIn;
+    console.log(
+      `Price: ${price.toFixed(6)} ${tokenSymbol(buyToken)}` +
+        ` per ${tokenSymbol(sellToken)}`
+    );
+  }
+
+  console.log(`Gas estimate: ${quote.gasEstimate}`);
+
+  if (quote.priceImpactBps !== undefined) {
+    console.log(`Price impact: ${(quote.priceImpactBps / 100).toFixed(2)}%`);
+  }
+
+  if (quote.route !== undefined) {
+    console.log(`\nRoute (${quote.route.swaps.length} hops):`);
+    for (const [i, swap] of quote.route.swaps.entries()) {
+      console.log(
+        `  ${i + 1}. ${tokenSymbol(swap.tokenIn)}` +
+          ` -> ${tokenSymbol(swap.tokenOut)}` +
+          ` via ${swap.protocol} (pool: ${swap.poolId})`
+      );
+    }
+  }
+
+  if (quote.transaction !== undefined) {
+    console.log(`\nTransaction encoded:`);
+    console.log(`  to: ${quote.transaction.to}`);
+    console.log(`  value: ${quote.transaction.value}`);
+    console.log(
+      `  data: ${quote.transaction.data.slice(0, 42)}...` +
+        ` (${(quote.transaction.data.length - 2) / 2} bytes)`
+    );
+  }
+
+  console.log("============================\n");
+}
+
+// ============================================================================
+// Main flow
+// ============================================================================
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+
+  // Step 1: Set up viem account and providers
+  const account = privateKeyToAccount(config.privateKey);
+  console.log(`Wallet address: ${account.address}`);
+
+  const publicClient = createPublicClient({
+    chain: mainnet,
+    transport: http(config.rpcUrl),
+  });
+
+  const walletClient = createWalletClient({
+    account,
+    chain: mainnet,
+    transport: http(config.rpcUrl),
+  });
+
+  // Step 2: Create FyndClient with an EthProvider adapter for viem
+  const fyndClient = new FyndClient({
+    baseUrl: config.solverUrl,
+    chainId: config.chainId,
+    sender: account.address,
+    provider: {
+      async getTransactionCount({ address }) {
+        return publicClient.getTransactionCount({ address });
+      },
+      async estimateFeesPerGas() {
+        const fees = await publicClient.estimateFeesPerGas();
+        return {
+          maxFeePerGas: fees.maxFeePerGas ?? 0n,
+          maxPriorityFeePerGas: fees.maxPriorityFeePerGas ?? 0n,
+        };
+      },
+      async call(tx) {
+        const result = await publicClient.call({
+          to: tx.to,
+          data: tx.data,
+          value: tx.value,
+          gas: tx.gas,
+          maxFeePerGas: tx.maxFeePerGas,
+          maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+        });
+        const hex = result.data as Hex | undefined;
+        return hex !== undefined ? { data: hex } : {};
+      },
+      async estimateGas(tx) {
+        return publicClient.estimateGas({
+          account: account.address,
+          to: tx.to,
+          data: tx.data,
+          value: tx.value,
+          maxFeePerGas: tx.maxFeePerGas,
+          maxPriorityFeePerGas: tx.maxPriorityFeePerGas,
+        });
+      },
+      async sendRawTransaction(rawTx) {
+        return publicClient.sendRawTransaction({ serializedTransaction: rawTx });
+      },
+      async getTransactionReceipt({ hash }) {
+        const receipt = await publicClient.getTransactionReceipt({ hash });
+        return {
+          transactionHash: receipt.transactionHash,
+          gasUsed: receipt.gasUsed,
+          effectiveGasPrice: receipt.effectiveGasPrice,
+          logs: receipt.logs.map((log) => ({
+            address: log.address as Address,
+            topics: log.topics as readonly Hex[],
+            data: log.data as Hex,
+          })),
+        };
+      },
+    },
+  });
+
+  // Step 3: Check solver health
+  console.log(`\nChecking solver health at ${config.solverUrl}...`);
+  const health = await fyndClient.health();
+  console.log(
+    `Solver healthy: ${String(health.healthy)},` +
+      ` last update: ${health.lastUpdateMs}ms ago,` +
+      ` ${health.numSolverPools} pools`
+  );
+  if (!health.healthy) {
+    throw new Error("Solver is not healthy. Wait for market data to load.");
+  }
+
+  // Step 4: Build Permit2 encoding options with signature
+  //
+  // The solver needs the Permit2 permit + signature included in the
+  // encoding options so it can encode the calldata server-side.
+  // We construct the permit, sign it via EIP-712, and attach both to
+  // the quote request.
+  const sellDecimals = tokenDecimals(config.sellToken);
+  const amountIn = parseUnits(config.sellAmount, sellDecimals);
+  const slippage = config.slippageBps / 10_000;
+
+  // Read the Permit2 nonce for the sell token from on-chain.
+  // For simplicity we use nonce 0; a production app would read
+  // the current nonce from the Permit2 contract.
+  const permit = {
+    details: {
+      token: config.sellToken,
+      amount: amountIn,
+      expiration: BigInt(Math.floor(Date.now() / 1000) + 3600),
+      nonce: 0n,
+    },
+    spender: "0x0000000000000000000000000000000000000000" as Address,
+    sigDeadline: BigInt(Math.floor(Date.now() / 1000) + 3600),
+  };
+
+  // Sign the Permit2 message (EIP-712)
+  const permitHash = permit2SigningHash(permit, config.chainId, PERMIT2);
+  const permitSig = await account.signMessage({
+    message: { raw: permitHash },
+  });
+
+  // Build encoding options: slippage + permit2
+  const encOpts = withPermit2(
+    encodingOptions(slippage),
+    permit,
+    permitSig,
+  );
+
+  // Step 5: Request a quote with encoding options
+  //
+  // When encoding options are provided, the solver returns a Transaction
+  // object with pre-built calldata. Without encoding options you only
+  // get the route/pricing.
+  console.log(
+    `\nGetting quote: ${config.sellAmount}` +
+      ` ${tokenSymbol(config.sellToken)}` +
+      ` -> ${tokenSymbol(config.buyToken)}`
+  );
+
+  const quote = await fyndClient.quote({
+    order: {
+      tokenIn: config.sellToken,
+      tokenOut: config.buyToken,
+      amount: amountIn,
+      side: "sell",
+      sender: account.address,
+    },
+    options: {
+      encodingOptions: encOpts,
+    },
+  });
+
+  displayQuote(quote, config.sellToken, config.buyToken);
+
+  if (quote.status !== "success") {
+    throw new Error(`Quote failed with status: ${quote.status}`);
+  }
+  if (quote.transaction === undefined) {
+    throw new Error(
+      "Quote has no transaction data. " +
+        "Ensure encodingOptions were provided in the quote request."
+    );
+  }
+
+  // Step 6: Build a signable payload (EIP-1559 transaction)
+  //
+  // signablePayload fills in nonce, gas fees, and gas limit from the
+  // provider, then wraps everything into a structure ready for signing.
+  console.log("Building signable payload...");
+  const payload = await fyndClient.signablePayload(quote, {
+    simulate: config.simulateOnly,
+  });
+
+  // Step 7: Sign the EIP-1559 transaction
+  const txHash = signingHash(payload);
+  const txSig = await account.signMessage({
+    message: { raw: txHash },
+  });
+  const signedOrder = assembleSignedOrder(payload, txSig);
+
+  if (config.simulateOnly) {
+    console.log("\nSimulation passed (via signablePayload simulate hint).");
+    console.log("Set SIMULATE_ONLY=false to execute on-chain.");
+    return;
+  }
+
+  // Step 8: Execute the swap
+  //
+  // execute() serializes the signed EIP-1559 transaction and submits it
+  // via sendRawTransaction. The returned receipt has a settle() method
+  // that polls for confirmation.
+  console.log("\nSubmitting transaction...");
+  const receipt = await fyndClient.execute(signedOrder);
+  console.log("Transaction submitted. Waiting for confirmation...");
+
+  const settled = await receipt.settle();
+  console.log("\nSwap executed!");
+  if (settled.txHash !== undefined) {
+    console.log(`  TX hash: ${settled.txHash}`);
+  }
+  console.log(`  Gas cost: ${settled.gasCost} wei`);
+  if (settled.settledAmount !== undefined) {
+    console.log(
+      `  Received: ${formatAmount(settled.settledAmount, config.buyToken)}` +
+        ` ${tokenSymbol(config.buyToken)}`
+    );
+  }
+}
+
+main().catch((err: unknown) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/clients/typescript/examples/tutorial/package.json
+++ b/clients/typescript/examples/tutorial/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@fynd/tutorial",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx main.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@fynd/client": "workspace:*",
+    "viem": "2.46.3"
+  },
+  "devDependencies": {
+    "tsx": "4.19.4",
+    "typescript": "5.8.2"
+  }
+}

--- a/clients/typescript/examples/tutorial/tsconfig.json
+++ b/clients/typescript/examples/tutorial/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/clients/typescript/pnpm-lock.yaml
+++ b/clients/typescript/pnpm-lock.yaml
@@ -33,12 +33,34 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 4.0.18
-        version: 4.0.18
+        version: 4.0.18(tsx@4.19.4)
+
+  examples/tutorial:
+    dependencies:
+      '@fynd/client':
+        specifier: workspace:*
+        version: link:../../client
+      viem:
+        specifier: 2.46.3
+        version: 2.46.3(typescript@5.8.2)
+    devDependencies:
+      tsx:
+        specifier: 4.19.4
+        version: 4.19.4
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
 
 packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
@@ -46,10 +68,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -58,16 +92,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -76,10 +128,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -88,10 +152,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -100,10 +176,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -112,10 +200,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -124,10 +224,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.3':
@@ -136,16 +248,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.3':
     resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.3':
@@ -154,10 +284,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -166,11 +308,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
@@ -178,16 +332,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -522,6 +694,11 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
@@ -550,6 +727,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
@@ -605,6 +785,9 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -637,6 +820,11 @@ packages:
   tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
+
+  tsx@4.19.4:
+    resolution: {integrity: sha512-gK5GVzDkJK1SI1zwHf32Mqxf2tSJkNx+eYcNly5+nHvWqXUJYUkWBQtKauoESz3ymezAI++ZwT855x5p5eop+Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.8.2:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
@@ -746,79 +934,157 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -999,13 +1265,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1)':
+  '@vitest/mocker@4.0.18(vite@7.3.1(tsx@4.19.4))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1
+      vite: 7.3.1(tsx@4.19.4)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -1038,6 +1304,35 @@ snapshots:
   chai@6.2.2: {}
 
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -1082,6 +1377,10 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   isows@1.0.7(ws@8.18.3):
     dependencies:
@@ -1150,6 +1449,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  resolve-pkg-maps@1.0.0: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -1200,6 +1501,13 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tsx@4.19.4:
+    dependencies:
+      esbuild: 0.25.12
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.8.2: {}
 
   viem@2.46.3(typescript@5.8.2):
@@ -1219,7 +1527,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@7.3.1:
+  vite@7.3.1(tsx@4.19.4):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -1229,11 +1537,12 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
+      tsx: 4.19.4
 
-  vitest@4.0.18:
+  vitest@4.0.18(tsx@4.19.4):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(tsx@4.19.4))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -1250,7 +1559,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1
+      vite: 7.3.1(tsx@4.19.4)
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - jiti

--- a/clients/typescript/pnpm-workspace.yaml
+++ b/clients/typescript/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - autogen
   - client
+  - examples/tutorial


### PR DESCRIPTION
## Summary

Ports the Permit2 and encoding options support from the Rust client (PR #90) to the TypeScript client:

- **New types:** `EncodingOptions`, `Transaction`, `PermitSingle`, `PermitDetails`, `UserTransferType`
- **Permit2 module:** `permit2SigningHash()` for EIP-712 signing, plus ergonomic builder helpers (`encodingOptions`, `withPermit2`, `withNoTransfer`)
- **Mapping layer:** Serializes `EncodingOptions` to wire format in quote requests; deserializes `Transaction` from quote responses
- **Client:** Reads `to`/`value`/`data` from server-provided `quote.transaction` instead of hardcoded `routerAddress`

### Breaking changes

1. `FyndClientOptions.routerAddress` removed — the server now provides the target address via `quote.transaction`
2. `fyndSignablePayload` requires `quote.transaction` to be present (set `encodingOptions` in `QuoteOptions`)

## Test plan

- [x] 11 new permit2 tests (signing hash determinism, field sensitivity, builder helpers, signature validation)
- [x] 5 new mapping tests (encoding options serialization, transaction deserialization)
- [x] 3 new client tests (transaction usage, missing transaction error)
- [x] All 113 tests passing
- [x] TypeScript: 0 errors
- [x] Lint: 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)