### PR TITLE
fix: blacklist malfunctioning AMPL and Fluid Lite pools

### DIFF
--- a/blacklist.toml
+++ b/blacklist.toml
@@ -3,7 +3,14 @@
 
 [blacklist]
 # Component IDs to exclude (pool addresses)
-# UniswapV3 AMPL pool - AMPL is a rebasing token that doesn't work correctly
+# AMPL pools - AMPL is a rebasing token that breaks simulation assumptions
+# UniswapV3 AMPL/WETH
+# UniswapV2 AMPL/WETH
 components = [
     "0x86d257cdb7bc9c0df10e84c8709697f92770b335",
+    "0xc5be99a02c6857f9eac67bbce58df5572498f40c",
+    # Fluid Lite pools with broken simulation (ENG-5696)
+    # Off-chain sim claims 50-100x more output than on-chain reality
+    "0x32aa6f5c6f771b39d383c6e36d7ef0702a28e32ad64671c059f41547b82ef0ef",
+    "0x7f31b44f032f125bb465c161343fccfdc88fee8dc94c068f6430d2345d80f1d1",
 ]


### PR DESCRIPTION
## Summary

Blacklist 3 pools with broken off-chain simulation, extracted from #43 and #78 so this fix can be merged independently.

**Pools added:**
- `0xc5be99...` — UniswapV2 AMPL/WETH. AMPL is a rebasing token that breaks simulation assumptions.
- `0x32aa6f5c...` — Fluid Lite (native ETH/MAGA). Off-chain sim overstates output 50-100x (ENG-5696).
- `0x7f31b44f...` — Fluid Lite (native ETH/small token). Same issue (ENG-5696).

These pools create phantom profit opportunities that waste gas on execution.

## Test plan

- [x] Verified these are the same addresses already tested in #43 and #78
- [ ] CI passes (config-only change, no code)