### PR TITLE
feat: improve error handling in computation manager

### DIFF
--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -693,7 +693,7 @@ mod tests {
         }
 
         let mut derived_data = DerivedData::new();
-        derived_data.set_token_prices(token_prices, 1);
+        derived_data.set_token_prices(token_prices, vec![], 1, true);
         Arc::new(RwLock::new(derived_data))
     }
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -94,27 +94,27 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
     ) -> Option<Self> {
         let key = (component_id.clone(), token_in.address.clone(), token_out.address.clone());
 
-        // Use pre-computed spot price; fall back to zero-weight on failure.
+        // Use pre-computed spot price; skip edge if unavailable.
         let spot_price = match derived
             .spot_prices()
             .and_then(|p| p.get(&key).copied())
         {
             Some(p) => p,
             None => {
-                trace!(component_id = %component_id, "spot price failed, using zero weight");
-                return Some(Self { spot_price: 0.0, depth: 0.0 });
+                trace!(component_id = %component_id, "spot price not found, skipping edge");
+                return None;
             }
         };
 
-        // Look up pre-computed depth; fall back to zero-weight on failure.
+        // Look up pre-computed depth; skip edge if unavailable.
         let depth = match derived
             .pool_depths()
             .and_then(|d| d.get(&key))
         {
             Some(d) => d.to_f64().unwrap_or(0.0),
             None => {
-                trace!(component_id = %component_id, "pool depth failed, using zero weight");
-                return Some(Self { spot_price: 0.0, depth: 0.0 });
+                trace!(component_id = %component_id, "pool depth not found, skipping edge");
+                return None;
             }
         };
 
@@ -765,7 +765,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_sim_and_derived_failed_spot_price_returns_zero_weight() {
+    fn test_from_sim_and_derived_failed_spot_price_returns_none() {
         let key = pair_key("pool1", 0x01, 0x02);
         let key_str = pair_key_str("pool1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
@@ -790,13 +790,11 @@ mod tests {
                 &sim, &key.0, &tok_in, &tok_out, &derived,
             );
 
-        let val = result.unwrap();
-        assert_eq!(val.spot_price, 0.0);
-        assert_eq!(val.depth, 0.0);
+        assert!(result.is_none());
     }
 
     #[test]
-    fn test_from_sim_and_derived_failed_pool_depth_returns_zero_weight() {
+    fn test_from_sim_and_derived_failed_pool_depth_returns_none() {
         let key = pair_key("pool1", 0x01, 0x02);
         let key_str = pair_key_str("pool1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
@@ -824,13 +822,11 @@ mod tests {
                 &sim, &key.0, &tok_in, &tok_out, &derived,
             );
 
-        let val = result.unwrap();
-        assert_eq!(val.spot_price, 0.0);
-        assert_eq!(val.depth, 0.0);
+        assert!(result.is_none());
     }
 
     #[test]
-    fn test_from_sim_and_derived_both_failed_returns_zero_weight() {
+    fn test_from_sim_and_derived_both_failed_returns_none() {
         let key = pair_key("pool1", 0x01, 0x02);
         let key_str = pair_key_str("pool1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
@@ -862,24 +858,7 @@ mod tests {
                 &sim, &key.0, &tok_in, &tok_out, &derived,
             );
 
-        let val = result.unwrap();
-        assert_eq!(val.spot_price, 0.0);
-        assert_eq!(val.depth, 0.0);
-    }
-
-    #[test]
-    fn test_try_score_path_with_zero_weight_edge_returns_zero() {
-        let (a, b, _, _) = addrs();
-        let mut m = linear_graph();
-
-        m.set_edge_weight(&"ab".to_string(), &a, &b, DepthAndPrice::new(0.0, 0.0), false)
-            .unwrap();
-
-        let graph = m.graph();
-        let paths = MostLiquidAlgorithm::find_paths(graph, &a, &b, 1, 1).unwrap();
-        assert_eq!(paths.len(), 1);
-        let score = MostLiquidAlgorithm::try_score_path(&paths[0]);
-        assert_eq!(score, Some(0.0));
+        assert!(result.is_none());
     }
 
     // ==================== find_paths Tests ====================

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -94,39 +94,27 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
     ) -> Option<Self> {
         let key = (component_id.clone(), token_in.address.clone(), token_out.address.clone());
 
-        // Use pre-computed spot price; fall back to zero-weight for explicit failures.
+        // Use pre-computed spot price; fall back to zero-weight on failure.
         let spot_price = match derived
             .spot_prices()
             .and_then(|p| p.get(&key).copied())
         {
             Some(p) => p,
             None => {
-                if derived
-                    .spot_price_failure(&key)
-                    .is_some()
-                {
-                    trace!(component_id = %component_id, "spot price failed, using zero weight");
-                    return Some(Self { spot_price: 0.0, depth: 0.0 });
-                }
-                return None; // never computed
+                trace!(component_id = %component_id, "spot price failed, using zero weight");
+                return Some(Self { spot_price: 0.0, depth: 0.0 });
             }
         };
 
-        // Look up pre-computed depth; fall back to zero-weight for explicit failures.
+        // Look up pre-computed depth; fall back to zero-weight on failure.
         let depth = match derived
             .pool_depths()
             .and_then(|d| d.get(&key))
         {
             Some(d) => d.to_f64()?,
             None => {
-                if derived
-                    .pool_depth_failure(&key)
-                    .is_some()
-                {
-                    trace!(component_id = %component_id, "pool depth failed, using zero weight");
-                    return Some(Self { spot_price: 0.0, depth: 0.0 });
-                }
-                return None; // never computed
+                trace!(component_id = %component_id, "pool depth failed, using zero weight");
+                return Some(Self { spot_price: 0.0, depth: 0.0 });
             }
         };
 
@@ -837,25 +825,6 @@ mod tests {
         assert_eq!(val.depth, 0.0);
     }
 
-    #[test]
-    fn test_from_sim_and_derived_never_computed_returns_none() {
-        let key = pair_key("pool1", 0x01, 0x02);
-        let tok_in = token(0x01, "A");
-        let tok_out = token(0x02, "B");
-
-        let mut derived = DerivedData::new();
-        // both maps are empty (no successes, no failures)
-        derived.set_spot_prices(Default::default(), vec![], 10, true);
-        derived.set_pool_depths(Default::default(), vec![], 10, true);
-
-        let sim = make_mock_sim();
-        let result =
-            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
-                &sim, &key.0, &tok_in, &tok_out, &derived,
-            );
-
-        assert!(result.is_none());
-    }
 
     #[test]
     fn test_from_sim_and_derived_both_failed_returns_zero_weight() {

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -111,7 +111,7 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
             .pool_depths()
             .and_then(|d| d.get(&key))
         {
-            Some(d) => d.to_f64()?,
+            Some(d) => d.to_f64().unwrap_or(0.0),
             None => {
                 trace!(component_id = %component_id, "pool depth failed, using zero weight");
                 return Some(Self { spot_price: 0.0, depth: 0.0 });
@@ -777,7 +777,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str,
-                error: FailedItemError::SpotPriceComputationFailed("sim error".into()),
+                error: FailedItemError::SimulationFailed("sim error".into()),
             }],
             10,
             true,
@@ -812,7 +812,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str,
-                error: FailedItemError::PoolDepthComputationFailed("depth error".into()),
+                error: FailedItemError::SimulationFailed("depth error".into()),
             }],
             10,
             true,
@@ -841,7 +841,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str.clone(),
-                error: FailedItemError::SpotPriceComputationFailed("spot error".into()),
+                error: FailedItemError::SimulationFailed("spot error".into()),
             }],
             10,
             true,
@@ -850,7 +850,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str,
-                error: FailedItemError::PoolDepthComputationFailed("depth error".into()),
+                error: FailedItemError::SimulationFailed("depth error".into()),
             }],
             10,
             true,

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -661,7 +661,7 @@ mod tests {
         }
 
         let mut derived_data = DerivedData::new();
-        derived_data.set_token_prices(token_prices, 1);
+        derived_data.set_token_prices(token_prices, vec![], 1, true);
         Arc::new(RwLock::new(derived_data))
     }
     // ==================== try_score_path Tests ====================

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -777,7 +777,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str,
-                error: FailedItemError::SpotPriceComputation("sim error".into()),
+                error: FailedItemError::SpotPriceComputationFailed("sim error".into()),
             }],
             10,
             true,
@@ -812,7 +812,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str,
-                error: FailedItemError::PoolDepthComputation("depth error".into()),
+                error: FailedItemError::PoolDepthComputationFailed("depth error".into()),
             }],
             10,
             true,
@@ -841,7 +841,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str.clone(),
-                error: FailedItemError::SpotPriceComputation("spot error".into()),
+                error: FailedItemError::SpotPriceComputationFailed("spot error".into()),
             }],
             10,
             true,
@@ -850,7 +850,7 @@ mod tests {
             Default::default(),
             vec![FailedItem {
                 key: key_str,
-                error: FailedItemError::PoolDepthComputation("depth error".into()),
+                error: FailedItemError::PoolDepthComputationFailed("depth error".into()),
             }],
             10,
             true,

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -650,7 +650,7 @@ mod tests {
             fixtures::{addrs, diamond_graph, linear_graph, parallel_graph},
             market_read, order, setup_market, token, MockProtocolSim, ONE_ETH,
         },
-        derived::{types::TokenGasPrices, DerivedData},
+        derived::{computation::FailedItem, types::TokenGasPrices, DerivedData},
         graph::GraphManager,
         types::OrderSide,
     };
@@ -771,10 +771,7 @@ mod tests {
         // spot price fails, pool depth not computed
         derived.set_spot_prices(
             Default::default(),
-            vec![crate::derived::computation::FailedItem {
-                key: key_str,
-                error: "sim error".to_string(),
-            }],
+            vec![FailedItem { key: key_str, error: "sim error".to_string() }],
             10,
             true,
         );
@@ -806,10 +803,7 @@ mod tests {
         // pool depth fails
         derived.set_pool_depths(
             Default::default(),
-            vec![crate::derived::computation::FailedItem {
-                key: key_str,
-                error: "depth error".to_string(),
-            }],
+            vec![FailedItem { key: key_str, error: "depth error".to_string() }],
             10,
             true,
         );
@@ -835,19 +829,13 @@ mod tests {
         let mut derived = DerivedData::new();
         derived.set_spot_prices(
             Default::default(),
-            vec![crate::derived::computation::FailedItem {
-                key: key_str.clone(),
-                error: "spot error".to_string(),
-            }],
+            vec![FailedItem { key: key_str.clone(), error: "spot error".to_string() }],
             10,
             true,
         );
         derived.set_pool_depths(
             Default::default(),
-            vec![crate::derived::computation::FailedItem {
-                key: key_str,
-                error: "depth error".to_string(),
-            }],
+            vec![FailedItem { key: key_str, error: "depth error".to_string() }],
             10,
             true,
         );

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -825,7 +825,6 @@ mod tests {
         assert_eq!(val.depth, 0.0);
     }
 
-
     #[test]
     fn test_from_sim_and_derived_both_failed_returns_zero_weight() {
         let key = pair_key("pool1", 0x01, 0x02);

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -94,16 +94,41 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
     ) -> Option<Self> {
         let key = (component_id.clone(), token_in.address.clone(), token_out.address.clone());
 
-        // Use pre-computed spot price
-        let spot_price = derived
+        // Use pre-computed spot price; fall back to zero-weight for explicit failures.
+        let spot_price = match derived
             .spot_prices()
-            .and_then(|prices| prices.get(&key).copied())?;
+            .and_then(|p| p.get(&key).copied())
+        {
+            Some(p) => p,
+            None => {
+                if derived
+                    .spot_price_failure(&key)
+                    .is_some()
+                {
+                    trace!(component_id = %component_id, "spot price failed, using zero weight");
+                    return Some(Self { spot_price: 0.0, depth: 0.0 });
+                }
+                return None; // never computed
+            }
+        };
 
-        // Look up pre-computed depth
-        let depth = derived
+        // Look up pre-computed depth; fall back to zero-weight for explicit failures.
+        let depth = match derived
             .pool_depths()
-            .and_then(|depths| depths.get(&key))?
-            .to_f64()?;
+            .and_then(|d| d.get(&key))
+        {
+            Some(d) => d.to_f64()?,
+            None => {
+                if derived
+                    .pool_depth_failure(&key)
+                    .is_some()
+                {
+                    trace!(component_id = %component_id, "pool depth failed, using zero weight");
+                    return Some(Self { spot_price: 0.0, depth: 0.0 });
+                }
+                return None; // never computed
+            }
+        };
 
         Some(Self { spot_price, depth })
     }
@@ -733,6 +758,156 @@ mod tests {
         let score = MostLiquidAlgorithm::try_score_path(&paths[0]).unwrap();
         let expected = 2.0 * 0.6 * 800.0;
         assert_eq!(score, expected, "expected {expected}, got {score}");
+    }
+
+    fn make_mock_sim() -> MockProtocolSim {
+        MockProtocolSim::new(2.0)
+    }
+
+    fn pair_key(comp: &str, b_in: u8, b_out: u8) -> (String, Address, Address) {
+        (comp.to_string(), addr(b_in), addr(b_out))
+    }
+
+    fn pair_key_str(comp: &str, b_in: u8, b_out: u8) -> String {
+        format!("{comp}/{}/{}", addr(b_in), addr(b_out))
+    }
+
+    #[test]
+    fn test_from_sim_and_derived_failed_spot_price_returns_zero_weight() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let key_str = pair_key_str("pool1", 0x01, 0x02);
+        let tok_in = token(0x01, "A");
+        let tok_out = token(0x02, "B");
+
+        let mut derived = DerivedData::new();
+        // spot price fails, pool depth not computed
+        derived.set_spot_prices(
+            Default::default(),
+            vec![crate::derived::computation::FailedItem {
+                key: key_str,
+                error: "sim error".to_string(),
+            }],
+            10,
+            true,
+        );
+        derived.set_pool_depths(Default::default(), vec![], 10, true);
+
+        let sim = make_mock_sim();
+        let result =
+            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
+                &sim, &key.0, &tok_in, &tok_out, &derived,
+            );
+
+        let val = result.unwrap();
+        assert_eq!(val.spot_price, 0.0);
+        assert_eq!(val.depth, 0.0);
+    }
+
+    #[test]
+    fn test_from_sim_and_derived_failed_pool_depth_returns_zero_weight() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let key_str = pair_key_str("pool1", 0x01, 0x02);
+        let tok_in = token(0x01, "A");
+        let tok_out = token(0x02, "B");
+
+        let mut derived = DerivedData::new();
+        // spot price succeeds
+        let mut prices = crate::derived::types::SpotPrices::default();
+        prices.insert(key.clone(), 1.5);
+        derived.set_spot_prices(prices, vec![], 10, true);
+        // pool depth fails
+        derived.set_pool_depths(
+            Default::default(),
+            vec![crate::derived::computation::FailedItem {
+                key: key_str,
+                error: "depth error".to_string(),
+            }],
+            10,
+            true,
+        );
+
+        let sim = make_mock_sim();
+        let result =
+            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
+                &sim, &key.0, &tok_in, &tok_out, &derived,
+            );
+
+        let val = result.unwrap();
+        assert_eq!(val.spot_price, 0.0);
+        assert_eq!(val.depth, 0.0);
+    }
+
+    #[test]
+    fn test_from_sim_and_derived_never_computed_returns_none() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let tok_in = token(0x01, "A");
+        let tok_out = token(0x02, "B");
+
+        let mut derived = DerivedData::new();
+        // both maps are empty (no successes, no failures)
+        derived.set_spot_prices(Default::default(), vec![], 10, true);
+        derived.set_pool_depths(Default::default(), vec![], 10, true);
+
+        let sim = make_mock_sim();
+        let result =
+            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
+                &sim, &key.0, &tok_in, &tok_out, &derived,
+            );
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_from_sim_and_derived_both_failed_returns_zero_weight() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let key_str = pair_key_str("pool1", 0x01, 0x02);
+        let tok_in = token(0x01, "A");
+        let tok_out = token(0x02, "B");
+
+        let mut derived = DerivedData::new();
+        derived.set_spot_prices(
+            Default::default(),
+            vec![crate::derived::computation::FailedItem {
+                key: key_str.clone(),
+                error: "spot error".to_string(),
+            }],
+            10,
+            true,
+        );
+        derived.set_pool_depths(
+            Default::default(),
+            vec![crate::derived::computation::FailedItem {
+                key: key_str,
+                error: "depth error".to_string(),
+            }],
+            10,
+            true,
+        );
+
+        let sim = make_mock_sim();
+        let result =
+            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
+                &sim, &key.0, &tok_in, &tok_out, &derived,
+            );
+
+        let val = result.unwrap();
+        assert_eq!(val.spot_price, 0.0);
+        assert_eq!(val.depth, 0.0);
+    }
+
+    #[test]
+    fn test_try_score_path_with_zero_weight_edge_returns_zero() {
+        let (a, b, _, _) = addrs();
+        let mut m = linear_graph();
+
+        m.set_edge_weight(&"ab".to_string(), &a, &b, DepthAndPrice::new(0.0, 0.0), false)
+            .unwrap();
+
+        let graph = m.graph();
+        let paths = MostLiquidAlgorithm::find_paths(graph, &a, &b, 1, 1).unwrap();
+        assert_eq!(paths.len(), 1);
+        let score = MostLiquidAlgorithm::try_score_path(&paths[0]);
+        assert_eq!(score, Some(0.0));
     }
 
     // ==================== find_paths Tests ====================

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -650,7 +650,11 @@ mod tests {
             fixtures::{addrs, diamond_graph, linear_graph, parallel_graph},
             market_read, order, setup_market, token, MockProtocolSim, ONE_ETH,
         },
-        derived::{computation::FailedItem, types::TokenGasPrices, DerivedData},
+        derived::{
+            computation::{FailedItem, FailedItemError},
+            types::TokenGasPrices,
+            DerivedData,
+        },
         graph::GraphManager,
         types::OrderSide,
     };
@@ -771,7 +775,10 @@ mod tests {
         // spot price fails, pool depth not computed
         derived.set_spot_prices(
             Default::default(),
-            vec![FailedItem { key: key_str, error: "sim error".to_string() }],
+            vec![FailedItem {
+                key: key_str,
+                error: FailedItemError::SpotPriceComputation("sim error".into()),
+            }],
             10,
             true,
         );
@@ -803,7 +810,10 @@ mod tests {
         // pool depth fails
         derived.set_pool_depths(
             Default::default(),
-            vec![FailedItem { key: key_str, error: "depth error".to_string() }],
+            vec![FailedItem {
+                key: key_str,
+                error: FailedItemError::PoolDepthComputation("depth error".into()),
+            }],
             10,
             true,
         );
@@ -829,13 +839,19 @@ mod tests {
         let mut derived = DerivedData::new();
         derived.set_spot_prices(
             Default::default(),
-            vec![FailedItem { key: key_str.clone(), error: "spot error".to_string() }],
+            vec![FailedItem {
+                key: key_str.clone(),
+                error: FailedItemError::SpotPriceComputation("spot error".into()),
+            }],
             10,
             true,
         );
         derived.set_pool_depths(
             Default::default(),
-            vec![FailedItem { key: key_str, error: "depth error".to_string() }],
+            vec![FailedItem {
+                key: key_str,
+                error: FailedItemError::PoolDepthComputation("depth error".into()),
+            }],
             10,
             true,
         );

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -135,10 +135,10 @@ pub enum FailedItemError {
     SpotPriceTooSmall(f64),
 
     #[error("spot price computation failed: {0}")]
-    SpotPriceComputation(String),
+    SpotPriceComputationFailed(String),
 
     #[error("pool depth computation failed: {0}")]
-    PoolDepthComputation(String),
+    PoolDepthComputationFailed(String),
 
     #[error("all simulation paths failed")]
     AllSimulationPathsFailed,

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -134,11 +134,8 @@ pub enum FailedItemError {
     #[error("spot price too small: {0}")]
     SpotPriceTooSmall(f64),
 
-    #[error("spot price computation failed: {0}")]
-    SpotPriceComputationFailed(String),
-
-    #[error("pool depth computation failed: {0}")]
-    PoolDepthComputationFailed(String),
+    #[error("simulation failed: {0}")]
+    SimulationFailed(String),
 
     #[error("all simulation paths failed")]
     AllSimulationPathsFailed,

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -116,6 +116,34 @@ impl ComputationRequirements {
     }
 }
 
+/// Typed error for a failed computation item.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum FailedItemError {
+    #[error("missing simulation state")]
+    MissingSimulationState,
+
+    #[error("missing token metadata")]
+    MissingTokenMetadata,
+
+    #[error("missing spot price")]
+    MissingSpotPrice,
+
+    #[error("extreme decimal mismatch ({from}\u{2192}{to})")]
+    ExtremeDecimalMismatch { from: u32, to: u32 },
+
+    #[error("spot price too small: {0}")]
+    SpotPriceTooSmall(f64),
+
+    #[error("spot price computation failed: {0}")]
+    SpotPriceComputation(String),
+
+    #[error("pool depth computation failed: {0}")]
+    PoolDepthComputation(String),
+
+    #[error("all simulation paths failed")]
+    AllSimulationPathsFailed,
+}
+
 /// A single item that failed during a computation.
 #[derive(Debug, Clone)]
 pub struct FailedItem {
@@ -123,8 +151,8 @@ pub struct FailedItem {
     /// - spot_prices/pool_depths: "component_id/token_in/token_out"
     /// - token_prices: "token_address"
     pub key: String,
-    /// Display string of the error.
-    pub error: String,
+    /// Typed error describing the failure.
+    pub error: FailedItemError,
 }
 
 /// Computation result with optional partial failure details.

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -116,6 +116,41 @@ impl ComputationRequirements {
     }
 }
 
+/// A single item that failed during a computation.
+#[derive(Debug, Clone)]
+pub struct FailedItem {
+    /// Human-readable key for the failed item.
+    /// - spot_prices/pool_depths: "component_id/token_in/token_out"
+    /// - token_prices: "token_address"
+    pub key: String,
+    /// Display string of the error.
+    pub error: String,
+}
+
+/// Computation result with optional partial failure details.
+///
+/// `Err(...)` = total failure (no usable data).
+/// `Ok(output)` = some data produced; `output.failed_items` may be non-empty.
+#[derive(Debug, Clone)]
+pub struct ComputationOutput<T> {
+    pub data: T,
+    pub failed_items: Vec<FailedItem>,
+}
+
+impl<T> ComputationOutput<T> {
+    pub fn success(data: T) -> Self {
+        Self { data, failed_items: vec![] }
+    }
+
+    pub fn with_failures(data: T, failed_items: Vec<FailedItem>) -> Self {
+        Self { data, failed_items }
+    }
+
+    pub fn has_failures(&self) -> bool {
+        !self.failed_items.is_empty()
+    }
+}
+
 /// Trait for derived data computations.
 ///
 /// Implement this trait to define a new type of derived data that can be
@@ -191,11 +226,10 @@ pub trait DerivedComputation: Send + Sync + 'static {
     ///
     /// Computations should acquire locks only when needed and release them as early
     /// as possible to minimize contention. Use `.read().await` for async lock acquisition.
-    // TODO: Support Partial Failures, including IDs for which computation failed.
     async fn compute(
         &self,
         market: &SharedMarketDataRef,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
-    ) -> Result<Self::Output, ComputationError>;
+    ) -> Result<ComputationOutput<Self::Output>, ComputationError>;
 }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -783,4 +783,108 @@ mod tests {
             "USDC→ETH should appear in failed_items with missing spot price error"
         );
     }
+
+    #[tokio::test]
+    async fn test_compute_partial_failure_missing_simulation_state() {
+        let eth = token(0x01, "ETH");
+        let usdc = token(0x02, "USDC");
+
+        // Empty market — no simulation state
+        let market = SharedMarketData::new_shared();
+        let derived = DerivedData::new_shared();
+        derived
+            .try_write()
+            .unwrap()
+            .set_spot_prices(SpotPrices::new(), vec![], 0, true);
+
+        let changed = ChangedComponents {
+            added: std::collections::HashMap::from([(
+                "phantom_pool".to_string(),
+                vec![eth.address.clone(), usdc.address.clone()],
+            )]),
+            removed: vec![],
+            updated: vec![],
+            is_full_recompute: false,
+        };
+
+        let output = PoolDepthComputation::default()
+            .compute(&market, &derived, &changed)
+            .await
+            .expect("should succeed with partial results");
+
+        assert!(output.has_failures());
+
+        let eth_usdc_key = format!("phantom_pool/{}/{}", eth.address, usdc.address);
+        let usdc_eth_key = format!("phantom_pool/{}/{}", usdc.address, eth.address);
+        assert!(
+            output
+                .failed_items
+                .iter()
+                .any(|item| item.key == eth_usdc_key &&
+                    matches!(item.error, FailedItemError::MissingSimulationState)),
+            "ETH→USDC should fail with MissingSimulationState"
+        );
+        assert!(
+            output
+                .failed_items
+                .iter()
+                .any(|item| item.key == usdc_eth_key &&
+                    matches!(item.error, FailedItemError::MissingSimulationState)),
+            "USDC→ETH should fail with MissingSimulationState"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_compute_partial_failure_pool_depth_computation() {
+        // Without .with_tokens(), get_limits doesn't scale by decimals,
+        // but get_amount_out does — causing a liquidity overflow on swap.
+        let token_in = token_with_decimals(0x01, "A", 6);
+        let token_out = token_with_decimals(0x02, "B", 18);
+
+        let (market, _) = setup_market(vec![(
+            "pool",
+            &token_in,
+            &token_out,
+            MockProtocolSim::new(1.0).with_liquidity(100),
+        )]);
+        let derived = DerivedData::new_shared();
+
+        let changed = ChangedComponents {
+            added: std::collections::HashMap::from([(
+                "pool".to_string(),
+                vec![token_in.address.clone(), token_out.address.clone()],
+            )]),
+            removed: vec![],
+            updated: vec![],
+            is_full_recompute: true,
+        };
+
+        let spot_output = SpotPriceComputation::new()
+            .compute(&market, &derived, &changed)
+            .await
+            .expect("spot price computation should succeed");
+        derived
+            .try_write()
+            .unwrap()
+            .set_spot_prices(spot_output.data, vec![], 0, true);
+
+        let output = PoolDepthComputation::default()
+            .compute(&market, &derived, &changed)
+            .await
+            .expect("should succeed with partial results");
+
+        assert!(
+            output.has_failures(),
+            "decimal mismatch between get_limits and get_amount_out should cause failures"
+        );
+        assert!(
+            output
+                .failed_items
+                .iter()
+                .any(|item| item.key.starts_with("pool/") &&
+                    matches!(&item.error, FailedItemError::PoolDepthComputation(_))),
+            "should have PoolDepthComputation failure, got: {:?}",
+            output.failed_items
+        );
+    }
 }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -26,7 +26,9 @@ use tycho_simulation::{
 
 use crate::{
     derived::{
-        computation::{ComputationId, ComputationOutput, DerivedComputation, FailedItem},
+        computation::{
+            ComputationId, ComputationOutput, DerivedComputation, FailedItem, FailedItemError,
+        },
         computations::spot_price::SpotPriceComputation,
         error::ComputationError,
         manager::{ChangedComponents, SharedDerivedDataRef},
@@ -157,7 +159,7 @@ impl DerivedComputation for PoolDepthComputation {
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
-                        error: "missing simulation state".to_string(),
+                        error: FailedItemError::MissingSimulationState,
                     });
                 }
                 continue;
@@ -173,7 +175,7 @@ impl DerivedComputation for PoolDepthComputation {
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
-                        error: "missing token metadata".to_string(),
+                        error: FailedItemError::MissingTokenMetadata,
                     });
                 }
                 continue;
@@ -195,7 +197,7 @@ impl DerivedComputation for PoolDepthComputation {
                     pool_depths.remove(&key);
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
-                        error: "missing spot price".to_string(),
+                        error: FailedItemError::MissingSpotPrice,
                     });
                     continue;
                 };
@@ -220,10 +222,10 @@ impl DerivedComputation for PoolDepthComputation {
                     pool_depths.remove(&key);
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
-                        error: format!(
-                            "extreme decimal mismatch ({}→{})",
-                            token_in.decimals, token_out.decimals
-                        ),
+                        error: FailedItemError::ExtremeDecimalMismatch {
+                            from: token_in.decimals,
+                            to: token_out.decimals,
+                        },
                     });
                     continue;
                 }
@@ -242,7 +244,7 @@ impl DerivedComputation for PoolDepthComputation {
                     pool_depths.remove(&key);
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
-                        error: format!("spot price too small: {spot_price}"),
+                        error: FailedItemError::SpotPriceTooSmall(*spot_price),
                     });
                     continue;
                 }
@@ -314,7 +316,9 @@ impl DerivedComputation for PoolDepthComputation {
                                 "{}/{}/{}",
                                 component_id, token_in.address, token_out.address
                             ),
-                            error: format!("{e}: {probe_info}, {limits_info}"),
+                            error: FailedItemError::PoolDepthComputation(format!(
+                                "{e}: {probe_info}, {limits_info}"
+                            )),
                         });
                     }
                 }
@@ -344,6 +348,7 @@ mod tests {
     use crate::{
         algorithm::test_utils::{setup_market, token, token_with_decimals, MockProtocolSim},
         derived::{
+            computation::FailedItemError,
             store::DerivedData,
             types::{PoolDepthKey, SpotPrices},
         },
@@ -774,8 +779,7 @@ mod tests {
                 .failed_items
                 .iter()
                 .any(|item| item.key == usdc_eth_key &&
-                    item.error
-                        .contains("missing spot price")),
+                    matches!(item.error, FailedItemError::MissingSpotPrice)),
             "USDC→ETH should appear in failed_items with missing spot price error"
         );
     }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -8,7 +8,7 @@
 //! # Dependencies
 //!
 //! This computation depends on [`SpotPrices`](crate::derived::types::SpotPrices) being
-//! available in the [`DerivedDataStore`](crate::derived::store::DerivedDataStore).
+//! available in the [`DerivedData`](crate::derived::store::DerivedData).
 //! Ensure `SpotPriceComputation` runs before this computation.
 
 use std::collections::HashSet;
@@ -26,7 +26,7 @@ use tycho_simulation::{
 
 use crate::{
     derived::{
-        computation::{ComputationId, DerivedComputation},
+        computation::{ComputationId, ComputationOutput, DerivedComputation, FailedItem},
         computations::spot_price::SpotPriceComputation,
         error::ComputationError,
         manager::{ChangedComponents, SharedDerivedDataRef},
@@ -138,7 +138,7 @@ impl DerivedComputation for PoolDepthComputation {
         let tokens = snapshot.token_registry_ref();
 
         let mut succeeded = 0usize;
-        let mut failed = 0usize;
+        let mut failed_items: Vec<FailedItem> = Vec::new();
 
         for component_id in &components_to_compute {
             // Get token addresses: changed.added for new components, topology for existing
@@ -154,6 +154,10 @@ impl DerivedComputation for PoolDepthComputation {
             let Some(sim_state) = snapshot.get_simulation_state(component_id) else {
                 warn!(component_id, "missing simulation state, skipping pool");
                 pool_depths.retain(|key, _| &key.0 != component_id);
+                failed_items.push(FailedItem {
+                    key: component_id.to_string(),
+                    error: "missing simulation state".to_string(),
+                });
                 continue;
             };
 
@@ -164,6 +168,10 @@ impl DerivedComputation for PoolDepthComputation {
             let Ok(pool_tokens) = pool_tokens else {
                 warn!(component_id, "missing token metadata, skipping pool");
                 pool_depths.retain(|key, _| &key.0 != component_id);
+                failed_items.push(FailedItem {
+                    key: component_id.to_string(),
+                    error: "missing token metadata".to_string(),
+                });
                 continue;
             };
 
@@ -181,7 +189,10 @@ impl DerivedComputation for PoolDepthComputation {
                         "missing spot price, skipping pair"
                     );
                     pool_depths.remove(&key);
-                    failed += 1;
+                    failed_items.push(FailedItem {
+                        key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
+                        error: "missing spot price".to_string(),
+                    });
                     continue;
                 };
 
@@ -203,7 +214,13 @@ impl DerivedComputation for PoolDepthComputation {
                         token_in.decimals, token_out.decimals
                     );
                     pool_depths.remove(&key);
-                    failed += 1;
+                    failed_items.push(FailedItem {
+                        key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
+                        error: format!(
+                            "extreme decimal mismatch ({}→{})",
+                            token_in.decimals, token_out.decimals
+                        ),
+                    });
                     continue;
                 }
 
@@ -219,7 +236,10 @@ impl DerivedComputation for PoolDepthComputation {
                         "spot price too small to compute depth, skipping pair"
                     );
                     pool_depths.remove(&key);
-                    failed += 1;
+                    failed_items.push(FailedItem {
+                        key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
+                        error: format!("spot price too small: {spot_price}"),
+                    });
                     continue;
                 }
 
@@ -285,16 +305,27 @@ impl DerivedComputation for PoolDepthComputation {
                             "pool depth failed, skipping pair"
                         );
                         pool_depths.remove(&key);
-                        failed += 1;
+                        failed_items.push(FailedItem {
+                            key: format!(
+                                "{}/{}/{}",
+                                component_id, token_in.address, token_out.address
+                            ),
+                            error: format!("{e}: {probe_info}, {limits_info}"),
+                        });
                     }
                 }
             }
         }
 
-        debug!(succeeded, failed, total = pool_depths.len(), "pool depth computation complete");
+        debug!(
+            succeeded,
+            failed = failed_items.len(),
+            total = pool_depths.len(),
+            "pool depth computation complete"
+        );
         Span::current().record("updated_pool_depths", pool_depths.len());
 
-        Ok(pool_depths)
+        Ok(ComputationOutput::with_failures(pool_depths, failed_items))
     }
 }
 
@@ -366,7 +397,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(output.is_empty());
+        assert!(output.data.is_empty());
     }
 
     #[tokio::test]
@@ -423,19 +454,20 @@ mod tests {
             updated: vec![],
             is_full_recompute: true,
         };
-        let spot_prices = spot_comp
+        let spot_output = spot_comp
             .compute(&market, &derived, &changed)
             .await
             .expect("spot price computation should succeed");
         derived
             .try_write()
             .unwrap()
-            .set_spot_prices(spot_prices, 0);
+            .set_spot_prices(spot_output.data, 0);
 
-        let pool_depths = PoolDepthComputation::default()
+        let pool_depths_output = PoolDepthComputation::default()
             .compute(&market, &derived, &changed)
             .await
             .expect("computation should succeed");
+        let pool_depths = pool_depths_output.data;
 
         assert_eq!(pool_depths.len(), 2, "should have depths for both directions");
 
@@ -684,5 +716,63 @@ mod tests {
                 slippage * 100.0
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_compute_partial_failure_missing_spot_price() {
+        let eth = token(0x01, "ETH");
+        let usdc = token(0x02, "USDC");
+
+        let (market, _) = setup_market(vec![(
+            "pool",
+            &eth,
+            &usdc,
+            MockProtocolSim::new(2000.0)
+                .with_liquidity(1_000_000)
+                .with_tokens(&[eth.clone(), usdc.clone()]),
+        )]);
+        let derived = DerivedData::new_shared();
+
+        // Provide spot price for only one direction so the other becomes a FailedItem
+        let mut partial_spot = SpotPrices::new();
+        let key_eth_usdc = ("pool".to_string(), eth.address.clone(), usdc.address.clone());
+        partial_spot.insert(key_eth_usdc, 2000.0);
+        derived
+            .try_write()
+            .unwrap()
+            .set_spot_prices(partial_spot, 0);
+
+        let changed = ChangedComponents {
+            added: std::collections::HashMap::from([(
+                "pool".to_string(),
+                vec![eth.address.clone(), usdc.address.clone()],
+            )]),
+            removed: vec![],
+            updated: vec![],
+            is_full_recompute: true,
+        };
+
+        let output = PoolDepthComputation::default()
+            .compute(&market, &derived, &changed)
+            .await
+            .expect("should succeed with partial results");
+
+        assert!(output.has_failures(), "missing USDC→ETH spot price should produce a failed item");
+
+        // ETH→USDC direction should succeed
+        let key_eth_usdc: PoolDepthKey = ("pool".into(), eth.address.clone(), usdc.address.clone());
+        assert!(output.data.contains_key(&key_eth_usdc), "ETH→USDC depth should be present");
+
+        // USDC→ETH direction should be in failed_items
+        let usdc_eth_key = format!("pool/{}/{}", usdc.address, eth.address);
+        assert!(
+            output
+                .failed_items
+                .iter()
+                .any(|item| item.key == usdc_eth_key &&
+                    item.error
+                        .contains("missing spot price")),
+            "USDC→ETH should appear in failed_items with missing spot price error"
+        );
     }
 }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -84,7 +84,7 @@ impl DerivedComputation for PoolDepthComputation {
         market: &SharedMarketDataRef,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
-    ) -> Result<Self::Output, ComputationError> {
+    ) -> Result<ComputationOutput<Self::Output>, ComputationError> {
         // Read derived data from store
         let (spot_prices, mut pool_depths) = {
             let store_guard = store.read().await;

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -316,7 +316,7 @@ impl DerivedComputation for PoolDepthComputation {
                                 "{}/{}/{}",
                                 component_id, token_in.address, token_out.address
                             ),
-                            error: FailedItemError::PoolDepthComputationFailed(format!(
+                            error: FailedItemError::SimulationFailed(format!(
                                 "{e}: {probe_info}, {limits_info}"
                             )),
                         });
@@ -882,8 +882,8 @@ mod tests {
                 .failed_items
                 .iter()
                 .any(|item| item.key.starts_with("pool/") &&
-                    matches!(&item.error, FailedItemError::PoolDepthComputationFailed(_))),
-            "should have PoolDepthComputation failure, got: {:?}",
+                    matches!(&item.error, FailedItemError::SimulationFailed(_))),
+            "should have ComputationFailed failure, got: {:?}",
             output.failed_items
         );
     }

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -316,7 +316,7 @@ impl DerivedComputation for PoolDepthComputation {
                                 "{}/{}/{}",
                                 component_id, token_in.address, token_out.address
                             ),
-                            error: FailedItemError::PoolDepthComputation(format!(
+                            error: FailedItemError::PoolDepthComputationFailed(format!(
                                 "{e}: {probe_info}, {limits_info}"
                             )),
                         });
@@ -882,7 +882,7 @@ mod tests {
                 .failed_items
                 .iter()
                 .any(|item| item.key.starts_with("pool/") &&
-                    matches!(&item.error, FailedItemError::PoolDepthComputation(_))),
+                    matches!(&item.error, FailedItemError::PoolDepthComputationFailed(_))),
             "should have PoolDepthComputation failure, got: {:?}",
             output.failed_items
         );

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -154,10 +154,12 @@ impl DerivedComputation for PoolDepthComputation {
             let Some(sim_state) = snapshot.get_simulation_state(component_id) else {
                 warn!(component_id, "missing simulation state, skipping pool");
                 pool_depths.retain(|key, _| &key.0 != component_id);
-                failed_items.push(FailedItem {
-                    key: component_id.to_string(),
-                    error: "missing simulation state".to_string(),
-                });
+                for perm in token_addresses.iter().permutations(2) {
+                    failed_items.push(FailedItem {
+                        key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
+                        error: "missing simulation state".to_string(),
+                    });
+                }
                 continue;
             };
 
@@ -168,10 +170,12 @@ impl DerivedComputation for PoolDepthComputation {
             let Ok(pool_tokens) = pool_tokens else {
                 warn!(component_id, "missing token metadata, skipping pool");
                 pool_depths.retain(|key, _| &key.0 != component_id);
-                failed_items.push(FailedItem {
-                    key: component_id.to_string(),
-                    error: "missing token metadata".to_string(),
-                });
+                for perm in token_addresses.iter().permutations(2) {
+                    failed_items.push(FailedItem {
+                        key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
+                        error: "missing token metadata".to_string(),
+                    });
+                }
                 continue;
             };
 
@@ -389,7 +393,7 @@ mod tests {
         derived
             .try_write()
             .unwrap()
-            .set_spot_prices(SpotPrices::new(), 0);
+            .set_spot_prices(SpotPrices::new(), vec![], 0, true);
         let changed = ChangedComponents::default();
 
         let output = PoolDepthComputation::default()
@@ -461,7 +465,7 @@ mod tests {
         derived
             .try_write()
             .unwrap()
-            .set_spot_prices(spot_output.data, 0);
+            .set_spot_prices(spot_output.data, vec![], 0, true);
 
         let pool_depths_output = PoolDepthComputation::default()
             .compute(&market, &derived, &changed)
@@ -740,7 +744,7 @@ mod tests {
         derived
             .try_write()
             .unwrap()
-            .set_spot_prices(partial_spot, 0);
+            .set_spot_prices(partial_spot, vec![], 0, true);
 
         let changed = ChangedComponents {
             added: std::collections::HashMap::from([(

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -52,7 +52,7 @@ impl DerivedComputation for SpotPriceComputation {
         market: &SharedMarketDataRef,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
-    ) -> Result<Self::Output, ComputationError> {
+    ) -> Result<ComputationOutput<Self::Output>, ComputationError> {
         // Start with existing prices (or empty for full recompute).
         let mut spot_prices = if changed.is_full_recompute {
             SpotPrices::new()
@@ -85,7 +85,6 @@ impl DerivedComputation for SpotPriceComputation {
                 .cloned()
                 .collect()
         };
-        let num_components_to_compute = components_to_compute.len();
 
         let mut succeeded = 0usize;
         let mut failed_items: Vec<FailedItem> = Vec::new();

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -103,10 +103,12 @@ impl DerivedComputation for SpotPriceComputation {
             let Some(sim_state) = market_guard.get_simulation_state(component_id) else {
                 warn!(component_id, "missing simulation state, skipping pool");
                 spot_prices.retain(|key, _| &key.0 != component_id);
-                failed_items.push(FailedItem {
-                    key: component_id.to_string(),
-                    error: "missing simulation state".to_string(),
-                });
+                for perm in token_addresses.iter().permutations(2) {
+                    failed_items.push(FailedItem {
+                        key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
+                        error: "missing simulation state".to_string(),
+                    });
+                }
                 continue;
             };
 
@@ -117,10 +119,12 @@ impl DerivedComputation for SpotPriceComputation {
             let Ok(pool_tokens) = pool_tokens else {
                 warn!(component_id, "missing token metadata, skipping pool");
                 spot_prices.retain(|key, _| &key.0 != component_id);
-                failed_items.push(FailedItem {
-                    key: component_id.to_string(),
-                    error: "missing token metadata".to_string(),
-                });
+                for perm in token_addresses.iter().permutations(2) {
+                    failed_items.push(FailedItem {
+                        key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
+                        error: "missing token metadata".to_string(),
+                    });
+                }
                 continue;
             };
 
@@ -242,12 +246,15 @@ mod tests {
         assert!(output.data.contains_key(&key_eth_usdc), "ETH→USDC price should be present");
         assert!(output.data.contains_key(&key_usdc_eth), "USDC→ETH price should be present");
 
+        // Component-level failures are expanded to pair-level keys
+        let key_eth_dai = format!("pool2/{}/{}", eth.address, dai.address);
+        let key_dai_eth = format!("pool2/{}/{}", dai.address, eth.address);
         assert!(
             output
                 .failed_items
                 .iter()
-                .any(|item| item.key == "pool2"),
-            "pool2 should appear in failed_items"
+                .any(|item| item.key == key_eth_dai || item.key == key_dai_eth),
+            "pool2 pair keys should appear in failed_items"
         );
     }
 

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -154,7 +154,7 @@ impl DerivedComputation for SpotPriceComputation {
                                 "{}/{}/{}",
                                 component_id, token_in.address, token_out.address
                             ),
-                            error: FailedItemError::SpotPriceComputationFailed(e.to_string()),
+                            error: FailedItemError::SimulationFailed(e.to_string()),
                         });
                     }
                 }

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -14,7 +14,9 @@ use tracing::{debug, instrument, warn, Span};
 
 use crate::{
     derived::{
-        computation::{ComputationId, ComputationOutput, DerivedComputation, FailedItem},
+        computation::{
+            ComputationId, ComputationOutput, DerivedComputation, FailedItem, FailedItemError,
+        },
         error::ComputationError,
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::SpotPrices,
@@ -106,7 +108,7 @@ impl DerivedComputation for SpotPriceComputation {
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
-                        error: "missing simulation state".to_string(),
+                        error: FailedItemError::MissingSimulationState,
                     });
                 }
                 continue;
@@ -122,7 +124,7 @@ impl DerivedComputation for SpotPriceComputation {
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
-                        error: "missing token metadata".to_string(),
+                        error: FailedItemError::MissingTokenMetadata,
                     });
                 }
                 continue;
@@ -152,7 +154,7 @@ impl DerivedComputation for SpotPriceComputation {
                                 "{}/{}/{}",
                                 component_id, token_in.address, token_out.address
                             ),
-                            error: e.to_string(),
+                            error: FailedItemError::SpotPriceComputation(e.to_string()),
                         });
                     }
                 }

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -154,7 +154,7 @@ impl DerivedComputation for SpotPriceComputation {
                                 "{}/{}/{}",
                                 component_id, token_in.address, token_out.address
                             ),
-                            error: FailedItemError::SpotPriceComputation(e.to_string()),
+                            error: FailedItemError::SpotPriceComputationFailed(e.to_string()),
                         });
                     }
                 }

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -14,7 +14,7 @@ use tracing::{debug, instrument, warn, Span};
 
 use crate::{
     derived::{
-        computation::{ComputationId, DerivedComputation},
+        computation::{ComputationId, ComputationOutput, DerivedComputation, FailedItem},
         error::ComputationError,
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::SpotPrices,
@@ -86,7 +86,8 @@ impl DerivedComputation for SpotPriceComputation {
         let num_components_to_compute = components_to_compute.len();
 
         let mut succeeded = 0usize;
-        let mut failed = 0usize;
+        let mut failed_items: Vec<FailedItem> = Vec::new();
+        let num_components_to_compute = components_to_compute.len();
 
         for component_id in &components_to_compute {
             // Get token addresses: changed.added for new components, topology for existing.
@@ -102,6 +103,10 @@ impl DerivedComputation for SpotPriceComputation {
             let Some(sim_state) = market_guard.get_simulation_state(component_id) else {
                 warn!(component_id, "missing simulation state, skipping pool");
                 spot_prices.retain(|key, _| &key.0 != component_id);
+                failed_items.push(FailedItem {
+                    key: component_id.to_string(),
+                    error: "missing simulation state".to_string(),
+                });
                 continue;
             };
 
@@ -112,6 +117,10 @@ impl DerivedComputation for SpotPriceComputation {
             let Ok(pool_tokens) = pool_tokens else {
                 warn!(component_id, "missing token metadata, skipping pool");
                 spot_prices.retain(|key, _| &key.0 != component_id);
+                failed_items.push(FailedItem {
+                    key: component_id.to_string(),
+                    error: "missing token metadata".to_string(),
+                });
                 continue;
             };
 
@@ -134,7 +143,13 @@ impl DerivedComputation for SpotPriceComputation {
                             "spot price failed, skipping pair"
                         );
                         spot_prices.remove(&key);
-                        failed += 1;
+                        failed_items.push(FailedItem {
+                            key: format!(
+                                "{}/{}/{}",
+                                component_id, token_in.address, token_out.address
+                            ),
+                            error: e.to_string(),
+                        });
                     }
                 }
             }
@@ -142,7 +157,12 @@ impl DerivedComputation for SpotPriceComputation {
 
         drop(market_guard);
 
-        debug!(succeeded, failed, total = spot_prices.len(), "spot price computation complete");
+        debug!(
+            succeeded,
+            failed = failed_items.len(),
+            total = spot_prices.len(),
+            "spot price computation complete"
+        );
         Span::current().record("updated_spot_prices", spot_prices.len());
 
         // Return error if all calculations failed for a full recompute.
@@ -154,7 +174,7 @@ impl DerivedComputation for SpotPriceComputation {
             });
         }
 
-        Ok(spot_prices)
+        Ok(ComputationOutput::with_failures(spot_prices, failed_items))
     }
 }
 
@@ -165,7 +185,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        algorithm::test_utils::{token, MockProtocolSim},
+        algorithm::test_utils::{component, setup_market, token, MockProtocolSim},
         derived::store::DerivedData,
         feed::market_data::SharedMarketData,
     };
@@ -186,7 +206,49 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(output.is_empty());
+        assert!(output.data.is_empty());
+    }
+
+    #[tokio::test]
+    async fn partial_failure_yields_ok_with_failed_items() {
+        // pool1: has sim state → spot prices computed
+        // pool2: no sim state → FailedItem
+        let eth = token(0x01, "ETH");
+        let usdc = token(0x02, "USDC");
+        let dai = token(0x03, "DAI");
+
+        let (market, _) = setup_market(vec![("pool1", &eth, &usdc, MockProtocolSim::new(2000.0))]);
+
+        // Add pool2 without sim state
+        {
+            let mut m = market.write().await;
+            let pool2 = component("pool2", &[eth.clone(), dai.clone()]);
+            m.upsert_components(std::iter::once(pool2));
+            m.upsert_tokens([dai.clone()]);
+        }
+
+        let derived = DerivedData::new_shared();
+        let changed = ChangedComponents { is_full_recompute: true, ..Default::default() };
+
+        let output = SpotPriceComputation::new()
+            .compute(&market, &derived, &changed)
+            .await
+            .expect("should not be total failure since pool1 succeeds");
+
+        assert!(output.has_failures(), "pool2 missing sim state should produce a failed item");
+
+        let key_eth_usdc = ("pool1".to_string(), eth.address.clone(), usdc.address.clone());
+        let key_usdc_eth = ("pool1".to_string(), usdc.address.clone(), eth.address.clone());
+        assert!(output.data.contains_key(&key_eth_usdc), "ETH→USDC price should be present");
+        assert!(output.data.contains_key(&key_usdc_eth), "USDC→ETH price should be present");
+
+        assert!(
+            output
+                .failed_items
+                .iter()
+                .any(|item| item.key == "pool2"),
+            "pool2 should appear in failed_items"
+        );
     }
 
     /// MockProtocolSim spot_price behavior:

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -670,7 +670,7 @@ mod tests {
         wrapped_store
             .try_write()
             .unwrap()
-            .set_spot_prices(spot_prices_output.data, 0);
+            .set_spot_prices(spot_prices_output.data, vec![], 0, true);
 
         (wrapped_market, wrapped_store)
     }
@@ -1288,7 +1288,7 @@ mod tests {
         derived
             .try_write()
             .unwrap()
-            .set_spot_prices(spot_output.data, 0);
+            .set_spot_prices(spot_output.data, vec![], 0, true);
 
         let computation = computation_for(&eth.address);
         let result = computation

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -324,8 +324,8 @@ impl TokenGasPriceComputation {
         market: &SharedMarketDataRef,
         spot_prices: &SpotPrices,
         filter_tokens: Option<&HashSet<Address>>,
-    ) -> Result<(
-        (HashMap<Address, (f64, Price, HashSet<ComponentId>)>, u64), Vec<FailedItem>),
+    ) -> Result<
+        (HashMap<Address, (f64, Price, HashSet<ComponentId>)>, u64, Vec<FailedItem>),
         ComputationError,
     > {
         // Brief lock 1: topology + gas_price + block (all cheap clones)
@@ -438,6 +438,14 @@ impl TokenGasPriceComputation {
             }
         }
 
+        // Extend each token's path_components with all candidate path components so
+        // incremental recomputation fires when any competing path's pool changes.
+        for (token, (_, _, components)) in best_prices.iter_mut() {
+            if let Some(all_comps) = all_candidate_components.get(token) {
+                components.extend(all_comps.iter().cloned());
+            }
+        }
+
         // Tokens with discovered paths but no successful simulation
         let failed_items: Vec<FailedItem> = paths_by_token
             .keys()
@@ -448,7 +456,7 @@ impl TokenGasPriceComputation {
             })
             .collect();
 
-        Ok((best_prices, failed_items))
+        Ok((best_prices, block, failed_items))
     }
 
     /// Attempts incremental recomputation for state-only changes.
@@ -462,8 +470,10 @@ impl TokenGasPriceComputation {
         market: &SharedMarketDataRef,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
-    ) -> Result<Option<TokenGasPrices>, ComputationError> {
-        let store_guard = store.read().await;
+    ) -> Result<Option<ComputationOutput<TokenGasPrices>>, ComputationError> {
+        // Read all needed data from store in a single lock acquisition.
+        let (existing_deps, existing_prices, spot_prices) = {
+            let store_guard = store.read().await;
 
             // Need existing deps to do incremental computation.
             let Some(existing_deps) = store_guard.token_prices_deps().cloned() else {
@@ -494,7 +504,7 @@ impl TokenGasPriceComputation {
             .collect();
 
         if tokens_to_recompute.is_empty() {
-            return Ok(Some(existing_prices.clone()));
+            return Ok(Some(ComputationOutput::success(existing_prices.clone())));
         }
 
         debug!(
@@ -503,30 +513,9 @@ impl TokenGasPriceComputation {
             "incremental token price recomputation"
         );
 
-        let market = market.read().await;
-        let block = market
-            .last_updated()
-            .map(|b| b.number())
-            .unwrap_or(0);
-
-        let store_guard = store.read().await;
-        let spot_prices = store_guard
-            .spot_prices()
-            .ok_or(ComputationError::MissingDependency("spot_prices"))?
-            .clone();
-        drop(store_guard);
-
-        let gas_price = market
-            .gas_price()
-            .ok_or(ComputationError::MissingDependency("gas_price"))?
-            .effective_gas_price();
-
-        let best_prices = self.simulate_token_prices(
-            &market,
-            &spot_prices,
-            &gas_price,
-            Some(&tokens_to_recompute),
-        )?;
+        let (best_prices, block, _) = self
+            .simulate_token_prices(market, &spot_prices, Some(&tokens_to_recompute))
+            .await?;
 
         // Merge results into existing prices and deps
         let mut result = existing_prices;
@@ -577,11 +566,11 @@ impl DerivedComputation for TokenGasPriceComputation {
         // For state-only changes, use incremental computation
         if !changed.is_full_recompute && !changed.is_topology_change() {
             // Try incremental computation if we have existing path dependencies
-            if let Some(output) = self
+            if let Some(result) = self
                 .try_incremental_compute(market, store, changed)
                 .await?
             {
-                return Ok(output);
+                return Ok(result);
             }
             // Fall through to full compute if incremental is not possible
         }
@@ -593,14 +582,10 @@ impl DerivedComputation for TokenGasPriceComputation {
             .spot_prices()
             .ok_or(ComputationError::MissingDependency("spot_prices"))?
             .clone();
-        drop(store_guard);
 
-        let gas_price = market
-            .gas_price()
-            .ok_or(ComputationError::MissingDependency("gas_price"))?
-            .effective_gas_price();
-
-        let best_prices = self.simulate_token_prices(&market, &spot_prices, &gas_price, None)?;
+        let (best_prices, block, failed_items) = self
+            .simulate_token_prices(market, &spot_prices, None)
+            .await?;
 
         // Build token prices with dependencies for incremental computation
         let mut token_prices_with_deps = TokenPricesWithDeps::new();

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -27,7 +27,7 @@
 //! # Dependencies
 //!
 //! This computation depends on [`SpotPrices`](crate::derived::types::SpotPrices) being
-//! available in the [`DerivedDataStore`](crate::derived::store::DerivedDataStore).
+//! available in the [`DerivedData`](crate::derived::store::DerivedData).
 //! Ensure `SpotPriceComputation` runs before this computation.
 
 use std::collections::{HashMap, HashSet};

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -43,7 +43,7 @@ use tycho_simulation::{
 
 use crate::{
     derived::{
-        computation::{ComputationId, DerivedComputation},
+        computation::{ComputationId, ComputationOutput, DerivedComputation, FailedItem},
         error::ComputationError,
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::{SpotPriceKey, SpotPrices, TokenGasPrices, TokenPriceEntry, TokenPricesWithDeps},
@@ -322,7 +322,10 @@ impl TokenGasPriceComputation {
         market: &SharedMarketDataRef,
         spot_prices: &SpotPrices,
         filter_tokens: Option<&HashSet<Address>>,
-    ) -> Result<(HashMap<Address, (f64, Price, HashSet<ComponentId>)>, u64), ComputationError> {
+    ) -> Result<(
+        (HashMap<Address, (f64, Price, HashSet<ComponentId>)>, u64), Vec<FailedItem>),
+        ComputationError,
+    > {
         // Brief lock 1: topology + gas_price + block (all cheap clones)
         let (topology, gas_price, block) = {
             let guard = market.read().await;
@@ -433,15 +436,7 @@ impl TokenGasPriceComputation {
             }
         }
 
-        // Extend each token's path_components with all candidate path components so
-        // incremental recomputation fires when any competing path's pool changes.
-        for (token, (_, _, components)) in best_prices.iter_mut() {
-            if let Some(all_comps) = all_candidate_components.get(token) {
-                components.extend(all_comps.iter().cloned());
-            }
-        }
-
-        Ok((best_prices, block))
+        Ok(best_prices)
     }
 
     /// Attempts incremental recomputation for state-only changes.
@@ -456,9 +451,7 @@ impl TokenGasPriceComputation {
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<Option<TokenGasPrices>, ComputationError> {
-        // Read all needed data from store in a single lock acquisition.
-        let (existing_deps, existing_prices, spot_prices) = {
-            let store_guard = store.read().await;
+        let store_guard = store.read().await;
 
             // Need existing deps to do incremental computation.
             let Some(existing_deps) = store_guard.token_prices_deps().cloned() else {
@@ -489,7 +482,7 @@ impl TokenGasPriceComputation {
             .collect();
 
         if tokens_to_recompute.is_empty() {
-            return Ok(Some(existing_prices));
+            return Ok(Some(existing_prices.clone()));
         }
 
         debug!(
@@ -498,13 +491,35 @@ impl TokenGasPriceComputation {
             "incremental token price recomputation"
         );
 
-        let (best_prices, block) = self
-            .simulate_token_prices(market, &spot_prices, Some(&tokens_to_recompute))
-            .await?;
+        let market = market.read().await;
+        let block = market
+            .last_updated()
+            .map(|b| b.number())
+            .unwrap_or(0);
+
+        let store_guard = store.read().await;
+        let spot_prices = store_guard
+            .spot_prices()
+            .ok_or(ComputationError::MissingDependency("spot_prices"))?
+            .clone();
+        drop(store_guard);
+
+        let gas_price = market
+            .gas_price()
+            .ok_or(ComputationError::MissingDependency("gas_price"))?
+            .effective_gas_price();
+
+        let best_prices = self.simulate_token_prices(
+            &market,
+            &spot_prices,
+            &gas_price,
+            Some(&tokens_to_recompute),
+        )?;
 
         // Merge results into existing prices and deps
         let mut result = existing_prices;
         let mut new_deps = existing_deps;
+        let mut failed_items: Vec<FailedItem> = Vec::new();
 
         for token in &tokens_to_recompute {
             if let Some((_, price, components)) = best_prices.get(token) {
@@ -516,6 +531,10 @@ impl TokenGasPriceComputation {
             } else {
                 result.remove(token);
                 new_deps.remove(token);
+                failed_items.push(FailedItem {
+                    key: token.to_string(),
+                    error: "all simulation paths failed".to_string(),
+                });
             }
         }
 
@@ -525,7 +544,7 @@ impl TokenGasPriceComputation {
             .set_token_prices_deps(new_deps, block);
         Span::current().record("updated_token_prices", result.len());
 
-        Ok(Some(result))
+        Ok(Some(ComputationOutput::with_failures(result, failed_items)))
     }
 }
 
@@ -541,16 +560,16 @@ impl DerivedComputation for TokenGasPriceComputation {
         market: &SharedMarketDataRef,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
-    ) -> Result<Self::Output, ComputationError> {
+    ) -> Result<ComputationOutput<Self::Output>, ComputationError> {
         // For topology changes or full recompute, do a full computation
         // For state-only changes, use incremental computation
         if !changed.is_full_recompute && !changed.is_topology_change() {
             // Try incremental computation if we have existing path dependencies
-            if let Some(result) = self
+            if let Some(output) = self
                 .try_incremental_compute(market, store, changed)
                 .await?
             {
-                return Ok(result);
+                return Ok(output);
             }
             // Fall through to full compute if incremental is not possible
         }
@@ -562,10 +581,14 @@ impl DerivedComputation for TokenGasPriceComputation {
             .spot_prices()
             .ok_or(ComputationError::MissingDependency("spot_prices"))?
             .clone();
+        drop(store_guard);
 
-        let (best_prices, block) = self
-            .simulate_token_prices(market, &spot_prices, None)
-            .await?;
+        let gas_price = market
+            .gas_price()
+            .ok_or(ComputationError::MissingDependency("gas_price"))?
+            .effective_gas_price();
+
+        let best_prices = self.simulate_token_prices(&market, &spot_prices, &gas_price, None)?;
 
         // Build token prices with dependencies for incremental computation
         let mut token_prices_with_deps = TokenPricesWithDeps::new();
@@ -597,7 +620,7 @@ impl DerivedComputation for TokenGasPriceComputation {
 
         Span::current().record("updated_token_prices", token_prices.len());
 
-        Ok(token_prices)
+        Ok(ComputationOutput::with_failures(token_prices, failed_items))
     }
 }
 
@@ -640,14 +663,14 @@ mod tests {
             updated: vec![],
             is_full_recompute: true,
         };
-        let spot_prices = spot_comp
+        let spot_prices_output = spot_comp
             .compute(&wrapped_market, &wrapped_store, &changed)
             .await
             .expect("spot price computation should succeed");
         wrapped_store
             .try_write()
             .unwrap()
-            .set_spot_prices(spot_prices, 0);
+            .set_spot_prices(spot_prices_output.data, 0);
 
         (wrapped_market, wrapped_store)
     }
@@ -914,7 +937,8 @@ mod tests {
         let prices = computation
             .compute(&market, &derived, &changed)
             .await
-            .unwrap();
+            .unwrap()
+            .data;
 
         // Exactly 2 prices: ETH (gas token) and USDC
         assert_eq!(prices.len(), 2, "should have exactly 2 token prices");
@@ -1001,7 +1025,8 @@ mod tests {
         let prices = computation
             .compute(&market, &derived, &changed)
             .await
-            .unwrap();
+            .unwrap()
+            .data;
 
         assert_eq!(prices.len(), 4, "should have prices for ETH, A, B, C");
 
@@ -1088,7 +1113,8 @@ mod tests {
         let prices = computation
             .compute(&market, &derived, &changed)
             .await
-            .unwrap();
+            .unwrap()
+            .data;
 
         // Only the gas token itself should have a price (1:1)
         assert_eq!(prices.len(), 1, "should only have gas token price");
@@ -1255,14 +1281,14 @@ mod tests {
         };
 
         let spot_comp = SpotPriceComputation::new();
-        let spot_prices = spot_comp
+        let spot_output = spot_comp
             .compute(&market, &derived, &changed)
             .await
             .unwrap();
         derived
             .try_write()
             .unwrap()
-            .set_spot_prices(spot_prices, 0);
+            .set_spot_prices(spot_output.data, 0);
 
         let computation = computation_for(&eth.address);
         let result = computation
@@ -1272,6 +1298,46 @@ mod tests {
         assert!(
             matches!(result, Err(ComputationError::MissingDependency("gas_price"))),
             "should return MissingDependency for gas_price"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_all_paths_fail_reported() {
+        // gas_units = 1e16, gas_price = 100 (set by setup_market)
+        // sell_gas_cost = 1e16 * 100 = 1e18 = sell_out (1e18 ETH) → path not viable
+        // → all paths for USDC fail → USDC lands in failed_items
+        let eth = token(0, "ETH");
+        let usdc = token(1, "USDC");
+
+        let (market, derived) = setup_test_env(vec![(
+            "eth_usdc",
+            &eth,
+            &usdc,
+            MockProtocolSim::new(2000.0).with_gas(10_000_000_000_000_000u64), // 1e16 gas units
+        )])
+        .await;
+        let changed = ChangedComponents::default();
+
+        let computation = computation_for(&eth.address);
+        let output = computation
+            .compute(&market, &derived, &changed)
+            .await
+            .unwrap();
+
+        // USDC has a discovered path but all simulations fail
+        assert!(
+            output
+                .failed_items
+                .iter()
+                .any(|item| item.key == usdc.address.to_string()),
+            "USDC should appear in failed_items when all simulation paths fail"
+        );
+        // Gas token always has a 1:1 price
+        assert!(output.data.contains_key(&eth.address), "gas token should always have price");
+        // USDC should not have a price
+        assert!(
+            !output.data.contains_key(&usdc.address),
+            "USDC should not have a price when all simulation paths fail"
         );
     }
 }

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -43,7 +43,9 @@ use tycho_simulation::{
 
 use crate::{
     derived::{
-        computation::{ComputationId, ComputationOutput, DerivedComputation, FailedItem},
+        computation::{
+            ComputationId, ComputationOutput, DerivedComputation, FailedItem, FailedItemError,
+        },
         error::ComputationError,
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::{SpotPriceKey, SpotPrices, TokenGasPrices, TokenPriceEntry, TokenPricesWithDeps},
@@ -436,7 +438,17 @@ impl TokenGasPriceComputation {
             }
         }
 
-        Ok(best_prices)
+        // Tokens with discovered paths but no successful simulation
+        let failed_items: Vec<FailedItem> = paths_by_token
+            .keys()
+            .filter(|token| !best_prices.contains_key(*token))
+            .map(|token| FailedItem {
+                key: token.to_string(),
+                error: FailedItemError::AllSimulationPathsFailed,
+            })
+            .collect();
+
+        Ok((best_prices, failed_items))
     }
 
     /// Attempts incremental recomputation for state-only changes.
@@ -533,7 +545,7 @@ impl TokenGasPriceComputation {
                 new_deps.remove(token);
                 failed_items.push(FailedItem {
                     key: token.to_string(),
-                    error: "all simulation paths failed".to_string(),
+                    error: FailedItemError::AllSimulationPathsFailed,
                 });
             }
         }

--- a/fynd-core/src/derived/events.rs
+++ b/fynd-core/src/derived/events.rs
@@ -28,4 +28,15 @@ pub enum DerivedDataEvent {
         /// Block number this computation was performed for.
         block: u64,
     },
+
+    /// A computation failed for a block and will not produce a result.
+    ///
+    /// Workers with `require_fresh` requirements use this to exit immediately
+    /// rather than waiting until timeout.
+    ComputationFailed {
+        /// Which computation failed.
+        computation_id: ComputationId,
+        /// Block number this computation was attempted for.
+        block: u64,
+    },
 }

--- a/fynd-core/src/derived/events.rs
+++ b/fynd-core/src/derived/events.rs
@@ -3,7 +3,7 @@
 //! Workers subscribe to these events to track readiness of derived data
 //! computations before solving.
 
-use super::computation::ComputationId;
+use super::computation::{ComputationId, FailedItem};
 
 /// Events broadcast when derived data computations complete.
 ///
@@ -27,6 +27,8 @@ pub enum DerivedDataEvent {
         computation_id: ComputationId,
         /// Block number this computation was performed for.
         block: u64,
+        /// Items that failed during this computation (empty = full success).
+        failed_items: Vec<FailedItem>,
     },
 
     /// A computation failed for a block and will not produce a result.

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -595,7 +595,8 @@ mod tests {
         market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
         market.upsert_components([pool1, pool2]);
         // Only pool1 has simulation state; pool2 intentionally has none
-        market.update_states([("eth_usdc".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
+        market
+            .update_states([("eth_usdc".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market.upsert_tokens([eth, usdc, dai]);
         Arc::new(RwLock::new(market))
     }
@@ -640,7 +641,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn token_price_failure_broadcasts_computation_failed() {
+    async fn test_token_price_failure_broadcasts_computation_failed() {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let market = market_with_sim_state_no_gas_price();
@@ -693,7 +694,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_all_partial_spot_price_failure_broadcasts_computation_complete() {
+    async fn partial_spot_price_failure_broadcasts_computation_complete() {
         // market_with_mixed_sim_states has pool1 (with sim state) and pool2 (without)
         // → spot price computation partially succeeds → ComputationComplete with failed_items
         let market = market_with_mixed_sim_states();

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -14,7 +14,7 @@ use std::{
 
 use async_trait::async_trait;
 use tokio::sync::{broadcast, RwLock};
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 use tycho_simulation::tycho_common::models::Address;
 
 use crate::{feed::market_data::SharedMarketData, types::ComponentId};
@@ -279,18 +279,30 @@ impl ComputationManager {
 
         // Write spot prices to store before dependent computations
         match spot_prices_result {
-            Ok(prices) => {
-                let count = prices.len();
+            Ok(output) => {
+                let count = output.data.len();
+                if output.has_failures() {
+                    warn!(
+                        count,
+                        failed = output.failed_items.len(),
+                        "spot prices partial failures"
+                    );
+                    for item in &output.failed_items {
+                        debug!(key = %item.key, error = %item.error, "spot price failed item");
+                    }
+                } else {
+                    info!(count, elapsed_ms = spot_elapsed.as_millis(), "spot prices computed");
+                }
                 self.store
                     .write()
                     .await
-                    .set_spot_prices(prices, block);
-                info!(count, elapsed_ms = spot_elapsed.as_millis(), "spot prices computed");
+                    .set_spot_prices(output.data, block);
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
                         computation_id: SpotPriceComputation::ID,
                         block,
+                        failed_items: output.failed_items,
                     });
             }
             Err(e) => {
@@ -332,15 +344,27 @@ impl ComputationManager {
         let mut store_write = self.store.write().await;
 
         match token_prices_result {
-            Ok(prices) => {
-                let count = prices.len();
-                store_write.set_token_prices(prices, block);
-                info!(count, elapsed_ms = token_elapsed.as_millis(), "token prices computed");
+            Ok(output) => {
+                let count = output.data.len();
+                if output.has_failures() {
+                    warn!(
+                        count,
+                        failed = output.failed_items.len(),
+                        "token prices partial failures"
+                    );
+                    for item in &output.failed_items {
+                        debug!(key = %item.key, error = %item.error, "token price failed item");
+                    }
+                } else {
+                    info!(count, elapsed_ms = token_elapsed.as_millis(), "token prices computed");
+                }
+                store_write.set_token_prices(output.data, block);
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
                         computation_id: TokenGasPriceComputation::ID,
                         block,
+                        failed_items: output.failed_items,
                     });
             }
             Err(e) => {
@@ -355,15 +379,27 @@ impl ComputationManager {
         }
 
         match pool_depths_result {
-            Ok(depths) => {
-                let count = depths.len();
-                store_write.set_pool_depths(depths, block);
-                info!(count, elapsed_ms = depth_elapsed.as_millis(), "pool depths computed");
+            Ok(output) => {
+                let count = output.data.len();
+                if output.has_failures() {
+                    warn!(
+                        count,
+                        failed = output.failed_items.len(),
+                        "pool depths partial failures"
+                    );
+                    for item in &output.failed_items {
+                        debug!(key = %item.key, error = %item.error, "pool depth failed item");
+                    }
+                } else {
+                    info!(count, elapsed_ms = depth_elapsed.as_millis(), "pool depths computed");
+                }
+                store_write.set_pool_depths(output.data, block);
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
                         computation_id: PoolDepthComputation::ID,
                         block,
+                        failed_items: output.failed_items,
                     });
             }
             Err(e) => {
@@ -545,6 +581,25 @@ mod tests {
         Arc::new(RwLock::new(market))
     }
 
+    /// Creates a market with two pools: one with sim state (pool succeeds) and one without (pool
+    /// fails). Used to trigger partial spot price failure.
+    fn market_with_mixed_sim_states() -> Arc<RwLock<SharedMarketData>> {
+        let eth = token(1, "ETH");
+        let usdc = token(2, "USDC");
+        let dai = token(3, "DAI");
+
+        let pool1 = component("eth_usdc", &[eth.clone(), usdc.clone()]);
+        let pool2 = component("eth_dai", &[eth.clone(), dai.clone()]);
+
+        let mut market = SharedMarketData::new();
+        market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
+        market.upsert_components([pool1, pool2]);
+        // Only pool1 has simulation state; pool2 intentionally has none
+        market.update_states([("eth_usdc".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
+        market.upsert_tokens([eth, usdc, dai]);
+        Arc::new(RwLock::new(market))
+    }
+
     /// Creates a market WITH sim_state but WITHOUT gas_price.
     ///
     /// Spot price computation succeeds (MockProtocolSim works), but token_price
@@ -635,5 +690,46 @@ mod tests {
             .await
             .expect("manager should shutdown on channel close")
             .expect("task should complete successfully");
+    }
+
+    #[tokio::test]
+    async fn compute_all_partial_spot_price_failure_broadcasts_computation_complete() {
+        // market_with_mixed_sim_states has pool1 (with sim state) and pool2 (without)
+        // → spot price computation partially succeeds → ComputationComplete with failed_items
+        let market = market_with_mixed_sim_states();
+        let config = ComputationManagerConfig::new();
+        let (manager, mut event_rx) = ComputationManager::new(config, market).unwrap();
+
+        let changed = ChangedComponents { is_full_recompute: true, ..Default::default() };
+        manager.compute_all(&changed).await;
+
+        let events = drain_events(&mut event_rx);
+
+        // Should broadcast ComputationComplete (not ComputationFailed) because pool1 succeeds
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                DerivedDataEvent::ComputationComplete { computation_id: "spot_prices", .. }
+            )),
+            "expected ComputationComplete(spot_prices), got: {events:?}"
+        );
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                DerivedDataEvent::ComputationFailed { computation_id: "spot_prices", .. }
+            )),
+            "should not broadcast ComputationFailed for partial failure"
+        );
+
+        // The ComputationComplete event should carry the failed item for pool2
+        let complete = events.iter().find(|e| {
+            matches!(e, DerivedDataEvent::ComputationComplete { computation_id: "spot_prices", .. })
+        });
+        if let Some(DerivedDataEvent::ComputationComplete { failed_items, .. }) = complete {
+            assert!(
+                !failed_items.is_empty(),
+                "ComputationComplete should carry failed_items for pool2"
+            );
+        }
     }
 }

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -296,7 +296,12 @@ impl ComputationManager {
                 self.store
                     .write()
                     .await
-                    .set_spot_prices(output.data, output.failed_items.clone(), block, changed.is_full_recompute);
+                    .set_spot_prices(
+                        output.data,
+                        output.failed_items.clone(),
+                        block,
+                        changed.is_full_recompute,
+                    );
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
@@ -358,7 +363,12 @@ impl ComputationManager {
                 } else {
                     info!(count, elapsed_ms = token_elapsed.as_millis(), "token prices computed");
                 }
-                store_write.set_token_prices(output.data, output.failed_items.clone(), block, changed.is_full_recompute);
+                store_write.set_token_prices(
+                    output.data,
+                    output.failed_items.clone(),
+                    block,
+                    changed.is_full_recompute,
+                );
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
@@ -393,7 +403,12 @@ impl ComputationManager {
                 } else {
                     info!(count, elapsed_ms = depth_elapsed.as_millis(), "pool depths computed");
                 }
-                store_write.set_pool_depths(output.data, output.failed_items.clone(), block, changed.is_full_recompute);
+                store_write.set_pool_depths(
+                    output.data,
+                    output.failed_items.clone(),
+                    block,
+                    changed.is_full_recompute,
+                );
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
@@ -739,13 +754,15 @@ mod tests {
         let dai = token(3, "DAI");
         let store = manager.store();
         let guard = store.read().await;
-        let key_eth_dai =
-            ("eth_dai".to_string(), eth.address.clone(), dai.address.clone());
-        let key_dai_eth =
-            ("eth_dai".to_string(), dai.address.clone(), eth.address.clone());
+        let key_eth_dai = ("eth_dai".to_string(), eth.address.clone(), dai.address.clone());
+        let key_dai_eth = ("eth_dai".to_string(), dai.address.clone(), eth.address.clone());
         assert!(
-            guard.spot_price_failure(&key_eth_dai).is_some() ||
-                guard.spot_price_failure(&key_dai_eth).is_some(),
+            guard
+                .spot_price_failure(&key_eth_dai)
+                .is_some() ||
+                guard
+                    .spot_price_failure(&key_dai_eth)
+                    .is_some(),
             "store should persist failure reason for eth_dai (missing sim state)"
         );
     }

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -296,7 +296,7 @@ impl ComputationManager {
                 self.store
                     .write()
                     .await
-                    .set_spot_prices(output.data, block);
+                    .set_spot_prices(output.data, output.failed_items.clone(), block, changed.is_full_recompute);
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
@@ -358,7 +358,7 @@ impl ComputationManager {
                 } else {
                     info!(count, elapsed_ms = token_elapsed.as_millis(), "token prices computed");
                 }
-                store_write.set_token_prices(output.data, block);
+                store_write.set_token_prices(output.data, output.failed_items.clone(), block, changed.is_full_recompute);
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
@@ -393,7 +393,7 @@ impl ComputationManager {
                 } else {
                     info!(count, elapsed_ms = depth_elapsed.as_millis(), "pool depths computed");
                 }
-                store_write.set_pool_depths(output.data, block);
+                store_write.set_pool_depths(output.data, output.failed_items.clone(), block, changed.is_full_recompute);
                 let _ = self
                     .event_tx
                     .send(DerivedDataEvent::ComputationComplete {
@@ -732,5 +732,21 @@ mod tests {
                 "ComputationComplete should carry failed_items for pool2"
             );
         }
+
+        // The store should persist the failure reason for the failed pool.
+        // market_with_mixed_sim_states uses token(1, "ETH") and token(3, "DAI") for pool2.
+        let eth = token(1, "ETH");
+        let dai = token(3, "DAI");
+        let store = manager.store();
+        let guard = store.read().await;
+        let key_eth_dai =
+            ("eth_dai".to_string(), eth.address.clone(), dai.address.clone());
+        let key_dai_eth =
+            ("eth_dai".to_string(), dai.address.clone(), eth.address.clone());
+        assert!(
+            guard.spot_price_failure(&key_eth_dai).is_some() ||
+                guard.spot_price_failure(&key_dai_eth).is_some(),
+            "store should persist failure reason for eth_dai (missing sim state)"
+        );
     }
 }

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -318,6 +318,18 @@ impl ComputationManager {
                         computation_id: SpotPriceComputation::ID,
                         block,
                     });
+                let _ = self
+                    .event_tx
+                    .send(DerivedDataEvent::ComputationFailed {
+                        computation_id: TokenGasPriceComputation::ID,
+                        block,
+                    });
+                let _ = self
+                    .event_tx
+                    .send(DerivedDataEvent::ComputationFailed {
+                        computation_id: PoolDepthComputation::ID,
+                        block,
+                    });
                 // Cannot proceed with token prices if spot prices failed
                 return;
             }

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -564,7 +564,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn spot_price_failure_broadcasts_computation_failed() {
+    async fn test_spot_price_failure_broadcasts_computation_failed() {
         let market = market_with_component_no_sim_state();
         let config = ComputationManagerConfig::new();
         let (manager, mut event_rx) = ComputationManager::new(config, market).unwrap();

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -295,6 +295,12 @@ impl ComputationManager {
             }
             Err(e) => {
                 warn!(error = ?e, elapsed_ms = spot_elapsed.as_millis(), "spot price computation failed");
+                let _ = self
+                    .event_tx
+                    .send(DerivedDataEvent::ComputationFailed {
+                        computation_id: SpotPriceComputation::ID,
+                        block,
+                    });
                 // Cannot proceed with token prices if spot prices failed
                 return;
             }
@@ -339,6 +345,12 @@ impl ComputationManager {
             }
             Err(e) => {
                 warn!(error = ?e, "token price computation failed");
+                let _ = self
+                    .event_tx
+                    .send(DerivedDataEvent::ComputationFailed {
+                        computation_id: TokenGasPriceComputation::ID,
+                        block,
+                    });
             }
         }
 
@@ -356,6 +368,12 @@ impl ComputationManager {
             }
             Err(e) => {
                 warn!(error = ?e, "pool depth computation failed");
+                let _ = self
+                    .event_tx
+                    .send(DerivedDataEvent::ComputationFailed {
+                        computation_id: PoolDepthComputation::ID,
+                        block,
+                    });
             }
         }
 
@@ -402,12 +420,30 @@ impl MarketEventHandler for ComputationManager {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, sync::Arc};
 
-    use tokio::sync::broadcast;
+    use tokio::sync::{broadcast, RwLock};
 
     use super::*;
-    use crate::algorithm::test_utils::{setup_market, token, MockProtocolSim};
+    use crate::{
+        algorithm::test_utils::{component, setup_market, token, MockProtocolSim},
+        feed::market_data::SharedMarketData,
+        types::BlockInfo,
+    };
+
+    /// Drains all currently-pending events from a broadcast receiver into a Vec.
+    fn drain_events(rx: &mut broadcast::Receiver<DerivedDataEvent>) -> Vec<DerivedDataEvent> {
+        let mut events = vec![];
+        loop {
+            match rx.try_recv() {
+                Ok(e) => events.push(e),
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(broadcast::error::TryRecvError::Closed) => break,
+            }
+        }
+        events
+    }
 
     #[test]
     fn invalid_slippage_threshold_returns_error() {
@@ -490,6 +526,94 @@ mod tests {
             .await
             .expect("manager should shutdown")
             .expect("task should complete successfully");
+    }
+
+    /// Creates a market with a component in topology but WITHOUT simulation state.
+    ///
+    /// Used to trigger `TotalFailure` in spot_price computation (full recompute with
+    /// all components missing sim_state → succeeded == 0 → failure).
+    fn market_with_component_no_sim_state() -> Arc<RwLock<SharedMarketData>> {
+        let eth = token(1, "ETH");
+        let usdc = token(2, "USDC");
+        let pool = component("pool", &[eth.clone(), usdc.clone()]);
+
+        let mut market = SharedMarketData::new();
+        market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
+        market.upsert_components(std::iter::once(pool));
+        // Note: no update_states() — simulation state is intentionally absent
+        market.upsert_tokens([eth, usdc]);
+        Arc::new(RwLock::new(market))
+    }
+
+    /// Creates a market WITH sim_state but WITHOUT gas_price.
+    ///
+    /// Spot price computation succeeds (MockProtocolSim works), but token_price
+    /// computation fails with `MissingDependency("gas_price")`.
+    fn market_with_sim_state_no_gas_price() -> Arc<RwLock<SharedMarketData>> {
+        let eth = token(1, "ETH");
+        let usdc = token(2, "USDC");
+        let pool = component("pool", &[eth.clone(), usdc.clone()]);
+
+        let mut market = SharedMarketData::new();
+        // Note: no update_gas_price() — gas price is intentionally absent
+        market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
+        market.upsert_components(std::iter::once(pool));
+        market.update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
+        market.upsert_tokens([eth, usdc]);
+        Arc::new(RwLock::new(market))
+    }
+
+    #[tokio::test]
+    async fn spot_price_failure_broadcasts_computation_failed() {
+        let market = market_with_component_no_sim_state();
+        let config = ComputationManagerConfig::new();
+        let (manager, mut event_rx) = ComputationManager::new(config, market).unwrap();
+
+        // Full recompute with components that have no sim_state → TotalFailure
+        let changed = ChangedComponents { is_full_recompute: true, ..Default::default() };
+        manager.compute_all(&changed).await;
+
+        let events = drain_events(&mut event_rx);
+
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                DerivedDataEvent::ComputationFailed { computation_id: "spot_prices", .. }
+            )),
+            "expected ComputationFailed(spot_prices) in events: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_price_failure_broadcasts_computation_failed() {
+        let eth = token(1, "ETH");
+        let usdc = token(2, "USDC");
+        let market = market_with_sim_state_no_gas_price();
+        let config = ComputationManagerConfig::new().with_gas_token(eth.address.clone());
+        let (mut manager, mut event_rx) = ComputationManager::new(config, market).unwrap();
+
+        // handle_event with added components — spot_price succeeds, token_price fails
+        let event = MarketEvent::MarketUpdated {
+            added_components: HashMap::from([(
+                "pool".to_string(),
+                vec![eth.address.clone(), usdc.address.clone()],
+            )]),
+            removed_components: vec![],
+            updated_components: vec![],
+        };
+        manager
+            .handle_event(&event)
+            .await
+            .unwrap();
+
+        let events = drain_events(&mut event_rx);
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                DerivedDataEvent::ComputationFailed { computation_id: "token_prices", .. }
+            )),
+            "expected ComputationFailed(token_prices) in events: {events:?}"
+        );
     }
 
     #[tokio::test]

--- a/fynd-core/src/derived/mod.rs
+++ b/fynd-core/src/derived/mod.rs
@@ -57,5 +57,6 @@ pub(crate) mod tracker;
 pub(crate) mod types;
 
 // Only export the public API: manager, config, store, and shared reference type
+pub use computation::FailedItemError;
 pub use manager::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef};
 pub use store::DerivedData;

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -28,21 +28,15 @@ struct ComputedValue<T> {
 #[derive(Debug, Default)]
 pub struct DerivedData {
     token_prices: Option<ComputedValue<TokenGasPrices>>,
-    /// Failure map for token_prices: key → (block_when_failed, error).
-    /// Persists across incremental runs — entries survive until the key is re-attempted
-    /// and succeeds. Full recomputes replace the map entirely.
+    /// Persistent failure map: key → (block, error). Merged on incremental runs, replaced on full.
     token_prices_failed: HashMap<TokenGasPriceKey, (u64, FailedItemError)>,
     /// Token prices with path dependency tracking for incremental computation.
     token_prices_deps: Option<ComputedValue<TokenPricesWithDeps>>,
     pool_depths: Option<ComputedValue<PoolDepths>>,
-    /// Failure map for pool_depths: key → (block_when_failed, error).
-    /// Persists across incremental runs — entries survive until the key is re-attempted
-    /// and succeeds. Full recomputes replace the map entirely.
+    /// Persistent failure map: key → (block, error). Merged on incremental runs, replaced on full.
     pool_depths_failed: HashMap<PoolDepthKey, (u64, FailedItemError)>,
     spot_prices: Option<ComputedValue<SpotPrices>>,
-    /// Failure map for spot_prices: key → (block_when_failed, error).
-    /// Persists across incremental runs — entries survive until the key is re-attempted
-    /// and succeeds. Full recomputes replace the map entirely.
+    /// Persistent failure map: key → (block, error). Merged on incremental runs, replaced on full.
     spot_prices_failed: HashMap<SpotPriceKey, (u64, FailedItemError)>,
 }
 

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -39,20 +39,12 @@ impl DerivedData {
         Arc::new(RwLock::new(Self::new()))
     }
 
-    /// Returns the block number at which any data was last computed.
-    ///
-    /// Returns the maximum block across all computed values, so it returns `Some` as long as
-    /// any computation has run. Used by health checks.
-    pub fn last_block(&self) -> Option<u64> {
-        [
-            self.token_prices_block(),
-            self.token_prices_deps_block(),
-            self.pool_depths_block(),
-            self.spot_prices_block(),
-        ]
-        .into_iter()
-        .flatten()
-        .max()
+    /// Returns `true` if all derived data types has been computed at least once.
+    pub fn derived_data_ready(&self) -> bool {
+        self.token_prices_block().is_some() &&
+            self.token_prices_deps_block().is_some() &&
+            self.pool_depths_block().is_some() &&
+            self.spot_prices_block().is_some()
     }
 
     // -------------------------------------------------------------------------
@@ -216,16 +208,16 @@ mod tests {
     #[test]
     fn last_block_returns_max_across_computations() {
         let mut store = DerivedData::new();
-        assert_eq!(store.last_block(), None);
+        assert!(!store.derived_data_ready());
 
         store.set_spot_prices(Default::default(), 5);
-        assert_eq!(store.last_block(), Some(5));
+        assert!(!store.derived_data_ready());
 
         store.set_token_prices(Default::default(), 10);
-        assert_eq!(store.last_block(), Some(10));
+        assert!(!store.derived_data_ready());
 
         store.set_pool_depths(Default::default(), 9);
-        assert_eq!(store.last_block(), Some(10)); // max is still 10
+        assert!(store.derived_data_ready());
     }
 
     #[test]
@@ -240,6 +232,6 @@ mod tests {
         assert!(store.token_prices().is_none());
         assert!(store.spot_prices().is_none());
         assert!(store.pool_depths().is_none());
-        assert_eq!(store.last_block(), None);
+        assert!(!store.derived_data_ready());
     }
 }

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -424,10 +424,7 @@ mod tests {
         let mut store = DerivedData::new();
         store.set_pool_depths(
             Default::default(),
-            vec![failed(
-                &key_str,
-                FailedItemError::SimulationFailed("depth error".into()),
-            )],
+            vec![failed(&key_str, FailedItemError::SimulationFailed("depth error".into()))],
             7,
             true,
         );

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -31,19 +31,19 @@ pub struct DerivedData {
     /// Failure map for token_prices: key → (block_when_failed, error_reason).
     /// Persists across incremental runs — entries survive until the key is re-attempted
     /// and succeeds. Full recomputes replace the map entirely.
-    token_prices_failed: Option<HashMap<TokenGasPriceKey, (u64, String)>>,
+    token_prices_failed: HashMap<TokenGasPriceKey, (u64, String)>,
     /// Token prices with path dependency tracking for incremental computation.
     token_prices_deps: Option<ComputedValue<TokenPricesWithDeps>>,
     pool_depths: Option<ComputedValue<PoolDepths>>,
     /// Failure map for pool_depths: key → (block_when_failed, error_reason).
     /// Persists across incremental runs — entries survive until the key is re-attempted
     /// and succeeds. Full recomputes replace the map entirely.
-    pool_depths_failed: Option<HashMap<PoolDepthKey, (u64, String)>>,
+    pool_depths_failed: HashMap<PoolDepthKey, (u64, String)>,
     spot_prices: Option<ComputedValue<SpotPrices>>,
     /// Failure map for spot_prices: key → (block_when_failed, error_reason).
     /// Persists across incremental runs — entries survive until the key is re-attempted
     /// and succeeds. Full recomputes replace the map entirely.
-    spot_prices_failed: Option<HashMap<SpotPriceKey, (u64, String)>>,
+    spot_prices_failed: HashMap<SpotPriceKey, (u64, String)>,
 }
 
 /// Parses `"component_id/token_in/token_out"` into a typed `(ComponentId, Address, Address)` key.
@@ -116,27 +116,22 @@ impl DerivedData {
             })
             .collect();
 
-        let merged = if is_full_recompute {
-            new_failures
+        if is_full_recompute {
+            self.token_prices_failed = new_failures;
         } else {
-            let mut existing = self
-                .token_prices_failed
-                .take()
-                .unwrap_or_default();
-            existing.retain(|k, _| !prices.contains_key(k));
-            existing.extend(new_failures);
-            existing
-        };
+            self.token_prices_failed
+                .retain(|k, _| !prices.contains_key(k));
+            self.token_prices_failed
+                .extend(new_failures);
+        }
 
         self.token_prices = Some(ComputedValue { data: prices, block });
-        self.token_prices_failed = Some(merged);
     }
 
     /// Returns `(block, error_reason)` for this token address if it failed in a past
     /// computation, or `None` if it succeeded or was not attempted.
     pub fn token_price_failure(&self, key: &TokenGasPriceKey) -> Option<(u64, &str)> {
         self.token_prices_failed
-            .as_ref()?
             .get(key)
             .map(|(block, error)| (*block, error.as_str()))
     }
@@ -144,7 +139,7 @@ impl DerivedData {
     /// Clears token prices and their failure map.
     pub fn clear_token_prices(&mut self) {
         self.token_prices = None;
-        self.token_prices_failed = None;
+        self.token_prices_failed.clear();
     }
 
     // -------------------------------------------------------------------------
@@ -210,20 +205,16 @@ impl DerivedData {
             .filter_map(|f| parse_pair_key(&f.key).map(|k| (k, (block, f.error))))
             .collect();
 
-        let merged = if is_full_recompute {
-            new_failures
+        if is_full_recompute {
+            self.pool_depths_failed = new_failures;
         } else {
-            let mut existing = self
-                .pool_depths_failed
-                .take()
-                .unwrap_or_default();
-            existing.retain(|k, _| !depths.contains_key(k));
-            existing.extend(new_failures);
-            existing
-        };
+            self.pool_depths_failed
+                .retain(|k, _| !depths.contains_key(k));
+            self.pool_depths_failed
+                .extend(new_failures);
+        }
 
         self.pool_depths = Some(ComputedValue { data: depths, block });
-        self.pool_depths_failed = Some(merged);
     }
 
     /// Returns `(block, error_reason)` for this key if it failed in a past pool depth
@@ -232,7 +223,6 @@ impl DerivedData {
     /// Key format: `(component_id, token_in, token_out)`
     pub fn pool_depth_failure(&self, key: &PoolDepthKey) -> Option<(u64, &str)> {
         self.pool_depths_failed
-            .as_ref()?
             .get(key)
             .map(|(block, error)| (*block, error.as_str()))
     }
@@ -240,7 +230,7 @@ impl DerivedData {
     /// Clears pool depths and their failure map.
     pub fn clear_pool_depths(&mut self) {
         self.pool_depths = None;
-        self.pool_depths_failed = None;
+        self.pool_depths_failed.clear();
     }
 
     // -------------------------------------------------------------------------
@@ -278,20 +268,16 @@ impl DerivedData {
             .filter_map(|f| parse_pair_key(&f.key).map(|k| (k, (block, f.error))))
             .collect();
 
-        let merged = if is_full_recompute {
-            new_failures
+        if is_full_recompute {
+            self.spot_prices_failed = new_failures;
         } else {
-            let mut existing = self
-                .spot_prices_failed
-                .take()
-                .unwrap_or_default();
-            existing.retain(|k, _| !prices.contains_key(k));
-            existing.extend(new_failures);
-            existing
-        };
+            self.spot_prices_failed
+                .retain(|k, _| !prices.contains_key(k));
+            self.spot_prices_failed
+                .extend(new_failures);
+        }
 
         self.spot_prices = Some(ComputedValue { data: prices, block });
-        self.spot_prices_failed = Some(merged);
     }
 
     /// Returns `(block, error_reason)` for this key if it failed in a past spot price
@@ -300,7 +286,6 @@ impl DerivedData {
     /// Key format: `(component_id, token_in, token_out)`
     pub fn spot_price_failure(&self, key: &SpotPriceKey) -> Option<(u64, &str)> {
         self.spot_prices_failed
-            .as_ref()?
             .get(key)
             .map(|(block, error)| (*block, error.as_str()))
     }
@@ -308,7 +293,7 @@ impl DerivedData {
     /// Clears spot prices and their failure map.
     pub fn clear_spot_prices(&mut self) {
         self.spot_prices = None;
-        self.spot_prices_failed = None;
+        self.spot_prices_failed.clear();
     }
 
     // -------------------------------------------------------------------------
@@ -318,12 +303,12 @@ impl DerivedData {
     /// Clears all stored data, including all failure maps.
     pub fn clear_all(&mut self) {
         self.token_prices = None;
-        self.token_prices_failed = None;
+        self.token_prices_failed.clear();
         self.token_prices_deps = None;
         self.pool_depths = None;
-        self.pool_depths_failed = None;
+        self.pool_depths_failed.clear();
         self.spot_prices = None;
-        self.spot_prices_failed = None;
+        self.spot_prices_failed.clear();
     }
 }
 

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -1,10 +1,17 @@
 //! Typed storage for derived data.
 
-use std::sync::Arc;
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use tokio::sync::RwLock;
+use tycho_simulation::tycho_common::models::Address;
 
-use super::types::{PoolDepths, SpotPrices, TokenGasPrices, TokenPricesWithDeps};
+use super::{
+    computation::FailedItem,
+    types::{
+        PoolDepthKey, PoolDepths, SpotPriceKey, SpotPrices, TokenGasPriceKey, TokenGasPrices,
+        TokenPricesWithDeps,
+    },
+};
 use crate::derived::SharedDerivedDataRef;
 
 /// A computed value paired with the block it was computed for.
@@ -21,10 +28,33 @@ struct ComputedValue<T> {
 #[derive(Debug, Default)]
 pub struct DerivedData {
     token_prices: Option<ComputedValue<TokenGasPrices>>,
+    /// Failure map for token_prices: key → (block_when_failed, error_reason).
+    /// Persists across incremental runs — entries survive until the key is re-attempted
+    /// and succeeds. Full recomputes replace the map entirely.
+    token_prices_failed: Option<HashMap<TokenGasPriceKey, (u64, String)>>,
     /// Token prices with path dependency tracking for incremental computation.
     token_prices_deps: Option<ComputedValue<TokenPricesWithDeps>>,
     pool_depths: Option<ComputedValue<PoolDepths>>,
+    /// Failure map for pool_depths: key → (block_when_failed, error_reason).
+    /// Persists across incremental runs — entries survive until the key is re-attempted
+    /// and succeeds. Full recomputes replace the map entirely.
+    pool_depths_failed: Option<HashMap<PoolDepthKey, (u64, String)>>,
     spot_prices: Option<ComputedValue<SpotPrices>>,
+    /// Failure map for spot_prices: key → (block_when_failed, error_reason).
+    /// Persists across incremental runs — entries survive until the key is re-attempted
+    /// and succeeds. Full recomputes replace the map entirely.
+    spot_prices_failed: Option<HashMap<SpotPriceKey, (u64, String)>>,
+}
+
+/// Parses `"component_id/token_in/token_out"` into a typed `(ComponentId, Address, Address)` key.
+fn parse_pair_key(s: &str) -> Option<(String, Address, Address)> {
+    let mut parts = s.rsplitn(3, '/');
+    let token_out_str = parts.next()?;
+    let token_in_str = parts.next()?;
+    let component_id = parts.next()?;
+    let token_in = Address::from_str(token_in_str).ok()?;
+    let token_out = Address::from_str(token_out_str).ok()?;
+    Some((component_id.to_string(), token_in, token_out))
 }
 
 impl DerivedData {
@@ -65,14 +95,56 @@ impl DerivedData {
             .map(|v| v.block)
     }
 
-    /// Sets token prices.
-    pub fn set_token_prices(&mut self, prices: TokenGasPrices, block: u64) {
+    /// Sets token prices, merging failures for incremental runs.
+    ///
+    /// For full recomputes, the failure map is replaced entirely. For incremental runs,
+    /// failures are merged: existing entries for keys that now succeed are removed, new
+    /// failures are inserted, and entries for keys not attempted this run are preserved.
+    pub fn set_token_prices(
+        &mut self,
+        prices: TokenGasPrices,
+        failed_items: Vec<FailedItem>,
+        block: u64,
+        is_full_recompute: bool,
+    ) {
+        let new_failures: HashMap<TokenGasPriceKey, (u64, String)> = failed_items
+            .into_iter()
+            .filter_map(|f| {
+                Address::from_str(&f.key)
+                    .ok()
+                    .map(|k| (k, (block, f.error)))
+            })
+            .collect();
+
+        let merged = if is_full_recompute {
+            new_failures
+        } else {
+            let mut existing = self
+                .token_prices_failed
+                .take()
+                .unwrap_or_default();
+            existing.retain(|k, _| !prices.contains_key(k));
+            existing.extend(new_failures);
+            existing
+        };
+
         self.token_prices = Some(ComputedValue { data: prices, block });
+        self.token_prices_failed = Some(merged);
     }
 
-    /// Clears token prices.
+    /// Returns `(block, error_reason)` for this token address if it failed in a past
+    /// computation, or `None` if it succeeded or was not attempted.
+    pub fn token_price_failure(&self, key: &TokenGasPriceKey) -> Option<(u64, &str)> {
+        self.token_prices_failed
+            .as_ref()?
+            .get(key)
+            .map(|(block, error)| (*block, error.as_str()))
+    }
+
+    /// Clears token prices and their failure map.
     pub fn clear_token_prices(&mut self) {
         self.token_prices = None;
+        self.token_prices_failed = None;
     }
 
     // -------------------------------------------------------------------------
@@ -121,14 +193,54 @@ impl DerivedData {
             .map(|v| v.block)
     }
 
-    /// Sets pool depths.
-    pub fn set_pool_depths(&mut self, depths: PoolDepths, block: u64) {
+    /// Sets pool depths, merging failures for incremental runs.
+    ///
+    /// For full recomputes, the failure map is replaced entirely. For incremental runs,
+    /// failures are merged: existing entries for keys that now succeed are removed, new
+    /// failures are inserted, and entries for keys not attempted this run are preserved.
+    pub fn set_pool_depths(
+        &mut self,
+        depths: PoolDepths,
+        failed_items: Vec<FailedItem>,
+        block: u64,
+        is_full_recompute: bool,
+    ) {
+        let new_failures: HashMap<PoolDepthKey, (u64, String)> = failed_items
+            .into_iter()
+            .filter_map(|f| parse_pair_key(&f.key).map(|k| (k, (block, f.error))))
+            .collect();
+
+        let merged = if is_full_recompute {
+            new_failures
+        } else {
+            let mut existing = self
+                .pool_depths_failed
+                .take()
+                .unwrap_or_default();
+            existing.retain(|k, _| !depths.contains_key(k));
+            existing.extend(new_failures);
+            existing
+        };
+
         self.pool_depths = Some(ComputedValue { data: depths, block });
+        self.pool_depths_failed = Some(merged);
     }
 
-    /// Clears pool depths.
+    /// Returns `(block, error_reason)` for this key if it failed in a past pool depth
+    /// computation, or `None` if it succeeded or was not attempted.
+    ///
+    /// Key format: `(component_id, token_in, token_out)`
+    pub fn pool_depth_failure(&self, key: &PoolDepthKey) -> Option<(u64, &str)> {
+        self.pool_depths_failed
+            .as_ref()?
+            .get(key)
+            .map(|(block, error)| (*block, error.as_str()))
+    }
+
+    /// Clears pool depths and their failure map.
     pub fn clear_pool_depths(&mut self) {
         self.pool_depths = None;
+        self.pool_depths_failed = None;
     }
 
     // -------------------------------------------------------------------------
@@ -149,39 +261,91 @@ impl DerivedData {
             .map(|v| v.block)
     }
 
-    /// Sets spot prices.
-    pub fn set_spot_prices(&mut self, prices: SpotPrices, block: u64) {
+    /// Sets spot prices, merging failures for incremental runs.
+    ///
+    /// For full recomputes, the failure map is replaced entirely. For incremental runs,
+    /// failures are merged: existing entries for keys that now succeed are removed, new
+    /// failures are inserted, and entries for keys not attempted this run are preserved.
+    pub fn set_spot_prices(
+        &mut self,
+        prices: SpotPrices,
+        failed_items: Vec<FailedItem>,
+        block: u64,
+        is_full_recompute: bool,
+    ) {
+        let new_failures: HashMap<SpotPriceKey, (u64, String)> = failed_items
+            .into_iter()
+            .filter_map(|f| parse_pair_key(&f.key).map(|k| (k, (block, f.error))))
+            .collect();
+
+        let merged = if is_full_recompute {
+            new_failures
+        } else {
+            let mut existing = self
+                .spot_prices_failed
+                .take()
+                .unwrap_or_default();
+            existing.retain(|k, _| !prices.contains_key(k));
+            existing.extend(new_failures);
+            existing
+        };
+
         self.spot_prices = Some(ComputedValue { data: prices, block });
+        self.spot_prices_failed = Some(merged);
     }
 
-    /// Clears spot prices.
+    /// Returns `(block, error_reason)` for this key if it failed in a past spot price
+    /// computation, or `None` if it succeeded or was not attempted.
+    ///
+    /// Key format: `(component_id, token_in, token_out)`
+    pub fn spot_price_failure(&self, key: &SpotPriceKey) -> Option<(u64, &str)> {
+        self.spot_prices_failed
+            .as_ref()?
+            .get(key)
+            .map(|(block, error)| (*block, error.as_str()))
+    }
+
+    /// Clears spot prices and their failure map.
     pub fn clear_spot_prices(&mut self) {
         self.spot_prices = None;
+        self.spot_prices_failed = None;
     }
 
     // -------------------------------------------------------------------------
     // Bulk Operations
     // -------------------------------------------------------------------------
 
-    /// Clears all stored data.
+    /// Clears all stored data, including all failure maps.
     pub fn clear_all(&mut self) {
         self.token_prices = None;
+        self.token_prices_failed = None;
         self.token_prices_deps = None;
         self.pool_depths = None;
+        self.pool_depths_failed = None;
         self.spot_prices = None;
+        self.spot_prices_failed = None;
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{algorithm::test_utils::addr, derived::types::SpotPrices};
+
+    fn failed(key: &str, error: &str) -> FailedItem {
+        FailedItem { key: key.to_string(), error: error.to_string() }
+    }
+
+    fn pair_key(comp: &str, b_in: u8, b_out: u8) -> SpotPriceKey {
+        (comp.to_string(), addr(b_in), addr(b_out))
+    }
 
     #[test]
     fn test_token_prices_block_tracks_independently() {
         let mut store = DerivedData::new();
         assert_eq!(store.token_prices_block(), None);
 
-        store.set_token_prices(Default::default(), 42);
+        store.set_token_prices(Default::default(), vec![], 42, true);
         assert_eq!(store.token_prices_block(), Some(42));
 
         // Other computations not set yet
@@ -192,7 +356,7 @@ mod tests {
     #[test]
     fn test_spot_prices_block_tracks_independently() {
         let mut store = DerivedData::new();
-        store.set_spot_prices(Default::default(), 10);
+        store.set_spot_prices(Default::default(), vec![], 10, true);
         assert_eq!(store.spot_prices_block(), Some(10));
         assert_eq!(store.token_prices_block(), None);
     }
@@ -200,7 +364,7 @@ mod tests {
     #[test]
     fn test_pool_depths_block_tracks_independently() {
         let mut store = DerivedData::new();
-        store.set_pool_depths(Default::default(), 7);
+        store.set_pool_depths(Default::default(), vec![], 7, true);
         assert_eq!(store.pool_depths_block(), Some(7));
         assert_eq!(store.token_prices_block(), None);
     }
@@ -210,25 +374,25 @@ mod tests {
         let mut store = DerivedData::new();
         assert!(!store.derived_data_ready());
 
-        store.set_spot_prices(Default::default(), 5);
+        store.set_spot_prices(Default::default(), vec![], 5, true);
         assert!(!store.derived_data_ready());
 
-        store.set_token_prices(Default::default(), 10);
+        store.set_token_prices(Default::default(), vec![], 10, true);
         assert!(!store.derived_data_ready());
 
         store.set_token_prices_deps(Default::default(), 10);
         assert!(!store.derived_data_ready());
 
-        store.set_pool_depths(Default::default(), 9);
+        store.set_pool_depths(Default::default(), vec![], 9, true);
         assert!(store.derived_data_ready());
     }
 
     #[test]
     fn test_clear_all_resets_all_fields() {
         let mut store = DerivedData::new();
-        store.set_token_prices(Default::default(), 1);
-        store.set_spot_prices(Default::default(), 1);
-        store.set_pool_depths(Default::default(), 1);
+        store.set_token_prices(Default::default(), vec![], 1, true);
+        store.set_spot_prices(Default::default(), vec![], 1, true);
+        store.set_pool_depths(Default::default(), vec![], 1, true);
 
         store.clear_all();
 
@@ -236,5 +400,142 @@ mod tests {
         assert!(store.spot_prices().is_none());
         assert!(store.pool_depths().is_none());
         assert!(!store.derived_data_ready());
+    }
+
+    #[test]
+    fn test_token_price_failure_stored_with_block() {
+        let token_addr = addr(0xab);
+        let key_str = format!("{token_addr}");
+        let mut store = DerivedData::new();
+        store.set_token_prices(Default::default(), vec![failed(&key_str, "sim error")], 42, true);
+        assert_eq!(store.token_price_failure(&token_addr), Some((42, "sim error")));
+        assert_eq!(store.token_price_failure(&addr(0xcd)), None);
+    }
+
+    #[test]
+    fn test_spot_price_failure_stored_with_block() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let mut store = DerivedData::new();
+        store.set_spot_prices(Default::default(), vec![failed(&key_str, "sim error")], 10, true);
+        assert_eq!(store.spot_price_failure(&key), Some((10, "sim error")));
+        assert_eq!(store.spot_price_failure(&pair_key("pool1", 0x01, 0x03)), None);
+    }
+
+    #[test]
+    fn test_pool_depth_failure_stored_with_block() {
+        let key: PoolDepthKey = pair_key("pool1", 0x01, 0x02);
+        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let mut store = DerivedData::new();
+        store.set_pool_depths(Default::default(), vec![failed(&key_str, "depth error")], 7, true);
+        assert_eq!(store.pool_depth_failure(&key), Some((7, "depth error")));
+        assert_eq!(store.pool_depth_failure(&pair_key("pool2", 0x01, 0x02)), None);
+    }
+
+    #[test]
+    fn test_rerunning_with_empty_failures_clears_old_reasons() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let mut store = DerivedData::new();
+        store.set_spot_prices(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        assert!(store.spot_price_failure(&key).is_some());
+
+        // Full re-run with no failures clears the map
+        store.set_spot_prices(Default::default(), vec![], 2, true);
+        assert_eq!(store.spot_price_failure(&key), None);
+    }
+
+    #[test]
+    fn test_clear_token_prices_clears_failure_map() {
+        let token_addr = addr(0xab);
+        let key_str = format!("{token_addr}");
+        let mut store = DerivedData::new();
+        store.set_token_prices(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        store.clear_token_prices();
+        assert_eq!(store.token_price_failure(&token_addr), None);
+    }
+
+    #[test]
+    fn test_clear_spot_prices_clears_failure_map() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let mut store = DerivedData::new();
+        store.set_spot_prices(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        store.clear_spot_prices();
+        assert_eq!(store.spot_price_failure(&key), None);
+    }
+
+    #[test]
+    fn test_clear_pool_depths_clears_failure_map() {
+        let key: PoolDepthKey = pair_key("pool1", 0x01, 0x02);
+        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let mut store = DerivedData::new();
+        store.set_pool_depths(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        store.clear_pool_depths();
+        assert_eq!(store.pool_depth_failure(&key), None);
+    }
+
+    #[test]
+    fn test_incremental_run_preserves_failures_for_unattempted_items() {
+        let key_a = pair_key("pool_a", 0x01, 0x02);
+        let key_a_str = format!("pool_a/{}/{}", addr(0x01), addr(0x02));
+        let key_b = pair_key("pool_b", 0x03, 0x04);
+        let key_b_str = format!("pool_b/{}/{}", addr(0x03), addr(0x04));
+
+        let mut store = DerivedData::new();
+
+        // Full recompute at block 10: both keys fail
+        store.set_spot_prices(
+            Default::default(),
+            vec![failed(&key_a_str, "err_a"), failed(&key_b_str, "err_b")],
+            10,
+            true,
+        );
+        assert_eq!(store.spot_price_failure(&key_a), Some((10, "err_a")));
+        assert_eq!(store.spot_price_failure(&key_b), Some((10, "err_b")));
+
+        // Incremental run at block 11: only pool_b is attempted and succeeds
+        let mut prices = SpotPrices::default();
+        prices.insert(key_b.clone(), 1.0);
+        store.set_spot_prices(prices, vec![], 11, false);
+
+        // pool_a was not attempted — failure is preserved from block 10
+        assert_eq!(store.spot_price_failure(&key_a), Some((10, "err_a")));
+        // pool_b succeeded — failure is cleared
+        assert_eq!(store.spot_price_failure(&key_b), None);
+    }
+
+    #[test]
+    fn test_incremental_run_updates_block_on_repeated_failure() {
+        let key = pair_key("pool_a", 0x01, 0x02);
+        let key_str = format!("pool_a/{}/{}", addr(0x01), addr(0x02));
+
+        let mut store = DerivedData::new();
+
+        store.set_spot_prices(Default::default(), vec![failed(&key_str, "err")], 10, true);
+        assert_eq!(store.spot_price_failure(&key), Some((10, "err")));
+
+        // Incremental run at block 11: pool_a fails again with a new error
+        store.set_spot_prices(Default::default(), vec![failed(&key_str, "new err")], 11, false);
+        assert_eq!(store.spot_price_failure(&key), Some((11, "new err")));
+    }
+
+    #[test]
+    fn test_clear_all_clears_all_failure_maps() {
+        let token_addr = addr(0xab);
+        let token_str = format!("{token_addr}");
+        let pair = pair_key("pool1", 0x01, 0x02);
+        let pair_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+
+        let mut store = DerivedData::new();
+        store.set_token_prices(Default::default(), vec![failed(&token_str, "err")], 1, true);
+        store.set_spot_prices(Default::default(), vec![failed(&pair_str, "err")], 1, true);
+        store.set_pool_depths(Default::default(), vec![failed(&pair_str, "err")], 1, true);
+
+        store.clear_all();
+
+        assert_eq!(store.token_price_failure(&token_addr), None);
+        assert_eq!(store.spot_price_failure(&pair), None);
+        assert_eq!(store.pool_depth_failure(&pair), None);
     }
 }

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -177,7 +177,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn token_prices_block_tracks_independently() {
+    fn test_token_prices_block_tracks_independently() {
         let mut store = DerivedData::new();
         assert_eq!(store.token_prices_block(), None);
 
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn spot_prices_block_tracks_independently() {
+    fn test_spot_prices_block_tracks_independently() {
         let mut store = DerivedData::new();
         store.set_spot_prices(Default::default(), 10);
         assert_eq!(store.spot_prices_block(), Some(10));
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    fn pool_depths_block_tracks_independently() {
+    fn test_pool_depths_block_tracks_independently() {
         let mut store = DerivedData::new();
         store.set_pool_depths(Default::default(), 7);
         assert_eq!(store.pool_depths_block(), Some(7));
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    fn last_block_returns_max_across_computations() {
+    fn test_derived_data_ready() {
         let mut store = DerivedData::new();
         assert!(!store.derived_data_ready());
 
@@ -216,12 +216,15 @@ mod tests {
         store.set_token_prices(Default::default(), 10);
         assert!(!store.derived_data_ready());
 
+        store.set_token_prices_deps(Default::default(), 10);
+        assert!(!store.derived_data_ready());
+
         store.set_pool_depths(Default::default(), 9);
         assert!(store.derived_data_ready());
     }
 
     #[test]
-    fn clear_all_resets_all_fields() {
+    fn test_clear_all_resets_all_fields() {
         let mut store = DerivedData::new();
         store.set_token_prices(Default::default(), 1);
         store.set_spot_prices(Default::default(), 1);

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -388,13 +388,13 @@ mod tests {
         let mut store = DerivedData::new();
         store.set_token_prices(
             Default::default(),
-            vec![failed(&key_str, FailedItemError::SpotPriceComputationFailed("sim error".into()))],
+            vec![failed(&key_str, FailedItemError::SimulationFailed("sim error".into()))],
             42,
             true,
         );
         assert_eq!(
             store.token_price_failure(&token_addr),
-            Some((42, &FailedItemError::SpotPriceComputationFailed("sim error".into())))
+            Some((42, &FailedItemError::SimulationFailed("sim error".into())))
         );
         assert_eq!(store.token_price_failure(&addr(0xcd)), None);
     }
@@ -406,13 +406,13 @@ mod tests {
         let mut store = DerivedData::new();
         store.set_spot_prices(
             Default::default(),
-            vec![failed(&key_str, FailedItemError::SpotPriceComputationFailed("sim error".into()))],
+            vec![failed(&key_str, FailedItemError::SimulationFailed("sim error".into()))],
             10,
             true,
         );
         assert_eq!(
             store.spot_price_failure(&key),
-            Some((10, &FailedItemError::SpotPriceComputationFailed("sim error".into())))
+            Some((10, &FailedItemError::SimulationFailed("sim error".into())))
         );
         assert_eq!(store.spot_price_failure(&pair_key("pool1", 0x01, 0x03)), None);
     }
@@ -426,14 +426,14 @@ mod tests {
             Default::default(),
             vec![failed(
                 &key_str,
-                FailedItemError::PoolDepthComputationFailed("depth error".into()),
+                FailedItemError::SimulationFailed("depth error".into()),
             )],
             7,
             true,
         );
         assert_eq!(
             store.pool_depth_failure(&key),
-            Some((7, &FailedItemError::PoolDepthComputationFailed("depth error".into())))
+            Some((7, &FailedItemError::SimulationFailed("depth error".into())))
         );
         assert_eq!(store.pool_depth_failure(&pair_key("pool2", 0x01, 0x02)), None);
     }

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -6,7 +6,7 @@ use tokio::sync::RwLock;
 use tycho_simulation::tycho_common::models::Address;
 
 use super::{
-    computation::FailedItem,
+    computation::{FailedItem, FailedItemError},
     types::{
         PoolDepthKey, PoolDepths, SpotPriceKey, SpotPrices, TokenGasPriceKey, TokenGasPrices,
         TokenPricesWithDeps,
@@ -28,22 +28,22 @@ struct ComputedValue<T> {
 #[derive(Debug, Default)]
 pub struct DerivedData {
     token_prices: Option<ComputedValue<TokenGasPrices>>,
-    /// Failure map for token_prices: key → (block_when_failed, error_reason).
+    /// Failure map for token_prices: key → (block_when_failed, error).
     /// Persists across incremental runs — entries survive until the key is re-attempted
     /// and succeeds. Full recomputes replace the map entirely.
-    token_prices_failed: HashMap<TokenGasPriceKey, (u64, String)>,
+    token_prices_failed: HashMap<TokenGasPriceKey, (u64, FailedItemError)>,
     /// Token prices with path dependency tracking for incremental computation.
     token_prices_deps: Option<ComputedValue<TokenPricesWithDeps>>,
     pool_depths: Option<ComputedValue<PoolDepths>>,
-    /// Failure map for pool_depths: key → (block_when_failed, error_reason).
+    /// Failure map for pool_depths: key → (block_when_failed, error).
     /// Persists across incremental runs — entries survive until the key is re-attempted
     /// and succeeds. Full recomputes replace the map entirely.
-    pool_depths_failed: HashMap<PoolDepthKey, (u64, String)>,
+    pool_depths_failed: HashMap<PoolDepthKey, (u64, FailedItemError)>,
     spot_prices: Option<ComputedValue<SpotPrices>>,
-    /// Failure map for spot_prices: key → (block_when_failed, error_reason).
+    /// Failure map for spot_prices: key → (block_when_failed, error).
     /// Persists across incremental runs — entries survive until the key is re-attempted
     /// and succeeds. Full recomputes replace the map entirely.
-    spot_prices_failed: HashMap<SpotPriceKey, (u64, String)>,
+    spot_prices_failed: HashMap<SpotPriceKey, (u64, FailedItemError)>,
 }
 
 /// Parses `"component_id/token_in/token_out"` into a typed `(ComponentId, Address, Address)` key.
@@ -107,7 +107,7 @@ impl DerivedData {
         block: u64,
         is_full_recompute: bool,
     ) {
-        let new_failures: HashMap<TokenGasPriceKey, (u64, String)> = failed_items
+        let new_failures: HashMap<TokenGasPriceKey, (u64, FailedItemError)> = failed_items
             .into_iter()
             .filter_map(|f| {
                 Address::from_str(&f.key)
@@ -128,12 +128,12 @@ impl DerivedData {
         self.token_prices = Some(ComputedValue { data: prices, block });
     }
 
-    /// Returns `(block, error_reason)` for this token address if it failed in a past
+    /// Returns `(block, error)` for this token address if it failed in a past
     /// computation, or `None` if it succeeded or was not attempted.
-    pub fn token_price_failure(&self, key: &TokenGasPriceKey) -> Option<(u64, &str)> {
+    pub fn token_price_failure(&self, key: &TokenGasPriceKey) -> Option<(u64, &FailedItemError)> {
         self.token_prices_failed
             .get(key)
-            .map(|(block, error)| (*block, error.as_str()))
+            .map(|(block, error)| (*block, error))
     }
 
     /// Clears token prices and their failure map.
@@ -200,7 +200,7 @@ impl DerivedData {
         block: u64,
         is_full_recompute: bool,
     ) {
-        let new_failures: HashMap<PoolDepthKey, (u64, String)> = failed_items
+        let new_failures: HashMap<PoolDepthKey, (u64, FailedItemError)> = failed_items
             .into_iter()
             .filter_map(|f| parse_pair_key(&f.key).map(|k| (k, (block, f.error))))
             .collect();
@@ -217,14 +217,14 @@ impl DerivedData {
         self.pool_depths = Some(ComputedValue { data: depths, block });
     }
 
-    /// Returns `(block, error_reason)` for this key if it failed in a past pool depth
+    /// Returns `(block, error)` for this key if it failed in a past pool depth
     /// computation, or `None` if it succeeded or was not attempted.
     ///
     /// Key format: `(component_id, token_in, token_out)`
-    pub fn pool_depth_failure(&self, key: &PoolDepthKey) -> Option<(u64, &str)> {
+    pub fn pool_depth_failure(&self, key: &PoolDepthKey) -> Option<(u64, &FailedItemError)> {
         self.pool_depths_failed
             .get(key)
-            .map(|(block, error)| (*block, error.as_str()))
+            .map(|(block, error)| (*block, error))
     }
 
     /// Clears pool depths and their failure map.
@@ -263,7 +263,7 @@ impl DerivedData {
         block: u64,
         is_full_recompute: bool,
     ) {
-        let new_failures: HashMap<SpotPriceKey, (u64, String)> = failed_items
+        let new_failures: HashMap<SpotPriceKey, (u64, FailedItemError)> = failed_items
             .into_iter()
             .filter_map(|f| parse_pair_key(&f.key).map(|k| (k, (block, f.error))))
             .collect();
@@ -280,14 +280,14 @@ impl DerivedData {
         self.spot_prices = Some(ComputedValue { data: prices, block });
     }
 
-    /// Returns `(block, error_reason)` for this key if it failed in a past spot price
+    /// Returns `(block, error)` for this key if it failed in a past spot price
     /// computation, or `None` if it succeeded or was not attempted.
     ///
     /// Key format: `(component_id, token_in, token_out)`
-    pub fn spot_price_failure(&self, key: &SpotPriceKey) -> Option<(u64, &str)> {
+    pub fn spot_price_failure(&self, key: &SpotPriceKey) -> Option<(u64, &FailedItemError)> {
         self.spot_prices_failed
             .get(key)
-            .map(|(block, error)| (*block, error.as_str()))
+            .map(|(block, error)| (*block, error))
     }
 
     /// Clears spot prices and their failure map.
@@ -317,8 +317,8 @@ mod tests {
     use super::*;
     use crate::{algorithm::test_utils::addr, derived::types::SpotPrices};
 
-    fn failed(key: &str, error: &str) -> FailedItem {
-        FailedItem { key: key.to_string(), error: error.to_string() }
+    fn failed(key: &str, error: FailedItemError) -> FailedItem {
+        FailedItem { key: key.to_string(), error }
     }
 
     fn pair_key(comp: &str, b_in: u8, b_out: u8) -> SpotPriceKey {
@@ -392,8 +392,16 @@ mod tests {
         let token_addr = addr(0xab);
         let key_str = format!("{token_addr}");
         let mut store = DerivedData::new();
-        store.set_token_prices(Default::default(), vec![failed(&key_str, "sim error")], 42, true);
-        assert_eq!(store.token_price_failure(&token_addr), Some((42, "sim error")));
+        store.set_token_prices(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::SpotPriceComputation("sim error".into()))],
+            42,
+            true,
+        );
+        assert_eq!(
+            store.token_price_failure(&token_addr),
+            Some((42, &FailedItemError::SpotPriceComputation("sim error".into())))
+        );
         assert_eq!(store.token_price_failure(&addr(0xcd)), None);
     }
 
@@ -402,8 +410,16 @@ mod tests {
         let key = pair_key("pool1", 0x01, 0x02);
         let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
-        store.set_spot_prices(Default::default(), vec![failed(&key_str, "sim error")], 10, true);
-        assert_eq!(store.spot_price_failure(&key), Some((10, "sim error")));
+        store.set_spot_prices(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::SpotPriceComputation("sim error".into()))],
+            10,
+            true,
+        );
+        assert_eq!(
+            store.spot_price_failure(&key),
+            Some((10, &FailedItemError::SpotPriceComputation("sim error".into())))
+        );
         assert_eq!(store.spot_price_failure(&pair_key("pool1", 0x01, 0x03)), None);
     }
 
@@ -412,8 +428,16 @@ mod tests {
         let key: PoolDepthKey = pair_key("pool1", 0x01, 0x02);
         let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
-        store.set_pool_depths(Default::default(), vec![failed(&key_str, "depth error")], 7, true);
-        assert_eq!(store.pool_depth_failure(&key), Some((7, "depth error")));
+        store.set_pool_depths(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::PoolDepthComputation("depth error".into()))],
+            7,
+            true,
+        );
+        assert_eq!(
+            store.pool_depth_failure(&key),
+            Some((7, &FailedItemError::PoolDepthComputation("depth error".into())))
+        );
         assert_eq!(store.pool_depth_failure(&pair_key("pool2", 0x01, 0x02)), None);
     }
 
@@ -422,7 +446,12 @@ mod tests {
         let key = pair_key("pool1", 0x01, 0x02);
         let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
-        store.set_spot_prices(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        store.set_spot_prices(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::MissingSimulationState)],
+            1,
+            true,
+        );
         assert!(store.spot_price_failure(&key).is_some());
 
         // Full re-run with no failures clears the map
@@ -435,7 +464,12 @@ mod tests {
         let token_addr = addr(0xab);
         let key_str = format!("{token_addr}");
         let mut store = DerivedData::new();
-        store.set_token_prices(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        store.set_token_prices(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::AllSimulationPathsFailed)],
+            1,
+            true,
+        );
         store.clear_token_prices();
         assert_eq!(store.token_price_failure(&token_addr), None);
     }
@@ -445,7 +479,12 @@ mod tests {
         let key = pair_key("pool1", 0x01, 0x02);
         let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
-        store.set_spot_prices(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        store.set_spot_prices(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::MissingSimulationState)],
+            1,
+            true,
+        );
         store.clear_spot_prices();
         assert_eq!(store.spot_price_failure(&key), None);
     }
@@ -455,7 +494,12 @@ mod tests {
         let key: PoolDepthKey = pair_key("pool1", 0x01, 0x02);
         let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
-        store.set_pool_depths(Default::default(), vec![failed(&key_str, "err")], 1, true);
+        store.set_pool_depths(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::MissingSpotPrice)],
+            1,
+            true,
+        );
         store.clear_pool_depths();
         assert_eq!(store.pool_depth_failure(&key), None);
     }
@@ -472,12 +516,21 @@ mod tests {
         // Full recompute at block 10: both keys fail
         store.set_spot_prices(
             Default::default(),
-            vec![failed(&key_a_str, "err_a"), failed(&key_b_str, "err_b")],
+            vec![
+                failed(&key_a_str, FailedItemError::MissingSimulationState),
+                failed(&key_b_str, FailedItemError::MissingTokenMetadata),
+            ],
             10,
             true,
         );
-        assert_eq!(store.spot_price_failure(&key_a), Some((10, "err_a")));
-        assert_eq!(store.spot_price_failure(&key_b), Some((10, "err_b")));
+        assert_eq!(
+            store.spot_price_failure(&key_a),
+            Some((10, &FailedItemError::MissingSimulationState))
+        );
+        assert_eq!(
+            store.spot_price_failure(&key_b),
+            Some((10, &FailedItemError::MissingTokenMetadata))
+        );
 
         // Incremental run at block 11: only pool_b is attempted and succeeds
         let mut prices = SpotPrices::default();
@@ -485,7 +538,10 @@ mod tests {
         store.set_spot_prices(prices, vec![], 11, false);
 
         // pool_a was not attempted — failure is preserved from block 10
-        assert_eq!(store.spot_price_failure(&key_a), Some((10, "err_a")));
+        assert_eq!(
+            store.spot_price_failure(&key_a),
+            Some((10, &FailedItemError::MissingSimulationState))
+        );
         // pool_b succeeded — failure is cleared
         assert_eq!(store.spot_price_failure(&key_b), None);
     }
@@ -497,12 +553,28 @@ mod tests {
 
         let mut store = DerivedData::new();
 
-        store.set_spot_prices(Default::default(), vec![failed(&key_str, "err")], 10, true);
-        assert_eq!(store.spot_price_failure(&key), Some((10, "err")));
+        store.set_spot_prices(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::MissingSimulationState)],
+            10,
+            true,
+        );
+        assert_eq!(
+            store.spot_price_failure(&key),
+            Some((10, &FailedItemError::MissingSimulationState))
+        );
 
         // Incremental run at block 11: pool_a fails again with a new error
-        store.set_spot_prices(Default::default(), vec![failed(&key_str, "new err")], 11, false);
-        assert_eq!(store.spot_price_failure(&key), Some((11, "new err")));
+        store.set_spot_prices(
+            Default::default(),
+            vec![failed(&key_str, FailedItemError::MissingTokenMetadata)],
+            11,
+            false,
+        );
+        assert_eq!(
+            store.spot_price_failure(&key),
+            Some((11, &FailedItemError::MissingTokenMetadata))
+        );
     }
 
     #[test]
@@ -513,9 +585,24 @@ mod tests {
         let pair_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
 
         let mut store = DerivedData::new();
-        store.set_token_prices(Default::default(), vec![failed(&token_str, "err")], 1, true);
-        store.set_spot_prices(Default::default(), vec![failed(&pair_str, "err")], 1, true);
-        store.set_pool_depths(Default::default(), vec![failed(&pair_str, "err")], 1, true);
+        store.set_token_prices(
+            Default::default(),
+            vec![failed(&token_str, FailedItemError::AllSimulationPathsFailed)],
+            1,
+            true,
+        );
+        store.set_spot_prices(
+            Default::default(),
+            vec![failed(&pair_str, FailedItemError::MissingSimulationState)],
+            1,
+            true,
+        );
+        store.set_pool_depths(
+            Default::default(),
+            vec![failed(&pair_str, FailedItemError::MissingSpotPrice)],
+            1,
+            true,
+        );
 
         store.clear_all();
 

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -388,13 +388,13 @@ mod tests {
         let mut store = DerivedData::new();
         store.set_token_prices(
             Default::default(),
-            vec![failed(&key_str, FailedItemError::SpotPriceComputation("sim error".into()))],
+            vec![failed(&key_str, FailedItemError::SpotPriceComputationFailed("sim error".into()))],
             42,
             true,
         );
         assert_eq!(
             store.token_price_failure(&token_addr),
-            Some((42, &FailedItemError::SpotPriceComputation("sim error".into())))
+            Some((42, &FailedItemError::SpotPriceComputationFailed("sim error".into())))
         );
         assert_eq!(store.token_price_failure(&addr(0xcd)), None);
     }
@@ -406,13 +406,13 @@ mod tests {
         let mut store = DerivedData::new();
         store.set_spot_prices(
             Default::default(),
-            vec![failed(&key_str, FailedItemError::SpotPriceComputation("sim error".into()))],
+            vec![failed(&key_str, FailedItemError::SpotPriceComputationFailed("sim error".into()))],
             10,
             true,
         );
         assert_eq!(
             store.spot_price_failure(&key),
-            Some((10, &FailedItemError::SpotPriceComputation("sim error".into())))
+            Some((10, &FailedItemError::SpotPriceComputationFailed("sim error".into())))
         );
         assert_eq!(store.spot_price_failure(&pair_key("pool1", 0x01, 0x03)), None);
     }
@@ -424,13 +424,16 @@ mod tests {
         let mut store = DerivedData::new();
         store.set_pool_depths(
             Default::default(),
-            vec![failed(&key_str, FailedItemError::PoolDepthComputation("depth error".into()))],
+            vec![failed(
+                &key_str,
+                FailedItemError::PoolDepthComputationFailed("depth error".into()),
+            )],
             7,
             true,
         );
         assert_eq!(
             store.pool_depth_failure(&key),
-            Some((7, &FailedItemError::PoolDepthComputation("depth error".into())))
+            Some((7, &FailedItemError::PoolDepthComputationFailed("depth error".into())))
         );
         assert_eq!(store.pool_depth_failure(&pair_key("pool2", 0x01, 0x02)), None);
     }

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -7,19 +7,24 @@ use tokio::sync::RwLock;
 use super::types::{PoolDepths, SpotPrices, TokenGasPrices, TokenPricesWithDeps};
 use crate::derived::SharedDerivedDataRef;
 
+/// A computed value paired with the block it was computed for.
+#[derive(Debug)]
+struct ComputedValue<T> {
+    data: T,
+    block: u64,
+}
+
 /// Typed storage for derived data computations.
 ///
 /// Provides typed access to previously computed derived data.
 /// Each field is `Option` to indicate whether the computation has run.
 #[derive(Debug, Default)]
 pub struct DerivedData {
-    token_prices: Option<TokenGasPrices>,
+    token_prices: Option<ComputedValue<TokenGasPrices>>,
     /// Token prices with path dependency tracking for incremental computation.
-    token_prices_deps: Option<TokenPricesWithDeps>,
-    pool_depths: Option<PoolDepths>,
-    spot_prices: Option<SpotPrices>,
-    /// Block number at which data was last computed.
-    last_block: Option<u64>,
+    token_prices_deps: Option<ComputedValue<TokenPricesWithDeps>>,
+    pool_depths: Option<ComputedValue<PoolDepths>>,
+    spot_prices: Option<ComputedValue<SpotPrices>>,
 }
 
 impl DerivedData {
@@ -34,9 +39,20 @@ impl DerivedData {
         Arc::new(RwLock::new(Self::new()))
     }
 
-    /// Returns the block number at which data was last computed.
+    /// Returns the block number at which any data was last computed.
+    ///
+    /// Returns the maximum block across all computed values, so it returns `Some` as long as
+    /// any computation has run. Used by health checks.
     pub fn last_block(&self) -> Option<u64> {
-        self.last_block
+        [
+            self.token_prices_block(),
+            self.token_prices_deps_block(),
+            self.pool_depths_block(),
+            self.spot_prices_block(),
+        ]
+        .into_iter()
+        .flatten()
+        .max()
     }
 
     // -------------------------------------------------------------------------
@@ -45,13 +61,21 @@ impl DerivedData {
 
     /// Returns token prices if computed.
     pub fn token_prices(&self) -> Option<&TokenGasPrices> {
-        self.token_prices.as_ref()
+        self.token_prices
+            .as_ref()
+            .map(|v| &v.data)
+    }
+
+    /// Returns the block at which token prices were last computed.
+    pub fn token_prices_block(&self) -> Option<u64> {
+        self.token_prices
+            .as_ref()
+            .map(|v| v.block)
     }
 
     /// Sets token prices.
     pub fn set_token_prices(&mut self, prices: TokenGasPrices, block: u64) {
-        self.token_prices = Some(prices);
-        self.last_block = Some(block);
+        self.token_prices = Some(ComputedValue { data: prices, block });
     }
 
     /// Clears token prices.
@@ -65,13 +89,21 @@ impl DerivedData {
 
     /// Returns token prices with path dependencies if computed.
     pub fn token_prices_deps(&self) -> Option<&TokenPricesWithDeps> {
-        self.token_prices_deps.as_ref()
+        self.token_prices_deps
+            .as_ref()
+            .map(|v| &v.data)
+    }
+
+    /// Returns the block at which token prices with dependencies were last computed.
+    pub fn token_prices_deps_block(&self) -> Option<u64> {
+        self.token_prices_deps
+            .as_ref()
+            .map(|v| v.block)
     }
 
     /// Sets token prices with path dependencies.
     pub fn set_token_prices_deps(&mut self, prices: TokenPricesWithDeps, block: u64) {
-        self.token_prices_deps = Some(prices);
-        self.last_block = Some(block);
+        self.token_prices_deps = Some(ComputedValue { data: prices, block });
     }
 
     /// Clears token prices with dependencies.
@@ -85,13 +117,21 @@ impl DerivedData {
 
     /// Returns pool depths if computed.
     pub fn pool_depths(&self) -> Option<&PoolDepths> {
-        self.pool_depths.as_ref()
+        self.pool_depths
+            .as_ref()
+            .map(|v| &v.data)
+    }
+
+    /// Returns the block at which pool depths were last computed.
+    pub fn pool_depths_block(&self) -> Option<u64> {
+        self.pool_depths
+            .as_ref()
+            .map(|v| v.block)
     }
 
     /// Sets pool depths.
     pub fn set_pool_depths(&mut self, depths: PoolDepths, block: u64) {
-        self.pool_depths = Some(depths);
-        self.last_block = Some(block);
+        self.pool_depths = Some(ComputedValue { data: depths, block });
     }
 
     /// Clears pool depths.
@@ -105,13 +145,21 @@ impl DerivedData {
 
     /// Returns spot prices if computed.
     pub fn spot_prices(&self) -> Option<&SpotPrices> {
-        self.spot_prices.as_ref()
+        self.spot_prices
+            .as_ref()
+            .map(|v| &v.data)
+    }
+
+    /// Returns the block at which spot prices were last computed.
+    pub fn spot_prices_block(&self) -> Option<u64> {
+        self.spot_prices
+            .as_ref()
+            .map(|v| v.block)
     }
 
     /// Sets spot prices.
     pub fn set_spot_prices(&mut self, prices: SpotPrices, block: u64) {
-        self.spot_prices = Some(prices);
-        self.last_block = Some(block);
+        self.spot_prices = Some(ComputedValue { data: prices, block });
     }
 
     /// Clears spot prices.
@@ -129,6 +177,69 @@ impl DerivedData {
         self.token_prices_deps = None;
         self.pool_depths = None;
         self.spot_prices = None;
-        self.last_block = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn token_prices_block_tracks_independently() {
+        let mut store = DerivedData::new();
+        assert_eq!(store.token_prices_block(), None);
+
+        store.set_token_prices(Default::default(), 42);
+        assert_eq!(store.token_prices_block(), Some(42));
+
+        // Other computations not set yet
+        assert_eq!(store.spot_prices_block(), None);
+        assert_eq!(store.pool_depths_block(), None);
+    }
+
+    #[test]
+    fn spot_prices_block_tracks_independently() {
+        let mut store = DerivedData::new();
+        store.set_spot_prices(Default::default(), 10);
+        assert_eq!(store.spot_prices_block(), Some(10));
+        assert_eq!(store.token_prices_block(), None);
+    }
+
+    #[test]
+    fn pool_depths_block_tracks_independently() {
+        let mut store = DerivedData::new();
+        store.set_pool_depths(Default::default(), 7);
+        assert_eq!(store.pool_depths_block(), Some(7));
+        assert_eq!(store.token_prices_block(), None);
+    }
+
+    #[test]
+    fn last_block_returns_max_across_computations() {
+        let mut store = DerivedData::new();
+        assert_eq!(store.last_block(), None);
+
+        store.set_spot_prices(Default::default(), 5);
+        assert_eq!(store.last_block(), Some(5));
+
+        store.set_token_prices(Default::default(), 10);
+        assert_eq!(store.last_block(), Some(10));
+
+        store.set_pool_depths(Default::default(), 9);
+        assert_eq!(store.last_block(), Some(10)); // max is still 10
+    }
+
+    #[test]
+    fn clear_all_resets_all_fields() {
+        let mut store = DerivedData::new();
+        store.set_token_prices(Default::default(), 1);
+        store.set_spot_prices(Default::default(), 1);
+        store.set_pool_depths(Default::default(), 1);
+
+        store.clear_all();
+
+        assert!(store.token_prices().is_none());
+        assert!(store.spot_prices().is_none());
+        assert!(store.pool_depths().is_none());
+        assert_eq!(store.last_block(), None);
     }
 }

--- a/fynd-core/src/derived/tracker.rs
+++ b/fynd-core/src/derived/tracker.rs
@@ -438,11 +438,8 @@ mod tests {
         assert!(tracker.is_ready()); // Both satisfied again
     }
 
-    // ==================== ComputationFailed / is_blocked_for_current_block Tests
-    // ====================
-
     #[test]
-    fn test_is_blocked_when_require_fresh_computation_fails_for_current_block() {
+    fn test_fresh_failure_blocks_current_block() {
         let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
         tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
 
@@ -455,7 +452,7 @@ mod tests {
     }
 
     #[test]
-    fn is_not_blocked_for_allow_stale_computation_failure() {
+    fn test_stale_failure_is_ignored() {
         let mut tracker = ReadinessTracker::new(stale_requirements(&["token_prices"]));
         tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
 
@@ -469,7 +466,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_for_block_cleared_on_new_block() {
+    fn test_failure_cleared_on_new_block() {
         let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
         tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
         tracker.handle_event(&DerivedDataEvent::ComputationFailed {
@@ -484,7 +481,7 @@ mod tests {
     }
 
     #[test]
-    fn failure_for_old_block_does_not_block_current() {
+    fn test_old_block_failure_does_not_block() {
         let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
         tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
 
@@ -498,7 +495,7 @@ mod tests {
     }
 
     #[test]
-    fn failure_then_new_block_then_success_becomes_ready() {
+    fn test_failure_recovers_on_next_block() {
         let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
 
         // Block 100: failure

--- a/fynd-core/src/derived/tracker.rs
+++ b/fynd-core/src/derived/tracker.rs
@@ -54,6 +54,11 @@ pub struct ReadinessTracker {
     ready_for_block: HashSet<ComputationId>,
     /// Set of computation IDs that have been computed at least once (any block).
     ever_computed: HashSet<ComputationId>,
+    /// `require_fresh` computations that have permanently failed for the current block.
+    ///
+    /// Cleared on `NewBlock`. A computation in this set will never produce a
+    /// `ComputationComplete` for the current block.
+    failed_for_block: HashSet<ComputationId>,
     /// Requirements for this worker's algorithm.
     requirements: ComputationRequirements,
 }
@@ -65,6 +70,7 @@ impl ReadinessTracker {
             current_block: None,
             ready_for_block: HashSet::new(),
             ever_computed: HashSet::new(),
+            failed_for_block: HashSet::new(),
             requirements,
         }
     }
@@ -84,6 +90,9 @@ impl ReadinessTracker {
             DerivedDataEvent::ComputationComplete { computation_id, block } => {
                 self.on_computation_complete(computation_id, *block);
             }
+            DerivedDataEvent::ComputationFailed { computation_id, block } => {
+                self.on_computation_failed(computation_id, *block);
+            }
         }
     }
 
@@ -96,7 +105,25 @@ impl ReadinessTracker {
         {
             self.current_block = Some(block);
             self.ready_for_block.clear();
+            self.failed_for_block.clear();
             // Note: ever_computed is NOT cleared - stale data persists
+        }
+    }
+
+    /// Handles a computation failure event.
+    ///
+    /// Only tracks failures for `require_fresh` computations on the current block.
+    /// `allow_stale` failures are ignored because stale data remains usable.
+    fn on_computation_failed(&mut self, computation_id: ComputationId, block: u64) {
+        if self
+            .requirements
+            .require_fresh
+            .contains(computation_id) &&
+            self.current_block
+                .is_some_and(|b| block == b)
+        {
+            self.failed_for_block
+                .insert(computation_id);
         }
     }
 
@@ -125,6 +152,18 @@ impl ReadinessTracker {
 
         self.ready_for_block
             .insert(computation_id);
+    }
+
+    /// Returns true if any `require_fresh` computation has failed for the
+    /// current block (i.e., it will never produce a `ComputationComplete` this block).
+    ///
+    /// Workers should return an error immediately rather than waiting for a timeout when
+    /// this is true.
+    pub fn is_blocked_for_current_block(&self) -> bool {
+        self.requirements
+            .require_fresh
+            .iter()
+            .any(|id| self.failed_for_block.contains(id))
     }
 
     /// Returns true if all requirements are satisfied:
@@ -397,6 +436,89 @@ mod tests {
             block: 101,
         });
         assert!(tracker.is_ready()); // Both satisfied again
+    }
+
+    // ==================== ComputationFailed / is_blocked_for_current_block Tests
+    // ====================
+
+    #[test]
+    fn is_blocked_when_require_fresh_computation_fails_for_current_block() {
+        let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
+        tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
+
+        tracker.handle_event(&DerivedDataEvent::ComputationFailed {
+            computation_id: "spot_prices",
+            block: 100,
+        });
+
+        assert!(tracker.is_blocked_for_current_block());
+    }
+
+    #[test]
+    fn is_not_blocked_for_allow_stale_computation_failure() {
+        let mut tracker = ReadinessTracker::new(stale_requirements(&["token_prices"]));
+        tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
+
+        tracker.handle_event(&DerivedDataEvent::ComputationFailed {
+            computation_id: "token_prices",
+            block: 100,
+        });
+
+        // allow_stale failures are ignored — stale data remains usable
+        assert!(!tracker.is_blocked_for_current_block());
+    }
+
+    #[test]
+    fn failed_for_block_cleared_on_new_block() {
+        let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
+        tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
+        tracker.handle_event(&DerivedDataEvent::ComputationFailed {
+            computation_id: "spot_prices",
+            block: 100,
+        });
+        assert!(tracker.is_blocked_for_current_block());
+
+        // New block clears the failure set
+        tracker.handle_event(&DerivedDataEvent::NewBlock { block: 101 });
+        assert!(!tracker.is_blocked_for_current_block());
+    }
+
+    #[test]
+    fn failure_for_old_block_does_not_block_current() {
+        let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
+        tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
+
+        // Failure event for block 99 (old) should not affect current block 100
+        tracker.handle_event(&DerivedDataEvent::ComputationFailed {
+            computation_id: "spot_prices",
+            block: 99,
+        });
+
+        assert!(!tracker.is_blocked_for_current_block());
+    }
+
+    #[test]
+    fn failure_then_new_block_then_success_becomes_ready() {
+        let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
+
+        // Block 100: failure
+        tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
+        tracker.handle_event(&DerivedDataEvent::ComputationFailed {
+            computation_id: "spot_prices",
+            block: 100,
+        });
+        assert!(tracker.is_blocked_for_current_block());
+        assert!(!tracker.is_ready());
+
+        // Block 101: success
+        tracker.handle_event(&DerivedDataEvent::NewBlock { block: 101 });
+        tracker.handle_event(&DerivedDataEvent::ComputationComplete {
+            computation_id: "spot_prices",
+            block: 101,
+        });
+
+        assert!(!tracker.is_blocked_for_current_block());
+        assert!(tracker.is_ready());
     }
 
     #[test]

--- a/fynd-core/src/derived/tracker.rs
+++ b/fynd-core/src/derived/tracker.rs
@@ -442,7 +442,7 @@ mod tests {
     // ====================
 
     #[test]
-    fn is_blocked_when_require_fresh_computation_fails_for_current_block() {
+    fn test_is_blocked_when_require_fresh_computation_fails_for_current_block() {
         let mut tracker = ReadinessTracker::new(fresh_requirements(&["spot_prices"]));
         tracker.handle_event(&DerivedDataEvent::NewBlock { block: 100 });
 

--- a/fynd-core/src/derived/tracker.rs
+++ b/fynd-core/src/derived/tracker.rs
@@ -87,7 +87,7 @@ impl ReadinessTracker {
             DerivedDataEvent::NewBlock { block } => {
                 self.on_new_block(*block);
             }
-            DerivedDataEvent::ComputationComplete { computation_id, block } => {
+            DerivedDataEvent::ComputationComplete { computation_id, block, .. } => {
                 self.on_computation_complete(computation_id, *block);
             }
             DerivedDataEvent::ComputationFailed { computation_id, block } => {
@@ -267,6 +267,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "spot_prices",
             block: 100,
+            failed_items: vec![],
         });
         assert!(tracker.is_ready());
         assert_eq!(tracker.current_block(), Some(100));
@@ -288,6 +289,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "spot_prices",
             block: 99,
+            failed_items: vec![],
         });
 
         assert!(!tracker.is_ready());
@@ -301,12 +303,14 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "token_prices",
             block: 100,
+            failed_items: vec![],
         });
         assert!(!tracker.is_ready()); // still missing spot_prices
 
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "spot_prices",
             block: 100,
+            failed_items: vec![],
         });
         assert!(tracker.is_ready());
     }
@@ -320,6 +324,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "token_prices",
             block: 100,
+            failed_items: vec![],
         });
 
         // Complete spot_prices for block 101 (newer block)
@@ -327,6 +332,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "spot_prices",
             block: 101,
+            failed_items: vec![],
         });
 
         assert!(!tracker.is_ready()); // token_prices not ready for block 101
@@ -355,6 +361,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "token_prices",
             block: 100,
+            failed_items: vec![],
         });
         assert!(tracker.is_ready());
 
@@ -374,6 +381,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "token_prices",
             block: 99,
+            failed_items: vec![],
         });
 
         assert!(tracker.is_ready()); // Old block is fine for stale
@@ -387,6 +395,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "token_prices",
             block: 100,
+            failed_items: vec![],
         });
         assert!(tracker.is_ready());
 
@@ -416,6 +425,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "token_prices",
             block: 100,
+            failed_items: vec![],
         });
         assert!(!tracker.is_ready()); // Missing fresh spot_prices
 
@@ -423,6 +433,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "spot_prices",
             block: 100,
+            failed_items: vec![],
         });
         assert!(tracker.is_ready());
 
@@ -434,6 +445,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "spot_prices",
             block: 101,
+            failed_items: vec![],
         });
         assert!(tracker.is_ready()); // Both satisfied again
     }
@@ -512,6 +524,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "spot_prices",
             block: 101,
+            failed_items: vec![],
         });
 
         assert!(!tracker.is_blocked_for_current_block());
@@ -537,6 +550,7 @@ mod tests {
         tracker.handle_event(&DerivedDataEvent::ComputationComplete {
             computation_id: "token_prices",
             block: 100,
+            failed_items: vec![],
         });
 
         let missing = tracker.missing();

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -681,8 +681,7 @@ impl Solver {
                 .derived_data
                 .read()
                 .await
-                .last_block()
-                .is_some();
+                .derived_data_ready();
 
             if market_ready && derived_ready {
                 return Ok(());

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -99,6 +99,14 @@ pub enum SolveError {
     #[error("no workers ready: {0}")]
     NotReady(String),
 
+    /// A required derived data computation failed for the current block.
+    ///
+    /// Unlike `NotReady` (data hasn't arrived yet), this is a permanent failure for
+    /// this block — the data will never arrive. Workers should not be retried until
+    /// the next block.
+    #[error("computation failed: {0}")]
+    ComputationFailed(String),
+
     /// Error when encoding
     #[error("failed to encode: {0}")]
     FailedEncoding(String),

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -283,7 +283,8 @@ where
     ///
     /// Uses a Notify pattern to know when it's available to solve.
     ///
-    /// Returns `Ok(())` if ready or no requirements, `Err` if timeout reached.
+    /// Returns `Ok(())` if ready or no requirements, `Err` if timeout reached or computation
+    /// failed.
     async fn wait_until_ready(&self, timeout: Duration) -> Result<(), SolveError> {
         // Fast path: no requirements or already ready
         if !self
@@ -323,6 +324,13 @@ where
                     )));
                 }
                 _ = notified => {
+                    // Check if any require_fresh computation permanently failed this block
+                    if self.readiness_tracker.is_blocked_for_current_block() {
+                        return Err(SolveError::ComputationFailed(format!(
+                            "required computation failed for current block: {:?}",
+                            self.readiness_tracker.missing()
+                        )));
+                    }
                     // Woken up by notify, loop to check readiness again
                     continue;
                 }
@@ -730,6 +738,54 @@ mod tests {
         let (r1, r2) = tokio::join!(waiter1, waiter2);
         assert!(r1.unwrap());
         assert!(r2.unwrap());
+    }
+
+    #[tokio::test]
+    async fn wait_until_ready_returns_immediately_on_blocked_state() {
+        let (market, _) = setup_market(vec![]);
+        let derived = DerivedData::new_shared();
+
+        let requirements = ComputationRequirements::none()
+            .require_fresh(SpotPriceComputation::ID)
+            .unwrap();
+        let algorithm = MockAlgorithm::new().with_requirements(requirements);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+
+        // Mark the current block and record a failure for spot_prices
+        worker
+            .readiness_tracker
+            .handle_event(&DerivedDataEvent::NewBlock { block: 1 });
+        worker
+            .readiness_tracker
+            .handle_event(&DerivedDataEvent::ComputationFailed {
+                computation_id: SpotPriceComputation::ID,
+                block: 1,
+            });
+
+        // Notify AFTER wait_until_ready starts waiting (must arrive after the
+        // Notified future is registered, not before).
+        let notify = worker.ready_notify.clone();
+        let notifier = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            notify.notify_waiters();
+        });
+
+        // wait_until_ready is woken by the notification, then checks
+        // is_blocked_for_current_block() → true → returns Err immediately.
+        let result = worker
+            .wait_until_ready(Duration::from_secs(5))
+            .await;
+        notifier.await.unwrap();
+
+        match result {
+            Err(SolveError::ComputationFailed(msg)) => {
+                assert!(
+                    msg.contains("required computation failed"),
+                    "expected 'required computation failed' message, got: {msg}"
+                );
+            }
+            other => panic!("Expected ComputationFailed error, got {:?}", other),
+        }
     }
 
     // ==================== Integration Tests with run() ====================

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -404,7 +404,7 @@ where
                             self.ready_notify.notify_waiters();
 
                             // Update edge weights when a relevant computation completes.
-                            if let DerivedDataEvent::ComputationComplete { computation_id, block } = &event {
+                            if let DerivedDataEvent::ComputationComplete { computation_id, block, .. } = &event {
                                 if self.requirements.is_required(computation_id) {
                                     let market = self.market_data.read().await;
                                     let derived = self.derived_data.read().await;
@@ -587,6 +587,7 @@ mod tests {
             .handle_event(&DerivedDataEvent::ComputationComplete {
                 computation_id: SpotPriceComputation::ID,
                 block: 1,
+            failed_items: vec![],
             });
 
         // Should return immediately since already ready
@@ -685,6 +686,7 @@ mod tests {
             .handle_event(&DerivedDataEvent::ComputationComplete {
                 computation_id: SpotPriceComputation::ID,
                 block: 1,
+            failed_items: vec![],
             });
 
         // Now wait - should succeed immediately since we're already ready
@@ -731,6 +733,7 @@ mod tests {
             .handle_event(&DerivedDataEvent::ComputationComplete {
                 computation_id: TokenGasPriceComputation::ID,
                 block: 1,
+            failed_items: vec![],
             });
         notify.notify_waiters();
 
@@ -819,6 +822,7 @@ mod tests {
             .send(DerivedDataEvent::ComputationComplete {
                 computation_id: SpotPriceComputation::ID,
                 block: 1,
+            failed_items: vec![],
             })
             .unwrap();
 

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -306,6 +306,17 @@ where
                 return Ok(());
             }
 
+            // Check if blocked before waiting for a notification that may never come
+            if self
+                .readiness_tracker
+                .is_blocked_for_current_block()
+            {
+                return Err(SolveError::ComputationFailed(format!(
+                    "required computation failed for current block: {:?}",
+                    self.readiness_tracker.missing()
+                )));
+            }
+
             // Calculate remaining time
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
@@ -779,6 +790,46 @@ mod tests {
             .wait_until_ready(Duration::from_secs(5))
             .await;
         notifier.await.unwrap();
+
+        match result {
+            Err(SolveError::ComputationFailed(msg)) => {
+                assert!(
+                    msg.contains("required computation failed"),
+                    "expected 'required computation failed' message, got: {msg}"
+                );
+            }
+            other => panic!("Expected ComputationFailed error, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_until_ready_returns_blocked_when_failure_already_processed() {
+        let (market, _) = setup_market(vec![]);
+        let derived = DerivedData::new_shared();
+
+        let requirements = ComputationRequirements::none()
+            .require_fresh(SpotPriceComputation::ID)
+            .unwrap();
+        let algorithm = MockAlgorithm::new().with_requirements(requirements);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+
+        // Mark the current block and record a failure for spot_prices
+        worker
+            .readiness_tracker
+            .handle_event(&DerivedDataEvent::NewBlock { block: 1 });
+        worker
+            .readiness_tracker
+            .handle_event(&DerivedDataEvent::ComputationFailed {
+                computation_id: SpotPriceComputation::ID,
+                block: 1,
+            });
+
+        // Do NOT spawn a notifier — the failure was already processed
+        // before wait_until_ready starts. Without the is_blocked_for_current_block() check in the
+        // loop body, this hangs for 1 second and returns NotReady.
+        let result = worker
+            .wait_until_ready(Duration::from_secs(1))
+            .await;
 
         match result {
             Err(SolveError::ComputationFailed(msg)) => {

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -587,7 +587,7 @@ mod tests {
             .handle_event(&DerivedDataEvent::ComputationComplete {
                 computation_id: SpotPriceComputation::ID,
                 block: 1,
-            failed_items: vec![],
+                failed_items: vec![],
             });
 
         // Should return immediately since already ready
@@ -686,7 +686,7 @@ mod tests {
             .handle_event(&DerivedDataEvent::ComputationComplete {
                 computation_id: SpotPriceComputation::ID,
                 block: 1,
-            failed_items: vec![],
+                failed_items: vec![],
             });
 
         // Now wait - should succeed immediately since we're already ready
@@ -733,7 +733,7 @@ mod tests {
             .handle_event(&DerivedDataEvent::ComputationComplete {
                 computation_id: TokenGasPriceComputation::ID,
                 block: 1,
-            failed_items: vec![],
+                failed_items: vec![],
             });
         notify.notify_waiters();
 
@@ -822,7 +822,7 @@ mod tests {
             .send(DerivedDataEvent::ComputationComplete {
                 computation_id: SpotPriceComputation::ID,
                 block: 1,
-            failed_items: vec![],
+                failed_items: vec![],
             })
             .unwrap();
 

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -60,6 +60,7 @@ impl ResponseError for ApiError {
                 SolveError::InvalidOrder(_) => "INVALID_ORDER",
                 SolveError::Internal(_) => "INTERNAL_ERROR",
                 SolveError::NotReady(_) => "NOT_READY",
+                SolveError::ComputationFailed(_) => "COMPUTATION_FAILED",
                 SolveError::FailedEncoding(_) => "FAILED_ENCODING",
                 other => {
                     warn!(?other, "unhandled SolveError variant");

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -39,6 +39,7 @@ impl ResponseError for ApiError {
                 SolveError::QueueFull => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::Timeout { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::MarketDataStale { .. } => StatusCode::SERVICE_UNAVAILABLE,
+                SolveError::ComputationFailed(_) => StatusCode::SERVICE_UNAVAILABLE,
                 _ => StatusCode::UNPROCESSABLE_ENTITY,
             },
             ApiError::ServiceOverloaded => StatusCode::SERVICE_UNAVAILABLE,

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -9,8 +9,8 @@ use super::{dto, ApiError, AppState};
 use crate::api::error::ErrorResponse;
 #[cfg(feature = "experimental")]
 use crate::api::prices::{
-    price_to_f64, IncludeField, PoolDepthEntry, PricesQuery, PricesResponse, SpotPriceEntry,
-    TokenPriceEntry,
+    price_to_f64, ComputationBlocks, IncludeField, PoolDepthEntry, PricesQuery, PricesResponse,
+    SpotPriceEntry, TokenPriceEntry,
 };
 
 /// Configures API routes under /v1 namespace.
@@ -192,9 +192,17 @@ pub async fn get_prices(
 
     // Acquire read lock, check staleness first (avoid cloning if 503), then clone
     let store = state.derived_data.read().await;
-    let last_block = store
-        .last_block()
+    let token_prices_block = store
+        .token_prices_block()
         .ok_or(ApiError::StaleData { age_ms: u64::MAX })?;
+    if want_spot && store.spot_prices_block().is_none() {
+        return Err(ApiError::StaleData { age_ms: u64::MAX });
+    }
+    if want_depths && store.pool_depths_block().is_none() {
+        return Err(ApiError::StaleData { age_ms: u64::MAX });
+    }
+    let spot_prices_block = store.spot_prices_block();
+    let pool_depths_block = store.pool_depths_block();
     let token_prices = store.token_prices().cloned();
     let spot_prices_data = if want_spot { store.spot_prices().cloned() } else { None };
     let pool_depths_data = if want_depths { store.pool_depths().cloned() } else { None };
@@ -270,7 +278,11 @@ pub async fn get_prices(
     let response = PricesResponse {
         prices,
         gas_token: state.gas_token.clone(),
-        last_block,
+        blocks: ComputationBlocks {
+            token_prices: token_prices_block,
+            spot_prices: spot_prices_block,
+            pool_depths: pool_depths_block,
+        },
         spot_prices,
         pool_depths,
     };

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -149,8 +149,7 @@ impl HealthTracker {
         self.derived_data
             .read()
             .await
-            .last_block()
-            .is_some()
+            .derived_data_ready()
     }
 }
 

--- a/fynd-rpc/src/api/prices.rs
+++ b/fynd-rpc/src/api/prices.rs
@@ -61,6 +61,19 @@ impl fmt::Display for IncludeField {
     }
 }
 
+/// Block numbers at which each computation was last run.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ComputationBlocks {
+    /// Block at which token gas prices were computed.
+    pub token_prices: u64,
+    /// Block at which spot prices were computed. `None` if not yet available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub spot_prices: Option<u64>,
+    /// Block at which pool depths were computed. `None` if not yet available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pool_depths: Option<u64>,
+}
+
 /// Top-level response for GET /v1/prices.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct PricesResponse {
@@ -69,8 +82,8 @@ pub struct PricesResponse {
     /// The gas token address (e.g. WETH).
     #[schema(value_type = String, example = "0x0000000000000000000000000000000000000000")]
     pub gas_token: Address,
-    /// Block number at which prices were last computed.
-    pub last_block: u64,
+    /// Block numbers at which each computation was last run.
+    pub blocks: ComputationBlocks,
     /// Spot prices per pool direction (only if requested via `include=spot_prices`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spot_prices: Option<Vec<SpotPriceEntry>>,


### PR DESCRIPTION
Before this change, when derived data computation failed for a block, workers waiting for that data had no way to know: they'd hold incoming orders until their timeout expired (several seconds), then return a generic "timeout" error.                                                                                                                                                                                                                                                                   
After this change, a failed computation immediately notifies waiting workers, which return a COMPUTATION_FAILED error to the client. This lets clients distinguish "system is slow" from "computation has failed".                                                                                                                                                                                                                                                            
Partial failure pools failures are tracked until success. Pools whose spot price or depth calculation failed are included in routing with zero weight, keeping them in the graph but deprioritized

Code changes:
- Add ComputationFailed { computation_id, block } variant to DerivedDataEvent and emit it from all Err branches in ComputationManager::compute_all                                                                                                                       
 - Replace the single last_block: Option<u64> in DerivedData with a per-field ComputedValue<T> wrapper; add per-computation block getters; last_block() returns the max across all fields                                                                               
 - Add failed_for_block set to ReadinessTracker with is_blocked_for_current_block(): tracks require_fresh failures for the current block, cleared on NewBlock                                                                                                             
 - Add SolveError::ComputationFailed and use it in wait_until_ready for an immediate early exit instead of waiting out the timeout  