### PR TITLE
feat(benchmark): add scale subcommand and benchmark results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3290,12 +3290,15 @@ dependencies = [
  "clap",
  "fastrand",
  "fynd-client",
+ "fynd-rpc",
  "num-bigint",
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber 0.3.22",
+ "tycho-simulation",
  "wiremock",
 ]
 

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -525,12 +525,19 @@ where
     pub async fn health(&self) -> Result<HealthStatus, FyndError> {
         let url = format!("{}/v1/health", self.base_url);
         let response = self.http.get(&url).send().await?;
-        if !response.status().is_success() {
-            let dto_err: fynd_rpc_types::ErrorResponse = response.json().await?;
+        let status = response.status();
+        let body = response.text().await?;
+        // The server returns HealthStatus JSON for both 200 and 503 (not-ready).
+        // Try parsing as HealthStatus first, then fall back to ErrorResponse.
+        if let Ok(dh) = serde_json::from_str::<fynd_rpc_types::HealthStatus>(&body) {
+            return Ok(HealthStatus::from(dh));
+        }
+        if let Ok(dto_err) = serde_json::from_str::<fynd_rpc_types::ErrorResponse>(&body) {
             return Err(mapping::dto_error_to_fynd(dto_err));
         }
-        let dh: fynd_rpc_types::HealthStatus = response.json().await?;
-        Ok(HealthStatus::from(dh))
+        Err(FyndError::Protocol(format!(
+            "unexpected health response ({status}): {body}"
+        )))
     }
 
     /// Build a signable payload for a given order quote.

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -535,9 +535,7 @@ where
         if let Ok(dto_err) = serde_json::from_str::<fynd_rpc_types::ErrorResponse>(&body) {
             return Err(mapping::dto_error_to_fynd(dto_err));
         }
-        Err(FyndError::Protocol(format!(
-            "unexpected health response ({status}): {body}"
-        )))
+        Err(FyndError::Protocol(format!("unexpected health response ({status}): {body}")))
     }
 
     /// Build a signable payload for a given order quote.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,3 +10,4 @@
 * [Quickstart](get-started/quickstart/README.md)
   * [Executing the solutions](get-started/quickstart/executing-the-solutions.md)
 * [Benchmarking](get-started/benchmarking.md)
+* [Benchmark Results](get-started/benchmark-results.md)

--- a/docs/get-started/benchmark-results.md
+++ b/docs/get-started/benchmark-results.md
@@ -23,6 +23,51 @@ layout:
 
 This page documents Fynd solver performance benchmarks across different configurations. All benchmarks use the `fynd-benchmark scale` subcommand, which builds a solver in-process for each worker count, runs a sustained load test, and reports throughput and latency statistics. See [benchmarking.md](benchmarking.md "mention") for how to run these yourself.
 
+All results below were produced using `scripts/bench-remote.sh`, which provisions an EC2 instance, builds the solver from source, and runs the full scaling sweep automatically. To reproduce:
+
+```bash
+WORKER_COUNTS="1,2,3,4,6,8" \
+NUM_REQUESTS=10000 \
+POOL_CONFIG="single_pool.toml" \
+TYCHO_URL="$TYCHO_URL" \
+TYCHO_API_KEY="$TYCHO_API_KEY" \
+  bash scripts/bench-remote.sh
+```
+
+## CPU Scaling: 2-Hop Routing
+
+Measures how throughput scales with worker thread count for 2-hop route finding using the `most_liquid` algorithm.
+
+### Setup
+
+| Parameter | Value |
+| --------- | ----- |
+| Instance | AWS `c7a.8xlarge` (32 vCPU, AMD EPYC) |
+| Algorithm | `most_liquid` |
+| Max hops | 2 |
+| Protocols | `uniswap_v2`, `uniswap_v3` |
+| Requests per iteration | 10,000 |
+| Concurrency | `fixed:48` |
+| Warmup | 30s after health check |
+| Min TVL | 10.0 (native token) |
+
+### Results
+
+| Workers | Throughput (req/s) | Median RT (ms) | P99 RT (ms) | RPS/Worker |
+| ------: | -----------------: | -------------: | ----------: | ---------: |
+|       1 |             501.55 |             95 |         102 |     501.55 |
+|       2 |             905.47 |             53 |          56 |     452.73 |
+|       3 |            1264.86 |             37 |          40 |     421.62 |
+|       4 |            1687.48 |             28 |          30 |     421.87 |
+|       6 |            2449.78 |             19 |          21 |     408.30 |
+|       8 |            3338.90 |             14 |          15 |     417.36 |
+
+### Analysis
+
+Throughput scales nearly linearly across all tested worker counts, with each worker contributing ~420-500 req/s. Per-worker efficiency remains stable from 3 to 8 workers (~420 req/s), indicating minimal contention at these counts. The solver crosses 1000 req/s at just **3 workers** (1265 req/s). Latency stays tight throughout — P99 is only 15ms at 8 workers.
+
+**Recommendation.** For 2-hop routing at 1000 req/s sustained throughput, provision at least 3 CPU cores. Use 4 cores for comfortable headroom.
+
 ## CPU Scaling: 3-Hop Routing
 
 Measures how throughput scales with worker thread count for 3-hop route finding using the `most_liquid` algorithm.
@@ -38,6 +83,7 @@ Measures how throughput scales with worker thread count for 3-hop route finding 
 | Requests per iteration | 10,000 |
 | Concurrency | `fixed:48` |
 | Warmup | 30s after health check |
+| Min TVL | 10.0 (native token) |
 
 ### Results
 
@@ -56,10 +102,14 @@ Measures how throughput scales with worker thread count for 3-hop route finding 
 
 ### Analysis
 
-**Scaling efficiency.** Throughput scales near-linearly up to 8 workers, with each worker contributing ~59 req/s. Beyond 8 workers, per-worker efficiency gradually declines due to contention and shared resource overhead. At 32 workers, per-worker throughput drops to ~39 req/s.
-
-**1000 req/s target.** The solver crosses 1000 req/s at **24 workers** (1122 req/s). For a comfortable margin, 28 workers (1206 req/s) provides ~20% headroom.
-
-**Latency.** Median round-trip time drops from 714ms at 1 worker to 31ms at 32 workers. The P99 latency follows a similar curve, settling around 70-78ms at high worker counts. The slight P99 increase from 28 to 32 workers (70ms to 78ms) reflects growing contention at the CPU limit of the instance.
+Throughput scales near-linearly up to 8 workers (~59 req/s per worker). Beyond that, per-worker efficiency gradually declines due to contention — dropping to ~39 req/s at 32 workers. The solver crosses 1000 req/s at **24 workers** (1122 req/s). Median latency drops from 714ms at 1 worker to 31ms at 32 workers, though P99 ticks up slightly at 32 workers (78ms vs 70ms at 28) reflecting the CPU limit of the instance.
 
 **Recommendation.** For 3-hop routing at 1000 req/s sustained throughput, provision at least 24 CPU cores. Use 28-32 cores for headroom under variable load.
+
+## Comparison: 2-Hop vs 3-Hop
+
+| Target RPS | 2-Hop Workers | 3-Hop Workers | Ratio |
+| ---------: | ------------: | ------------: | ----: |
+|      1,000 |             3 |            24 |    8x |
+
+2-hop routing requires roughly **8x fewer CPU cores** than 3-hop to reach the same throughput target. This reflects the combinatorial growth in route search space as hop count increases.

--- a/docs/get-started/benchmark-results.md
+++ b/docs/get-started/benchmark-results.md
@@ -1,0 +1,65 @@
+---
+description: Solver performance benchmarks across configurations.
+icon: chart-line
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+---
+
+# Benchmark Results
+
+This page documents Fynd solver performance benchmarks across different configurations. All benchmarks use the `fynd-benchmark scale` subcommand, which builds a solver in-process for each worker count, runs a sustained load test, and reports throughput and latency statistics. See [benchmarking.md](benchmarking.md "mention") for how to run these yourself.
+
+## CPU Scaling: 3-Hop Routing
+
+Measures how throughput scales with worker thread count for 3-hop route finding using the `most_liquid` algorithm.
+
+### Setup
+
+| Parameter | Value |
+| --------- | ----- |
+| Instance | AWS `c7a.8xlarge` (32 vCPU, AMD EPYC) |
+| Algorithm | `most_liquid` |
+| Max hops | 3 |
+| Protocols | `uniswap_v2`, `uniswap_v3` |
+| Requests per iteration | 10,000 |
+| Concurrency | `fixed:48` |
+| Warmup | 30s after health check |
+
+### Results
+
+| Workers | Throughput (req/s) | Median RT (ms) | P99 RT (ms) | RPS/Worker |
+| ------: | -----------------: | -------------: | ----------: | ---------: |
+|       1 |              66.68 |            714 |         884 |      66.68 |
+|       2 |             128.07 |            372 |         458 |      64.04 |
+|       4 |             240.02 |            198 |         256 |      60.01 |
+|       8 |             469.44 |             99 |         136 |      58.68 |
+|      12 |             642.88 |             70 |         110 |      53.57 |
+|      16 |             820.75 |             53 |          91 |      51.30 |
+|      20 |             939.58 |             45 |          92 |      46.98 |
+|      24 |            1122.21 |             37 |          73 |      46.76 |
+|      28 |            1205.98 |             33 |          70 |      43.07 |
+|      32 |            1237.47 |             31 |          78 |      38.67 |
+
+### Analysis
+
+**Scaling efficiency.** Throughput scales near-linearly up to 8 workers, with each worker contributing ~59 req/s. Beyond 8 workers, per-worker efficiency gradually declines due to contention and shared resource overhead. At 32 workers, per-worker throughput drops to ~39 req/s.
+
+**1000 req/s target.** The solver crosses 1000 req/s at **24 workers** (1122 req/s). For a comfortable margin, 28 workers (1206 req/s) provides ~20% headroom.
+
+**Latency.** Median round-trip time drops from 714ms at 1 worker to 31ms at 32 workers. The P99 latency follows a similar curve, settling around 70-78ms at high worker counts. The slight P99 increase from 28 to 32 workers (70ms to 78ms) reflects growing contention at the CPU limit of the instance.
+
+**Recommendation.** For 3-hop routing at 1000 req/s sustained throughput, provision at least 24 CPU cores. Use 28-32 cores for headroom under variable load.

--- a/docs/get-started/benchmarking.md
+++ b/docs/get-started/benchmarking.md
@@ -164,6 +164,75 @@ Prints a summary table to stdout showing win/loss counts and bps differences. Wr
 
 ---
 
+## CPU Scaling
+
+Measures how solver throughput (req/s) scales with worker thread count. The tool builds a solver in-process for each worker count, runs a load test, shuts down, and repeats.
+
+```bash
+cargo run -p fynd-benchmark --release -- scale [OPTIONS]
+```
+
+{% hint style="warning" %}
+Requires a `worker_pools.toml` with exactly **one** pool defined.
+{% endhint %}
+
+### Options
+
+| Flag | Default | Description |
+| ---- | ------- | ----------- |
+| `--base-config` | `worker_pools.toml` | Single-pool TOML config |
+| `--worker-counts` | _(required)_ | Comma-separated worker counts (e.g. `1,2,4,8,16`) |
+| `--protocols` | _(required)_ | Comma-separated protocols for solver |
+| `--tycho-url` | `localhost:4242` | Tycho WebSocket URL |
+| `--tycho-api-key` | _(none)_ | Tycho API key |
+| `--disable-tls` | `false` | Disable TLS for Tycho connection |
+| `--rpc-url` | _(none)_ | Node RPC URL |
+| `--chain` | `ethereum` | Chain name |
+| `--http-port` | `3000` | Solver HTTP port |
+| `-n` | `100` | Requests per iteration |
+| `-m` | `fixed:8` | Parallelization mode |
+| `--requests-file` | _(none)_ | Custom request templates |
+| `--warmup-secs` | `30` | Seconds to wait after health before benchmarking |
+| `--health-timeout-secs` | `300` | Max seconds to wait for solver health |
+| `--output-file` | _(none)_ | JSON output file |
+
+### Example
+
+```bash
+cargo run -p fynd-benchmark --release -- scale \
+  --base-config single_pool.toml \
+  --worker-counts 1,2,4,8,16 \
+  --protocols uniswap_v2,uniswap_v3 \
+  --tycho-url wss://tycho.example.com \
+  --tycho-api-key $TYCHO_API_KEY \
+  -n 200 \
+  -m fixed:8 \
+  --output-file scale_results.json
+```
+
+### Output
+
+The tool prints a summary table showing throughput, latency, and per-worker efficiency at each worker count:
+
+```
+=== CPU Scaling Results ===
+
+Pool: most_liquid_2_hops_fast (algorithm: most_liquid)
+Requests per run: 200, Mode: fixed:8
+
+ Workers | Throughput (req/s) | Median RT (ms) | P99 RT (ms) | RPS/Worker
+---------+--------------------+----------------+-------------+-----------
+       1 |               8.50 |             95 |          142 |      8.50
+       2 |              16.20 |             50 |           98 |      8.10
+       4 |              30.10 |             28 |           65 |      7.53
+       8 |              48.90 |             18 |           52 |      6.11
+      16 |              62.30 |             15 |           48 |      3.89
+```
+
+Pass `--output-file` to export the full results as JSON for further analysis.
+
+---
+
 ## Custom Request Templates
 
 By default, the load test uses a single WETH→USDC swap and the compare tool generates random requests from a built-in set of token pairs. Both commands accept `--requests-file` to supply custom requests.

--- a/scripts/bench-remote.sh
+++ b/scripts/bench-remote.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------- configurable variables ----------
+REGION="${AWS_REGION:-eu-west-1}"
+INSTANCE_TYPE="${INSTANCE_TYPE:-c7a.8xlarge}" # 32 vCPU, compute-optimized
+AMI_ID="${AMI_ID:-}"                          # auto-resolved if empty (Amazon Linux 2023)
+WORKER_COUNTS="${WORKER_COUNTS:-1,2,4,8,12,16,20,24}"
+NUM_REQUESTS="${NUM_REQUESTS:-200}"
+CONCURRENCY_MODE="${CONCURRENCY_MODE:-fixed:48}"
+WARMUP_SECS="${WARMUP_SECS:-30}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-600}"
+PROTOCOLS="${PROTOCOLS:-uniswap_v2,uniswap_v3}"
+TYCHO_URL="${TYCHO_URL:?TYCHO_URL must be set}"
+TYCHO_API_KEY="${TYCHO_API_KEY:?TYCHO_API_KEY must be set}"
+HTTP_PORT="${HTTP_PORT:-3456}"
+POOL_CONFIG="${POOL_CONFIG:-single_pool.toml}"
+REQUESTS_FILE="${REQUESTS_FILE:-tools/benchmark/requests_set.json}"
+VOLUME_SIZE="${VOLUME_SIZE:-60}" # GB, needs space for Rust toolchain + build
+KEY_NAME="bench-remote-$$"
+SG_NAME="bench-remote-sg-$$"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ---------- derived ----------
+KEY_FILE="/tmp/${KEY_NAME}.pem"
+REMOTE_DIR="/home/ec2-user/fynd"
+CLEANUP_ITEMS=()
+
+cleanup() {
+	echo ""
+	echo "=== Cleanup ==="
+	for item in "${CLEANUP_ITEMS[@]}"; do
+		case "$item" in
+		instance:*)
+			local iid="${item#instance:}"
+			echo "Terminating instance ${iid}..."
+			aws ec2 terminate-instances \
+				--region "$REGION" \
+				--instance-ids "$iid" \
+				--output text >/dev/null 2>&1 || true
+			echo "Waiting for instance termination..."
+			aws ec2 wait instance-terminated \
+				--region "$REGION" \
+				--instance-ids "$iid" 2>/dev/null || true
+			;;
+		sg:*)
+			local sgid="${item#sg:}"
+			echo "Deleting security group ${sgid}..."
+			aws ec2 delete-security-group \
+				--region "$REGION" \
+				--group-id "$sgid" 2>/dev/null || true
+			;;
+		key:*)
+			local kn="${item#key:}"
+			echo "Deleting key pair ${kn}..."
+			aws ec2 delete-key-pair \
+				--region "$REGION" \
+				--key-name "$kn" 2>/dev/null || true
+			rm -f "$KEY_FILE"
+			;;
+		esac
+	done
+	echo "Cleanup complete."
+}
+trap cleanup EXIT
+
+echo "=== Remote Benchmark Runner ==="
+echo "Region:        ${REGION}"
+echo "Instance type: ${INSTANCE_TYPE}"
+echo "Worker counts: ${WORKER_COUNTS}"
+echo "Requests:      ${NUM_REQUESTS} per iteration, mode ${CONCURRENCY_MODE}"
+echo ""
+
+# ---------- resolve AMI ----------
+if [[ -z "$AMI_ID" ]]; then
+	echo "Resolving latest Amazon Linux 2023 AMI..."
+	AMI_ID=$(aws ec2 describe-images \
+		--region "$REGION" \
+		--owners amazon \
+		--filters \
+		"Name=name,Values=al2023-ami-2023*-x86_64" \
+		"Name=state,Values=available" \
+		--query 'sort_by(Images, &CreationDate)[-1].ImageId' \
+		--output text)
+	echo "AMI: ${AMI_ID}"
+fi
+
+# ---------- create key pair ----------
+echo "Creating key pair ${KEY_NAME}..."
+aws ec2 create-key-pair \
+	--region "$REGION" \
+	--key-name "$KEY_NAME" \
+	--query 'KeyMaterial' \
+	--output text >"$KEY_FILE"
+chmod 600 "$KEY_FILE"
+CLEANUP_ITEMS+=("key:${KEY_NAME}")
+
+# ---------- create security group ----------
+echo "Creating security group..."
+VPC_ID=$(aws ec2 describe-vpcs \
+	--region "$REGION" \
+	--filters "Name=isDefault,Values=true" \
+	--query 'Vpcs[0].VpcId' \
+	--output text)
+
+SG_ID=$(aws ec2 create-security-group \
+	--region "$REGION" \
+	--group-name "$SG_NAME" \
+	--description "Temporary SG for benchmark runner" \
+	--vpc-id "$VPC_ID" \
+	--query 'GroupId' \
+	--output text)
+CLEANUP_ITEMS+=("sg:${SG_ID}")
+
+MY_IP=$(curl -s https://checkip.amazonaws.com)
+aws ec2 authorize-security-group-ingress \
+	--region "$REGION" \
+	--group-id "$SG_ID" \
+	--protocol tcp \
+	--port 22 \
+	--cidr "${MY_IP}/32" \
+	--output text >/dev/null
+echo "Security group ${SG_ID} allows SSH from ${MY_IP}"
+
+# ---------- launch instance ----------
+echo "Launching ${INSTANCE_TYPE} instance..."
+INSTANCE_ID=$(aws ec2 run-instances \
+	--region "$REGION" \
+	--image-id "$AMI_ID" \
+	--instance-type "$INSTANCE_TYPE" \
+	--key-name "$KEY_NAME" \
+	--security-group-ids "$SG_ID" \
+	--block-device-mappings "DeviceName=/dev/xvda,Ebs={VolumeSize=${VOLUME_SIZE},VolumeType=gp3}" \
+	--tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=fynd-benchmark-runner}]" \
+	--query 'Instances[0].InstanceId' \
+	--output text)
+CLEANUP_ITEMS+=("instance:${INSTANCE_ID}")
+echo "Instance: ${INSTANCE_ID}"
+
+echo "Waiting for instance to be running..."
+aws ec2 wait instance-running \
+	--region "$REGION" \
+	--instance-ids "$INSTANCE_ID"
+
+PUBLIC_IP=$(aws ec2 describe-instances \
+	--region "$REGION" \
+	--instance-ids "$INSTANCE_ID" \
+	--query 'Reservations[0].Instances[0].PublicIpAddress' \
+	--output text)
+echo "Public IP: ${PUBLIC_IP}"
+
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o LogLevel=ERROR"
+SSH="ssh ${SSH_OPTS} -i ${KEY_FILE} ec2-user@${PUBLIC_IP}"
+SCP="scp ${SSH_OPTS} -i ${KEY_FILE}"
+
+echo "Waiting for SSH to become available..."
+for i in $(seq 1 30); do
+	if $SSH true 2>/dev/null; then
+		break
+	fi
+	if [[ $i -eq 30 ]]; then
+		echo "ERROR: SSH not available after 30 attempts"
+		exit 1
+	fi
+	sleep 5
+done
+echo "SSH connected."
+
+# ---------- install dependencies ----------
+echo ""
+echo "=== Installing dependencies on remote ==="
+$SSH <<'INSTALL_EOF'
+set -euo pipefail
+sudo dnf install -y gcc gcc-c++ make openssl-devel pkg-config git rsync --quiet
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+source "$HOME/.cargo/env"
+rustc --version
+cargo --version
+INSTALL_EOF
+echo "Rust toolchain installed."
+
+# ---------- sync code ----------
+echo ""
+echo "=== Syncing code to remote ==="
+rsync -az --progress \
+	-e "ssh ${SSH_OPTS} -i ${KEY_FILE}" \
+	--exclude target/ \
+	--exclude .git/ \
+	--exclude .idea/ \
+	--exclude clients/typescript/node_modules/ \
+	"${REPO_ROOT}/" \
+	"ec2-user@${PUBLIC_IP}:${REMOTE_DIR}/"
+echo "Code synced."
+
+# ---------- build ----------
+echo ""
+echo "=== Building fynd-benchmark (release) ==="
+$SSH <<'BUILD_EOF'
+set -euo pipefail
+source "$HOME/.cargo/env"
+cd ~/fynd
+cargo build -p fynd-benchmark --release 2>&1 | tail -5
+echo "Build complete."
+BUILD_EOF
+
+# ---------- run benchmark ----------
+echo ""
+echo "=== Running scale benchmark ==="
+$SSH <<BENCH_EOF
+set -euo pipefail
+source "\$HOME/.cargo/env"
+cd ~/fynd
+
+RUST_LOG=info cargo run -p fynd-benchmark --release -- scale \\
+    --base-config "${POOL_CONFIG}" \\
+    --worker-counts "${WORKER_COUNTS}" \\
+    --protocols "${PROTOCOLS}" \\
+    --tycho-url "${TYCHO_URL}" \\
+    --tycho-api-key "${TYCHO_API_KEY}" \\
+    --http-port ${HTTP_PORT} \\
+    -n ${NUM_REQUESTS} \\
+    -m "${CONCURRENCY_MODE}" \\
+    --requests-file "${REQUESTS_FILE}" \\
+    --warmup-secs ${WARMUP_SECS} \\
+    --health-timeout-secs ${HEALTH_TIMEOUT} \\
+    --output-file scale_results_remote.json 2>&1 | \
+    grep -E '(=== CPU|Pool:|Requests per|Workers|--------|^\s+[0-9]|INFO.*Scale results)'
+BENCH_EOF
+
+# ---------- fetch results ----------
+echo ""
+echo "=== Fetching results ==="
+$SCP "ec2-user@${PUBLIC_IP}:${REMOTE_DIR}/scale_results_remote.json" \
+	"${REPO_ROOT}/scale_results_remote.json"
+echo "Results saved to: ${REPO_ROOT}/scale_results_remote.json"
+
+echo ""
+echo "=== Done ==="
+echo "Instance will be terminated during cleanup."

--- a/scripts/bench-remote.sh
+++ b/scripts/bench-remote.sh
@@ -12,6 +12,9 @@ WARMUP_SECS="${WARMUP_SECS:-30}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-600}"
 PROTOCOLS="${PROTOCOLS:-uniswap_v2,uniswap_v3}"
 TYCHO_URL="${TYCHO_URL:?TYCHO_URL must be set}"
+# Strip protocol prefix — the solver handles TLS internally
+TYCHO_URL="${TYCHO_URL#https://}"
+TYCHO_URL="${TYCHO_URL#http://}"
 TYCHO_API_KEY="${TYCHO_API_KEY:?TYCHO_API_KEY must be set}"
 HTTP_PORT="${HTTP_PORT:-3456}"
 POOL_CONFIG="${POOL_CONFIG:-single_pool.toml}"
@@ -187,7 +190,7 @@ rsync -az --progress \
 	--exclude target/ \
 	--exclude .git/ \
 	--exclude .idea/ \
-	--exclude clients/typescript/node_modules/ \
+	--exclude node_modules/ \
 	"${REPO_ROOT}/" \
 	"ec2-user@${PUBLIC_IP}:${REMOTE_DIR}/"
 echo "Code synced."
@@ -224,7 +227,7 @@ RUST_LOG=info cargo run -p fynd-benchmark --release -- scale \\
     --warmup-secs ${WARMUP_SECS} \\
     --health-timeout-secs ${HEALTH_TIMEOUT} \\
     --output-file scale_results_remote.json 2>&1 | \
-    grep -E '(=== CPU|Pool:|Requests per|Workers|--------|^\s+[0-9]|INFO.*Scale results)'
+    grep -E '(--- Testing|=== CPU|Pool:|Requests per|Workers|--------|^\s+[0-9]|INFO.*(Scale results|healthy|warming|Loaded|Worker counts))'
 BENCH_EOF
 
 # ---------- fetch results ----------

--- a/scripts/bench-remote.sh
+++ b/scripts/bench-remote.sh
@@ -226,8 +226,7 @@ RUST_LOG=info cargo run -p fynd-benchmark --release -- scale \\
     --requests-file "${REQUESTS_FILE}" \\
     --warmup-secs ${WARMUP_SECS} \\
     --health-timeout-secs ${HEALTH_TIMEOUT} \\
-    --output-file scale_results_remote.json 2>&1 | \
-    grep -E '(--- Testing|=== CPU|Pool:|Requests per|Workers|--------|^\s+[0-9]|INFO.*(Scale results|healthy|warming|Loaded|Worker counts))'
+    --output-file scale_results_remote.json 2>&1
 BENCH_EOF
 
 # ---------- fetch results ----------

--- a/single_pool.toml
+++ b/single_pool.toml
@@ -1,0 +1,8 @@
+# Single-pool config for CPU scaling benchmark
+[pools.most_liquid_3_hops]
+algorithm = "most_liquid"
+num_workers = 1
+task_queue_capacity = 1000
+max_hops = 3
+timeout_ms = 5000
+max_routes = 50

--- a/tools/benchmark/CLAUDE.md
+++ b/tools/benchmark/CLAUDE.md
@@ -4,21 +4,24 @@ Benchmark and comparison tooling for Fynd solvers. Requires one or more running 
 
 ## Commands
 
-Two subcommands available via `cargo run -p fynd-benchmark --release --`:
+Three subcommands available via `cargo run -p fynd-benchmark --release --`:
 
 - **`load`** — Load-test a single solver. Measures latency (round-trip, solve time, overhead) and throughput. Supports sequential, fixed-concurrency, and rate-based parallelization modes. Prints statistics and ASCII histograms to stdout; optionally exports results to JSON.
 
 - **`compare`** — Compare output quality between two solver instances. Sends identical quote requests to both and reports differences in amount out (bps), gas estimates, route selection, and status. Requires two solvers running on different ports (use git worktrees to run different branches simultaneously).
 
-Run `--help` on either subcommand for detailed options.
+- **`scale`** — Measure throughput scaling across different worker counts. Builds a solver in-process for each worker count via `FyndBuilder`, runs a load test, shuts down, and repeats. Requires a single-pool `worker_pools.toml`.
+
+Run `--help` on any subcommand for detailed options.
 
 ## Module Overview
 
 | Module | Purpose |
 |---|---|
-| `main.rs` | CLI entry point. Parses `load` / `compare` subcommands via clap and dispatches to the corresponding handler. |
+| `main.rs` | CLI entry point. Parses `load` / `compare` / `scale` subcommands via clap and dispatches to the corresponding handler. |
 | `benchmark.rs` | `load` subcommand handler. Builds a `FyndClient`, checks solver health, loads request templates, runs the benchmark via `runner`, and prints results via `exporter`. |
 | `compare.rs` | `compare` subcommand handler. Builds two `FyndClient` instances, sends identical requests sequentially to both, computes per-request metrics (amount out diff in bps, gas diff, route match), prints a summary table, and exports full results to JSON. |
+| `scale.rs` | `scale` subcommand handler. Iterates over worker counts, builds a solver in-process via `FyndBuilder`, waits for health, runs a load test, collects timing stats, then shuts down. Prints a summary table and optionally exports JSON. |
 | `config.rs` | Shared types: `ParallelizationMode` enum (`Sequential`, `FixedConcurrency`, `RateBased`), `BenchmarkConfig`, `BenchmarkResults`, `TimingStats`. |
 | `runner.rs` | Benchmark execution engine. Implements three strategies: sequential (one-at-a-time), fixed concurrency (semaphore-bounded), and rate-based (fire at fixed intervals). Returns timing vectors and order counts. |
 | `exporter.rs` | Statistics calculation (`TimingStats::from_measurements` — min/max/mean/median/p95/p99/stddev), ASCII histogram rendering, and JSON export of `BenchmarkResults`. |

--- a/tools/benchmark/Cargo.toml
+++ b/tools/benchmark/Cargo.toml
@@ -11,6 +11,9 @@ clap              = { workspace = true }
 serde             = { workspace = true }
 serde_json        = { workspace = true }
 anyhow            = { workspace = true }
+fynd-rpc          = { workspace = true }
+toml              = { workspace = true }
+tycho-simulation  = { workspace = true }
 tracing           = { workspace = true }
 tracing-subscriber = { workspace = true }
 alloy             = { workspace = true }

--- a/tools/benchmark/README.md
+++ b/tools/benchmark/README.md
@@ -56,6 +56,25 @@ Console output shows real-time progress, summary statistics, and ASCII histogram
 
 ---
 
+## Scale
+
+Measures how solver throughput scales with worker thread count. Builds a solver in-process for each worker count, runs a load test, shuts down, and repeats.
+
+```bash
+cargo run -p fynd-benchmark --release -- scale \
+  --base-config single_pool.toml \
+  --worker-counts 1,2,4,8,16 \
+  --protocols uniswap_v2,uniswap_v3 \
+  --tycho-url wss://tycho.example.com \
+  --tycho-api-key $TYCHO_API_KEY \
+  -n 200 \
+  -m fixed:8
+```
+
+Requires a `worker_pools.toml` with exactly one pool defined. Run `--help` for all options.
+
+---
+
 ## Compare
 
 Sends identical quote requests to two running Fynd instances and compares output quality (amount out, gas, routes).
@@ -165,9 +184,10 @@ By default, the benchmark uses a single WETH->USDC swap and the compare tool gen
 
 | File | Description |
 |------|-------------|
-| `src/main.rs` | CLI entry point with `load` and `compare` subcommands |
+| `src/main.rs` | CLI entry point with `load`, `compare`, and `scale` subcommands |
 | `src/benchmark.rs` | Load-test implementation |
 | `src/compare.rs` | Comparison tool implementation |
+| `src/scale.rs` | CPU scaling benchmark implementation |
 | `src/config.rs` | Benchmark config, request templates, statistics types |
 | `src/runner.rs` | Benchmark execution (sequential, fixed concurrency, rate-based) |
 | `src/exporter.rs` | Statistics calculation and JSON export |

--- a/tools/benchmark/src/main.rs
+++ b/tools/benchmark/src/main.rs
@@ -9,6 +9,7 @@ mod config;
 mod exporter;
 mod requests;
 mod runner;
+mod scale;
 
 use clap::{Parser, Subcommand};
 use tracing_subscriber::EnvFilter;
@@ -31,6 +32,8 @@ enum Command {
     Load(benchmark::Args),
     /// Diff output quality (amount out, gas, routes) between two solvers
     Compare(compare::Args),
+    /// Measure throughput scaling across different worker counts
+    Scale(scale::Args),
 }
 
 #[tokio::main]
@@ -44,6 +47,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::Load(args) => benchmark::run(args).await,
         Command::Compare(args) => compare::run(args).await,
+        Command::Scale(args) => scale::run(args).await,
     }
 }
 

--- a/tools/benchmark/src/scale.rs
+++ b/tools/benchmark/src/scale.rs
@@ -213,7 +213,12 @@ async fn wait_for_health(url: &str, timeout: Duration) -> Result<()> {
         if Instant::now() >= deadline {
             bail!("solver did not become healthy within {}s", timeout.as_secs());
         }
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::select! {
+            () = tokio::time::sleep(Duration::from_secs(2)) => {}
+            _ = tokio::signal::ctrl_c() => {
+                bail!("interrupted by ctrl+c");
+            }
+        }
     }
 }
 
@@ -289,8 +294,16 @@ pub async fn run(args: Args) -> Result<()> {
         let handle = fynd.server_handle();
         let server_task = tokio::spawn(fynd.run());
 
-        let result =
-            run_iteration(&solver_url, &parallelization_mode, &requests, &args, workers).await;
+        let result = tokio::select! {
+            r = run_iteration(
+                &solver_url, &parallelization_mode, &requests, &args, workers,
+            ) => r,
+            _ = tokio::signal::ctrl_c() => {
+                handle.stop(true).await;
+                let _ = server_task.await;
+                bail!("interrupted by ctrl+c");
+            }
+        };
 
         handle.stop(true).await;
         if let Err(e) = server_task.await {

--- a/tools/benchmark/src/scale.rs
+++ b/tools/benchmark/src/scale.rs
@@ -1,0 +1,479 @@
+//! CPU scaling subcommand.
+//!
+//! Measures how solver throughput scales with worker thread count by running
+//! repeated load tests across different `num_workers` values, building and
+//! tearing down the solver in-process for each iteration.
+
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use fynd_client::FyndClientBuilder;
+use fynd_rpc::{
+    builder::{parse_chain, Fynd, FyndBuilder},
+    config::{PoolConfig, WorkerPoolsConfig},
+};
+use serde::Serialize;
+use tracing::info;
+
+use crate::{
+    config::{ParallelizationMode, TimingStats},
+    requests::{default_request, load_request_templates, SwapRequest},
+    runner::RunnerResults,
+};
+
+/// Measure how solver throughput scales with worker thread count.
+#[derive(Parser, Debug)]
+#[command(
+    about = "Benchmark throughput scaling across different worker counts",
+    long_about = "Benchmark throughput scaling across different worker counts.\n\n\
+        Builds a solver in-process for each worker count, runs a load test,\n\
+        then shuts down and repeats. Requires a single-pool worker_pools.toml."
+)]
+pub struct Args {
+    /// Path to a single-pool worker_pools.toml config
+    #[arg(long, default_value = "worker_pools.toml")]
+    pub base_config: PathBuf,
+
+    /// Comma-separated worker counts to test (e.g. "1,2,4,8,16")
+    #[arg(long)]
+    pub worker_counts: String,
+
+    /// Comma-separated protocols for the solver
+    #[arg(long)]
+    pub protocols: String,
+
+    /// Tycho WebSocket URL
+    #[arg(long, default_value = "localhost:4242")]
+    pub tycho_url: String,
+
+    /// Tycho API key
+    #[arg(long, env = "TYCHO_API_KEY")]
+    pub tycho_api_key: Option<String>,
+
+    /// Disable TLS for Tycho connection
+    #[arg(long, default_value_t = false)]
+    pub disable_tls: bool,
+
+    /// Node RPC URL
+    #[arg(long, env = "RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    /// Chain name (e.g. "ethereum")
+    #[arg(long, default_value = "ethereum")]
+    pub chain: String,
+
+    /// HTTP port for the solver
+    #[arg(long, default_value_t = 3000)]
+    pub http_port: u16,
+
+    /// Number of requests per iteration
+    #[arg(long, short = 'n', default_value_t = 100)]
+    pub num_requests: usize,
+
+    /// Parallelization mode for load test (e.g. "fixed:8")
+    #[arg(long, short = 'm', default_value = "fixed:8")]
+    pub parallelization_mode: String,
+
+    /// JSON file of request templates
+    #[arg(long)]
+    pub requests_file: Option<String>,
+
+    /// Seconds to sleep after health before benchmarking
+    #[arg(long, default_value_t = 30)]
+    pub warmup_secs: u64,
+
+    /// Max seconds to wait for solver health
+    #[arg(long, default_value_t = 300)]
+    pub health_timeout_secs: u64,
+
+    /// Write JSON results to this file
+    #[arg(long)]
+    pub output_file: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ScalePoint {
+    total_workers: usize,
+    throughput_rps: f64,
+    total_duration_ms: u64,
+    successful_requests: usize,
+    failed_requests: usize,
+    round_trip: TimingStats,
+    solve_time: TimingStats,
+}
+
+#[derive(Debug, Serialize)]
+struct ScaleConfig {
+    base_config: String,
+    worker_counts: Vec<usize>,
+    num_requests: usize,
+    parallelization_mode: String,
+    warmup_secs: u64,
+    pool_name: String,
+    algorithm: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ScaleResults {
+    config: ScaleConfig,
+    points: Vec<ScalePoint>,
+}
+
+fn parse_worker_counts(s: &str) -> Result<Vec<usize>> {
+    let counts: Vec<usize> = s
+        .split(',')
+        .map(|v| {
+            v.trim()
+                .parse::<usize>()
+                .with_context(|| format!("invalid worker count '{v}'"))
+        })
+        .collect::<Result<_>>()?;
+
+    if counts.is_empty() {
+        bail!("--worker-counts must contain at least one value");
+    }
+    for &c in &counts {
+        if c == 0 {
+            bail!("worker count must be >= 1, got 0");
+        }
+    }
+    Ok(counts)
+}
+
+fn validate_single_pool(config: &WorkerPoolsConfig) -> Result<(String, PoolConfig)> {
+    if config.pools.is_empty() {
+        bail!("base config has no pools; exactly one pool is required");
+    }
+    if config.pools.len() > 1 {
+        bail!("base config has {} pools; exactly one pool is required", config.pools.len());
+    }
+    let (name, pool) = config
+        .pools
+        .iter()
+        .next()
+        .expect("checked non-empty");
+    Ok((name.clone(), pool.clone()))
+}
+
+fn build_solver(
+    args: &Args,
+    pool_name: &str,
+    pool_config: &PoolConfig,
+    workers: usize,
+) -> Result<Fynd> {
+    let chain = parse_chain(&args.chain)?;
+    let protocols: Vec<String> = args
+        .protocols
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .collect();
+    let rpc_url = args
+        .rpc_url
+        .clone()
+        .unwrap_or_else(|| fynd_rpc::config::defaults::DEFAULT_RPC_URL.to_string());
+
+    let mut pool = pool_config.clone();
+    pool.num_workers = workers;
+
+    let pools = HashMap::from([(pool_name.to_string(), pool)]);
+
+    let mut builder = FyndBuilder::new(chain, pools, args.tycho_url.clone(), rpc_url, protocols)
+        .http_port(args.http_port);
+
+    if let Some(ref key) = args.tycho_api_key {
+        builder = builder.tycho_api_key(key.clone());
+    }
+    if args.disable_tls {
+        builder = builder.disable_tls();
+    }
+
+    builder.build()
+}
+
+async fn wait_for_health(url: &str, timeout: Duration) -> Result<()> {
+    let client = FyndClientBuilder::new(url, "")
+        .build_quote_only()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        match client.health().await {
+            Ok(h) if h.healthy() => return Ok(()),
+            Ok(_) => {}
+            Err(e) => {
+                info!("Health check not ready: {e}");
+            }
+        }
+        if Instant::now() >= deadline {
+            bail!("solver did not become healthy within {}s", timeout.as_secs());
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
+}
+
+fn load_requests(requests_file: Option<&str>) -> Result<Vec<SwapRequest>> {
+    if let Some(file_path) = requests_file {
+        info!("Loading requests from: {}", file_path);
+        let loaded =
+            load_request_templates(file_path, 10000).map_err(|e| anyhow::anyhow!("{e}"))?;
+        info!("Loaded {} request template(s)", loaded.len());
+        Ok(loaded)
+    } else {
+        info!("Using default WETH->USDC request template");
+        Ok(vec![default_request(10000)])
+    }
+}
+
+fn print_summary(pool_name: &str, algorithm: &str, args: &Args, points: &[ScalePoint]) {
+    println!("\n=== CPU Scaling Results ===\n");
+    println!("Pool: {} (algorithm: {})", pool_name, algorithm);
+    println!("Requests per run: {}, Mode: {}\n", args.num_requests, args.parallelization_mode);
+    println!(
+        "{:>8} | {:>18} | {:>14} | {:>11} | {:>10}",
+        "Workers", "Throughput (req/s)", "Median RT (ms)", "P99 RT (ms)", "RPS/Worker"
+    );
+    println!("{:-<8}-+-{:-<18}-+-{:-<14}-+-{:-<11}-+-{:-<10}", "", "", "", "", "");
+    for p in points {
+        let rps_per_worker =
+            if p.total_workers > 0 { p.throughput_rps / p.total_workers as f64 } else { 0.0 };
+        println!(
+            "{:>8} | {:>18.2} | {:>14} | {:>11} | {:>10.2}",
+            p.total_workers,
+            p.throughput_rps,
+            p.round_trip.median,
+            p.round_trip.p99,
+            rps_per_worker,
+        );
+    }
+    println!();
+}
+
+fn export_results(results: &ScaleResults, path: &str) -> Result<()> {
+    let json = serde_json::to_string_pretty(results)?;
+    std::fs::write(path, json)?;
+    info!("Scale results exported to: {}", path);
+    Ok(())
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let worker_counts = parse_worker_counts(&args.worker_counts)?;
+    let parallelization_mode: ParallelizationMode = args
+        .parallelization_mode
+        .parse()
+        .map_err(|e: Box<dyn std::error::Error>| anyhow::anyhow!("{e}"))?;
+
+    let pools_config = WorkerPoolsConfig::load_from_file(&args.base_config)
+        .with_context(|| format!("failed to load base config: {}", args.base_config.display()))?;
+    let (pool_name, pool_config) = validate_single_pool(&pools_config)?;
+
+    info!("Pool: {} (algorithm: {})", pool_name, pool_config.algorithm);
+    info!("Worker counts: {:?}", worker_counts);
+    info!("Requests per run: {}", args.num_requests);
+
+    let requests = load_requests(args.requests_file.as_deref())?;
+    let solver_url = format!("http://127.0.0.1:{}", args.http_port);
+
+    let mut points = Vec::new();
+
+    for &workers in &worker_counts {
+        println!("\n--- Testing with {} worker(s) ---\n", workers);
+
+        let fynd = build_solver(&args, &pool_name, &pool_config, workers)
+            .with_context(|| format!("failed to build solver with {workers} workers"))?;
+        let handle = fynd.server_handle();
+        let server_task = tokio::spawn(fynd.run());
+
+        let result =
+            run_iteration(&solver_url, &parallelization_mode, &requests, &args, workers).await;
+
+        handle.stop(true).await;
+        if let Err(e) = server_task.await {
+            tracing::warn!("Server task join error: {e}");
+        }
+
+        match result {
+            Ok(point) => points.push(point),
+            Err(e) => {
+                tracing::error!("Iteration with {workers} workers failed: {e}");
+            }
+        }
+    }
+
+    if points.is_empty() {
+        bail!("all iterations failed; no results to report");
+    }
+
+    print_summary(&pool_name, &pool_config.algorithm, &args, &points);
+
+    if let Some(ref path) = args.output_file {
+        let results = ScaleResults {
+            config: ScaleConfig {
+                base_config: args.base_config.display().to_string(),
+                worker_counts,
+                num_requests: args.num_requests,
+                parallelization_mode: args.parallelization_mode.clone(),
+                warmup_secs: args.warmup_secs,
+                pool_name: pool_name.clone(),
+                algorithm: pool_config.algorithm.clone(),
+            },
+            points,
+        };
+        export_results(&results, path)?;
+    }
+
+    Ok(())
+}
+
+async fn run_iteration(
+    solver_url: &str,
+    mode: &ParallelizationMode,
+    requests: &[SwapRequest],
+    args: &Args,
+    workers: usize,
+) -> Result<ScalePoint> {
+    let timeout = Duration::from_secs(args.health_timeout_secs);
+    wait_for_health(solver_url, timeout).await?;
+
+    info!("Solver healthy, warming up for {}s...", args.warmup_secs);
+    tokio::time::sleep(Duration::from_secs(args.warmup_secs)).await;
+
+    let client = Arc::new(
+        FyndClientBuilder::new(solver_url, "")
+            .build_quote_only()
+            .map_err(|e| anyhow::anyhow!("{e}"))?,
+    );
+
+    let benchmark_start = Instant::now();
+    let RunnerResults { round_trip_times, solve_times, successful_requests, .. } = mode
+        .run(Arc::clone(&client), requests, args.num_requests)
+        .await;
+    let total_duration_ms = benchmark_start.elapsed().as_millis() as u64;
+
+    let failed_requests = args.num_requests - successful_requests;
+
+    if successful_requests == 0 {
+        bail!("no successful requests for {workers} workers");
+    }
+
+    let throughput_rps = if total_duration_ms > 0 {
+        (successful_requests as f64 * 1000.0) / total_duration_ms as f64
+    } else {
+        0.0
+    };
+
+    let round_trip =
+        TimingStats::from_measurements(&round_trip_times).context("no round-trip timing data")?;
+    let solve_time =
+        TimingStats::from_measurements(&solve_times).context("no solve-time timing data")?;
+
+    Ok(ScalePoint {
+        total_workers: workers,
+        throughput_rps,
+        total_duration_ms,
+        successful_requests,
+        failed_requests,
+        round_trip,
+        solve_time,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_worker_counts_valid() {
+        let counts = parse_worker_counts("1,2,4,8,16").unwrap();
+        assert_eq!(counts, vec![1, 2, 4, 8, 16]);
+    }
+
+    #[test]
+    fn parse_worker_counts_single() {
+        let counts = parse_worker_counts("4").unwrap();
+        assert_eq!(counts, vec![4]);
+    }
+
+    #[test]
+    fn parse_worker_counts_with_spaces() {
+        let counts = parse_worker_counts("1, 2, 4").unwrap();
+        assert_eq!(counts, vec![1, 2, 4]);
+    }
+
+    #[test]
+    fn parse_worker_counts_zero_rejected() {
+        let err = parse_worker_counts("1,0,4").unwrap_err();
+        assert!(err.to_string().contains("must be >= 1"));
+    }
+
+    #[test]
+    fn parse_worker_counts_non_numeric() {
+        assert!(parse_worker_counts("1,abc,4").is_err());
+    }
+
+    #[test]
+    fn validate_single_pool_empty() {
+        let config = WorkerPoolsConfig { pools: HashMap::new() };
+        let err = validate_single_pool(&config).unwrap_err();
+        assert!(err.to_string().contains("no pools"));
+    }
+
+    #[test]
+    fn validate_single_pool_one() {
+        let mut pools = HashMap::new();
+        pools.insert(
+            "test_pool".to_string(),
+            PoolConfig {
+                algorithm: "most_liquid".to_string(),
+                num_workers: 4,
+                task_queue_capacity: 1000,
+                min_hops: 1,
+                max_hops: 3,
+                timeout_ms: 100,
+                max_routes: None,
+            },
+        );
+        let config = WorkerPoolsConfig { pools };
+        let (name, pool) = validate_single_pool(&config).unwrap();
+        assert_eq!(name, "test_pool");
+        assert_eq!(pool.algorithm, "most_liquid");
+        assert_eq!(pool.num_workers, 4);
+    }
+
+    #[test]
+    fn validate_single_pool_two() {
+        let mut pools = HashMap::new();
+        pools.insert(
+            "a".to_string(),
+            PoolConfig {
+                algorithm: "most_liquid".to_string(),
+                num_workers: 4,
+                task_queue_capacity: 1000,
+                min_hops: 1,
+                max_hops: 3,
+                timeout_ms: 100,
+                max_routes: None,
+            },
+        );
+        pools.insert(
+            "b".to_string(),
+            PoolConfig {
+                algorithm: "dijkstra".to_string(),
+                num_workers: 2,
+                task_queue_capacity: 500,
+                min_hops: 1,
+                max_hops: 2,
+                timeout_ms: 200,
+                max_routes: Some(10),
+            },
+        );
+        let config = WorkerPoolsConfig { pools };
+        let err = validate_single_pool(&config).unwrap_err();
+        assert!(err.to_string().contains("2 pools"));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `scale` subcommand to `fynd-benchmark` for measuring throughput scaling across worker counts
- Add benchmark results doc page with 3-hop CPU scaling data (2-hop results pending)
- Fix `FyndClient::health()` to handle 503 responses that return `HealthStatus` JSON (during solver startup)
- Fix `bench-remote.sh`: strip URL protocol prefixes, exclude `node_modules/` at any depth, add ctrl+c support

## Benchmark Results (3-hop, most_liquid)

| Workers | Throughput (req/s) | Median RT (ms) | P99 RT (ms) |
| ------: | -----------------: | -------------: | ----------: |
|       1 |              66.68 |            714 |         884 |
|       4 |             240.02 |            198 |         256 |
|       8 |             469.44 |             99 |         136 |
|      16 |             820.75 |             53 |          91 |
|      24 |            1122.21 |             37 |          73 |
|      32 |            1237.47 |             31 |          78 |

24 workers crosses the 1000 req/s target for 3-hop routing.

## Test plan
- [x] 3-hop benchmark completed on `c7a.8xlarge` (32 vCPU) with 10k requests per iteration
- [x] 2-hop benchmark in progress — results will be added in a follow-up commit
- [ ] Existing unit tests pass (`cargo test -p fynd-benchmark`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)