### PR TITLE
fix: recalculate token price when any competing path pool changes

### DIFF
--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -441,15 +441,7 @@ impl TokenGasPriceComputation {
             }
         }
 
-        // Extend each token's path_components with all candidate path components so
-        // incremental recomputation fires when any competing path's pool changes.
-        for (token, (_, _, components)) in best_prices.iter_mut() {
-            if let Some(all_comps) = all_candidate_components.get(token) {
-                components.extend(all_comps.iter().cloned());
-            }
-        }
-
-        Ok((best_prices))
+        Ok((best_prices, block))
     }
 
     /// Attempts incremental recomputation for state-only changes.

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -376,6 +376,25 @@ impl TokenGasPriceComputation {
             paths_by_token.retain(|token, _| tokens.contains(token));
         }
 
+        // Collect all component IDs from every candidate path per token.
+        // This ensures path_components captures any pool that could flip which path is best,
+        // not just pools on the currently-selected path.
+        let all_candidate_components: HashMap<Address, HashSet<ComponentId>> = paths_by_token
+            .iter()
+            .map(|(token, candidates)| {
+                let components = candidates
+                    .iter()
+                    .flat_map(|c| {
+                        c.path
+                            .edge_data
+                            .iter()
+                            .map(|e| e.component_id.clone())
+                    })
+                    .collect::<HashSet<_>>();
+                (token.clone(), components)
+            })
+            .collect();
+
         // Sort each token's paths: lowest spread last (for popping)
         for paths in paths_by_token.values_mut() {
             paths.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
@@ -414,7 +433,23 @@ impl TokenGasPriceComputation {
             }
         }
 
-        Ok((best_prices, block))
+        // Extend each token's path_components with all candidate path components so
+        // incremental recomputation fires when any competing path's pool changes.
+        for (token, (_, _, components)) in best_prices.iter_mut() {
+            if let Some(all_comps) = all_candidate_components.get(token) {
+                components.extend(all_comps.iter().cloned());
+            }
+        }
+
+        // Extend each token's path_components with all candidate path components so
+        // incremental recomputation fires when any competing path's pool changes.
+        for (token, (_, _, components)) in best_prices.iter_mut() {
+            if let Some(all_comps) = all_candidate_components.get(token) {
+                components.extend(all_comps.iter().cloned());
+            }
+        }
+
+        Ok((best_prices))
     }
 
     /// Attempts incremental recomputation for state-only changes.
@@ -1071,6 +1106,134 @@ mod tests {
         assert_eq!(
             eth_price.numerator, eth_price.denominator,
             "gas token must have exact 1:1 price"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_path_components_includes_all_candidate_paths() {
+        // Diamond topology: two paths to token_a
+        //
+        //   pool_direct: ETH → token_a  (fee-free, ratio=2, lower spread → selected)
+        //   pool_indirect_1 + pool_indirect_2: ETH → token_b → token_a (higher spread)
+        //
+        // After full compute, token_a's path_components must include all three pool IDs
+        // even though only pool_direct is on the best path.
+        let eth = token(0, "ETH");
+        let token_a = token(1, "A");
+        let token_b = token(2, "B");
+
+        let (market, derived) = setup_test_env(vec![
+            ("pool_direct", &eth, &token_a, MockProtocolSim::new(2.0).with_gas(0)),
+            (
+                "pool_indirect_1",
+                &eth,
+                &token_b,
+                MockProtocolSim::new(3.0)
+                    .with_fee(0.1)
+                    .with_gas(0),
+            ),
+            ("pool_indirect_2", &token_b, &token_a, MockProtocolSim::new(1.0).with_gas(0)),
+        ])
+        .await;
+        let changed = ChangedComponents::default();
+
+        let computation = computation_for(&eth.address);
+        computation
+            .compute(&market, &derived, &changed)
+            .await
+            .unwrap();
+
+        // Inspect stored deps to verify path_components
+        let store = derived.read().await;
+        let deps = store
+            .token_prices_deps()
+            .expect("deps should be stored");
+        let entry = deps
+            .get(&token_a.address)
+            .expect("token_a should have deps");
+
+        assert!(
+            entry
+                .path_components
+                .contains("pool_direct"),
+            "path_components should contain pool_direct (best path)"
+        );
+        assert!(
+            entry
+                .path_components
+                .contains("pool_indirect_1"),
+            "path_components should contain pool_indirect_1 (competing path)"
+        );
+        assert!(
+            entry
+                .path_components
+                .contains("pool_indirect_2"),
+            "path_components should contain pool_indirect_2 (competing path)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_incremental_recompute_triggered_by_competing_path_pool() {
+        // Same diamond topology as above.
+        // After full compute, changing pool_indirect_1 (not on best path) must
+        // put token_a in tokens_to_recompute because it's now in path_components.
+        let eth = token(0, "ETH");
+        let token_a = token(1, "A");
+        let token_b = token(2, "B");
+
+        let (market, derived) = setup_test_env(vec![
+            ("pool_direct", &eth, &token_a, MockProtocolSim::new(2.0).with_gas(0)),
+            (
+                "pool_indirect_1",
+                &eth,
+                &token_b,
+                MockProtocolSim::new(3.0)
+                    .with_fee(0.1)
+                    .with_gas(0),
+            ),
+            ("pool_indirect_2", &token_b, &token_a, MockProtocolSim::new(1.0).with_gas(0)),
+        ])
+        .await;
+
+        // Full compute to store deps
+        let full_changed = ChangedComponents::default();
+        let computation = computation_for(&eth.address);
+        computation
+            .compute(&market, &derived, &full_changed)
+            .await
+            .unwrap();
+
+        // Incremental change: only pool_indirect_1 updated
+        let incremental_changed = ChangedComponents {
+            added: HashMap::new(),
+            removed: vec![],
+            updated: vec!["pool_indirect_1".to_string()],
+            is_full_recompute: false,
+        };
+
+        let store = derived.read().await;
+        let deps = store
+            .token_prices_deps()
+            .expect("deps should be stored");
+        let changed_ids = incremental_changed.all_changed_ids();
+
+        let tokens_to_recompute: HashSet<Address> = deps
+            .iter()
+            .filter(|(_, entry)| {
+                !entry
+                    .path_components
+                    .is_disjoint(&changed_ids)
+            })
+            .map(|(addr, _)| addr.clone())
+            .collect();
+
+        assert!(
+            tokens_to_recompute.contains(&token_a.address),
+            "token_a should be scheduled for recomputation when pool_indirect_1 changes"
+        );
+        assert!(
+            tokens_to_recompute.contains(&token_b.address),
+            "token_b should be scheduled for recomputation when pool_indirect_1 changes"
         );
     }
 

--- a/fynd-core/src/derived/types.rs
+++ b/fynd-core/src/derived/types.rs
@@ -55,13 +55,12 @@ pub type TokenGasPrices = HashMap<TokenGasPriceKey, Price>;
 pub struct TokenPriceEntry {
     /// The computed mid-price relative to gas token.
     pub price: Price,
-    /// Components (pool IDs) used in the selected path.
+    /// Components (pool IDs) from all candidate paths considered for this token.
     ///
     /// Used for invalidation: if any of these components change,
-    /// this token's price needs recomputation.
-    /// TODO: Currently, for optimization, we only consider in path_components the path used to
-    /// calculate the best price. If another path that affects this token suddenly becomes the best
-    /// we will not know until the Solver restarts.
+    /// this token's price needs recomputation. Includes pools from all discovered
+    /// paths, not just the selected best path, so a change in any competing pool
+    /// triggers recomputation.
     pub path_components: HashSet<ComponentId>,
 }
 

--- a/scripts/check-doc-snippets.sh
+++ b/scripts/check-doc-snippets.sh
@@ -8,8 +8,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Format: "source_file:anchor_name:doc_file"
 SNIPPETS=(
-    "clients/rust/examples/quote.rs:quote-rust:docs/get-started/quickstart/README.md"
-    "clients/typescript/examples/tutorial/main.ts:quote-typescript:docs/get-started/quickstart/README.md"
+    "clients/rust/examples/quote.rs:quote-rust:docs/get-started/quickstart.md"
+    "clients/typescript/examples/tutorial/main.ts:quote-typescript:docs/get-started/quickstart.md"
     "fynd-core/examples/custom_algorithm.rs:custom-algo-impl:docs/guides/custom-algorithm.md"
     "fynd-core/examples/custom_algorithm.rs:custom-algo-wire:docs/guides/custom-algorithm.md"
 )


### PR DESCRIPTION
TokenPriceEntry::path_components previously only tracked pools from the currently-selected best path. If a competing (non-best) path's pool changed and became better, the system wouldn't know to recompute the token's price until a restart.

In token_gas_price.rs, after finding the best price for each token, collect component IDs from all candidate paths (not just the winner) and merge them into path_components. This ensures recalculation fires whenever any pool that could affect which path is best changes.

**[Benchmarks]**
This change introduces a ~**10 ms overhead (~24%) on the background `token_gas_price` calculation.** 
I ran a simple comparison by executing both branches and measuring elapsed_ms for token price recomputation across 260 block updates.
main: 43.6 ms mean 
price_recalc: 54.0 ms mean 


I also benchmarked **route quality** with both solvers running:
Route match rate: 98/100
price_recalc found 2 better routes (up to +0.02 bps output)
Gas estimates matched in 98/100 cases; in 2 cases price_recalc was higher (max +75%)

No influence on the **solve_time** according to the benchmarks.