### PR TITLE
feat(rpc): always return JSON error bodies

### DIFF
--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.22.0"
+    "version": "0.24.2"
   },
   "paths": {
     "/v1/health": {
@@ -48,7 +48,7 @@
           "solver"
         ],
         "summary": "POST /v1/quote - Request a quote.",
-        "description": "Accepts a `QuoteRequest` and returns a `Quote` with the best routes found, or an error\nif the request could not be filled.\n\n# Errors\n\n- 400 Bad Request: Invalid request format\n- 422 Unprocessable Entity: No routes found\n- 503 Service Unavailable: Queue full or service overloaded\n- 504 Gateway Timeout: Quote timeout",
+        "description": "Accepts a `QuoteRequest` and returns a `Quote` with the best routes found, or an error\nif the request could not be filled.\n\n# Errors\n\n- 400 Bad Request: Invalid request format\n- 422 Unprocessable Entity: No routes found\n- 503 Service Unavailable: Queue full or service overloaded\n- 503 Service Unavailable: Queue full, service overloaded, or quote timeout",
         "operationId": "quote",
         "requestBody": {
           "content": {
@@ -92,17 +92,7 @@
             }
           },
           "503": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "Quote timeout",
+            "description": "Queue full, overloaded, stale data, or timeout",
             "content": {
               "application/json": {
                 "schema": {

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 /// Mapped from the raw string `code` field in
 /// [`fynd_rpc_types::ErrorResponse`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ErrorCode {
     /// The request was malformed or contained invalid parameters.
     ///

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -32,7 +32,17 @@ pub enum ErrorCode {
     /// Server codes: `QUEUE_FULL`, `SERVICE_OVERLOADED`, `STALE_DATA`, `NOT_READY`.
     ServiceUnavailable,
 
-    /// An unrecognised server error code. The raw string is preserved for debugging.
+    /// The server encountered an internal error processing the request. Not retryable.
+    ///
+    /// Server codes: `ALGORITHM_ERROR`, `INTERNAL_ERROR`, `FAILED_ENCODING`.
+    ServerError,
+
+    /// The requested endpoint does not exist. Indicates a client misconfiguration.
+    ///
+    /// Server code: `NOT_FOUND`.
+    NotFound,
+
+    /// A truly unrecognised server error code. The raw string is preserved for debugging.
     Unknown(String),
 }
 
@@ -49,6 +59,8 @@ impl ErrorCode {
             "QUEUE_FULL" | "SERVICE_OVERLOADED" | "STALE_DATA" | "NOT_READY" => {
                 Self::ServiceUnavailable
             }
+            "ALGORITHM_ERROR" | "INTERNAL_ERROR" | "FAILED_ENCODING" => Self::ServerError,
+            "NOT_FOUND" => Self::NotFound,
             other => Self::Unknown(other.to_string()),
         }
     }
@@ -135,10 +147,21 @@ mod tests {
     }
 
     #[test]
+    fn error_code_server_error_for_server_fault_codes() {
+        assert_eq!(ErrorCode::from_server_code("ALGORITHM_ERROR"), ErrorCode::ServerError);
+        assert_eq!(ErrorCode::from_server_code("INTERNAL_ERROR"), ErrorCode::ServerError);
+        assert_eq!(ErrorCode::from_server_code("FAILED_ENCODING"), ErrorCode::ServerError);
+    }
+
+    #[test]
+    fn error_code_not_found_for_not_found_code() {
+        assert_eq!(ErrorCode::from_server_code("NOT_FOUND"), ErrorCode::NotFound);
+    }
+
+    #[test]
     fn error_code_unknown_for_unrecognised_codes() {
-        assert!(matches!(ErrorCode::from_server_code("ALGORITHM_ERROR"), ErrorCode::Unknown(_)));
-        assert!(matches!(ErrorCode::from_server_code("INTERNAL_ERROR"), ErrorCode::Unknown(_)));
         assert!(matches!(ErrorCode::from_server_code("WHATEVER"), ErrorCode::Unknown(_)));
+        assert!(matches!(ErrorCode::from_server_code("SOME_FUTURE_CODE"), ErrorCode::Unknown(_)));
     }
 
     #[test]

--- a/clients/typescript/autogen/src/schema.d.ts
+++ b/clients/typescript/autogen/src/schema.d.ts
@@ -43,7 +43,7 @@ export interface paths {
          *     - 400 Bad Request: Invalid request format
          *     - 422 Unprocessable Entity: No routes found
          *     - 503 Service Unavailable: Queue full or service overloaded
-         *     - 504 Gateway Timeout: Quote timeout
+         *     - 503 Service Unavailable: Queue full, service overloaded, or quote timeout
          */
         post: operations["quote"];
         delete?: never;
@@ -485,17 +485,8 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorResponse"];
                 };
             };
-            /** @description Service unavailable */
+            /** @description Queue full, overloaded, stale data, or timeout */
             503: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-            /** @description Quote timeout */
-            504: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -112,4 +112,20 @@ impl SolveError {
             SolveError::Timeout { .. } | SolveError::MarketDataStale { .. } | SolveError::QueueFull
         )
     }
+
+    pub fn no_route_found(order_id: impl Into<String>) -> Self {
+        Self::NoRouteFound { order_id: order_id.into() }
+    }
+
+    pub fn insufficient_liquidity(required: BigUint, available: BigUint) -> Self {
+        Self::InsufficientLiquidity { required, available }
+    }
+
+    pub fn timeout(elapsed_ms: u64) -> Self {
+        Self::Timeout { elapsed_ms }
+    }
+
+    pub fn market_data_stale(age_ms: u64) -> Self {
+        Self::MarketDataStale { age_ms }
+    }
 }

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -113,18 +113,22 @@ impl SolveError {
         )
     }
 
+    /// Creates a [`SolveError::NoRouteFound`] for the given order ID.
     pub fn no_route_found(order_id: impl Into<String>) -> Self {
         Self::NoRouteFound { order_id: order_id.into() }
     }
 
+    /// Creates a [`SolveError::InsufficientLiquidity`] with the required and available amounts.
     pub fn insufficient_liquidity(required: BigUint, available: BigUint) -> Self {
         Self::InsufficientLiquidity { required, available }
     }
 
+    /// Creates a [`SolveError::Timeout`] with the elapsed time in milliseconds.
     pub fn timeout(elapsed_ms: u64) -> Self {
         Self::Timeout { elapsed_ms }
     }
 
+    /// Creates a [`SolveError::MarketDataStale`] with the data age in milliseconds.
     pub fn market_data_stale(age_ms: u64) -> Self {
         Self::MarketDataStale { age_ms }
     }

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -38,6 +38,7 @@ impl ResponseError for ApiError {
             ApiError::SolveFailed(e) => match e {
                 SolveError::QueueFull => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::Timeout { .. } => StatusCode::GATEWAY_TIMEOUT,
+                SolveError::MarketDataStale { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 _ => StatusCode::UNPROCESSABLE_ENTITY,
             },
             ApiError::ServiceOverloaded => StatusCode::SERVICE_UNAVAILABLE,
@@ -155,6 +156,14 @@ mod tests {
     #[actix_web::test]
     async fn test_stale_data() {
         let (status, body) = json_body(ApiError::StaleData { age_ms: 90_000 }).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["code"], "STALE_DATA");
+    }
+
+    #[actix_web::test]
+    async fn test_market_data_stale_via_solve_failed() {
+        let err = SolveError::market_data_stale(5_000);
+        let (status, body) = json_body(ApiError::SolveFailed(err)).await;
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(body["code"], "STALE_DATA");
     }

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -37,7 +37,7 @@ impl ResponseError for ApiError {
             ApiError::BadRequest(_) => StatusCode::BAD_REQUEST,
             ApiError::SolveFailed(e) => match e {
                 SolveError::QueueFull => StatusCode::SERVICE_UNAVAILABLE,
-                SolveError::Timeout { .. } => StatusCode::GATEWAY_TIMEOUT,
+                SolveError::Timeout { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::MarketDataStale { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 _ => StatusCode::UNPROCESSABLE_ENTITY,
             },
@@ -128,7 +128,7 @@ mod tests {
     #[actix_web::test]
     async fn test_timeout() {
         let (status, body) = json_body(ApiError::SolveFailed(SolveError::timeout(100))).await;
-        assert_eq!(status, StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(body["code"], "TIMEOUT");
     }
 

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -81,3 +81,81 @@ impl From<serde_json::Error> for ApiError {
         ApiError::BadRequest(format!("invalid JSON: {}", err))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use actix_web::{body::to_bytes, http::StatusCode, ResponseError};
+    use fynd_core::SolveError;
+    use num_bigint::BigUint;
+    use serde_json::Value;
+
+    use super::ApiError;
+
+    async fn json_body(err: ApiError) -> (StatusCode, Value) {
+        let status = err.status_code();
+        let resp = err.error_response();
+        let bytes = to_bytes(resp.into_body())
+            .await
+            .unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        (status, body)
+    }
+
+    #[actix_web::test]
+    async fn test_bad_request() {
+        let (status, body) = json_body(ApiError::BadRequest("missing field".into())).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["code"], "BAD_REQUEST");
+    }
+
+    #[actix_web::test]
+    async fn test_no_route_found() {
+        let (status, body) =
+            json_body(ApiError::SolveFailed(SolveError::no_route_found("order-1"))).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["code"], "NO_ROUTE_FOUND");
+    }
+
+    #[actix_web::test]
+    async fn test_insufficient_liquidity() {
+        let err = SolveError::insufficient_liquidity(BigUint::from(100u64), BigUint::from(50u64));
+        let (status, body) = json_body(ApiError::SolveFailed(err)).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["code"], "INSUFFICIENT_LIQUIDITY");
+    }
+
+    #[actix_web::test]
+    async fn test_timeout() {
+        let (status, body) = json_body(ApiError::SolveFailed(SolveError::timeout(100))).await;
+        assert_eq!(status, StatusCode::GATEWAY_TIMEOUT);
+        assert_eq!(body["code"], "TIMEOUT");
+    }
+
+    #[actix_web::test]
+    async fn test_queue_full() {
+        let (status, body) = json_body(ApiError::SolveFailed(SolveError::QueueFull)).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["code"], "QUEUE_FULL");
+    }
+
+    #[actix_web::test]
+    async fn test_service_overloaded() {
+        let (status, body) = json_body(ApiError::ServiceOverloaded).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["code"], "SERVICE_OVERLOADED");
+    }
+
+    #[actix_web::test]
+    async fn test_internal_error() {
+        let (status, body) = json_body(ApiError::Internal("db down".into())).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(body["code"], "INTERNAL_ERROR");
+    }
+
+    #[actix_web::test]
+    async fn test_stale_data() {
+        let (status, body) = json_body(ApiError::StaleData { age_ms: 90_000 }).await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body["code"], "STALE_DATA");
+    }
+}

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -33,7 +33,7 @@ pub(crate) fn configure_routes(cfg: &mut web::ServiceConfig) {
 /// - 400 Bad Request: Invalid request format
 /// - 422 Unprocessable Entity: No routes found
 /// - 503 Service Unavailable: Queue full or service overloaded
-/// - 504 Gateway Timeout: Quote timeout
+/// - 503 Service Unavailable: Queue full, service overloaded, or quote timeout
 #[utoipa::path(
     post,
     path = "/v1/quote",
@@ -44,7 +44,7 @@ pub(crate) fn configure_routes(cfg: &mut web::ServiceConfig) {
         (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 422, description = "No route found", body = ErrorResponse),
         (status = 503, description = "Service unavailable", body = ErrorResponse),
-        (status = 504, description = "Quote timeout", body = ErrorResponse),
+        (status = 503, description = "Queue full, overloaded, stale data, or timeout", body = ErrorResponse),
     )
 )]
 #[instrument(skip(state, request), fields(num_orders = request.orders().len()))]

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -268,5 +268,167 @@ pub async fn get_prices(
 
 #[cfg(test)]
 mod tests {
-    // TODO: Add integration tests for handlers
+    use actix_web::{test, web, App, HttpResponse};
+    use serde_json::Value;
+
+    use crate::api::dto::QuoteRequest;
+
+    /// Minimal handler that mirrors the real quote handler's JSON extraction.
+    /// The body deserialization error happens before this is called.
+    async fn echo_quote(_req: web::Json<QuoteRequest>) -> HttpResponse {
+        HttpResponse::Ok().finish()
+    }
+
+    /// Creates a test service that mirrors `configure_app`'s extractor setup.
+    /// This intentionally matches the real server's `configure_app` call so that
+    /// fixes to the app config are reflected here.
+    macro_rules! make_test_app {
+        () => {
+            test::init_service(
+                App::new()
+                    .configure(crate::api::configure_error_handlers)
+                    .route("/v1/quote", web::post().to(echo_quote)),
+            )
+            .await
+        };
+    }
+
+    async fn body_json(resp: actix_web::dev::ServiceResponse) -> Value {
+        let bytes = test::read_body(resp).await;
+        serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).into_owned()))
+    }
+
+    // ── Unknown route (default_service) ────────────────────────────────────
+
+    #[actix_web::test]
+    async fn test_unknown_route_returns_json_404() {
+        use crate::api::error::ErrorResponse;
+
+        let app = test::init_service(
+            App::new()
+                .configure(crate::api::configure_error_handlers)
+                .route("/v1/quote", web::post().to(echo_quote))
+                .default_service(web::to(|| async {
+                    let body = ErrorResponse::new("not found".into(), "NOT_FOUND".into());
+                    HttpResponse::NotFound().json(body)
+                })),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/v1/does-not-exist")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 404);
+        let body = body_json(resp).await;
+        assert_eq!(body["code"], "NOT_FOUND", "body was: {body}");
+    }
+
+    // ── JSON body errors ────────────────────────────────────────────────────
+
+    #[actix_web::test]
+    async fn test_malformed_json_returns_json_error() {
+        let app = make_test_app!();
+        let req = test::TestRequest::post()
+            .uri("/v1/quote")
+            .insert_header(("content-type", "application/json"))
+            .set_payload("{not valid json}")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 400);
+        let body = body_json(resp).await;
+        assert_eq!(body["code"], "BAD_REQUEST", "body was: {body}");
+        assert!(body["error"].is_string(), "body was: {body}");
+    }
+
+    #[actix_web::test]
+    async fn test_empty_body_returns_json_error() {
+        let app = make_test_app!();
+        let req = test::TestRequest::post()
+            .uri("/v1/quote")
+            .insert_header(("content-type", "application/json"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 400);
+        let body = body_json(resp).await;
+        assert_eq!(body["code"], "BAD_REQUEST", "body was: {body}");
+        assert!(body["error"].is_string(), "body was: {body}");
+    }
+
+    #[actix_web::test]
+    async fn test_wrong_content_type_returns_json_error() {
+        let app = make_test_app!();
+        let req = test::TestRequest::post()
+            .uri("/v1/quote")
+            .insert_header(("content-type", "text/plain"))
+            .set_payload(r#"{"orders":[]}"#)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 400);
+        let body = body_json(resp).await;
+        assert_eq!(body["code"], "BAD_REQUEST", "body was: {body}");
+        assert!(body["error"].is_string(), "body was: {body}");
+    }
+
+    // ── Query-string errors (QueryConfig) ──────────────────────────────────
+    //
+    // The prices endpoint uses `web::Query<PricesQuery>` to extract URL query
+    // params like `?limit=100&include=depths`. This is completely separate from
+    // the JSON body: `JsonConfig` only applies to `web::Json<T>` (request body),
+    // while `QueryConfig` applies to `web::Query<T>` (URL query string).
+    //
+    // Without `QueryConfig`, a request like `?limit=not-a-number` would trigger
+    // actix-web's default `QueryPayloadError` handler which returns plain text.
+
+    #[actix_web::test]
+    async fn test_invalid_query_param_returns_json_error() {
+        #[derive(serde::Deserialize)]
+        struct Params {
+            #[allow(dead_code)]
+            limit: usize,
+        }
+
+        async fn handler(_: web::Query<Params>) -> HttpResponse {
+            HttpResponse::Ok().finish()
+        }
+
+        let app = test::init_service(
+            App::new()
+                .configure(crate::api::configure_error_handlers)
+                .route("/v1/prices", web::get().to(handler)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/v1/prices?limit=not-a-number")
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 400);
+        let body = body_json(resp).await;
+        assert_eq!(body["code"], "BAD_REQUEST", "body was: {body}");
+        assert!(body["error"].is_string(), "body was: {body}");
+    }
+
+    #[actix_web::test]
+    async fn test_invalid_field_type_returns_json_error() {
+        let app = make_test_app!();
+        // `orders` must be an array, not a string
+        let req = test::TestRequest::post()
+            .uri("/v1/quote")
+            .insert_header(("content-type", "application/json"))
+            .set_payload(r#"{"orders": "not-an-array"}"#)
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert_eq!(resp.status().as_u16(), 400);
+        let body = body_json(resp).await;
+        assert_eq!(body["code"], "BAD_REQUEST", "body was: {body}");
+        assert!(body["error"].is_string(), "body was: {body}");
+    }
 }

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -15,7 +15,7 @@ use std::{
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
-use actix_web::web;
+use actix_web::{web, HttpResponse, ResponseError};
 pub use dto::HealthStatus;
 pub use error::ApiError;
 use fynd_core::{
@@ -190,6 +190,20 @@ impl AppState {
     }
 }
 
+/// Registers JSON and query-string extractor error handlers so that malformed
+/// requests always receive a JSON `ErrorResponse` body instead of actix-web's
+/// default plain-text response.
+pub(crate) fn configure_error_handlers(cfg: &mut web::ServiceConfig) {
+    cfg.app_data(web::JsonConfig::default().error_handler(|err, _req| {
+        let api_err = ApiError::BadRequest(format!("invalid JSON: {err}"));
+        actix_web::error::InternalError::from_response(err, api_err.error_response()).into()
+    }))
+    .app_data(web::QueryConfig::default().error_handler(|err, _req| {
+        let api_err = ApiError::BadRequest(format!("invalid query parameter: {err}"));
+        actix_web::error::InternalError::from_response(err, api_err.error_response()).into()
+    }));
+}
+
 /// Configures the Actix Web application with routes and state.
 pub(crate) fn configure_app(cfg: &mut web::ServiceConfig, state: AppState) {
     #[allow(unused_mut)]
@@ -199,7 +213,12 @@ pub(crate) fn configure_app(cfg: &mut web::ServiceConfig, state: AppState) {
         let experimental = ExperimentalApiDoc::openapi();
         openapi.merge(experimental);
     }
-    cfg.app_data(web::Data::new(state))
+    cfg.configure(configure_error_handlers)
+        .app_data(web::Data::new(state))
         .configure(configure_routes)
-        .service(SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", openapi));
+        .service(SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", openapi))
+        .default_service(web::to(|| async {
+            let body = ErrorResponse::new("not found".into(), "NOT_FOUND".into());
+            HttpResponse::NotFound().json(body)
+        }));
 }


### PR DESCRIPTION
## Summary

- Register `JsonConfig` and `QueryConfig` error handlers so every extraction failure (malformed JSON body, wrong `Content-Type`, empty body, invalid query param) returns a typed `{"error": "...", "code": "BAD_REQUEST"}` response instead of actix-web's plain-text default
- Add a `default_service` so unknown routes return `{"error": "not found", "code": "NOT_FOUND"}` JSON 404 instead of actix-web's plain-text default
- Fix `SolveError::MarketDataStale` returning 422 instead of 503 — stale data means the server is temporarily unavailable, consistent with `QueueFull` and `StaleData`
- Fix solver `Timeout` returning 504 Gateway Timeout — 504 implies an upstream proxy timed out; the solver timeout is an internal condition, 503 is the correct code and consistent with other transient failures
- Add constructors for `#[non_exhaustive]` `SolveError` struct variants (`NoRouteFound`, `InsufficientLiquidity`, `Timeout`, `MarketDataStale`) so they are constructible from outside `fynd-core`
- Map all known server error codes in the Rust client (`ALGORITHM_ERROR`, `INTERNAL_ERROR`, `FAILED_ENCODING` → `ServerError`; `NOT_FOUND` → `NotFound`); `Unknown` is now truly reserved for unseen codes
- Regenerate OpenAPI spec and TypeScript schema

## Test plan

- [ ] All `ApiError` variants produce the correct JSON body and HTTP status code (`api::error` tests)
- [ ] Malformed JSON body, empty body, wrong `Content-Type`, bad field type → 400 JSON (`api::handlers` tests)
- [ ] Invalid query param (`?limit=not-a-number`) → 400 JSON
- [ ] Unknown route → 404 JSON
- [ ] All known server error codes map to typed `ErrorCode` variants in the Rust client

🤖 Generated with [Claude Code](https://claude.com/claude-code)