### PR TITLE
refactor: expose graph types as experimental API in fynd-core

### DIFF
--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -34,6 +34,9 @@ reqwest.workspace = true
 tokio-tungstenite.workspace = true
 alloy = { workspace = true, features = ["sol-types"] }
 
+[features]
+experimental = []
+
 [dev-dependencies]
 rstest.workspace = true
 tracing-subscriber.workspace = true

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -9,14 +9,17 @@ use tycho_simulation::{tycho_core::traits::FeePriceGetter, tycho_ethereum::gas::
 use crate::feed::market_data::MarketData;
 
 // TODO: Refactor gas price fetching into a `DerivedComputation`.
-pub(crate) struct GasPriceFetcher<C: FeePriceGetter<FeePrice = BlockGasPrice>> {
+/// Periodically fetches the latest block gas price from an RPC client and writes it
+/// into the shared market data.
+pub struct GasPriceFetcher<C: FeePriceGetter<FeePrice = BlockGasPrice>> {
     client: C,
     refresh_interval: Duration,
     shared_market_data: MarketData,
 }
 
 impl<C: FeePriceGetter<FeePrice = BlockGasPrice>> GasPriceFetcher<C> {
-    pub(crate) fn new(
+    /// Creates a new fetcher that refreshes gas prices at the given interval.
+    pub fn new(
         client: C,
         shared_market_data: MarketData,
         refresh_interval: Duration,
@@ -24,7 +27,8 @@ impl<C: FeePriceGetter<FeePrice = BlockGasPrice>> GasPriceFetcher<C> {
         Self { client, refresh_interval, shared_market_data }
     }
 
-    pub(crate) async fn run(&mut self) {
+    /// Runs the refresh loop indefinitely; intended to be spawned in a dedicated task.
+    pub async fn run(&mut self) {
         let mut ticker = interval(self.refresh_interval);
         // Skip missed ticks rather than catching up — fetches are best-effort.
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -13,7 +13,7 @@ pub mod tycho_feed;
 
 /// Configuration for the TychoFeed.
 #[derive(Debug, Clone)]
-pub(crate) struct TychoFeedConfig {
+pub struct TychoFeedConfig {
     /// Tycho WebSocket URL.
     pub(crate) tycho_url: String,
     /// Blockchain to connect to.
@@ -50,7 +50,8 @@ pub(crate) struct TychoFeedConfig {
 }
 
 impl TychoFeedConfig {
-    pub(crate) fn new(
+    /// Creates a new config with the given connection parameters and sensible defaults.
+    pub fn new(
         tycho_url: String,
         chain: Chain,
         tycho_api_key: Option<String>,
@@ -74,32 +75,38 @@ impl TychoFeedConfig {
         }
     }
 
-    pub(crate) fn tvl_buffer_ratio(mut self, tvl_buffer_ratio: f64) -> Self {
+    /// Sets the TVL hysteresis buffer ratio (lower bound = `min_tvl / ratio`).
+    pub fn tvl_buffer_ratio(mut self, tvl_buffer_ratio: f64) -> Self {
         self.tvl_buffer_ratio = tvl_buffer_ratio;
         self
     }
 
-    pub(crate) fn reconnect_delay(mut self, reconnect_delay: Duration) -> Self {
+    /// Sets the delay before reconnecting after a connection failure.
+    pub fn reconnect_delay(mut self, reconnect_delay: Duration) -> Self {
         self.reconnect_delay = reconnect_delay;
         self
     }
 
-    pub(crate) fn min_token_quality(mut self, min_token_quality: i32) -> Self {
+    /// Sets the minimum token quality filter.
+    pub fn min_token_quality(mut self, min_token_quality: i32) -> Self {
         self.min_token_quality = min_token_quality;
         self
     }
 
-    pub(crate) fn traded_n_days_ago(mut self, days: u64) -> Self {
+    /// Only includes tokens traded within the given number of days.
+    pub fn traded_n_days_ago(mut self, days: u64) -> Self {
         self.traded_n_days_ago = Some(days);
         self
     }
 
-    pub(crate) fn blocklisted_components(mut self, components: HashSet<String>) -> Self {
+    /// Sets the component IDs to exclude from the Tycho stream.
+    pub fn blocklisted_components(mut self, components: HashSet<String>) -> Self {
         self.blocklisted_components = components;
         self
     }
 
-    pub(crate) fn partial_blocks(mut self, enabled: bool) -> Self {
+    /// Enables or disables partial block (flashblock) updates from the stream.
+    pub fn partial_blocks(mut self, enabled: bool) -> Self {
         self.partial_blocks = enabled;
         self
     }
@@ -107,7 +114,7 @@ impl TychoFeedConfig {
 
 /// Errors that can occur in the indexer.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum DataFeedError {
+pub enum DataFeedError {
     /// Configuration error.
     #[error("configuration error: {0}")]
     Config(String),

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -38,7 +38,7 @@ use crate::{
 /// - Update MarketState (holds exclusive write access)
 /// - Broadcast MarketEvents to all subscribed Solvers
 /// - Periodically refresh gas prices from RPC
-pub(crate) struct TychoFeed {
+pub struct TychoFeed {
     /// Configuration.
     config: TychoFeedConfig,
     /// Shared market data (we have write access).
@@ -54,14 +54,14 @@ impl TychoFeed {
     ///
     /// * `config` - Indexer configuration
     /// * `market_data` - Shared market data reference
-    pub(crate) fn new(config: TychoFeedConfig, market_data: MarketData) -> Self {
+    pub fn new(config: TychoFeedConfig, market_data: MarketData) -> Self {
         let (event_tx, _event_rx) = broadcast::channel(1024);
 
         Self { config, market_data, event_tx }
     }
 
     /// Returns a new subscriber for market events.
-    pub(crate) fn subscribe(&self) -> broadcast::Receiver<MarketEvent> {
+    pub fn subscribe(&self) -> broadcast::Receiver<MarketEvent> {
         self.event_tx.subscribe()
     }
 
@@ -75,7 +75,7 @@ impl TychoFeed {
     ///
     /// This method runs indefinitely, reconnecting on failures.
     /// It is recommended to call this in a dedicated tokio task.
-    pub(crate) async fn run(self) -> Result<(), DataFeedError> {
+    pub async fn run(self) -> Result<(), DataFeedError> {
         info!(
             tycho_url = %self.config.tycho_url,
             protocols = ?self.config.protocols,

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -67,3 +67,29 @@ pub use worker_pool::{
     TaskQueueHandle,
 };
 pub use worker_pool_router::{config::WorkerPoolRouterConfig, SolverPoolHandle, WorkerPoolRouter};
+
+// Experimental: internal graph, feed, and derived-data types for downstream consumers
+// (e.g. atomic-searcher). Gated behind the `experimental` feature flag — this API is
+// unstable and may change between releases.
+/// Unstable, semver-exempt re-exports of internal graph, feed, and derived-data
+/// types for downstream consumers such as `atomic-searcher`.
+#[cfg(feature = "experimental")]
+pub mod experimental {
+    pub use crate::{
+        derived::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef},
+        feed::{
+            events::{EventError, MarketEvent, MarketEventHandler},
+            gas::GasPriceFetcher,
+            // `SharedMarketData`/`SharedMarketDataRef` were renamed to `MarketState`/`MarketData`
+            // on main (commit d89beb5). Re-export under the original names downstream expects.
+            market_data::{MarketData as SharedMarketDataRef, MarketState as SharedMarketData},
+            tycho_feed::TychoFeed,
+            TychoFeedConfig,
+        },
+        graph::{
+            petgraph::{PetgraphStableDiGraphManager, StableDiGraph},
+            GraphManager,
+        },
+        types::native_token,
+    };
+}


### PR DESCRIPTION
## Summary
- Adds an `experimental` feature flag to `fynd-core`
- Re-exports only the specific types needed by downstream consumers (e.g. searchers) through a new `fynd_core::experimental` module, rather than making the entire `graph` or `feed::events` modules public
- Keeps `graph` and `feed::events` as `pub(crate)` internally

### Exported types (behind `experimental` feature)

**Graph:** `GraphManager`, `PetgraphStableDiGraphManager`, `StableDiGraph`, `EdgeData`, `EdgeIndex`, `Path`, `GraphError`, `EdgeWeightFromSimAndDerived`, `EdgeWeightUpdaterWithDerived`

**Events:** `MarketEvent`, `MarketEventHandler`, `EventError`

### Usage
```toml
[dependencies]
fynd-core = { version = "...", features = ["experimental"] }
```
```rust
use fynd_core::experimental::{GraphManager, StableDiGraph, MarketEventHandler};
```

## Test plan
- [x] `cargo check -p fynd-core` passes (no feature)
- [x] `cargo check -p fynd-core --features experimental` passes
- [ ] CI passes