### PR TITLE
chore(ci): pre-build current rustdoc to fix experimental feature false positives

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -88,6 +88,26 @@ jobs:
             --workspace \
             --no-deps
 
+      - name: Build current rustdoc from full workspace
+        # Pre-build current rustdoc using the same workspace+lockfile approach as the baseline.
+        # This ensures both sides use identical feature resolution (workspace default features,
+        # no --all-features), preventing false positives from feature-gated APIs such as the
+        # `experimental` feature in fynd-rpc. Passing --current-rustdoc to cargo-semver-checks
+        # below bypasses its internal build, which may use a different feature set.
+        env:
+          CARGO_TERM_COLOR: never
+          RUSTC_BOOTSTRAP: "1"
+          RUSTDOCFLAGS: >-
+            -Z unstable-options
+            --document-private-items
+            --document-hidden-items
+            --output-format=json
+            --cap-lints=allow
+        run: |
+          cargo doc \
+            --workspace \
+            --no-deps
+
       - name: Check for breaking changes
         id: check
         env:
@@ -113,10 +133,17 @@ jobs:
               continue
             fi
 
+            CURRENT_JSON="target/doc/${RUSTDOC_NAME}.json"
+            if [ ! -f "${CURRENT_JSON}" ]; then
+              echo "Warning: current rustdoc for '${name}' not found, skipping"
+              continue
+            fi
+
             HAS_PACKAGES=true
             if ! cargo semver-checks \
               --package "${name}" \
               --baseline-rustdoc "${BASELINE_JSON}" \
+              --current-rustdoc "${CURRENT_JSON}" \
               >> semver-output.txt 2>&1; then
               BREAKING=true
             fi


### PR DESCRIPTION
## Summary

- `cargo semver-checks` builds the current crate internally when only `--baseline-rustdoc` is provided, and may use `--all-features` for that build
- The baseline is built with `cargo doc --workspace --no-deps` (workspace default features, no `experimental`), creating an asymmetry
- This causes `AppState`'s feature-gated fields and `AppState::new()`'s conditional parameters (both behind `#[cfg(feature = "experimental")]`) to appear as breaking changes on every PR
- Fix: add a "Build current rustdoc from full workspace" step that mirrors the baseline build exactly, then pass the pre-built JSON to `cargo semver-checks` via `--current-rustdoc` — bypassing its internal build and ensuring both sides use the same feature set

## Test plan

- [ ] Open a PR that does not touch `experimental`-gated code and confirm the semver check passes without a breaking-change comment
- [ ] Open a PR that adds a non-experimental public API change and confirm it is still caught correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)