### PR TITLE
feat: harden fynd-core public API

### DIFF
--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.13.0"
+    "version": "0.22.0"
   },
   "paths": {
     "/v1/health": {

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -91,14 +91,14 @@ impl AlgorithmConfig {
         self.max_hops
     }
 
+    /// Returns the maximum number of paths to simulate.
+    pub fn max_routes(&self) -> Option<usize> {
+        self.max_routes
+    }
+
     /// Returns the timeout for solving.
     pub fn timeout(&self) -> Duration {
         self.timeout
-    }
-
-    /// Returns the maximum number of routes to simulate.
-    pub fn max_routes(&self) -> Option<usize> {
-        self.max_routes
     }
 }
 
@@ -176,13 +176,16 @@ pub trait Algorithm: Send + Sync {
 }
 
 /// Errors that can occur during route finding.
+#[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error, PartialEq)]
 pub enum AlgorithmError {
     /// Invalid algorithm configuration (programmer error).
+    #[non_exhaustive]
     #[error("invalid configuration: {reason}")]
     InvalidConfiguration { reason: String },
 
     /// No path exists between the tokens.
+    #[non_exhaustive]
     #[error("no path from {from:?} to {to:?}: {reason}")]
     NoPath { from: Address, to: Address, reason: NoPathReason },
 
@@ -191,6 +194,7 @@ pub enum AlgorithmError {
     InsufficientLiquidity,
 
     /// Route finding timed out.
+    #[non_exhaustive]
     #[error("timeout after {elapsed_ms}ms")]
     Timeout { elapsed_ms: u64 },
 
@@ -199,10 +203,12 @@ pub enum AlgorithmError {
     ExactOutNotSupported,
 
     /// Simulation failed for a specific component.
+    #[non_exhaustive]
     #[error("simulation failed for {component_id}: {error}")]
     SimulationFailed { component_id: String, error: String },
 
     /// Required data not found in market.
+    #[non_exhaustive]
     #[error("{kind} not found{}", id.as_ref().map(|i| format!(": {i}")).unwrap_or_default())]
     DataNotFound { kind: &'static str, id: Option<String> },
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -119,10 +119,10 @@ impl MostLiquidAlgorithm {
     /// Creates a new MostLiquidAlgorithm with custom settings.
     pub fn with_config(config: AlgorithmConfig) -> Result<Self, AlgorithmError> {
         Ok(Self {
-            min_hops: config.min_hops,
-            max_hops: config.max_hops,
-            timeout: config.timeout,
-            max_routes: config.max_routes,
+            min_hops: config.min_hops(),
+            max_hops: config.max_hops(),
+            timeout: config.timeout(),
+            max_routes: config.max_routes(),
         })
     }
 

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -20,7 +20,14 @@ pub type ComputationId = &'static str;
 #[error("conflicting requirement: '{id}' cannot be both fresh and stale")]
 pub struct RequirementConflict {
     /// The computation ID that was added with conflicting freshness.
-    pub id: ComputationId,
+    pub(crate) id: ComputationId,
+}
+
+impl RequirementConflict {
+    /// Returns the conflicting computation ID.
+    pub fn id(&self) -> ComputationId {
+        self.id
+    }
 }
 
 /// Requirements for derived data computations.
@@ -48,15 +55,25 @@ pub struct RequirementConflict {
 #[derive(Debug, Clone, Default)]
 pub struct ComputationRequirements {
     /// Computations that must be from the current block.
-    pub require_fresh: HashSet<ComputationId>,
+    pub(crate) require_fresh: HashSet<ComputationId>,
     /// Computations that can use data from any past block.
     ///
     /// TODO: Stale data can be dangerous if stale for too long. In the future, associate staleness
     /// to a block limit might be implemented.
-    pub allow_stale: HashSet<ComputationId>,
+    pub(crate) allow_stale: HashSet<ComputationId>,
 }
 
 impl ComputationRequirements {
+    /// Returns the set of computations that require fresh data.
+    pub fn fresh_requirements(&self) -> &HashSet<ComputationId> {
+        &self.require_fresh
+    }
+
+    /// Returns the set of computations that allow stale data.
+    pub fn stale_requirements(&self) -> &HashSet<ComputationId> {
+        &self.allow_stale
+    }
+
     /// Creates empty requirements (no derived data needed).
     pub fn none() -> Self {
         Self::default()

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -86,11 +86,11 @@ pub type SharedDerivedDataRef = Arc<RwLock<DerivedData>>;
 #[derive(Debug, Clone)]
 pub struct ComputationManagerConfig {
     /// Gas token address (e.g., WETH) for token price computation.
-    pub gas_token: Address,
+    gas_token: Address,
     /// Max hop count for token gas price computation.
-    pub max_hop: usize,
+    max_hop: usize,
     /// Slippage threshold for pool depth computation (0.0 < threshold < 1.0).
-    pub depth_slippage_threshold: f64,
+    depth_slippage_threshold: f64,
 }
 
 impl ComputationManagerConfig {
@@ -115,6 +115,21 @@ impl ComputationManagerConfig {
     pub fn with_gas_token(mut self, gas_token: Address) -> Self {
         self.gas_token = gas_token;
         self
+    }
+
+    /// Returns the gas token address.
+    pub fn gas_token(&self) -> &Address {
+        &self.gas_token
+    }
+
+    /// Returns the max hop count.
+    pub fn max_hop(&self) -> usize {
+        self.max_hop
+    }
+
+    /// Returns the depth slippage threshold.
+    pub fn depth_slippage_threshold(&self) -> f64 {
+        self.depth_slippage_threshold
     }
 }
 

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -9,14 +9,14 @@ use crate::feed::{market_data::SharedMarketDataRef, DataFeedError};
 // TODO: Refactor gas price fetching into a `DerivedComputation`.
 pub const GAS_PRICE_DEPENDENCY_ID: &str = "gas_price";
 
-pub struct GasPriceFetcher<C: FeePriceGetter<FeePrice = BlockGasPrice>> {
+pub(crate) struct GasPriceFetcher<C: FeePriceGetter<FeePrice = BlockGasPrice>> {
     client: C,
     signal_rx: mpsc::Receiver<oneshot::Sender<()>>,
     shared_market_data: SharedMarketDataRef,
 }
 
 impl<C: FeePriceGetter<FeePrice = BlockGasPrice>> GasPriceFetcher<C> {
-    pub fn new(
+    pub(crate) fn new(
         client: C,
         shared_market_data: SharedMarketDataRef,
     ) -> (Self, mpsc::Sender<oneshot::Sender<()>>) {
@@ -24,7 +24,7 @@ impl<C: FeePriceGetter<FeePrice = BlockGasPrice>> GasPriceFetcher<C> {
         (Self { client, signal_rx, shared_market_data }, signal_tx)
     }
 
-    pub async fn run(&mut self) -> Result<(), DataFeedError> {
+    pub(crate) async fn run(&mut self) -> Result<(), DataFeedError> {
         loop {
             let update_tx = self
                 .signal_rx

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -12,8 +12,8 @@ pub mod tycho_feed;
 
 /// Configuration for the TychoFeed.
 #[derive(Debug, Clone)]
-pub struct TychoFeedConfig {
-    /// Tycho URL.
+pub(crate) struct TychoFeedConfig {
+    /// Tycho WebSocket URL.
     pub(crate) tycho_url: String,
     /// Blockchain to connect to.
     pub(crate) chain: Chain,
@@ -48,7 +48,7 @@ pub struct TychoFeedConfig {
 }
 
 impl TychoFeedConfig {
-    pub fn new(
+    pub(crate) fn new(
         tycho_url: String,
         chain: Chain,
         tycho_api_key: Option<String>,
@@ -72,32 +72,32 @@ impl TychoFeedConfig {
         }
     }
 
-    pub fn tvl_buffer_ratio(mut self, tvl_buffer_ratio: f64) -> Self {
+    pub(crate) fn tvl_buffer_ratio(mut self, tvl_buffer_ratio: f64) -> Self {
         self.tvl_buffer_ratio = tvl_buffer_ratio;
         self
     }
 
-    pub fn gas_refresh_interval(mut self, gas_refresh_interval: Duration) -> Self {
+    pub(crate) fn gas_refresh_interval(mut self, gas_refresh_interval: Duration) -> Self {
         self.gas_refresh_interval = gas_refresh_interval;
         self
     }
 
-    pub fn reconnect_delay(mut self, reconnect_delay: Duration) -> Self {
+    pub(crate) fn reconnect_delay(mut self, reconnect_delay: Duration) -> Self {
         self.reconnect_delay = reconnect_delay;
         self
     }
 
-    pub fn min_token_quality(mut self, min_token_quality: i32) -> Self {
+    pub(crate) fn min_token_quality(mut self, min_token_quality: i32) -> Self {
         self.min_token_quality = min_token_quality;
         self
     }
 
-    pub fn traded_n_days_ago(mut self, days: u64) -> Self {
+    pub(crate) fn traded_n_days_ago(mut self, days: u64) -> Self {
         self.traded_n_days_ago = Some(days);
         self
     }
 
-    pub fn blacklisted_components(mut self, components: HashSet<String>) -> Self {
+    pub(crate) fn blacklisted_components(mut self, components: HashSet<String>) -> Self {
         self.blacklisted_components = components;
         self
     }
@@ -105,7 +105,7 @@ impl TychoFeedConfig {
 
 /// Errors that can occur in the indexer.
 #[derive(Debug, thiserror::Error)]
-pub enum DataFeedError {
+pub(crate) enum DataFeedError {
     #[error("gas price fetcher error: {0}")]
     GasPriceFetcherError(String),
 

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -44,7 +44,7 @@ use crate::{
 /// - Update SharedMarketData (holds exclusive write access)
 /// - Broadcast MarketEvents to all subscribed Solvers
 /// - Periodically refresh gas prices from RPC
-pub struct TychoFeed {
+pub(crate) struct TychoFeed {
     /// Configuration.
     config: TychoFeedConfig,
     /// Shared market data (we have write access).
@@ -62,20 +62,20 @@ impl TychoFeed {
     ///
     /// * `config` - Indexer configuration
     /// * `market_data` - Shared market data reference
-    pub fn new(config: TychoFeedConfig, market_data: SharedMarketDataRef) -> Self {
+    pub(crate) fn new(config: TychoFeedConfig, market_data: SharedMarketDataRef) -> Self {
         let (event_tx, _event_rx) = broadcast::channel(1024);
 
         Self { config, market_data, event_tx, gas_price_worker_signal_tx: None }
     }
 
     /// Returns a new subscriber for market events.
-    pub fn subscribe(&self) -> broadcast::Receiver<MarketEvent> {
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<MarketEvent> {
         self.event_tx.subscribe()
     }
 
     /// Sets the signal channel to notify the gas price worker to refresh gas price.
     /// If not set, gas price refresh will not be triggered by the TychoFeed.
-    pub fn with_gas_price_worker_signal_tx(
+    pub(crate) fn with_gas_price_worker_signal_tx(
         self,
         gas_price_worker_signal_tx: mpsc::Sender<oneshot::Sender<()>>,
     ) -> Self {
@@ -92,7 +92,7 @@ impl TychoFeed {
     ///
     /// This method runs indefinitely, reconnecting on failures.
     /// It is recommended to call this in a dedicated tokio task.
-    pub async fn run(self) -> Result<(), DataFeedError> {
+    pub(crate) async fn run(self) -> Result<(), DataFeedError> {
         info!(
             tycho_url = %self.config.tycho_url,
             protocols = ?self.config.protocols,

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -88,25 +88,111 @@ fn default_algo_timeout_ms() -> u64 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolConfig {
     /// Algorithm name for this pool (e.g., `"most_liquid"`).
-    pub algorithm: String,
+    algorithm: String,
     /// Number of worker threads for this pool.
     #[serde(default = "num_cpus::get")]
-    pub num_workers: usize,
+    num_workers: usize,
     /// Task queue capacity for this pool.
     #[serde(default = "default_task_queue_capacity")]
-    pub task_queue_capacity: usize,
+    task_queue_capacity: usize,
     /// Minimum hops to search (must be >= 1).
     #[serde(default = "default_min_hops")]
-    pub min_hops: usize,
+    min_hops: usize,
     /// Maximum hops to search.
     #[serde(default = "default_max_hops")]
-    pub max_hops: usize,
+    max_hops: usize,
     /// Timeout for solving in milliseconds.
     #[serde(default = "default_algo_timeout_ms")]
-    pub timeout_ms: u64,
+    timeout_ms: u64,
     /// Maximum number of paths to simulate per solve. `None` simulates all scored paths.
     #[serde(default)]
-    pub max_routes: Option<usize>,
+    max_routes: Option<usize>,
+}
+
+impl PoolConfig {
+    /// Creates a new pool config with the given algorithm name and defaults for all other fields.
+    pub fn new(algorithm: impl Into<String>) -> Self {
+        Self {
+            algorithm: algorithm.into(),
+            num_workers: num_cpus::get(),
+            task_queue_capacity: defaults::POOL_TASK_QUEUE_CAPACITY,
+            min_hops: defaults::POOL_MIN_HOPS,
+            max_hops: defaults::POOL_MAX_HOPS,
+            timeout_ms: defaults::POOL_TIMEOUT_MS,
+            max_routes: None,
+        }
+    }
+
+    /// Returns the algorithm name.
+    pub fn algorithm(&self) -> &str {
+        &self.algorithm
+    }
+
+    /// Returns the number of worker threads.
+    pub fn num_workers(&self) -> usize {
+        self.num_workers
+    }
+
+    /// Sets the number of worker threads.
+    pub fn with_num_workers(mut self, num_workers: usize) -> Self {
+        self.num_workers = num_workers;
+        self
+    }
+
+    /// Sets the task queue capacity.
+    pub fn with_task_queue_capacity(mut self, task_queue_capacity: usize) -> Self {
+        self.task_queue_capacity = task_queue_capacity;
+        self
+    }
+
+    /// Sets the minimum hops.
+    pub fn with_min_hops(mut self, min_hops: usize) -> Self {
+        self.min_hops = min_hops;
+        self
+    }
+
+    /// Sets the maximum hops.
+    pub fn with_max_hops(mut self, max_hops: usize) -> Self {
+        self.max_hops = max_hops;
+        self
+    }
+
+    /// Sets the timeout in milliseconds.
+    pub fn with_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.timeout_ms = timeout_ms;
+        self
+    }
+
+    /// Sets the maximum number of routes to simulate.
+    pub fn with_max_routes(mut self, max_routes: Option<usize>) -> Self {
+        self.max_routes = max_routes;
+        self
+    }
+
+    /// Returns the task queue capacity.
+    pub fn task_queue_capacity(&self) -> usize {
+        self.task_queue_capacity
+    }
+
+    /// Returns the minimum hops.
+    pub fn min_hops(&self) -> usize {
+        self.min_hops
+    }
+
+    /// Returns the maximum hops.
+    pub fn max_hops(&self) -> usize {
+        self.max_hops
+    }
+
+    /// Returns the timeout in milliseconds.
+    pub fn timeout_ms(&self) -> u64 {
+        self.timeout_ms
+    }
+
+    /// Returns the maximum number of routes to simulate.
+    pub fn max_routes(&self) -> Option<usize> {
+        self.max_routes
+    }
 }
 
 /// Error returned by [`Solver::wait_until_ready`].
@@ -117,6 +203,7 @@ pub struct WaitReadyError {
 }
 
 /// Error returned by [`FyndBuilder::build`].
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum SolverBuildError {
     /// The Ethereum RPC client could not be created (e.g. malformed URL).
@@ -171,7 +258,7 @@ struct CustomPoolEntry {
 }
 
 /// Builder for assembling the full solver pipeline.
-///
+#[must_use = "a builder does nothing until .build() is called"]
 /// Configures the Tycho market-data feed, gas price fetcher, derived-data
 /// computation manager, one or more worker pools, encoder, and router.
 pub struct FyndBuilder {
@@ -347,13 +434,13 @@ impl FyndBuilder {
     pub fn add_pool(mut self, name: impl Into<String>, config: &PoolConfig) -> Self {
         self.pools.push(PoolEntry::BuiltIn {
             name: name.into(),
-            algorithm: config.algorithm.clone(),
-            num_workers: config.num_workers,
-            task_queue_capacity: config.task_queue_capacity,
-            min_hops: config.min_hops,
-            max_hops: config.max_hops,
-            timeout_ms: config.timeout_ms,
-            max_routes: config.max_routes,
+            algorithm: config.algorithm().to_string(),
+            num_workers: config.num_workers(),
+            task_queue_capacity: config.task_queue_capacity(),
+            min_hops: config.min_hops(),
+            max_hops: config.max_hops(),
+            timeout_ms: config.timeout_ms(),
+            max_routes: config.max_routes(),
         });
         self
     }
@@ -629,19 +716,67 @@ impl Solver {
 /// Obtained via [`Solver::into_parts`].
 pub struct SolverParts {
     /// Routes quote requests across worker pools.
-    pub router: WorkerPoolRouter,
+    router: WorkerPoolRouter,
     /// One [`WorkerPool`] per configured algorithm pool.
-    pub worker_pools: Vec<WorkerPool>,
+    worker_pools: Vec<WorkerPool>,
     /// Live market snapshot shared across all components.
-    pub market_data: SharedMarketDataRef,
+    market_data: SharedMarketDataRef,
     /// Derived on-chain data (spot prices, depths, gas costs) shared across all components.
-    pub derived_data: SharedDerivedDataRef,
+    derived_data: SharedDerivedDataRef,
     /// Background task running the Tycho market-data feed.
-    pub feed_handle: JoinHandle<()>,
+    feed_handle: JoinHandle<()>,
     /// Background task polling the RPC node for gas prices.
-    pub gas_price_handle: JoinHandle<()>,
+    gas_price_handle: JoinHandle<()>,
     /// Background task running the computation manager.
-    pub computation_handle: JoinHandle<()>,
+    computation_handle: JoinHandle<()>,
     /// Send a unit value on this channel to trigger a graceful computation-manager shutdown.
-    pub computation_shutdown_tx: broadcast::Sender<()>,
+    computation_shutdown_tx: broadcast::Sender<()>,
+}
+
+impl SolverParts {
+    /// Returns a reference to the worker pools.
+    pub fn worker_pools(&self) -> &[WorkerPool] {
+        &self.worker_pools
+    }
+
+    /// Returns a reference to the shared market data.
+    pub fn market_data(&self) -> &SharedMarketDataRef {
+        &self.market_data
+    }
+
+    /// Returns a reference to the shared derived data.
+    pub fn derived_data(&self) -> &SharedDerivedDataRef {
+        &self.derived_data
+    }
+
+    /// Consumes the parts and returns the router.
+    pub fn into_router(self) -> WorkerPoolRouter {
+        self.router
+    }
+
+    /// Consumes the parts, returning all owned components.
+    #[allow(clippy::type_complexity)]
+    pub fn into_components(
+        self,
+    ) -> (
+        WorkerPoolRouter,
+        Vec<WorkerPool>,
+        SharedMarketDataRef,
+        SharedDerivedDataRef,
+        JoinHandle<()>,
+        JoinHandle<()>,
+        JoinHandle<()>,
+        broadcast::Sender<()>,
+    ) {
+        (
+            self.router,
+            self.worker_pools,
+            self.market_data,
+            self.derived_data,
+            self.feed_handle,
+            self.gas_price_handle,
+            self.computation_handle,
+            self.computation_shutdown_tx,
+        )
+    }
 }

--- a/fynd-core/src/types/constants.rs
+++ b/fynd-core/src/types/constants.rs
@@ -8,7 +8,7 @@ lazy_static! {
     ///
     /// These are the ERC-20 wrapped versions of each chain's native gas token
     /// (e.g., WETH on Ethereum, WBNB on BSC).
-    pub static ref NATIVE_TOKEN: HashMap<Chain, Address> = {
+    pub(crate) static ref NATIVE_TOKEN: HashMap<Chain, Address> = {
         let mut map = HashMap::new();
 
         // Ethereum Mainnet - WETH (0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2)
@@ -37,7 +37,14 @@ lazy_static! {
 #[derive(Debug, Clone, thiserror::Error)]
 #[error("native token not configured for chain: {chain:?}")]
 pub struct UnsupportedChainError {
-    pub chain: Chain,
+    pub(crate) chain: Chain,
+}
+
+impl UnsupportedChainError {
+    /// Returns the unsupported chain.
+    pub fn chain(&self) -> Chain {
+        self.chain
+    }
 }
 
 /// Returns the wrapped native token address for the given chain.

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -56,17 +56,21 @@ impl SolveTask {
 }
 
 /// Errors that can occur during solving.
+#[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum SolveError {
     /// No route found between the tokens.
+    #[non_exhaustive]
     #[error("no route found for order {order_id}")]
     NoRouteFound { order_id: String },
 
     /// Insufficient liquidity for the requested amount.
+    #[non_exhaustive]
     #[error("insufficient liquidity: need {required}, have {available}")]
     InsufficientLiquidity { required: BigUint, available: BigUint },
 
     /// Solving timed out.
+    #[non_exhaustive]
     #[error("solve timeout after {elapsed_ms}ms")]
     Timeout { elapsed_ms: u64 },
 
@@ -75,6 +79,7 @@ pub enum SolveError {
     AlgorithmError(String),
 
     /// Market data is too old.
+    #[non_exhaustive]
     #[error("market data stale: last update {age_ms}ms ago")]
     MarketDataStale { age_ms: u64 },
 

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -286,6 +286,7 @@ impl PermitDetails {
 ///
 /// Contains a solution for each order in the request, along with aggregate
 /// gas estimates and timing information.
+#[must_use]
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Quote {
@@ -461,6 +462,7 @@ pub enum OrderSide {
 }
 
 /// Errors that can occur when validating an [`Order`].
+#[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum OrderValidationError {
     #[error("token_in and token_out must be different")]
@@ -502,6 +504,7 @@ impl SingleOrderQuote {
 ///
 /// Contains the route to execute (if found), along with expected amounts,
 /// gas estimates, and status information.
+#[must_use]
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrderQuote {
@@ -537,11 +540,11 @@ pub struct OrderQuote {
     #[serde_as(as = "Option<DisplayFromStr>")]
     gas_price: Option<BigUint>,
     /// An encoded EVM transaction ready to be submitted on-chain.
-    pub transaction: Option<Transaction>,
+    pub(crate) transaction: Option<Transaction>,
     /// Address of the sender.
-    pub sender: Bytes,
+    pub(crate) sender: Bytes,
     /// Address of the receiver.
-    pub receiver: Bytes,
+    pub(crate) receiver: Bytes,
 }
 
 impl OrderQuote {
@@ -666,9 +669,20 @@ impl OrderQuote {
     pub fn transaction(&self) -> Option<&Transaction> {
         self.transaction.as_ref()
     }
+
+    /// Returns the sender address.
+    pub fn sender(&self) -> &Bytes {
+        &self.sender
+    }
+
+    /// Returns the receiver address.
+    pub fn receiver(&self) -> &Bytes {
+        &self.receiver
+    }
 }
 
 /// Status of an order solution.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum QuoteStatus {
@@ -743,6 +757,7 @@ impl BlockInfo {
 ///
 /// A route describes the path through liquidity pools to execute a swap.
 /// For multi-hop swaps, the output of each swap becomes the input of the next.
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Route {
     /// Ordered sequence of swaps to execute.
@@ -918,12 +933,15 @@ impl Route {
 }
 
 /// Errors that can occur when validating a [`Route`].
+#[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum RouteValidationError {
     #[error("route must contain at least one swap")]
     EmptyRoute,
+    #[non_exhaustive]
     #[error("swaps are not connected: {first_out} != {second_in}")]
     DisconnectedSwaps { first_out: Address, second_in: Address },
+    #[non_exhaustive]
     #[error(
         "unsupported cycle: token {token} appears more than once in route \
          {first} -> ... -> {last} (only first == last cycles are supported)"

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -185,6 +185,7 @@ impl WorkerPool {
 /// Use [`with_algorithm`](Self::with_algorithm) to plug in any type implementing
 /// [`Algorithm`](crate::algorithm::Algorithm) via a factory closure, bypassing the built-in
 /// registry entirely. See the `custom_algorithm` example for a full walkthrough.
+#[must_use = "a builder does nothing until .build() is called"]
 pub struct WorkerPoolBuilder {
     config: WorkerPoolConfig,
 }

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -60,7 +60,14 @@ pub(crate) struct SpawnWorkersParams {
 #[error("unknown algorithm '{name}'. Available: {}", AVAILABLE_ALGORITHMS.join(", "))]
 pub struct UnknownAlgorithmError {
     /// The algorithm name that was not found.
-    pub name: String,
+    pub(crate) name: String,
+}
+
+impl UnknownAlgorithmError {
+    /// Returns the algorithm name that was not found.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
 }
 
 /// Determines how a worker pool spawns its workers.

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -635,6 +635,8 @@ mod conversions {
                 fynd_core::QuoteStatus::InsufficientLiquidity => Self::InsufficientLiquidity,
                 fynd_core::QuoteStatus::Timeout => Self::Timeout,
                 fynd_core::QuoteStatus::NotReady => Self::NotReady,
+                // Fallback for future variants added to fynd_core::QuoteStatus.
+                _ => Self::NotReady,
             }
         }
     }

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -3,6 +3,7 @@
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
 use fynd_core::SolveError;
 pub use fynd_rpc_types::ErrorResponse;
+use tracing::warn;
 
 /// API error type that converts to HTTP responses.
 #[derive(Debug, thiserror::Error)]
@@ -57,6 +58,10 @@ impl ResponseError for ApiError {
                 SolveError::Internal(_) => "INTERNAL_ERROR",
                 SolveError::NotReady(_) => "NOT_READY",
                 SolveError::FailedEncoding(_) => "FAILED_ENCODING",
+                other => {
+                    warn!(?other, "unhandled SolveError variant");
+                    "INTERNAL_ERROR"
+                }
             },
             ApiError::ServiceOverloaded => "SERVICE_OVERLOADED",
             ApiError::Internal(_) => "INTERNAL_ERROR",

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -173,7 +173,7 @@ impl FyndRPCBuilder {
             .map_err(|e| anyhow::anyhow!("{}", e))?
             .into_parts();
 
-        for pool in &parts.worker_pools {
+        for pool in parts.worker_pools() {
             info!(
                 name = %pool.name(),
                 algorithm = %pool.algorithm(),
@@ -183,7 +183,7 @@ impl FyndRPCBuilder {
         }
 
         let health_tracker =
-            HealthTracker::new(Arc::clone(&parts.market_data), Arc::clone(&parts.derived_data))
+            HealthTracker::new(Arc::clone(parts.market_data()), Arc::clone(parts.derived_data()))
                 .with_gas_price_stale_threshold(self.gas_price_stale_threshold);
 
         #[cfg(feature = "experimental")]
@@ -192,11 +192,22 @@ impl FyndRPCBuilder {
             native_token(&chain).context("gas token not configured for chain")?
         };
 
+        let (
+            router,
+            worker_pools,
+            _market_data,
+            _derived_data,
+            feed_handle,
+            gas_price_handle,
+            computation_handle,
+            computation_shutdown_tx,
+        ) = parts.into_components();
+
         let app_state = AppState::new(
-            parts.router,
+            router,
             health_tracker,
             #[cfg(feature = "experimental")]
-            Arc::clone(&parts.derived_data),
+            Arc::clone(&_derived_data),
             #[cfg(feature = "experimental")]
             gas_token,
         );
@@ -220,11 +231,11 @@ impl FyndRPCBuilder {
         Ok(Fynd {
             server_handle,
             server_task,
-            worker_pools: parts.worker_pools,
-            feed_handle: parts.feed_handle,
-            gas_price_worker_handle: parts.gas_price_handle,
-            computation_manager_handle: parts.computation_handle,
-            computation_shutdown_tx: parts.computation_shutdown_tx,
+            worker_pools,
+            feed_handle,
+            gas_price_worker_handle: gas_price_handle,
+            computation_manager_handle: computation_handle,
+            computation_shutdown_tx,
         })
     }
 }

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -72,13 +72,13 @@ mod tests {
         "#;
         let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
         let pool = &config.pools["basic"];
-        assert_eq!(pool.algorithm, "most_liquid");
-        assert_eq!(pool.num_workers, num_cpus::get());
-        assert_eq!(pool.task_queue_capacity, defaults::POOL_TASK_QUEUE_CAPACITY);
-        assert_eq!(pool.min_hops, defaults::POOL_MIN_HOPS);
-        assert_eq!(pool.max_hops, defaults::POOL_MAX_HOPS);
-        assert_eq!(pool.timeout_ms, defaults::POOL_TIMEOUT_MS);
-        assert_eq!(pool.max_routes, None);
+        assert_eq!(pool.algorithm(), "most_liquid");
+        assert_eq!(pool.num_workers(), num_cpus::get());
+        assert_eq!(pool.task_queue_capacity(), defaults::POOL_TASK_QUEUE_CAPACITY);
+        assert_eq!(pool.min_hops(), defaults::POOL_MIN_HOPS);
+        assert_eq!(pool.max_hops(), defaults::POOL_MAX_HOPS);
+        assert_eq!(pool.timeout_ms(), defaults::POOL_TIMEOUT_MS);
+        assert_eq!(pool.max_routes(), None);
     }
 
     #[test]
@@ -95,13 +95,13 @@ mod tests {
         "#;
         let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
         let pool = &config.pools["custom"];
-        assert_eq!(pool.algorithm, "most_liquid");
-        assert_eq!(pool.num_workers, 8);
-        assert_eq!(pool.task_queue_capacity, 500);
-        assert_eq!(pool.min_hops, 2);
-        assert_eq!(pool.max_hops, 4);
-        assert_eq!(pool.timeout_ms, 200);
-        assert_eq!(pool.max_routes, Some(50));
+        assert_eq!(pool.algorithm(), "most_liquid");
+        assert_eq!(pool.num_workers(), 8);
+        assert_eq!(pool.task_queue_capacity(), 500);
+        assert_eq!(pool.min_hops(), 2);
+        assert_eq!(pool.max_hops(), 4);
+        assert_eq!(pool.timeout_ms(), 200);
+        assert_eq!(pool.max_routes(), Some(50));
     }
 }
 

--- a/tools/benchmark/src/scale.rs
+++ b/tools/benchmark/src/scale.rs
@@ -178,8 +178,9 @@ fn build_solver(
         .clone()
         .unwrap_or_else(|| fynd_rpc::config::defaults::DEFAULT_RPC_URL.to_string());
 
-    let mut pool = pool_config.clone();
-    pool.num_workers = workers;
+    let pool = pool_config
+        .clone()
+        .with_num_workers(workers);
 
     let pools = HashMap::from([(pool_name.to_string(), pool)]);
 
@@ -277,7 +278,7 @@ pub async fn run(args: Args) -> Result<()> {
         .with_context(|| format!("failed to load base config: {}", args.base_config.display()))?;
     let (pool_name, pool_config) = validate_single_pool(&pools_config)?;
 
-    info!("Pool: {} (algorithm: {})", pool_name, pool_config.algorithm);
+    info!("Pool: {} (algorithm: {})", pool_name, pool_config.algorithm());
     info!("Worker counts: {:?}", worker_counts);
     info!("Requests per run: {}", args.num_requests);
 
@@ -322,7 +323,7 @@ pub async fn run(args: Args) -> Result<()> {
         bail!("all iterations failed; no results to report");
     }
 
-    print_summary(&pool_name, &pool_config.algorithm, &args, &points);
+    print_summary(&pool_name, pool_config.algorithm(), &args, &points);
 
     if let Some(ref path) = args.output_file {
         let results = ScaleResults {
@@ -333,7 +334,7 @@ pub async fn run(args: Args) -> Result<()> {
                 parallelization_mode: args.parallelization_mode.clone(),
                 warmup_secs: args.warmup_secs,
                 pool_name: pool_name.clone(),
-                algorithm: pool_config.algorithm.clone(),
+                algorithm: pool_config.algorithm().to_string(),
             },
             points,
         };
@@ -441,21 +442,18 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             "test_pool".to_string(),
-            PoolConfig {
-                algorithm: "most_liquid".to_string(),
-                num_workers: 4,
-                task_queue_capacity: 1000,
-                min_hops: 1,
-                max_hops: 3,
-                timeout_ms: 100,
-                max_routes: None,
-            },
+            PoolConfig::new("most_liquid")
+                .with_num_workers(4)
+                .with_task_queue_capacity(1000)
+                .with_min_hops(1)
+                .with_max_hops(3)
+                .with_timeout_ms(100),
         );
         let config = WorkerPoolsConfig { pools };
         let (name, pool) = validate_single_pool(&config).unwrap();
         assert_eq!(name, "test_pool");
-        assert_eq!(pool.algorithm, "most_liquid");
-        assert_eq!(pool.num_workers, 4);
+        assert_eq!(pool.algorithm(), "most_liquid");
+        assert_eq!(pool.num_workers(), 4);
     }
 
     #[test]
@@ -463,27 +461,22 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             "a".to_string(),
-            PoolConfig {
-                algorithm: "most_liquid".to_string(),
-                num_workers: 4,
-                task_queue_capacity: 1000,
-                min_hops: 1,
-                max_hops: 3,
-                timeout_ms: 100,
-                max_routes: None,
-            },
+            PoolConfig::new("most_liquid")
+                .with_num_workers(4)
+                .with_task_queue_capacity(1000)
+                .with_min_hops(1)
+                .with_max_hops(3)
+                .with_timeout_ms(100),
         );
         pools.insert(
             "b".to_string(),
-            PoolConfig {
-                algorithm: "dijkstra".to_string(),
-                num_workers: 2,
-                task_queue_capacity: 500,
-                min_hops: 1,
-                max_hops: 2,
-                timeout_ms: 200,
-                max_routes: Some(10),
-            },
+            PoolConfig::new("dijkstra")
+                .with_num_workers(2)
+                .with_task_queue_capacity(500)
+                .with_min_hops(1)
+                .with_max_hops(2)
+                .with_timeout_ms(200)
+                .with_max_routes(Some(10)),
         );
         let config = WorkerPoolsConfig { pools };
         let err = validate_single_pool(&config).unwrap_err();


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to 6 public enums and 11 struct variants to allow adding variants/fields without breaking downstream matches
- Make fields private on 8 structs (`PoolConfig`, `SolverParts`, `OrderQuote`, `ComputationManagerConfig`, `AlgorithmConfig`, `UnsupportedChainError`, `UnknownAlgorithmError`, `ComputationRequirements`) and add public getters/constructors
- Reduce visibility to `pub(crate)` for 5 internal items (`GasPriceFetcher`, `TychoFeed`, `TychoFeedConfig`, `DataFeedError`, `NATIVE_TOKEN`)
- Add `#[must_use]` to `Quote`, `OrderQuote`, `Route`, `SolverBuilder`, `WorkerPoolBuilder`
- Update downstream match arms in fynd-rpc and fynd-rpc-types with wildcard fallbacks

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` passes (415 tests, 0 failures)
- [ ] Verify fynd-rpc-types `core` feature still compiles: `cargo check -p fynd-rpc-types --features core`
- [ ] Verify experimental feature compiles: `cargo check -p fynd-rpc --features experimental`

🤖 Generated with [Claude Code](https://claude.com/claude-code)