### PR TITLE
fix: remove accidentally committed .env file

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-TYCHO_API_KEY=5278b64c-9640-4c6a-8f39-d4a6b6584135
-TYCHO_URL=tycho-fynd-ethereum.propellerheads.xyz

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 clients/typescript/client/dist/
 clients/typescript/node_modules/
 comparison_results.json
+.env


### PR DESCRIPTION
## Summary

- Untracks `.env` from git (was committed in 7274636)
- Adds `.env` to `.gitignore` to prevent recurrence

The `TYCHO_API_KEY` in the committed `.env` has already been rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)