### PR TITLE
ci: add crates.io release and docs build workflows

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,43 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: "-D warnings"
+
+jobs:
+  docs:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@aa7c1c80a07a27a84c0aa76d0cef0aad3830e330 # v2.7.8
+        with:
+          cache-on-failure: true
+
+      # Build docs for all publishable crates, matching what docs.rs
+      # will generate. --no-deps avoids building docs for all
+      # transitive dependencies. --document-private-items is omitted
+      # to match docs.rs defaults.
+      - name: Build docs
+        run: |
+          cargo doc --no-deps --locked \
+            --package fynd-core \
+            --package fynd-rpc-types \
+            --package fynd-rpc \
+            --package fynd-client

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish-dry-run:
+    name: Publish Crates (dry-run)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust Cache
+        uses: Swatinem/rust-cache@aa7c1c80a07a27a84c0aa76d0cef0aad3830e330 # v2.7.8
+        with:
+          cache-on-failure: true
+
+      # Publish in dependency order. --dry-run validates packaging
+      # without uploading. Remove --dry-run once the repo is public
+      # and CRATESIO_REGISTRY_TOKEN is configured.
+      - name: Publish fynd-core
+        run: cargo publish --dry-run --locked --verbose --package fynd-core
+
+      - name: Publish fynd-rpc-types
+        run: cargo publish --dry-run --locked --verbose --package fynd-rpc-types
+
+      - name: Publish fynd-client
+        run: cargo publish --dry-run --locked --verbose --package fynd-client
+
+      - name: Publish fynd-rpc
+        run: cargo publish --dry-run --locked --verbose --package fynd-rpc

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -406,7 +406,7 @@ impl QuoteParams {
 // RESPONSE TYPES
 // ============================================================================
 
-/// Which backend solver produced a given [`OrderQuote`].
+/// Which backend solver produced a given order quote.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendKind {
     /// The native Fynd solver.


### PR DESCRIPTION
## Summary

- **release.yaml** — Validates crate publishing in dependency order (`fynd-core` → `fynd-rpc-types` → `fynd-client` → `fynd-rpc`) using `cargo publish --dry-run`. Triggered on GitHub release creation and `workflow_dispatch`. Remove `--dry-run` and add `CRATESIO_REGISTRY_TOKEN` secret when the repo goes public.
- **docs.yaml** — Builds documentation with `RUSTDOCFLAGS="-D warnings"` on push to main, PRs, and `workflow_dispatch`. Catches broken doc links before docs.rs generates them on publish. No separate docs.rs push is needed — docs.rs builds automatically when a crate is published to crates.io.

## Test plan

- [ ] Trigger release workflow via `workflow_dispatch` and verify all four `cargo publish --dry-run` steps pass
- [x] Verify docs workflow runs on this PR and passes
- [x] Confirm no unrelated changes are included in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)