### PR TITLE
feat(rust-client): add approval flow (info, approval, execute_swap, execute_approval)

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -19,6 +19,7 @@ jobs:
     env:
       TYCHO_API_KEY: ${{ secrets.TYCHO_API_KEY }}
       FORK_RPC_URL: ${{ secrets.ETH_RPC_URL }}
+      RUST_LOG: info
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     env:
       TYCHO_API_KEY: ${{ secrets.TYCHO_API_KEY }}
-      TYCHO_URL: ${{ secrets.TYCHO_URL }}
+      TYCHO_URL: tycho-beta.propellerheads.xyz
       FORK_RPC_URL: ${{ secrets.ETH_RPC_URL }}
       RUST_LOG: info
     steps:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -37,5 +37,8 @@ jobs:
         with:
           cache-on-failure: true
 
+      - name: Build fynd (release)
+        run: cargo build --release --locked --quiet
+
       - name: Run all examples
         run: ./scripts/run-all-examples.sh

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     env:
       TYCHO_API_KEY: ${{ secrets.TYCHO_API_KEY }}
-      FORK_RPC_URL: ${{ secrets.FORK_RPC_URL }}
+      FORK_RPC_URL: ${{ secrets.ETH_RPC_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 60
     env:
       TYCHO_API_KEY: ${{ secrets.TYCHO_API_KEY }}
+      TYCHO_URL: ${{ secrets.TYCHO_URL }}
       FORK_RPC_URL: ${{ secrets.ETH_RPC_URL }}
       RUST_LOG: info
     steps:

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -1,0 +1,40 @@
+name: Examples
+
+on:
+  pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  run_examples:
+    name: Run Rust client examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      TYCHO_API_KEY: ${{ secrets.TYCHO_API_KEY }}
+      FORK_RPC_URL: ${{ secrets.FORK_RPC_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
+      - name: Run all examples
+        run: ./scripts/run-all-examples.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,17 +28,14 @@ jobs:
         with:
           cache-on-failure: true
 
-      # Publish in dependency order. --dry-run validates packaging
-      # without uploading. Remove --dry-run once the repo is public
-      # and CRATESIO_REGISTRY_TOKEN is configured.
       - name: Publish fynd-core
-        run: cargo publish --dry-run --locked --verbose --package fynd-core
+        run: cargo publish --locked --verbose --package fynd-core
 
       - name: Publish fynd-rpc-types
-        run: cargo publish --dry-run --locked --verbose --package fynd-rpc-types
+        run: cargo publish --locked --verbose --package fynd-rpc-types
 
       - name: Publish fynd-client
-        run: cargo publish --dry-run --locked --verbose --package fynd-client
+        run: cargo publish --locked --verbose --package fynd-client
 
       - name: Publish fynd-rpc
-        run: cargo publish --dry-run --locked --verbose --package fynd-rpc
+        run: cargo publish --locked --verbose --package fynd-rpc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7550,9 +7550,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.169.0"
+version = "0.170.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c508534303c5c51590a0efdc3010fabdcbddd0a1aa12c531c2bb8ad929b072fa"
+checksum = "4e63bfe29aee2d12e1e49674056bfb94a264dd8d7bb66ca70200de0ab58eea06"
 dependencies = [
  "alloy",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Tycho
 tycho-simulation = ">=0.251.1"
-tycho-execution = { version = ">=0.169.0", features = ["evm"] }
+tycho-execution = { version = ">=0.170.0", features = ["evm"] }
 typetag = "0.2"
 
 # Graph algorithms

--- a/clients/rust/examples/quote.rs
+++ b/clients/rust/examples/quote.rs
@@ -4,15 +4,23 @@
 //! `http://localhost:3000`. Only quote retrieval is exercised; no transactions
 //! are formed.
 //!
+//! Run with the local dev environment:
+//!
+//! ```sh
+//! ./scripts/run-example.sh quote
 //! ```
-//! cargo run --example quote
+//!
+//! Or manually after starting `./scripts/dev-env.sh`:
+//!
+//! ```sh
+//! cargo run --example quote -p fynd-client
 //! ```
 
 use bytes::Bytes;
 use fynd_client::{FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams, QuoteStatus};
 use num_bigint::BigUint;
 
-const FYND_URL: &str = "http://localhost:3000";
+const DEFAULT_FYND_URL: &str = "http://localhost:3000";
 
 // Mainnet token addresses.
 const WETH: &str = "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
@@ -37,10 +45,18 @@ fn one_usdc() -> BigUint {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fynd_url = std::env::var("FYND_URL").unwrap_or_else(|_| DEFAULT_FYND_URL.to_owned());
+
     // [doc:start quote-rust]
-    let client = FyndClientBuilder::new(FYND_URL, FYND_URL)
+    let client = FyndClientBuilder::new(&fynd_url, &fynd_url)
         .build_quote_only()
-        .expect("valid URL");
+        .map_err(|e| {
+            format!(
+                "{e}\n\nFynd not running at {fynd_url}. \
+            Start the dev environment:\n  ./scripts/run-example.sh {}",
+                env!("CARGO_BIN_NAME")
+            )
+        })?;
 
     // -----------------------------------------------------------------------
     // Health check

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -30,7 +30,9 @@ use fynd_client::{
 use num_bigint::BigUint;
 
 const DEFAULT_FYND_URL: &str = "http://localhost:3000";
-const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
+const DEFAULT_RPC_URL: &str = "http://localhost:8545";
+// Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
+const DEV_PRIVATE_KEY: &str = "0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5";
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const SELL_AMOUNT: u128 = 1_000_000_000; // 1000 USDC (6 decimals)
@@ -46,7 +48,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fynd_url = std::env::var("FYND_URL").unwrap_or_else(|_| DEFAULT_FYND_URL.to_owned());
     let rpc_url = std::env::var("RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_owned());
 
-    let sender_signer = PrivateKeySigner::random();
+    let private_key = std::env::var("PRIVATE_KEY").unwrap_or_else(|_| DEV_PRIVATE_KEY.to_owned());
+    let sender_signer: PrivateKeySigner = private_key.parse()?;
     let sender = sender_signer.address();
     let sell_token: Address = USDC.parse()?;
     let buy_token: Address = WETH.parse()?;

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sign and execute.
     let payload = client
-        .swap_payload(quote, &SigningHints::default())
+        .swap_payload(quote, &SigningHints::default().with_simulate(true))
         .await?;
     let tx_sig = sender_signer
         .sign_hash(&payload.signing_hash())

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -146,6 +146,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     println!("settled:    {:?} USDC", result.settled_amount());
-    println!("gas:        {}", result.gas_cost());
+    println!("gas cost:   {}", result.gas_cost());
     Ok(())
 }

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -6,10 +6,16 @@
 //! Two ephemeral keys are used: one for the sender and one for the fee receiver.
 //! ERC-20 storage overrides inject a synthetic balance so no real funds are needed.
 //!
-//! Run against a local Fynd instance:
+//! Run with the local dev environment:
 //!
 //! ```sh
-//! cargo run --example swap_client_fee -p fynd-client
+//! ./scripts/run-example.sh swap_client_fee
+//! ```
+//!
+//! Or manually after starting `./scripts/dev-env.sh`:
+//!
+//! ```sh
+//! RPC_URL=http://localhost:8545 cargo run --example swap_client_fee -p fynd-client
 //! ```
 
 use alloy::{
@@ -23,8 +29,8 @@ use fynd_client::{
 };
 use num_bigint::BigUint;
 
-const FYND_URL: &str = "http://localhost:3000";
-const RPC_URL: &str = "https://eth.llamarpc.com";
+const DEFAULT_FYND_URL: &str = "http://localhost:3000";
+const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const SELL_AMOUNT: u128 = 1_000_000_000; // 1000 USDC (6 decimals)
@@ -37,6 +43,9 @@ const USDC_ALLOWANCE_SLOT: u64 = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fynd_url = std::env::var("FYND_URL").unwrap_or_else(|_| DEFAULT_FYND_URL.to_owned());
+    let rpc_url = std::env::var("RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_owned());
+
     let sender_signer = PrivateKeySigner::random();
     let sender = sender_signer.address();
     let sell_token: Address = USDC.parse()?;
@@ -46,10 +55,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fee_signer = PrivateKeySigner::random();
     let fee_receiver = fee_signer.address();
 
-    let client = FyndClientBuilder::new(FYND_URL, RPC_URL)
+    let client = FyndClientBuilder::new(&fynd_url, &rpc_url)
         .with_sender(sender)
         .build()
-        .await?;
+        .await
+        .map_err(|e| {
+            format!(
+                "{e}\n\nFynd not running at {fynd_url}. \
+            Start the dev environment:\n  ./scripts/run-example.sh {}",
+                env!("CARGO_BIN_NAME")
+            )
+        })?;
 
     let info = client.info().await?;
     let router_address = info.router_address().clone();

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -19,7 +19,7 @@ use alloy::{
 use bytes::Bytes;
 use fynd_client::{
     ClientFeeParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
-    QuoteOptions, QuoteParams, SignedOrder, SigningHints, StorageOverrides,
+    QuoteOptions, QuoteParams, SignedSwap, SigningHints, StorageOverrides,
 };
 use num_bigint::BigUint;
 
@@ -121,12 +121,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sign the order.
     let payload = client
-        .signable_payload(quote, &SigningHints::default())
+        .swap_payload(quote, &SigningHints::default())
         .await?;
     let tx_sig = sender_signer
         .sign_hash(&payload.signing_hash())
         .await?;
-    let signed = SignedOrder::assemble(payload, tx_sig);
+    let signed = SignedSwap::assemble(payload, tx_sig);
 
     // Dry-run: inject a synthetic ERC-20 balance and router allowance via state overrides.
     let max = Bytes::copy_from_slice(&B256::from(U256::MAX).0);
@@ -144,7 +144,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let result = client
-        .execute(signed, &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) })
+        .execute_swap(
+            signed,
+            &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) },
+        )
         .await?
         .await?;
 

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -51,28 +51,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build()
         .await?;
 
-    // TODO: fix this after the router address is exposed
-    // First, get a quote without fees to discover the router address.
-    let discovery_quote = client
-        .quote(QuoteParams::new(
-            Order::new(
-                Bytes::copy_from_slice(sell_token.as_slice()),
-                Bytes::copy_from_slice(buy_token.as_slice()),
-                BigUint::from(SELL_AMOUNT),
-                OrderSide::Sell,
-                Bytes::copy_from_slice(sender.as_slice()),
-                None,
-            ),
-            QuoteOptions::default()
-                .with_timeout_ms(5_000)
-                .with_encoding_options(EncodingOptions::new(SLIPPAGE)),
-        ))
-        .await?;
-
-    let router_address = discovery_quote
-        .transaction()
-        .map(|tx| Bytes::copy_from_slice(tx.to().as_ref()))
-        .ok_or("discovery quote has no calldata")?;
+    let info = client.info().await?;
+    let router_address = info.router_address().clone();
+    let chain_id = info.chain_id();
 
     // [doc:start client-fee-rust]
     // Build the fee params (without signature).
@@ -84,7 +65,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Compute the EIP-712 signing hash and sign it with the fee receiver's key.
-    let hash = fee.eip712_signing_hash(1, &router_address)?; // chainId = Ethereum mainnet
+    let hash = fee.eip712_signing_hash(chain_id, &router_address)?;
     let sig = fee_signer
         .sign_hash(&B256::from(hash))
         .await?;
@@ -114,11 +95,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("amount_in:  {}", quote.amount_in());
     println!("amount_out: {}", quote.amount_out());
 
-    let tx = quote
-        .transaction()
-        .ok_or("no calldata in quote")?;
-    let router = Address::from_slice(tx.to().as_ref());
-
     // Sign the order.
     let payload = client
         .swap_payload(quote, &SigningHints::default())
@@ -139,7 +115,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
     overrides.insert(
         token_key,
-        Bytes::copy_from_slice(&nested_mapping_slot(sender, router, USDC_ALLOWANCE_SLOT).0),
+        Bytes::copy_from_slice(
+            &nested_mapping_slot(sender, Address::from_slice(&router_address), USDC_ALLOWANCE_SLOT)
+                .0,
+        ),
         max,
     );
 

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -1,10 +1,10 @@
-//! Example: quote and dry-run a USDC → WETH swap with a client fee.
+//! Example: sell 1 WETH for USDC with a client fee.
 //!
 //! Demonstrates how to attach `ClientFeeParams` to a quote request so the
 //! Tycho Router charges a client fee on the swap output.
 //!
-//! Two ephemeral keys are used: one for the sender and one for the fee receiver.
-//! ERC-20 storage overrides inject a synthetic balance so no real funds are needed.
+//! Two keys are used: the dev key as the sender, and a random ephemeral key
+//! as the fee receiver (in production this is the integrator's key).
 //!
 //! Run with the local dev environment:
 //!
@@ -15,17 +15,17 @@
 //! Or manually after starting `./scripts/dev-env.sh`:
 //!
 //! ```sh
-//! RPC_URL=http://localhost:8545 cargo run --example swap_client_fee -p fynd-client
+//! cargo run --example swap_client_fee -p fynd-client
 //! ```
 
 use alloy::{
-    primitives::{keccak256, Address, B256, U256},
+    primitives::{Address, B256},
     signers::{local::PrivateKeySigner, Signer},
 };
 use bytes::Bytes;
 use fynd_client::{
-    ClientFeeParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
-    QuoteOptions, QuoteParams, SignedSwap, SigningHints, StorageOverrides,
+    ApprovalParams, ClientFeeParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order,
+    OrderSide, QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints,
 };
 use num_bigint::BigUint;
 
@@ -33,15 +33,11 @@ const DEFAULT_FYND_URL: &str = "http://localhost:3000";
 const DEFAULT_RPC_URL: &str = "http://localhost:8545";
 // Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
 const DEV_PRIVATE_KEY: &str = "0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d870ef9c9edd3c0fe29";
-const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-const SELL_AMOUNT: u128 = 1_000_000_000; // 1000 USDC (6 decimals)
+const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const SELL_AMOUNT: u128 = 1_000_000_000_000_000_000; // 1 WETH (18 decimals)
 const SLIPPAGE: f64 = 0.005; // 0.5%
 const FEE_BPS: u16 = 50; // 0.5% client fee
-
-// USDC storage layout (FiatTokenV2.1): balances at slot 9, allowances at slot 10.
-const USDC_BALANCE_SLOT: u64 = 9;
-const USDC_ALLOWANCE_SLOT: u64 = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -51,8 +47,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let private_key = std::env::var("PRIVATE_KEY").unwrap_or_else(|_| DEV_PRIVATE_KEY.to_owned());
     let sender_signer: PrivateKeySigner = private_key.parse()?;
     let sender = sender_signer.address();
-    let sell_token: Address = USDC.parse()?;
-    let buy_token: Address = WETH.parse()?;
+    let sell_token: Address = WETH.parse()?;
+    let buy_token: Address = USDC.parse()?;
 
     // Separate fee receiver key — in production this is the integrator's key.
     let fee_signer = PrivateKeySigner::random();
@@ -74,6 +70,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let router_address = info.router_address().clone();
     let chain_id = info.chain_id();
 
+    // Approve the router to spend WETH if the current allowance is insufficient.
+    if let Some(approval_payload) = client
+        .approval(
+            &ApprovalParams::new(
+                Bytes::copy_from_slice(sell_token.as_slice()),
+                BigUint::from(SELL_AMOUNT),
+                true,
+            ),
+            &SigningHints::default(),
+        )
+        .await?
+    {
+        println!("Approving router to spend WETH...");
+        let sig = sender_signer
+            .sign_hash(&approval_payload.signing_hash())
+            .await?;
+        client
+            .execute_approval(SignedApproval::assemble(approval_payload, sig))
+            .await?
+            .await?;
+        println!("Approved.");
+    }
+
     // [doc:start client-fee-rust]
     // Build the fee params (without signature).
     let fee = ClientFeeParams::new(
@@ -94,7 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let encoding_options = EncodingOptions::new(SLIPPAGE).with_client_fee(fee);
     // [doc:end client-fee-rust]
 
-    // Request a quote with the client fee.
+    // Request a quote: sell 1 WETH for USDC with the client fee.
     let quote = client
         .quote(QuoteParams::new(
             Order::new(
@@ -114,58 +133,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("amount_in:  {}", quote.amount_in());
     println!("amount_out: {}", quote.amount_out());
 
-    // Sign the order.
+    // Sign and execute.
     let payload = client
         .swap_payload(quote, &SigningHints::default())
         .await?;
     let tx_sig = sender_signer
         .sign_hash(&payload.signing_hash())
         .await?;
-    let signed = SignedSwap::assemble(payload, tx_sig);
-
-    // Dry-run: inject a synthetic ERC-20 balance and router allowance via state overrides.
-    let max = Bytes::copy_from_slice(&B256::from(U256::MAX).0);
-    let token_key = Bytes::copy_from_slice(sell_token.as_slice());
-    let mut overrides = StorageOverrides::default();
-    overrides.insert(
-        token_key.clone(),
-        Bytes::copy_from_slice(&mapping_slot(sender, USDC_BALANCE_SLOT).0),
-        max.clone(),
-    );
-    overrides.insert(
-        token_key,
-        Bytes::copy_from_slice(
-            &nested_mapping_slot(sender, Address::from_slice(&router_address), USDC_ALLOWANCE_SLOT)
-                .0,
-        ),
-        max,
-    );
-
     let result = client
-        .execute_swap(
-            signed,
-            &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) },
-        )
+        .execute_swap(SignedSwap::assemble(payload, tx_sig), &ExecutionOptions::default())
         .await?
         .await?;
 
-    println!("gas: {}", result.gas_cost());
+    println!("settled:    {:?} USDC", result.settled_amount());
+    println!("gas:        {}", result.gas_cost());
     Ok(())
-}
-
-/// Solidity mapping slot: `keccak256(abi.encode(key, base_slot))`.
-fn mapping_slot(key: Address, base_slot: u64) -> B256 {
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(key.as_slice());
-    buf[56..64].copy_from_slice(&base_slot.to_be_bytes());
-    keccak256(buf)
-}
-
-/// Nested mapping slot: `keccak256(abi.encode(key2, mapping_slot(key1, base_slot)))`.
-fn nested_mapping_slot(key1: Address, key2: Address, base_slot: u64) -> B256 {
-    let inner = mapping_slot(key1, base_slot);
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(key2.as_slice());
-    buf[32..64].copy_from_slice(inner.as_slice());
-    keccak256(buf)
 }

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -32,7 +32,7 @@ use num_bigint::BigUint;
 const DEFAULT_FYND_URL: &str = "http://localhost:3000";
 const DEFAULT_RPC_URL: &str = "http://localhost:8545";
 // Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
-const DEV_PRIVATE_KEY: &str = "0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5";
+const DEV_PRIVATE_KEY: &str = "0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d870ef9c9edd3c0fe29";
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const SELL_AMOUNT: u128 = 1_000_000_000; // 1000 USDC (6 decimals)

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -36,7 +36,7 @@ const DEV_PRIVATE_KEY: &str = "0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d8
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const SELL_AMOUNT: u128 = 1_000_000_000_000_000_000; // 1 WETH (18 decimals)
-const SLIPPAGE: f64 = 0.005; // 0.5%
+const SLIPPAGE: f64 = 0.01; // 1%
 const FEE_BPS: u16 = 50; // 0.5% client fee
 
 #[tokio::main]

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -74,11 +74,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let sig = signer
             .sign_hash(&approval_payload.signing_hash())
             .await?;
-        client
+        let tx = client
             .execute_approval(SignedApproval::assemble(approval_payload, sig))
             .await?
             .await?;
-        println!("Approved.");
+        println!("Approved {}.", tx.tx_hash());
     }
 
     // Request a quote: sell 1 WETH for USDC.
@@ -114,6 +114,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     println!("settled:    {:?} USDC", result.settled_amount());
-    println!("gas:        {}", result.gas_cost());
+    println!("gas cost:   {}", result.gas_cost());
     Ok(())
 }

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -29,7 +29,7 @@ use num_bigint::BigUint;
 const DEFAULT_FYND_URL: &str = "http://localhost:3000";
 const DEFAULT_RPC_URL: &str = "http://localhost:8545";
 // Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
-const DEV_PRIVATE_KEY: &str = "0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5";
+const DEV_PRIVATE_KEY: &str = "0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d870ef9c9edd3c0fe29";
 // 1000 USDC → WETH on Ethereum mainnet
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -16,7 +16,7 @@ use alloy::{
 use bytes::Bytes;
 use fynd_client::{
     EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide, QuoteOptions,
-    QuoteParams, SignedOrder, SigningHints, StorageOverrides,
+    QuoteParams, SignedSwap, SigningHints, StorageOverrides,
 };
 use num_bigint::BigUint;
 
@@ -71,12 +71,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sign the order.
     let payload = client
-        .signable_payload(quote, &SigningHints::default())
+        .swap_payload(quote, &SigningHints::default())
         .await?;
     let sig = signer
         .sign_hash(&payload.signing_hash())
         .await?;
-    let signed = SignedOrder::assemble(payload, sig);
+    let signed = SignedSwap::assemble(payload, sig);
 
     // Dry-run: inject a synthetic ERC-20 balance and router allowance via state overrides.
     let max = Bytes::copy_from_slice(&B256::from(U256::MAX).0);
@@ -94,7 +94,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let result = client
-        .execute(signed, &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) })
+        .execute_swap(
+            signed,
+            &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) },
+        )
         .await?
         .await?;
 

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -27,7 +27,9 @@ use fynd_client::{
 use num_bigint::BigUint;
 
 const DEFAULT_FYND_URL: &str = "http://localhost:3000";
-const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
+const DEFAULT_RPC_URL: &str = "http://localhost:8545";
+// Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
+const DEV_PRIVATE_KEY: &str = "0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5";
 // 1000 USDC → WETH on Ethereum mainnet
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
@@ -42,8 +44,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fynd_url = std::env::var("FYND_URL").unwrap_or_else(|_| DEFAULT_FYND_URL.to_owned());
     let rpc_url = std::env::var("RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_owned());
 
-    // Ephemeral key — storage overrides inject a synthetic balance so no real funds are needed.
-    let signer = PrivateKeySigner::random();
+    let private_key = std::env::var("PRIVATE_KEY").unwrap_or_else(|_| DEV_PRIVATE_KEY.to_owned());
+    let signer: PrivateKeySigner = private_key.parse()?;
     let sender = signer.address();
     let sell_token: Address = USDC.parse()?;
     let buy_token: Address = WETH.parse()?;

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sign and execute.
     let payload = client
-        .swap_payload(quote, &SigningHints::default())
+        .swap_payload(quote, &SigningHints::default().with_simulate(true))
         .await?;
     let sig = signer
         .sign_hash(&payload.signing_hash())

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -3,10 +3,16 @@
 //! An ephemeral key is used and ERC-20 storage overrides inject a synthetic
 //! balance so no real funds are required.
 //!
-//! Run against a local Fynd instance:
+//! Run with the local dev environment:
 //!
 //! ```sh
-//! cargo run --example swap_erc20 -p fynd-client
+//! ./scripts/run-example.sh swap_erc20
+//! ```
+//!
+//! Or manually after starting `./scripts/dev-env.sh`:
+//!
+//! ```sh
+//! RPC_URL=http://localhost:8545 cargo run --example swap_erc20 -p fynd-client
 //! ```
 
 use alloy::{
@@ -20,8 +26,8 @@ use fynd_client::{
 };
 use num_bigint::BigUint;
 
-const FYND_URL: &str = "http://localhost:3000";
-const RPC_URL: &str = "https://eth.llamarpc.com";
+const DEFAULT_FYND_URL: &str = "http://localhost:3000";
+const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
 // 1000 USDC → WETH on Ethereum mainnet
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
@@ -33,16 +39,26 @@ const USDC_ALLOWANCE_SLOT: u64 = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fynd_url = std::env::var("FYND_URL").unwrap_or_else(|_| DEFAULT_FYND_URL.to_owned());
+    let rpc_url = std::env::var("RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_owned());
+
     // Ephemeral key — storage overrides inject a synthetic balance so no real funds are needed.
     let signer = PrivateKeySigner::random();
     let sender = signer.address();
     let sell_token: Address = USDC.parse()?;
     let buy_token: Address = WETH.parse()?;
 
-    let client = FyndClientBuilder::new(FYND_URL, RPC_URL)
+    let client = FyndClientBuilder::new(&fynd_url, &rpc_url)
         .with_sender(sender)
         .build()
-        .await?;
+        .await
+        .map_err(|e| {
+            format!(
+                "{e}\n\nFynd not running at {fynd_url}. \
+            Start the dev environment:\n  ./scripts/run-example.sh {}",
+                env!("CARGO_BIN_NAME")
+            )
+        })?;
 
     // Check whether a router approval is needed and sign it if so.
     // In this dry-run example the broadcast is skipped — storage overrides inject the allowance

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -15,8 +15,8 @@ use alloy::{
 };
 use bytes::Bytes;
 use fynd_client::{
-    EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide, QuoteOptions,
-    QuoteParams, SignedSwap, SigningHints, StorageOverrides,
+    ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
+    QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints, StorageOverrides,
 };
 use num_bigint::BigUint;
 
@@ -43,6 +43,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_sender(sender)
         .build()
         .await?;
+
+    // Check whether a router approval is needed and sign it if so.
+    // In this dry-run example the broadcast is skipped — storage overrides inject the allowance
+    // below. In production, remove the `let _ =` line and uncomment `execute_approval`.
+    if let Some(approval_payload) = client
+        .approval(
+            &ApprovalParams::new(
+                Bytes::copy_from_slice(sell_token.as_slice()),
+                BigUint::from(SELL_AMOUNT),
+                true, // check on-chain allowance first
+            ),
+            &SigningHints::default(),
+        )
+        .await?
+    {
+        println!("approval needed — signing");
+        let approval_sig = signer
+            .sign_hash(&approval_payload.signing_hash())
+            .await?;
+        let signed_approval = SignedApproval::assemble(approval_payload, approval_sig);
+        // In production: client.execute_approval(signed_approval).await?.await?;
+        let _ = signed_approval;
+    } else {
+        println!("allowance sufficient — skipping approval");
+    }
 
     // Request a quote with ERC-20 encoding.
     let quote = client

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -1,7 +1,7 @@
-//! Example: quote and dry-run a USDC → WETH swap using ERC-20 `transferFrom`.
+//! Example: sell 1 WETH for USDC using ERC-20 `transferFrom`.
 //!
-//! An ephemeral key is used and ERC-20 storage overrides inject a synthetic
-//! balance so no real funds are required.
+//! Approves the Fynd router to spend WETH (if needed), then executes
+//! a real swap via the local Anvil fork started by the dev environment.
 //!
 //! Run with the local dev environment:
 //!
@@ -12,17 +12,17 @@
 //! Or manually after starting `./scripts/dev-env.sh`:
 //!
 //! ```sh
-//! RPC_URL=http://localhost:8545 cargo run --example swap_erc20 -p fynd-client
+//! cargo run --example swap_erc20 -p fynd-client
 //! ```
 
 use alloy::{
-    primitives::{keccak256, Address, B256, U256},
+    primitives::Address,
     signers::{local::PrivateKeySigner, Signer},
 };
 use bytes::Bytes;
 use fynd_client::{
     ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
-    QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints, StorageOverrides,
+    QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints,
 };
 use num_bigint::BigUint;
 
@@ -30,14 +30,10 @@ const DEFAULT_FYND_URL: &str = "http://localhost:3000";
 const DEFAULT_RPC_URL: &str = "http://localhost:8545";
 // Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
 const DEV_PRIVATE_KEY: &str = "0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d870ef9c9edd3c0fe29";
-// 1000 USDC → WETH on Ethereum mainnet
-const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-const SELL_AMOUNT: u128 = 1_000_000_000; // 1000 USDC (6 decimals)
+const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const SELL_AMOUNT: u128 = 1_000_000_000_000_000_000; // 1 WETH (18 decimals)
 const SLIPPAGE: f64 = 0.005; // 0.5%
-                             // USDC storage layout (FiatTokenV2.1): balances at slot 9, allowances at slot 10.
-const USDC_BALANCE_SLOT: u64 = 9;
-const USDC_ALLOWANCE_SLOT: u64 = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -47,8 +43,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let private_key = std::env::var("PRIVATE_KEY").unwrap_or_else(|_| DEV_PRIVATE_KEY.to_owned());
     let signer: PrivateKeySigner = private_key.parse()?;
     let sender = signer.address();
-    let sell_token: Address = USDC.parse()?;
-    let buy_token: Address = WETH.parse()?;
+    let sell_token: Address = WETH.parse()?;
+    let buy_token: Address = USDC.parse()?;
 
     let client = FyndClientBuilder::new(&fynd_url, &rpc_url)
         .with_sender(sender)
@@ -62,32 +58,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             )
         })?;
 
-    // Check whether a router approval is needed and sign it if so.
-    // In this dry-run example the broadcast is skipped — storage overrides inject the allowance
-    // below. In production, remove the `let _ =` line and uncomment `execute_approval`.
+    // Approve the router to spend WETH if the current allowance is insufficient.
     if let Some(approval_payload) = client
         .approval(
             &ApprovalParams::new(
                 Bytes::copy_from_slice(sell_token.as_slice()),
                 BigUint::from(SELL_AMOUNT),
-                true, // check on-chain allowance first
+                true,
             ),
             &SigningHints::default(),
         )
         .await?
     {
-        println!("approval needed — signing");
-        let approval_sig = signer
+        println!("Approving router to spend WETH...");
+        let sig = signer
             .sign_hash(&approval_payload.signing_hash())
             .await?;
-        let signed_approval = SignedApproval::assemble(approval_payload, approval_sig);
-        // In production: client.execute_approval(signed_approval).await?.await?;
-        let _ = signed_approval;
-    } else {
-        println!("allowance sufficient — skipping approval");
+        client
+            .execute_approval(SignedApproval::assemble(approval_payload, sig))
+            .await?
+            .await?;
+        println!("Approved.");
     }
 
-    // Request a quote with ERC-20 encoding.
+    // Request a quote: sell 1 WETH for USDC.
     let quote = client
         .quote(QuoteParams::new(
             Order::new(
@@ -107,60 +101,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("amount_in:  {}", quote.amount_in());
     println!("amount_out: {}", quote.amount_out());
 
-    let tx = quote
-        .transaction()
-        .ok_or("no calldata in quote")?;
-    let router = Address::from_slice(tx.to().as_ref());
-
-    // Sign the order.
+    // Sign and execute.
     let payload = client
         .swap_payload(quote, &SigningHints::default())
         .await?;
     let sig = signer
         .sign_hash(&payload.signing_hash())
         .await?;
-    let signed = SignedSwap::assemble(payload, sig);
-
-    // Dry-run: inject a synthetic ERC-20 balance and router allowance via state overrides.
-    let max = Bytes::copy_from_slice(&B256::from(U256::MAX).0);
-    let token_key = Bytes::copy_from_slice(sell_token.as_slice());
-    let mut overrides = StorageOverrides::default();
-    overrides.insert(
-        token_key.clone(),
-        Bytes::copy_from_slice(&mapping_slot(sender, USDC_BALANCE_SLOT).0),
-        max.clone(),
-    );
-    overrides.insert(
-        token_key,
-        Bytes::copy_from_slice(&nested_mapping_slot(sender, router, USDC_ALLOWANCE_SLOT).0),
-        max,
-    );
-
     let result = client
-        .execute_swap(
-            signed,
-            &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) },
-        )
+        .execute_swap(SignedSwap::assemble(payload, sig), &ExecutionOptions::default())
         .await?
         .await?;
 
-    println!("gas: {}", result.gas_cost());
+    println!("settled:    {:?} USDC", result.settled_amount());
+    println!("gas:        {}", result.gas_cost());
     Ok(())
-}
-
-/// Solidity mapping slot: `keccak256(abi.encode(key, base_slot))`.
-fn mapping_slot(key: Address, base_slot: u64) -> B256 {
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(key.as_slice());
-    buf[56..64].copy_from_slice(&base_slot.to_be_bytes());
-    keccak256(buf)
-}
-
-/// Nested mapping slot: `keccak256(abi.encode(key2, mapping_slot(key1, base_slot)))`.
-fn nested_mapping_slot(key1: Address, key2: Address, base_slot: u64) -> B256 {
-    let inner = mapping_slot(key1, base_slot);
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(key2.as_slice());
-    buf[32..64].copy_from_slice(inner.as_slice());
-    keccak256(buf)
 }

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -1,8 +1,8 @@
-//! Example: quote and dry-run a USDC → WETH swap using Permit2.
+//! Example: sell 1 WETH for USDC using Permit2.
 //!
-//! An ephemeral key is used (nonce 0 requires no Permit2 chain state) and
-//! ERC-20 storage overrides inject a synthetic balance and allowance to the
-//! Permit2 contract. No real funds or on-chain approvals are required.
+//! Approves the Permit2 contract to spend WETH (if needed), signs the
+//! Permit2 EIP-712 message, then executes a real swap via the local
+//! Anvil fork started by the dev environment.
 //!
 //! Run with the local dev environment:
 //!
@@ -13,20 +13,18 @@
 //! Or manually after starting `./scripts/dev-env.sh`:
 //!
 //! ```sh
-//! RPC_URL=http://localhost:8545 cargo run --example swap_permit2 -p fynd-client
+//! cargo run --example swap_permit2 -p fynd-client
 //! ```
 
 use alloy::{
-    network::Ethereum,
-    primitives::{keccak256, Address, B256, U256},
-    providers::{Provider, ProviderBuilder, RootProvider},
+    primitives::{Address, B256},
     signers::{local::PrivateKeySigner, Signer},
 };
 use bytes::Bytes;
 use fynd_client::{
     ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
     PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle, QuoteOptions,
-    QuoteParams, SignedApproval, SignedSwap, SigningHints, StorageOverrides, UserTransferType,
+    QuoteParams, SignedApproval, SignedSwap, SigningHints, UserTransferType,
 };
 use num_bigint::BigUint;
 
@@ -35,14 +33,10 @@ const DEFAULT_RPC_URL: &str = "http://localhost:8545";
 // Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
 const DEV_PRIVATE_KEY: &str = "0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d870ef9c9edd3c0fe29";
 const PERMIT2: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
-// 1000 USDC → WETH on Ethereum mainnet
-const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 const WETH: &str = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
-const SELL_AMOUNT: u128 = 1_000_000_000; // 1000 USDC (6 decimals)
+const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const SELL_AMOUNT: u128 = 1_000_000_000_000_000_000; // 1 WETH (18 decimals)
 const SLIPPAGE: f64 = 0.005; // 0.5%
-                             // USDC storage layout (FiatTokenV2.1): balances at slot 9, allowances at slot 10.
-const USDC_BALANCE_SLOT: u64 = 9;
-const USDC_ALLOWANCE_SLOT: u64 = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -52,11 +46,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let private_key = std::env::var("PRIVATE_KEY").unwrap_or_else(|_| DEV_PRIVATE_KEY.to_owned());
     let signer: PrivateKeySigner = private_key.parse()?;
     let sender = signer.address();
-
-    let provider: RootProvider<Ethereum> =
-        ProviderBuilder::default().connect_http(rpc_url.parse::<reqwest::Url>()?);
-    let sell_token: Address = USDC.parse()?;
-    let buy_token: Address = WETH.parse()?;
+    let sell_token: Address = WETH.parse()?;
+    let buy_token: Address = USDC.parse()?;
+    let permit2_addr: Address = PERMIT2.parse()?;
 
     let client = FyndClientBuilder::new(&fynd_url, &rpc_url)
         .with_sender(sender)
@@ -70,39 +62,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             )
         })?;
 
-    // Resolve the router address from the instance info endpoint.
     let info = client.info().await?;
     let router = Address::from_slice(info.router_address().as_ref());
-    let permit2_addr: Address = PERMIT2.parse()?;
+    let chain_id = info.chain_id();
 
-    // Check whether an ERC-20 approval to the Permit2 contract is needed and sign it if so.
-    // In this dry-run example the broadcast is skipped — storage overrides inject the allowance
-    // below. In production, remove the `let _ =` line and uncomment `execute_approval`.
+    // Approve the Permit2 contract to spend WETH if the current allowance is insufficient.
     if let Some(approval_payload) = client
         .approval(
             &ApprovalParams::new(
                 Bytes::copy_from_slice(sell_token.as_slice()),
                 BigUint::from(SELL_AMOUNT),
-                true, // check on-chain allowance first
+                true,
             )
             .with_transfer_type(UserTransferType::TransferFromPermit2),
             &SigningHints::default(),
         )
         .await?
     {
-        println!("Permit2 approval needed — signing");
-        let approval_sig = signer
+        println!("Approving Permit2 to spend WETH...");
+        let sig = signer
             .sign_hash(&approval_payload.signing_hash())
             .await?;
-        let signed_approval = SignedApproval::assemble(approval_payload, approval_sig);
-        // In production: client.execute_approval(signed_approval).await?.await?;
-        let _ = signed_approval;
-    } else {
-        println!("Permit2 allowance sufficient — skipping approval");
+        client
+            .execute_approval(SignedApproval::assemble(approval_payload, sig))
+            .await?
+            .await?;
+        println!("Approved.");
     }
 
-    // Build and sign the Permit2 EIP-712 message off-chain.
-    // Dry-run: nonce 0, uint48::MAX deadlines — no chain reads needed.
+    // Sign the Permit2 EIP-712 message authorising the router to pull WETH.
     let permit = FyndPermitSingle::new(
         FyndPermitDetails::new(
             Bytes::copy_from_slice(sell_token.as_slice()),
@@ -113,7 +101,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Bytes::copy_from_slice(router.as_slice()),
         BigUint::from(281_474_976_710_655u64), // sig_deadline
     );
-    let chain_id = provider.get_chain_id().await?;
     let permit_hash =
         permit.eip712_signing_hash(chain_id, &Bytes::copy_from_slice(permit2_addr.as_slice()))?;
     let permit_sig = Bytes::copy_from_slice(
@@ -123,7 +110,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .as_bytes(),
     );
 
-    // Request a quote with Permit2 encoding.
+    // Request a quote: sell 1 WETH for USDC with Permit2 encoding.
     let quote = client
         .quote(QuoteParams::new(
             Order::new(
@@ -145,54 +132,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("amount_in:  {}", quote.amount_in());
     println!("amount_out: {}", quote.amount_out());
 
-    // Sign the order.
+    // Sign and execute.
     let payload = client
         .swap_payload(quote, &SigningHints::default())
         .await?;
     let sig = signer
         .sign_hash(&payload.signing_hash())
         .await?;
-    let signed = SignedSwap::assemble(payload, sig);
-
-    // Dry-run: inject synthetic ERC-20 balance and allowance to the Permit2 contract.
-    let max = Bytes::copy_from_slice(&B256::from(U256::MAX).0);
-    let token_key = Bytes::copy_from_slice(sell_token.as_slice());
-    let mut overrides = StorageOverrides::default();
-    overrides.insert(
-        token_key.clone(),
-        Bytes::copy_from_slice(&mapping_slot(sender, USDC_BALANCE_SLOT).0),
-        max.clone(),
-    );
-    overrides.insert(
-        token_key,
-        Bytes::copy_from_slice(&nested_mapping_slot(sender, permit2_addr, USDC_ALLOWANCE_SLOT).0),
-        max,
-    );
     let result = client
-        .execute_swap(
-            signed,
-            &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) },
-        )
+        .execute_swap(SignedSwap::assemble(payload, sig), &ExecutionOptions::default())
         .await?
         .await?;
 
-    println!("gas: {}", result.gas_cost());
+    println!("settled:    {:?} USDC", result.settled_amount());
+    println!("gas:        {}", result.gas_cost());
     Ok(())
-}
-
-/// Solidity mapping slot: `keccak256(abi.encode(key, base_slot))`.
-fn mapping_slot(key: Address, base_slot: u64) -> B256 {
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(key.as_slice());
-    buf[56..64].copy_from_slice(&base_slot.to_be_bytes());
-    keccak256(buf)
-}
-
-/// Nested mapping slot: `keccak256(abi.encode(key2, mapping_slot(key1, base_slot)))`.
-fn nested_mapping_slot(key1: Address, key2: Address, base_slot: u64) -> B256 {
-    let inner = mapping_slot(key1, base_slot);
-    let mut buf = [0u8; 64];
-    buf[12..32].copy_from_slice(key2.as_slice());
-    buf[32..64].copy_from_slice(inner.as_slice());
-    keccak256(buf)
 }

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -145,6 +145,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     println!("settled:    {:?} USDC", result.settled_amount());
-    println!("gas:        {}", result.gas_cost());
+    println!("gas cost:   {}", result.gas_cost());
     Ok(())
 }

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -31,7 +31,9 @@ use fynd_client::{
 use num_bigint::BigUint;
 
 const DEFAULT_FYND_URL: &str = "http://localhost:3000";
-const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
+const DEFAULT_RPC_URL: &str = "http://localhost:8545";
+// Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
+const DEV_PRIVATE_KEY: &str = "0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5";
 const PERMIT2: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 // 1000 USDC → WETH on Ethereum mainnet
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
@@ -47,8 +49,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let fynd_url = std::env::var("FYND_URL").unwrap_or_else(|_| DEFAULT_FYND_URL.to_owned());
     let rpc_url = std::env::var("RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_owned());
 
-    // Ephemeral key — nonce 0 requires no Permit2 chain state for the dry-run.
-    let signer = PrivateKeySigner::random();
+    let private_key = std::env::var("PRIVATE_KEY").unwrap_or_else(|_| DEV_PRIVATE_KEY.to_owned());
+    let signer: PrivateKeySigner = private_key.parse()?;
     let sender = signer.address();
 
     let provider: RootProvider<Ethereum> =

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -4,10 +4,16 @@
 //! ERC-20 storage overrides inject a synthetic balance and allowance to the
 //! Permit2 contract. No real funds or on-chain approvals are required.
 //!
-//! Run against a local Fynd instance:
+//! Run with the local dev environment:
 //!
 //! ```sh
-//! cargo run --example swap_permit2 -p fynd-client
+//! ./scripts/run-example.sh swap_permit2
+//! ```
+//!
+//! Or manually after starting `./scripts/dev-env.sh`:
+//!
+//! ```sh
+//! RPC_URL=http://localhost:8545 cargo run --example swap_permit2 -p fynd-client
 //! ```
 
 use alloy::{
@@ -24,8 +30,8 @@ use fynd_client::{
 };
 use num_bigint::BigUint;
 
-const FYND_URL: &str = "http://localhost:3000";
-const RPC_URL: &str = "https://eth.llamarpc.com";
+const DEFAULT_FYND_URL: &str = "http://localhost:3000";
+const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
 const PERMIT2: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 // 1000 USDC → WETH on Ethereum mainnet
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
@@ -38,19 +44,29 @@ const USDC_ALLOWANCE_SLOT: u64 = 10;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let fynd_url = std::env::var("FYND_URL").unwrap_or_else(|_| DEFAULT_FYND_URL.to_owned());
+    let rpc_url = std::env::var("RPC_URL").unwrap_or_else(|_| DEFAULT_RPC_URL.to_owned());
+
     // Ephemeral key — nonce 0 requires no Permit2 chain state for the dry-run.
     let signer = PrivateKeySigner::random();
     let sender = signer.address();
 
     let provider: RootProvider<Ethereum> =
-        ProviderBuilder::default().connect_http(RPC_URL.parse::<reqwest::Url>()?);
+        ProviderBuilder::default().connect_http(rpc_url.parse::<reqwest::Url>()?);
     let sell_token: Address = USDC.parse()?;
     let buy_token: Address = WETH.parse()?;
 
-    let client = FyndClientBuilder::new(FYND_URL, RPC_URL)
+    let client = FyndClientBuilder::new(&fynd_url, &rpc_url)
         .with_sender(sender)
         .build()
-        .await?;
+        .await
+        .map_err(|e| {
+            format!(
+                "{e}\n\nFynd not running at {fynd_url}. \
+            Start the dev environment:\n  ./scripts/run-example.sh {}",
+                env!("CARGO_BIN_NAME")
+            )
+        })?;
 
     // Resolve the router address from the instance info endpoint.
     let info = client.info().await?;

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -134,7 +134,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sign and execute.
     let payload = client
-        .swap_payload(quote, &SigningHints::default())
+        .swap_payload(quote, &SigningHints::default().with_simulate(true))
         .await?;
     let sig = signer
         .sign_hash(&payload.signing_hash())

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -18,9 +18,9 @@ use alloy::{
 };
 use bytes::Bytes;
 use fynd_client::{
-    EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
+    ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
     PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle, QuoteOptions,
-    QuoteParams, SignedSwap, SigningHints, StorageOverrides,
+    QuoteParams, SignedApproval, SignedSwap, SigningHints, StorageOverrides, UserTransferType,
 };
 use num_bigint::BigUint;
 
@@ -46,37 +46,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ProviderBuilder::default().connect_http(RPC_URL.parse::<reqwest::Url>()?);
     let sell_token: Address = USDC.parse()?;
     let buy_token: Address = WETH.parse()?;
-    let permit2_addr: Address = PERMIT2.parse()?;
 
     let client = FyndClientBuilder::new(FYND_URL, RPC_URL)
         .with_sender(sender)
         .build()
         .await?;
 
-    // Discover the router address from a plain ERC-20 quote — it becomes the Permit2 spender.
-    let router = {
-        let q = client
-            .quote(QuoteParams::new(
-                Order::new(
-                    Bytes::copy_from_slice(sell_token.as_slice()),
-                    Bytes::copy_from_slice(buy_token.as_slice()),
-                    BigUint::from(SELL_AMOUNT),
-                    OrderSide::Sell,
-                    Bytes::copy_from_slice(sender.as_slice()),
-                    None,
-                ),
-                QuoteOptions::default()
-                    .with_timeout_ms(5_000)
-                    .with_encoding_options(EncodingOptions::new(SLIPPAGE)),
-            ))
-            .await?;
-        Address::from_slice(
-            q.transaction()
-                .ok_or("no calldata in quote")?
-                .to()
-                .as_ref(),
+    // Resolve the router address from the instance info endpoint.
+    let info = client.info().await?;
+    let router = Address::from_slice(info.router_address().as_ref());
+    let permit2_addr: Address = PERMIT2.parse()?;
+
+    // Check whether an ERC-20 approval to the Permit2 contract is needed and sign it if so.
+    // In this dry-run example the broadcast is skipped — storage overrides inject the allowance
+    // below. In production, remove the `let _ =` line and uncomment `execute_approval`.
+    if let Some(approval_payload) = client
+        .approval(
+            &ApprovalParams::new(
+                Bytes::copy_from_slice(sell_token.as_slice()),
+                BigUint::from(SELL_AMOUNT),
+                true, // check on-chain allowance first
+            )
+            .with_transfer_type(UserTransferType::TransferFromPermit2),
+            &SigningHints::default(),
         )
-    };
+        .await?
+    {
+        println!("Permit2 approval needed — signing");
+        let approval_sig = signer
+            .sign_hash(&approval_payload.signing_hash())
+            .await?;
+        let signed_approval = SignedApproval::assemble(approval_payload, approval_sig);
+        // In production: client.execute_approval(signed_approval).await?.await?;
+        let _ = signed_approval;
+    } else {
+        println!("Permit2 allowance sufficient — skipping approval");
+    }
 
     // Build and sign the Permit2 EIP-712 message off-chain.
     // Dry-run: nonce 0, uint48::MAX deadlines — no chain reads needed.

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -33,7 +33,7 @@ use num_bigint::BigUint;
 const DEFAULT_FYND_URL: &str = "http://localhost:3000";
 const DEFAULT_RPC_URL: &str = "http://localhost:8545";
 // Matches the key funded by scripts/dev-env.sh. Override with PRIVATE_KEY env var.
-const DEV_PRIVATE_KEY: &str = "0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5";
+const DEV_PRIVATE_KEY: &str = "0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d870ef9c9edd3c0fe29";
 const PERMIT2: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 // 1000 USDC → WETH on Ethereum mainnet
 const USDC: &str = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -20,7 +20,7 @@ use bytes::Bytes;
 use fynd_client::{
     EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
     PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle, QuoteOptions,
-    QuoteParams, SignedOrder, SigningHints, StorageOverrides,
+    QuoteParams, SignedSwap, SigningHints, StorageOverrides,
 };
 use num_bigint::BigUint;
 
@@ -124,12 +124,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sign the order.
     let payload = client
-        .signable_payload(quote, &SigningHints::default())
+        .swap_payload(quote, &SigningHints::default())
         .await?;
     let sig = signer
         .sign_hash(&payload.signing_hash())
         .await?;
-    let signed = SignedOrder::assemble(payload, sig);
+    let signed = SignedSwap::assemble(payload, sig);
 
     // Dry-run: inject synthetic ERC-20 balance and allowance to the Permit2 contract.
     let max = Bytes::copy_from_slice(&B256::from(U256::MAX).0);
@@ -146,7 +146,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         max,
     );
     let result = client
-        .execute(signed, &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) })
+        .execute_swap(
+            signed,
+            &ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) },
+        )
         .await?
         .await?;
 

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -13,7 +13,6 @@ use alloy::{
 };
 use bytes::Bytes;
 use num_bigint::BigUint;
-use num_traits::ToPrimitive;
 use reqwest::Client as HttpClient;
 
 use crate::{
@@ -124,7 +123,9 @@ impl SigningHints {
         self
     }
 
-    /// Override the gas limit. If not set, taken from the quote's `gas_estimate`.
+    /// Override the gas limit. If not set, estimated via `eth_estimateGas` against the
+    /// current chain state. Set explicitly to opt out (e.g. use `quote.gas_estimate()`
+    /// as a pre-buffered fallback).
     pub fn with_gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = Some(gas_limit);
         self
@@ -658,17 +659,6 @@ where
                 }
             };
 
-        // Resolve gas limit. Add a 200_000 fixed buffer on top of the server estimate to
-        // account for cold storage slots on forked chains (EIP-2929). TODO: fix server-side.
-        let gas_limit = match hints.gas_limit() {
-            Some(g) => g,
-            None => quote
-                .gas_estimate()
-                .to_u64()
-                .ok_or_else(|| FyndError::Protocol("gas estimate exceeds u64".into()))?
-                .saturating_add(200_000),
-        };
-
         let tx_data = quote.transaction().ok_or_else(|| {
             FyndError::Protocol(
                 "quote has no calldata; set encoding_options in QuoteOptions".into(),
@@ -677,6 +667,24 @@ where
         let to_addr = mapping::bytes_to_alloy_address(tx_data.to())?;
         let value = mapping::biguint_to_u256(tx_data.value());
         let input = AlloyBytes::from(tx_data.data().to_vec());
+
+        // Resolve gas limit. If not explicitly set, estimate via eth_estimateGas so the
+        // limit reflects the actual chain state. Pass with_gas_limit() to use a fixed value
+        // instead (e.g. quote.gas_estimate() as a pre-buffered fallback).
+        let gas_limit = match hints.gas_limit() {
+            Some(g) => g,
+            None => {
+                let req = alloy::rpc::types::TransactionRequest::default()
+                    .from(sender)
+                    .to(to_addr)
+                    .value(value)
+                    .input(input.clone().into());
+                self.provider
+                    .estimate_gas(req)
+                    .await
+                    .map_err(FyndError::Provider)?
+            }
+        };
 
         let tx_eip1559 = TxEip1559 {
             chain_id: self.chain_id,
@@ -875,9 +883,23 @@ where
                 }
             };
 
-        let gas_limit = hints.gas_limit().unwrap_or(65_000);
         let calldata =
             erc20::approveCall { spender: spender_addr, amount: amount_u256 }.abi_encode();
+
+        // Resolve gas limit via eth_estimateGas unless the caller provided an explicit value.
+        let gas_limit = match hints.gas_limit() {
+            Some(g) => g,
+            None => {
+                let req = alloy::rpc::types::TransactionRequest::default()
+                    .from(sender)
+                    .to(token_addr)
+                    .input(AlloyBytes::from(calldata.clone()).into());
+                self.provider
+                    .estimate_gas(req)
+                    .await
+                    .map_err(FyndError::Provider)?
+            }
+        };
 
         let tx = TxEip1559 {
             chain_id: self.chain_id,
@@ -1397,6 +1419,8 @@ mod tests {
             "reward": [["0xf4240", "0x1e8480"]]
         });
         asserter.push_success(&fee_history);
+        // eth_estimateGas → 150_000
+        asserter.push_success(&150_000u64);
 
         let quote = make_order_quote();
         let hints = SigningHints::default();
@@ -1413,6 +1437,7 @@ mod tests {
             panic!("expected EIP-1559 transaction");
         };
         assert_eq!(tx.nonce, 7, "nonce should come from mock");
+        assert_eq!(tx.gas_limit, 150_000, "gas limit should come from eth_estimateGas");
     }
 
     #[tokio::test]
@@ -1769,9 +1794,8 @@ mod tests {
             gas_limit: None, // should default to 65_000
             simulate: false,
         };
-        // push dummy response to satisfy alloy mock (not actually consumed here since no
-        // allowance check)
-        let _ = &asserter; // suppress unused warning
+        // eth_estimateGas → 65_000
+        asserter.push_success(&65_000u64);
 
         let params = ApprovalParams::new(
             bytes::Bytes::copy_from_slice(&[0xdd; 20]),
@@ -1788,7 +1812,7 @@ mod tests {
         // Verify function selector is approve(address,uint256) = 0x095ea7b3.
         let selector = &payload.tx().input[0..4];
         assert_eq!(selector, &[0x09, 0x5e, 0xa7, 0xb3]);
-        assert_eq!(payload.tx().gas_limit, 65_000);
+        assert_eq!(payload.tx().gas_limit, 65_000, "gas limit should come from eth_estimateGas");
         assert_eq!(payload.tx().nonce, 3);
     }
 
@@ -1824,6 +1848,8 @@ mod tests {
         // Mock eth_call for allowance: return 0 (allowance insufficient).
         let zero_allowance = alloy::primitives::Bytes::copy_from_slice(&[0u8; 32]);
         asserter.push_success(&zero_allowance);
+        // eth_estimateGas → 65_000
+        asserter.push_success(&65_000u64);
 
         let params = ApprovalParams::new(
             bytes::Bytes::copy_from_slice(&[0xdd; 20]),

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -658,13 +658,15 @@ where
                 }
             };
 
-        // Resolve gas limit.
+        // Resolve gas limit. Add a 200_000 fixed buffer on top of the server estimate to
+        // account for cold storage slots on forked chains (EIP-2929). TODO: fix server-side.
         let gas_limit = match hints.gas_limit() {
             Some(g) => g,
             None => quote
                 .gas_estimate()
                 .to_u64()
-                .ok_or_else(|| FyndError::Protocol("gas estimate exceeds u64".into()))?,
+                .ok_or_else(|| FyndError::Protocol("gas estimate exceeds u64".into()))?
+                .saturating_add(200_000),
         };
 
         let tx_data = quote.transaction().ok_or_else(|| {
@@ -690,7 +692,10 @@ where
 
         // Optionally simulate the transaction.
         if hints.simulate() {
-            let req: alloy::rpc::types::TransactionRequest = tx_eip1559.clone().into();
+            let req = alloy::rpc::types::TransactionRequest::from_transaction_with_sender(
+                tx_eip1559.clone(),
+                sender,
+            );
             self.provider
                 .call(req)
                 .await

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -240,7 +240,6 @@ fn bytes_to_b256(b: &Bytes) -> Result<B256, FyndError> {
 // ============================================================================
 
 /// Options controlling the behaviour of [`FyndClient::execute_swap`].
-#[derive(Default)]
 pub struct ExecutionOptions {
     /// When `true`, simulate the transaction via `eth_call` and `estimate_gas` instead of
     /// broadcasting it. The returned [`ExecutionReceipt`] resolves immediately with the
@@ -250,6 +249,17 @@ pub struct ExecutionOptions {
     /// Storage slot overrides to apply during dry-run simulation. Ignored when `dry_run` is
     /// `false`.
     pub storage_overrides: Option<StorageOverrides>,
+    /// When `true` (default), a reverted transaction triggers a `debug_traceTransaction` call
+    /// to retrieve the revert reason, falling back to `eth_call` if the node does not support
+    /// the debug API. Set to `false` to skip the extra round-trip and return a bare
+    /// [`FyndError::TransactionReverted`] with only the transaction hash.
+    pub fetch_revert_reason: bool,
+}
+
+impl Default for ExecutionOptions {
+    fn default() -> Self {
+        Self { dry_run: false, storage_overrides: None, fetch_revert_reason: true }
+    }
 }
 
 // ============================================================================
@@ -747,12 +757,24 @@ where
         }
 
         let tx_hash = self
-            .send_raw(tx_eip1559, signature)
+            .send_raw(tx_eip1559.clone(), signature)
             .await?;
 
         let token_out_addr = mapping::bytes_to_alloy_address(quote.token_out())?;
         let receiver_addr = mapping::bytes_to_alloy_address(quote.receiver())?;
         let provider = self.submit_provider.clone();
+        let fetch_revert = options.fetch_revert_reason;
+        // Pre-build the eth_call fallback request from the original transaction.
+        // `from` is omitted — eth_call does not require it and `sender` is not
+        // available in the outer execute_swap context.
+        let fallback_to = match tx_eip1559.to {
+            TxKind::Call(addr) => addr,
+            TxKind::Create => Address::ZERO,
+        };
+        let fallback_req = TransactionRequest::default()
+            .to(fallback_to)
+            .value(tx_eip1559.value)
+            .input(tx_eip1559.input.clone().into());
 
         Ok(ExecutionReceipt::Transaction(Box::pin(async move {
             loop {
@@ -762,6 +784,47 @@ where
                     .map_err(FyndError::Provider)?
                 {
                     Some(receipt) => {
+                        if !receipt.status() {
+                            let reason = if fetch_revert {
+                                // Inline the revert_reason logic (no self available here).
+                                let trace: Result<serde_json::Value, _> = provider
+                                    .raw_request(
+                                        std::borrow::Cow::Borrowed("debug_traceTransaction"),
+                                        (tx_hash, serde_json::json!({})),
+                                    )
+                                    .await;
+                                match trace {
+                                    Ok(t) => {
+                                        let hex_str = t
+                                            .get("returnValue")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("");
+                                        match alloy::primitives::hex::decode(
+                                            hex_str.trim_start_matches("0x"),
+                                        ) {
+                                            Ok(b) => decode_revert_bytes(&b),
+                                            Err(_) => format!("{tx_hash:#x} reverted"),
+                                        }
+                                    }
+                                    Err(_) => {
+                                        tracing::warn!(
+                                            tx = ?tx_hash,
+                                            "debug_traceTransaction unavailable; replaying via \
+                                             eth_call — block state may differ"
+                                        );
+                                        match provider.call(fallback_req).await {
+                                            Err(e) => e.to_string(),
+                                            Ok(_) => {
+                                                format!("{tx_hash:#x} reverted (no reason)")
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                format!("{tx_hash:#x}")
+                            };
+                            return Err(FyndError::TransactionReverted(reason));
+                        }
                         let settled_amount =
                             compute_settled_amount(&receipt, &token_out_addr, &receiver_addr);
                         let gas_cost = BigUint::from(receipt.gas_used) *
@@ -926,6 +989,9 @@ where
     /// and has no built-in timeout; wrap with [`tokio::time::timeout`] to bound the wait.
     pub async fn execute_approval(&self, approval: SignedApproval) -> Result<TxReceipt, FyndError> {
         let (payload, signature) = approval.into_parts();
+        let fallback_req = TransactionRequest::default()
+            .to(mapping::bytes_to_alloy_address(&payload.token)?)
+            .input(payload.tx.input.clone().into());
         let tx_hash = self
             .send_raw(payload.tx, signature)
             .await?;
@@ -939,6 +1005,40 @@ where
                     .map_err(FyndError::Provider)?
                 {
                     Some(receipt) => {
+                        if !receipt.status() {
+                            let trace: Result<serde_json::Value, _> = provider
+                                .raw_request(
+                                    std::borrow::Cow::Borrowed("debug_traceTransaction"),
+                                    (tx_hash, serde_json::json!({})),
+                                )
+                                .await;
+                            let reason = match trace {
+                                Ok(t) => {
+                                    let hex_str = t
+                                        .get("returnValue")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("");
+                                    match alloy::primitives::hex::decode(
+                                        hex_str.trim_start_matches("0x"),
+                                    ) {
+                                        Ok(b) => decode_revert_bytes(&b),
+                                        Err(_) => format!("{tx_hash:#x} reverted"),
+                                    }
+                                }
+                                Err(_) => {
+                                    tracing::warn!(
+                                        tx = ?tx_hash,
+                                        "debug_traceTransaction unavailable; replaying via \
+                                         eth_call — block state may differ"
+                                    );
+                                    match provider.call(fallback_req).await {
+                                        Err(e) => e.to_string(),
+                                        Ok(_) => format!("{tx_hash:#x} reverted (no reason)"),
+                                    }
+                                }
+                            };
+                            return Err(FyndError::TransactionReverted(reason));
+                        }
                         let gas_cost = BigUint::from(receipt.gas_used) *
                             BigUint::from(receipt.effective_gas_price);
                         return Ok(MinedTx::new(tx_hash, gas_cost));
@@ -1006,6 +1106,32 @@ where
         let settled = SettledOrder::new(settled_amount, gas_cost);
 
         Ok(ExecutionReceipt::Transaction(Box::pin(async move { Ok(settled) })))
+    }
+}
+
+/// Decode a standard Solidity `Error(string)` revert payload.
+///
+/// Returns the decoded string for `0x08c379a0`-prefixed data, or a hex dump
+/// for unrecognised payloads.
+fn decode_revert_bytes(data: &[u8]) -> String {
+    // Error(string): selector(4) + offset(32) + length(32) + string_bytes
+    const SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
+    if data.len() >= 68 && data[..4] == SELECTOR {
+        let str_len = u64::from_be_bytes(
+            data[60..68]
+                .try_into()
+                .unwrap_or([0u8; 8]),
+        ) as usize;
+        if data.len() >= 68 + str_len {
+            if let Ok(s) = std::str::from_utf8(&data[68..68 + str_len]) {
+                return s.to_owned();
+            }
+        }
+    }
+    if data.is_empty() {
+        "empty revert data".to_owned()
+    } else {
+        format!("0x{}", alloy::primitives::hex::encode(data))
     }
 }
 
@@ -1557,7 +1683,8 @@ mod tests {
         asserter.push_success(&50_000u64); // estimate_gas response
 
         let order = make_signed_swap();
-        let opts = ExecutionOptions { dry_run: true, storage_overrides: None };
+        let opts =
+            ExecutionOptions { dry_run: true, storage_overrides: None, fetch_revert_reason: false };
         let receipt = client
             .execute_swap(order, &opts)
             .await
@@ -1591,7 +1718,11 @@ mod tests {
         asserter.push_success(&21_000u64);
 
         let order = make_signed_swap();
-        let opts = ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) };
+        let opts = ExecutionOptions {
+            dry_run: true,
+            storage_overrides: Some(overrides),
+            fetch_revert_reason: false,
+        };
         let receipt = client
             .execute_swap(order, &opts)
             .await
@@ -1608,7 +1739,8 @@ mod tests {
         asserter.push_failure_msg("execution reverted");
 
         let order = make_signed_swap();
-        let opts = ExecutionOptions { dry_run: true, storage_overrides: None };
+        let opts =
+            ExecutionOptions { dry_run: true, storage_overrides: None, fetch_revert_reason: false };
         let result = client.execute_swap(order, &opts).await;
         let err = match result {
             Err(e) => e,
@@ -1631,7 +1763,8 @@ mod tests {
         asserter.push_success(&21_000u64);
 
         let order = make_signed_swap();
-        let opts = ExecutionOptions { dry_run: true, storage_overrides: None };
+        let opts =
+            ExecutionOptions { dry_run: true, storage_overrides: None, fetch_revert_reason: false };
         let receipt = client
             .execute_swap(order, &opts)
             .await

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -24,7 +24,7 @@ use crate::{
         compute_settled_amount, ApprovalPayload, ExecutionReceipt, FyndPayload, MinedTx,
         SettledOrder, SignedApproval, SignedSwap, SwapPayload, TxReceipt,
     },
-    types::{BackendKind, HealthStatus, InstanceInfo, Quote, QuoteParams},
+    types::{BackendKind, HealthStatus, InstanceInfo, Quote, QuoteParams, UserTransferType},
 };
 // ============================================================================
 // RETRY CONFIG
@@ -261,10 +261,15 @@ pub struct ApprovalParams {
     pub token: bytes::Bytes,
     /// Amount to approve (token units).
     pub amount: num_bigint::BigUint,
+    /// Which contract to set as the ERC-20 spender.
+    ///
+    /// `UserTransferType::TransferFrom` approves the router contract (default).
+    /// `UserTransferType::TransferFromPermit2` approves the Permit2 contract.
+    pub spender: UserTransferType,
     /// When `true`, check the current ERC-20 allowance before building the transaction.
     ///
-    /// If the allowance is already sufficient, [`ApprovalPayload::is_needed`] returns
-    /// `Some(false)`; otherwise `Some(true)`. When `false`, `is_needed` is always `None`.
+    /// If the allowance is already sufficient, [`FyndClient::approval`] returns `None`.
+    /// When `false`, the payload is always built.
     pub check_allowance: bool,
 }
 
@@ -766,29 +771,70 @@ where
         mapping::dto_to_instance_info(dto_info)
     }
 
-    /// Build an unsigned EIP-1559 `approve(router, amount)` transaction for the given token.
+    /// Build an unsigned EIP-1559 `approve(spender, amount)` transaction for the given token,
+    /// or `None` if the allowance is already sufficient.
     ///
-    /// 1. Calls [`info()`](Self::info) to resolve the router address (used as spender).
-    /// 2. Resolves nonce and EIP-1559 fees via `hints` (same semantics as
+    /// 1. Calls [`info()`](Self::info) to resolve the spender address from `params.spender`.
+    /// 2. If `params.check_allowance` is `true`, checks the current ERC-20 allowance and returns
+    ///    `None` immediately if it is already sufficient (skipping nonce and fee resolution).
+    /// 3. Resolves nonce and EIP-1559 fees via `hints` (same semantics as
     ///    [`swap_payload`](Self::swap_payload)).
-    /// 3. Encodes the `approve(router, amount)` calldata using the ERC-20 ABI.
-    /// 4. Optionally checks the current allowance if `params.check_allowance` is `true` and sets
-    ///    [`ApprovalPayload::is_needed`] accordingly.
+    /// 4. Encodes the `approve(spender, amount)` calldata using the ERC-20 ABI.
     ///
     /// Gas defaults to `hints.gas_limit().unwrap_or(65_000)`.
     pub async fn approval(
         &self,
         params: &ApprovalParams,
         hints: &SigningHints,
-    ) -> Result<ApprovalPayload, FyndError> {
-        let info = self.info().await?;
-        let router_addr = mapping::bytes_to_alloy_address(info.router_address())?;
+    ) -> Result<Option<ApprovalPayload>, FyndError> {
+        use alloy::sol_types::SolCall;
 
-        // Resolve sender.
+        let info = self.info().await?;
+        let spender_addr = match params.spender {
+            UserTransferType::TransferFrom => {
+                mapping::bytes_to_alloy_address(info.router_address())?
+            }
+            UserTransferType::TransferFromPermit2 => {
+                mapping::bytes_to_alloy_address(info.permit2_address())?
+            }
+            UserTransferType::None => {
+                return Err(FyndError::Config(
+                    "UserTransferType::None does not require an approval".into(),
+                ))
+            }
+        };
+
         let sender = hints
             .sender()
             .or(self.default_sender)
             .ok_or_else(|| FyndError::Config("no sender configured".into()))?;
+
+        let token_addr = mapping::bytes_to_alloy_address(&params.token)?;
+        let amount_u256 = mapping::biguint_to_u256(&params.amount);
+
+        // Check allowance before any other RPC calls so we can return early.
+        if params.check_allowance {
+            let call_data =
+                erc20::allowanceCall { owner: sender, spender: spender_addr }.abi_encode();
+            let req = alloy::rpc::types::TransactionRequest {
+                to: Some(alloy::primitives::TxKind::Call(token_addr)),
+                input: alloy::rpc::types::TransactionInput::new(AlloyBytes::from(call_data)),
+                ..Default::default()
+            };
+            let result = self
+                .provider
+                .call(req)
+                .await
+                .map_err(|e| FyndError::Protocol(format!("allowance call failed: {e}")))?;
+            let current_allowance = if result.len() >= 32 {
+                alloy::primitives::U256::from_be_slice(&result[0..32])
+            } else {
+                alloy::primitives::U256::ZERO
+            };
+            if current_allowance >= amount_u256 {
+                return Ok(None);
+            }
+        }
 
         // Resolve nonce.
         let nonce = match hints.nonce() {
@@ -815,13 +861,8 @@ where
             };
 
         let gas_limit = hints.gas_limit().unwrap_or(65_000);
-        let token_addr = mapping::bytes_to_alloy_address(&params.token)?;
-        let amount_u256 = mapping::biguint_to_u256(&params.amount);
-
-        // Encode approve(router, amount).
-        use alloy::sol_types::SolCall;
         let calldata =
-            erc20::approveCall { spender: router_addr, amount: amount_u256 }.abi_encode();
+            erc20::approveCall { spender: spender_addr, amount: amount_u256 }.abi_encode();
 
         let tx = TxEip1559 {
             chain_id: self.chain_id,
@@ -835,39 +876,13 @@ where
             access_list: alloy::eips::eip2930::AccessList::default(),
         };
 
-        // Optionally check current allowance.
-        let is_needed = if params.check_allowance {
-            use alloy::sol_types::SolCall;
-            let call_data =
-                erc20::allowanceCall { owner: sender, spender: router_addr }.abi_encode();
-            let req = alloy::rpc::types::TransactionRequest {
-                to: Some(alloy::primitives::TxKind::Call(token_addr)),
-                input: alloy::rpc::types::TransactionInput::new(AlloyBytes::from(call_data)),
-                ..Default::default()
-            };
-            let result = self
-                .provider
-                .call(req)
-                .await
-                .map_err(|e| FyndError::Protocol(format!("allowance call failed: {e}")))?;
-            let current_allowance = if result.len() >= 32 {
-                alloy::primitives::U256::from_be_slice(&result[0..32])
-            } else {
-                alloy::primitives::U256::ZERO
-            };
-            Some(current_allowance < amount_u256)
-        } else {
-            None
-        };
-
-        let spender = bytes::Bytes::copy_from_slice(router_addr.as_slice());
-        Ok(ApprovalPayload {
+        let spender = bytes::Bytes::copy_from_slice(spender_addr.as_slice());
+        Ok(Some(ApprovalPayload {
             tx,
             token: params.token.clone(),
             spender,
             amount: params.amount.clone(),
-            is_needed,
-        })
+        }))
     }
 
     /// Broadcast a signed approval transaction and return a [`TxReceipt`] that resolves once
@@ -1746,24 +1761,25 @@ mod tests {
         let params = ApprovalParams {
             token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
             amount: num_bigint::BigUint::from(1_000_000u64),
+            spender: crate::types::UserTransferType::TransferFrom,
             check_allowance: false,
         };
 
         let payload = client
             .approval(&params, &hints)
             .await
-            .expect("approval should succeed");
+            .expect("approval should succeed")
+            .expect("should build payload when check_allowance is false");
 
         // Verify function selector is approve(address,uint256) = 0x095ea7b3.
         let selector = &payload.tx().input[0..4];
         assert_eq!(selector, &[0x09, 0x5e, 0xa7, 0xb3]);
         assert_eq!(payload.tx().gas_limit, 65_000);
         assert_eq!(payload.tx().nonce, 3);
-        assert!(payload.is_needed().is_none());
     }
 
     #[tokio::test]
-    async fn approval_with_check_allowance_sets_is_needed() {
+    async fn approval_with_insufficient_allowance_returns_some() {
         use wiremock::{
             matchers::{method, path},
             Mock, MockServer, ResponseTemplate,
@@ -1798,19 +1814,20 @@ mod tests {
         let params = ApprovalParams {
             token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
             amount: num_bigint::BigUint::from(500_000u64),
+            spender: crate::types::UserTransferType::TransferFrom,
             check_allowance: true,
         };
 
-        let payload = client
+        let result = client
             .approval(&params, &hints)
             .await
             .expect("approval with allowance check should succeed");
 
-        assert_eq!(payload.is_needed(), Some(true), "zero allowance should mean approval needed");
+        assert!(result.is_some(), "zero allowance should return a payload");
     }
 
     #[tokio::test]
-    async fn approval_with_check_allowance_sufficient_sets_is_needed_false() {
+    async fn approval_with_sufficient_allowance_returns_none() {
         use wiremock::{
             matchers::{method, path},
             Mock, MockServer, ResponseTemplate,
@@ -1848,19 +1865,16 @@ mod tests {
         let params = ApprovalParams {
             token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
             amount: num_bigint::BigUint::from(500_000u64),
+            spender: crate::types::UserTransferType::TransferFrom,
             check_allowance: true,
         };
 
-        let payload = client
+        let result = client
             .approval(&params, &hints)
             .await
             .expect("approval with sufficient allowance check should succeed");
 
-        assert_eq!(
-            payload.is_needed(),
-            Some(false),
-            "sufficient allowance should mean approval not needed"
-        );
+        assert!(result.is_none(), "sufficient allowance should return None");
     }
 
     // ========================================================================
@@ -1888,7 +1902,6 @@ mod tests {
             token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
             spender: bytes::Bytes::copy_from_slice(&[0x01; 20]),
             amount: num_bigint::BigUint::from(1_000_000u64),
-            is_needed: None,
         };
         SignedApproval::assemble(payload, Signature::test_signature())
     }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -176,7 +176,7 @@ impl SigningHints {
 ///
 /// Maps 20-byte contract addresses to a set of 32-byte slot → value pairs. Passed via
 /// [`ExecutionOptions::storage_overrides`] to override on-chain state during a
-/// [`FyndClient::execute`] dry run.
+/// [`FyndClient::execute_swap`] dry run.
 ///
 /// # Example
 ///
@@ -238,7 +238,7 @@ fn bytes_to_b256(b: &Bytes) -> Result<B256, FyndError> {
 // EXECUTION OPTIONS
 // ============================================================================
 
-/// Options controlling the behaviour of [`FyndClient::execute`].
+/// Options controlling the behaviour of [`FyndClient::execute_swap`].
 #[derive(Default)]
 pub struct ExecutionOptions {
     /// When `true`, simulate the transaction via `eth_call` and `estimate_gas` instead of
@@ -347,7 +347,7 @@ impl FyndClientBuilder {
     /// Build a [`FyndClient`] without connecting to an Ethereum RPC node.
     ///
     /// Suitable for [`FyndClient::quote`] and [`FyndClient::health`] calls only.
-    /// [`FyndClient::swap_payload`] and [`FyndClient::execute`] require a live RPC URL and
+    /// [`FyndClient::swap_payload`] and [`FyndClient::execute_swap`] require a live RPC URL and
     /// will fail if called on a client built this way.
     ///
     /// Returns [`FyndError::Config`] if `base_url` is invalid.

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -401,7 +401,7 @@ impl FyndClientBuilder {
             default_sender: self.sender,
             provider,
             submit_provider,
-            info_cache: std::sync::OnceLock::new(),
+            info_cache: tokio::sync::OnceCell::new(),
         })
     }
 
@@ -458,7 +458,7 @@ impl FyndClientBuilder {
             default_sender: self.sender,
             provider,
             submit_provider,
-            info_cache: std::sync::OnceLock::new(),
+            info_cache: tokio::sync::OnceCell::new(),
         })
     }
 }
@@ -484,7 +484,7 @@ where
     default_sender: Option<Address>,
     provider: P,
     submit_provider: P,
-    info_cache: std::sync::OnceLock<InstanceInfo>,
+    info_cache: tokio::sync::OnceCell<InstanceInfo>,
 }
 
 impl<P> FyndClient<P>
@@ -513,7 +513,7 @@ where
             default_sender,
             provider,
             submit_provider,
-            info_cache: std::sync::OnceLock::new(),
+            info_cache: tokio::sync::OnceCell::new(),
         }
     }
 
@@ -649,13 +649,13 @@ where
         let (max_fee_per_gas, max_priority_fee_per_gas) =
             match (hints.max_fee_per_gas(), hints.max_priority_fee_per_gas()) {
                 (Some(mf), Some(mp)) => (mf, mp),
-                _ => {
+                (mf, mp) => {
                     let est = self
                         .provider
                         .estimate_eip1559_fees()
                         .await
                         .map_err(FyndError::Provider)?;
-                    (est.max_fee_per_gas, est.max_priority_fee_per_gas)
+                    (mf.unwrap_or(est.max_fee_per_gas), mp.unwrap_or(est.max_priority_fee_per_gas))
                 }
             };
 
@@ -779,12 +779,9 @@ where
     /// The result is fetched at most once per [`FyndClient`] instance; subsequent calls return the
     /// cached value without making a network request.
     pub async fn info(&self) -> Result<&InstanceInfo, FyndError> {
-        if let Some(cached) = self.info_cache.get() {
-            return Ok(cached);
-        }
-        let fetched = self.fetch_info().await?;
-        let _ = self.info_cache.set(fetched);
-        Ok(self.info_cache.get().expect("just set"))
+        self.info_cache
+            .get_or_try_init(|| self.fetch_info())
+            .await
     }
 
     async fn fetch_info(&self) -> Result<InstanceInfo, FyndError> {
@@ -795,7 +792,7 @@ where
             return Err(mapping::dto_error_to_fynd(dto_err));
         }
         let dto_info: fynd_rpc_types::InstanceInfo = response.json().await?;
-        mapping::dto_to_instance_info(dto_info)
+        dto_info.try_into()
     }
 
     /// Build an unsigned EIP-1559 `approve(spender, amount)` transaction for the given token,
@@ -873,13 +870,13 @@ where
         let (max_fee_per_gas, max_priority_fee_per_gas) =
             match (hints.max_fee_per_gas(), hints.max_priority_fee_per_gas()) {
                 (Some(mf), Some(mp)) => (mf, mp),
-                _ => {
+                (mf, mp) => {
                     let est = self
                         .provider
                         .estimate_eip1559_fees()
                         .await
                         .map_err(FyndError::Provider)?;
-                    (est.max_fee_per_gas, est.max_priority_fee_per_gas)
+                    (mf.unwrap_or(est.max_fee_per_gas), mp.unwrap_or(est.max_priority_fee_per_gas))
                 }
             };
 

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -803,7 +803,9 @@ where
                                             hex_str.trim_start_matches("0x"),
                                         ) {
                                             Ok(b) => decode_revert_bytes(&b),
-                                            Err(_) => format!("{tx_hash:#x} reverted"),
+                                            Err(_) => format!(
+                                                "{tx_hash:#x} reverted (return value: {hex_str})"
+                                            ),
                                         }
                                     }
                                     Err(_) => {
@@ -1022,7 +1024,9 @@ where
                                         hex_str.trim_start_matches("0x"),
                                     ) {
                                         Ok(b) => decode_revert_bytes(&b),
-                                        Err(_) => format!("{tx_hash:#x} reverted"),
+                                        Err(_) => format!(
+                                            "{tx_hash:#x} reverted (return value: {hex_str})"
+                                        ),
                                     }
                                 }
                                 Err(_) => {

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use alloy::{
     consensus::{TxEip1559, TypedTransaction},
-    eips::{eip2718::Encodable2718, eip2930::AccessList},
+    eips::eip2930::AccessList,
     network::Ethereum,
     primitives::{Address, Bytes as AlloyBytes, TxKind, B256},
     providers::{Provider, ProviderBuilder, RootProvider},
@@ -21,10 +21,10 @@ use crate::{
     mapping,
     mapping::dto_to_batch_quote,
     signing::{
-        compute_settled_amount, ExecutionReceipt, FyndPayload, SettledOrder, SignablePayload,
-        SignedOrder,
+        compute_settled_amount, ApprovalPayload, ExecutionReceipt, FyndPayload, MinedTx,
+        SettledOrder, SignablePayload, SignedApproval, SignedOrder, TxReceipt,
     },
-    types::{BackendKind, HealthStatus, Quote, QuoteParams},
+    types::{BackendKind, HealthStatus, InstanceInfo, Quote, QuoteParams},
 };
 // ============================================================================
 // RETRY CONFIG
@@ -252,6 +252,37 @@ pub struct ExecutionOptions {
 }
 
 // ============================================================================
+// APPROVAL OPTIONS
+// ============================================================================
+
+/// Options controlling the behaviour of [`FyndClient::approval`].
+#[derive(Default)]
+pub struct ApprovalOptions {
+    /// When `true`, check the current ERC-20 allowance before building the transaction.
+    ///
+    /// If the allowance is already sufficient, [`ApprovalPayload::is_needed`] returns
+    /// `Some(false)`; otherwise `Some(true)`. When `false`, `is_needed` is always `None`.
+    pub check_allowance: bool,
+}
+
+/// Options controlling the behaviour of [`FyndClient::submit`].
+#[derive(Default)]
+pub struct SubmitOptions {}
+
+// ============================================================================
+// ERC-20 ABI
+// ============================================================================
+
+mod erc20 {
+    use alloy::sol;
+
+    sol! {
+        function approve(address spender, uint256 amount) returns (bool);
+        function allowance(address owner, address spender) returns (uint256);
+    }
+}
+
+// ============================================================================
 // CLIENT BUILDER
 // ============================================================================
 
@@ -351,6 +382,7 @@ impl FyndClientBuilder {
             default_sender: self.sender,
             provider,
             submit_provider,
+            info_cache: std::sync::OnceLock::new(),
         })
     }
 
@@ -407,6 +439,7 @@ impl FyndClientBuilder {
             default_sender: self.sender,
             provider,
             submit_provider,
+            info_cache: std::sync::OnceLock::new(),
         })
     }
 }
@@ -432,6 +465,7 @@ where
     default_sender: Option<Address>,
     provider: P,
     submit_provider: P,
+    info_cache: std::sync::OnceLock<InstanceInfo>,
 }
 
 impl<P> FyndClient<P>
@@ -455,7 +489,16 @@ where
         provider: P,
         submit_provider: P,
     ) -> Self {
-        Self { http, base_url, retry, chain_id, default_sender, provider, submit_provider }
+        Self {
+            http,
+            base_url,
+            retry,
+            chain_id,
+            default_sender,
+            provider,
+            submit_provider,
+            info_cache: std::sync::OnceLock::new(),
+        }
     }
 
     /// Request a quote for one or more swap orders.
@@ -675,15 +718,9 @@ where
                 .await;
         }
 
-        let envelope = TypedTransaction::Eip1559(tx_eip1559).into_envelope(signature);
-        let raw = envelope.encoded_2718();
-
-        let pending = self
-            .submit_provider
-            .send_raw_transaction(&raw)
-            .await
-            .map_err(FyndError::Provider)?;
-        let tx_hash = *pending.tx_hash();
+        let tx_hash = self
+            .send_raw(tx_eip1559, signature)
+            .await?;
 
         let token_out_addr = mapping::bytes_to_alloy_address(quote.token_out())?;
         let receiver_addr = mapping::bytes_to_alloy_address(quote.receiver())?;
@@ -707,6 +744,181 @@ where
                 }
             }
         })))
+    }
+
+    /// Fetch and cache static instance metadata from `GET /v1/info`.
+    ///
+    /// The result is fetched at most once per [`FyndClient`] instance; subsequent calls return the
+    /// cached value without making a network request.
+    pub async fn info(&self) -> Result<&InstanceInfo, FyndError> {
+        if let Some(cached) = self.info_cache.get() {
+            return Ok(cached);
+        }
+        let fetched = self.fetch_info().await?;
+        let _ = self.info_cache.set(fetched);
+        Ok(self.info_cache.get().expect("just set"))
+    }
+
+    async fn fetch_info(&self) -> Result<InstanceInfo, FyndError> {
+        let url = format!("{}/v1/info", self.base_url);
+        let response = self.http.get(&url).send().await?;
+        if !response.status().is_success() {
+            let dto_err: fynd_rpc_types::ErrorResponse = response.json().await?;
+            return Err(mapping::dto_error_to_fynd(dto_err));
+        }
+        let dto_info: fynd_rpc_types::InstanceInfo = response.json().await?;
+        mapping::dto_to_instance_info(dto_info)
+    }
+
+    /// Build an unsigned EIP-1559 `approve(spender, amount)` transaction.
+    ///
+    /// 1. Calls [`info()`](Self::info) to resolve the router address (used as spender).
+    /// 2. Resolves nonce and EIP-1559 fees via `hints` (same semantics as
+    ///    [`signable_payload`](Self::signable_payload)).
+    /// 3. Encodes the `approve(router, amount)` calldata using the ERC-20 ABI.
+    /// 4. Optionally checks the current allowance if `options.check_allowance` is `true` and sets
+    ///    [`ApprovalPayload::is_needed`] accordingly.
+    ///
+    /// Gas defaults to `hints.gas_limit().unwrap_or(65_000)`.
+    pub async fn approval(
+        &self,
+        token: bytes::Bytes,
+        amount: num_bigint::BigUint,
+        hints: &SigningHints,
+        options: &ApprovalOptions,
+    ) -> Result<ApprovalPayload, FyndError> {
+        let info = self.info().await?;
+        let router_addr = mapping::bytes_to_alloy_address(&info.router_address)?;
+
+        // Resolve sender.
+        let sender = hints
+            .sender()
+            .or(self.default_sender)
+            .ok_or_else(|| FyndError::Config("no sender configured".into()))?;
+
+        // Resolve nonce.
+        let nonce = match hints.nonce() {
+            Some(n) => n,
+            None => self
+                .provider
+                .get_transaction_count(sender)
+                .await
+                .map_err(FyndError::Provider)?,
+        };
+
+        // Resolve EIP-1559 fees.
+        let (max_fee_per_gas, max_priority_fee_per_gas) =
+            match (hints.max_fee_per_gas(), hints.max_priority_fee_per_gas()) {
+                (Some(mf), Some(mp)) => (mf, mp),
+                _ => {
+                    let est = self
+                        .provider
+                        .estimate_eip1559_fees()
+                        .await
+                        .map_err(FyndError::Provider)?;
+                    (est.max_fee_per_gas, est.max_priority_fee_per_gas)
+                }
+            };
+
+        let gas_limit = hints.gas_limit().unwrap_or(65_000);
+        let token_addr = mapping::bytes_to_alloy_address(&token)?;
+        let amount_u256 = mapping::biguint_to_u256(&amount);
+
+        // Encode approve(router, amount).
+        use alloy::sol_types::SolCall;
+        let calldata =
+            erc20::approveCall { spender: router_addr, amount: amount_u256 }.abi_encode();
+
+        let tx = TxEip1559 {
+            chain_id: self.chain_id,
+            nonce,
+            max_fee_per_gas,
+            max_priority_fee_per_gas,
+            gas_limit,
+            to: alloy::primitives::TxKind::Call(token_addr),
+            value: alloy::primitives::U256::ZERO,
+            input: AlloyBytes::from(calldata),
+            access_list: alloy::eips::eip2930::AccessList::default(),
+        };
+
+        // Optionally check current allowance.
+        let is_needed = if options.check_allowance {
+            use alloy::sol_types::SolCall;
+            let call_data =
+                erc20::allowanceCall { owner: sender, spender: router_addr }.abi_encode();
+            let req = alloy::rpc::types::TransactionRequest {
+                to: Some(alloy::primitives::TxKind::Call(token_addr)),
+                input: alloy::rpc::types::TransactionInput::new(AlloyBytes::from(call_data)),
+                ..Default::default()
+            };
+            let result = self
+                .provider
+                .call(req)
+                .await
+                .map_err(|e| FyndError::Protocol(format!("allowance call failed: {e}")))?;
+            let current_allowance = if result.len() >= 32 {
+                alloy::primitives::U256::from_be_slice(&result[0..32])
+            } else {
+                alloy::primitives::U256::ZERO
+            };
+            Some(current_allowance < amount_u256)
+        } else {
+            None
+        };
+
+        let spender = bytes::Bytes::copy_from_slice(router_addr.as_slice());
+        Ok(ApprovalPayload { tx, token, spender, amount, is_needed })
+    }
+
+    /// Broadcast a signed approval transaction and return a [`TxReceipt`] that resolves once
+    /// the transaction is mined.
+    ///
+    /// This method returns immediately after broadcasting. The inner future polls every 2 seconds
+    /// and has no built-in timeout; wrap with [`tokio::time::timeout`] to bound the wait.
+    pub async fn submit(
+        &self,
+        approval: SignedApproval,
+        _options: &SubmitOptions,
+    ) -> Result<TxReceipt, FyndError> {
+        let (payload, signature) = approval.into_parts();
+        let tx_hash = self
+            .send_raw(payload.tx, signature)
+            .await?;
+        let provider = self.submit_provider.clone();
+
+        Ok(TxReceipt::Pending(Box::pin(async move {
+            loop {
+                match provider
+                    .get_transaction_receipt(tx_hash)
+                    .await
+                    .map_err(FyndError::Provider)?
+                {
+                    Some(receipt) => {
+                        let gas_cost = BigUint::from(receipt.gas_used) *
+                            BigUint::from(receipt.effective_gas_price);
+                        return Ok(MinedTx::new(tx_hash, gas_cost));
+                    }
+                    None => tokio::time::sleep(Duration::from_secs(2)).await,
+                }
+            }
+        })))
+    }
+
+    /// Encode, sign, and broadcast an EIP-1559 transaction, returning its hash.
+    async fn send_raw(
+        &self,
+        tx: TxEip1559,
+        signature: alloy::primitives::Signature,
+    ) -> Result<B256, FyndError> {
+        use alloy::eips::eip2718::Encodable2718;
+        let envelope = TypedTransaction::Eip1559(tx).into_envelope(signature);
+        let raw = envelope.encoded_2718();
+        let pending = self
+            .submit_provider
+            .send_raw_transaction(&raw)
+            .await
+            .map_err(FyndError::Provider)?;
+        Ok(*pending.tx_hash())
     }
 
     async fn dry_run_execute(
@@ -1450,5 +1662,229 @@ mod tests {
         );
 
         QuoteParams::new(order, QuoteOptions::default())
+    }
+
+    // ========================================================================
+    // info() tests
+    // ========================================================================
+
+    fn make_info_body() -> serde_json::Value {
+        serde_json::json!({
+            "chain_id": 1,
+            "router_address": "0x0101010101010101010101010101010101010101",
+            "permit2_address": "0x0202020202020202020202020202020202020202"
+        })
+    }
+
+    #[tokio::test]
+    async fn info_fetches_and_caches() {
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_info_body()))
+            .expect(1) // only one HTTP hit expected despite two calls
+            .mount(&server)
+            .await;
+
+        let (client, _asserter) = make_test_client(server.uri(), RetryConfig::default(), None);
+
+        let info1 = client
+            .info()
+            .await
+            .expect("first info call should succeed");
+        let info2 = client
+            .info()
+            .await
+            .expect("second info call should use cache");
+
+        assert_eq!(info1.chain_id(), 1);
+        assert_eq!(info2.chain_id(), 1);
+        assert_eq!(info1.router_address().as_ref(), &[0x01u8; 20]);
+        assert_eq!(info1.permit2_address().as_ref(), &[0x02u8; 20]);
+        // MockServer verifies expect(1) on drop.
+    }
+
+    // ========================================================================
+    // approval() tests
+    // ========================================================================
+
+    #[tokio::test]
+    async fn approval_builds_correct_calldata() {
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_info_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let sender = Address::with_last_byte(0xab);
+        let (client, asserter) =
+            make_test_client(server.uri(), RetryConfig::default(), Some(sender));
+
+        // Hints provide nonce + fees so no RPC calls needed.
+        let hints = SigningHints {
+            sender: Some(sender),
+            nonce: Some(3),
+            max_fee_per_gas: Some(2_000_000_000),
+            max_priority_fee_per_gas: Some(1_000_000),
+            gas_limit: None, // should default to 65_000
+            simulate: false,
+        };
+        // push dummy response to satisfy alloy mock (not actually consumed here since no
+        // allowance check)
+        let _ = &asserter; // suppress unused warning
+
+        let token = bytes::Bytes::copy_from_slice(&[0xdd; 20]);
+        let amount = num_bigint::BigUint::from(1_000_000u64);
+
+        let payload = client
+            .approval(token, amount, &hints, &ApprovalOptions::default())
+            .await
+            .expect("approval should succeed");
+
+        // Verify function selector is approve(address,uint256) = 0x095ea7b3.
+        let selector = &payload.tx().input[0..4];
+        assert_eq!(selector, &[0x09, 0x5e, 0xa7, 0xb3]);
+        assert_eq!(payload.tx().gas_limit, 65_000);
+        assert_eq!(payload.tx().nonce, 3);
+        assert!(payload.is_needed().is_none());
+    }
+
+    #[tokio::test]
+    async fn approval_with_check_allowance_sets_is_needed() {
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_info_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let sender = Address::with_last_byte(0xab);
+        let (client, asserter) =
+            make_test_client(server.uri(), RetryConfig::default(), Some(sender));
+
+        let hints = SigningHints {
+            sender: Some(sender),
+            nonce: Some(0),
+            max_fee_per_gas: Some(1_000_000_000),
+            max_priority_fee_per_gas: Some(1_000_000),
+            gas_limit: None,
+            simulate: false,
+        };
+
+        // Mock eth_call for allowance: return 0 (allowance insufficient).
+        let zero_allowance = alloy::primitives::Bytes::copy_from_slice(&[0u8; 32]);
+        asserter.push_success(&zero_allowance);
+
+        let token = bytes::Bytes::copy_from_slice(&[0xdd; 20]);
+        let amount = num_bigint::BigUint::from(500_000u64);
+
+        let payload = client
+            .approval(token, amount, &hints, &ApprovalOptions { check_allowance: true })
+            .await
+            .expect("approval with allowance check should succeed");
+
+        assert_eq!(payload.is_needed(), Some(true), "zero allowance should mean approval needed");
+    }
+
+    // ========================================================================
+    // submit() tests
+    // ========================================================================
+
+    fn make_signed_approval() -> crate::signing::SignedApproval {
+        use alloy::primitives::{Signature, TxKind, U256};
+
+        use crate::signing::ApprovalPayload;
+
+        let tx = TxEip1559 {
+            chain_id: 1,
+            nonce: 0,
+            max_fee_per_gas: 1_000_000_000,
+            max_priority_fee_per_gas: 1_000_000,
+            gas_limit: 65_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: AlloyBytes::from(vec![0x09, 0x5e, 0xa7, 0xb3]),
+            access_list: AccessList::default(),
+        };
+        let payload = ApprovalPayload {
+            tx,
+            token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
+            spender: bytes::Bytes::copy_from_slice(&[0x01; 20]),
+            amount: num_bigint::BigUint::from(1_000_000u64),
+            is_needed: None,
+        };
+        SignedApproval::assemble(payload, Signature::test_signature())
+    }
+
+    #[tokio::test]
+    async fn submit_broadcasts_and_polls() {
+        let sender = Address::with_last_byte(0xab);
+        let (client, asserter) =
+            make_test_client("http://localhost".to_string(), RetryConfig::default(), Some(sender));
+
+        // send_raw_transaction response: tx hash
+        let tx_hash = alloy::primitives::B256::repeat_byte(0xef);
+        asserter.push_success(&tx_hash);
+
+        // get_transaction_receipt: first call returns null (pending), second returns receipt.
+        asserter.push_success::<Option<()>>(&None);
+        let receipt = alloy::rpc::types::TransactionReceipt {
+            inner: alloy::consensus::ReceiptEnvelope::Eip1559(alloy::consensus::ReceiptWithBloom {
+                receipt: alloy::consensus::Receipt::<alloy::primitives::Log> {
+                    status: alloy::consensus::Eip658Value::Eip658(true),
+                    cumulative_gas_used: 50_000,
+                    logs: vec![],
+                },
+                logs_bloom: alloy::primitives::Bloom::default(),
+            }),
+            transaction_hash: tx_hash,
+            transaction_index: None,
+            block_hash: None,
+            block_number: None,
+            gas_used: 45_000,
+            effective_gas_price: 1_500_000_000,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            from: Address::ZERO,
+            to: None,
+            contract_address: None,
+        };
+        asserter.push_success(&receipt);
+
+        let approval = make_signed_approval();
+        let tx_receipt = client
+            .submit(approval, &SubmitOptions::default())
+            .await
+            .expect("submit should succeed");
+
+        let mined = tx_receipt
+            .await
+            .expect("receipt should resolve");
+
+        assert_eq!(mined.tx_hash(), tx_hash);
+        let expected_cost =
+            num_bigint::BigUint::from(45_000u64) * num_bigint::BigUint::from(1_500_000_000u64);
+        assert_eq!(mined.gas_cost(), &expected_cost);
     }
 }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -257,20 +257,34 @@ pub struct ExecutionOptions {
 
 /// Parameters for [`FyndClient::approval`].
 pub struct ApprovalParams {
-    /// ERC-20 token to approve (20 raw bytes).
-    pub token: bytes::Bytes,
-    /// Amount to approve (token units).
-    pub amount: num_bigint::BigUint,
-    /// Which contract to set as the ERC-20 spender.
+    token: bytes::Bytes,
+    amount: num_bigint::BigUint,
+    transfer_type: UserTransferType,
+    check_allowance: bool,
+}
+
+impl ApprovalParams {
+    /// Create approval parameters for the given token and amount.
     ///
-    /// `UserTransferType::TransferFrom` approves the router contract (default).
-    /// `UserTransferType::TransferFromPermit2` approves the Permit2 contract.
-    pub spender: UserTransferType,
-    /// When `true`, check the current ERC-20 allowance before building the transaction.
+    /// Defaults to a standard ERC-20 approval against the router contract.
+    /// Use [`with_transfer_type`](Self::with_transfer_type) to approve the Permit2 contract
+    /// instead.
     ///
-    /// If the allowance is already sufficient, [`FyndClient::approval`] returns `None`.
-    /// When `false`, the payload is always built.
-    pub check_allowance: bool,
+    /// When `check_allowance` is `true`, [`FyndClient::approval`] checks the on-chain allowance
+    /// first and returns `None` if it is already sufficient.
+    pub fn new(token: bytes::Bytes, amount: num_bigint::BigUint, check_allowance: bool) -> Self {
+        Self { token, amount, transfer_type: UserTransferType::TransferFrom, check_allowance }
+    }
+
+    /// Override the transfer type (and thus the spender contract).
+    ///
+    /// `UserTransferType::TransferFrom` → router (default).
+    /// `UserTransferType::TransferFromPermit2` → Permit2.
+    /// `UserTransferType::None` → [`FyndClient::approval`] returns `None` immediately.
+    pub fn with_transfer_type(mut self, transfer_type: UserTransferType) -> Self {
+        self.transfer_type = transfer_type;
+        self
+    }
 }
 
 // ============================================================================
@@ -789,19 +803,19 @@ where
     ) -> Result<Option<ApprovalPayload>, FyndError> {
         use alloy::sol_types::SolCall;
 
+        if params.transfer_type == UserTransferType::None {
+            return Ok(None);
+        }
+
         let info = self.info().await?;
-        let spender_addr = match params.spender {
+        let spender_addr = match params.transfer_type {
             UserTransferType::TransferFrom => {
                 mapping::bytes_to_alloy_address(info.router_address())?
             }
             UserTransferType::TransferFromPermit2 => {
                 mapping::bytes_to_alloy_address(info.permit2_address())?
             }
-            UserTransferType::None => {
-                return Err(FyndError::Config(
-                    "UserTransferType::None does not require an approval".into(),
-                ))
-            }
+            UserTransferType::None => unreachable!(),
         };
 
         let sender = hints
@@ -1758,12 +1772,11 @@ mod tests {
         // allowance check)
         let _ = &asserter; // suppress unused warning
 
-        let params = ApprovalParams {
-            token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
-            amount: num_bigint::BigUint::from(1_000_000u64),
-            spender: crate::types::UserTransferType::TransferFrom,
-            check_allowance: false,
-        };
+        let params = ApprovalParams::new(
+            bytes::Bytes::copy_from_slice(&[0xdd; 20]),
+            num_bigint::BigUint::from(1_000_000u64),
+            false,
+        );
 
         let payload = client
             .approval(&params, &hints)
@@ -1811,12 +1824,11 @@ mod tests {
         let zero_allowance = alloy::primitives::Bytes::copy_from_slice(&[0u8; 32]);
         asserter.push_success(&zero_allowance);
 
-        let params = ApprovalParams {
-            token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
-            amount: num_bigint::BigUint::from(500_000u64),
-            spender: crate::types::UserTransferType::TransferFrom,
-            check_allowance: true,
-        };
+        let params = ApprovalParams::new(
+            bytes::Bytes::copy_from_slice(&[0xdd; 20]),
+            num_bigint::BigUint::from(500_000u64),
+            true,
+        );
 
         let result = client
             .approval(&params, &hints)
@@ -1862,12 +1874,11 @@ mod tests {
         asserter.push_success(&alloy::primitives::Bytes::copy_from_slice(&allowance_bytes));
 
         // Request 500_000, but allowance is 1_000_000 — sufficient.
-        let params = ApprovalParams {
-            token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
-            amount: num_bigint::BigUint::from(500_000u64),
-            spender: crate::types::UserTransferType::TransferFrom,
-            check_allowance: true,
-        };
+        let params = ApprovalParams::new(
+            bytes::Bytes::copy_from_slice(&[0xdd; 20]),
+            num_bigint::BigUint::from(500_000u64),
+            true,
+        );
 
         let result = client
             .approval(&params, &hints)

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -474,9 +474,6 @@ where
 {
     /// Construct a client directly from its individual fields.
     ///
-    /// This is intended for testing; production code should use [`FyndClientBuilder`].
-    /// Construct a client directly from its individual fields.
-    ///
     /// Intended for testing only. Use [`FyndClientBuilder`] for production code.
     #[doc(hidden)]
     #[allow(clippy::too_many_arguments)]
@@ -788,7 +785,7 @@ where
         options: &ApprovalOptions,
     ) -> Result<ApprovalPayload, FyndError> {
         let info = self.info().await?;
-        let router_addr = mapping::bytes_to_alloy_address(&info.router_address)?;
+        let router_addr = mapping::bytes_to_alloy_address(info.router_address())?;
 
         // Resolve sender.
         let sender = hints
@@ -1805,6 +1802,57 @@ mod tests {
             .expect("approval with allowance check should succeed");
 
         assert_eq!(payload.is_needed(), Some(true), "zero allowance should mean approval needed");
+    }
+
+    #[tokio::test]
+    async fn approval_with_check_allowance_sufficient_sets_is_needed_false() {
+        use wiremock::{
+            matchers::{method, path},
+            Mock, MockServer, ResponseTemplate,
+        };
+
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/v1/info"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(make_info_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let sender = Address::with_last_byte(0xab);
+        let (client, asserter) =
+            make_test_client(server.uri(), RetryConfig::default(), Some(sender));
+
+        let hints = SigningHints {
+            sender: Some(sender),
+            nonce: Some(0),
+            max_fee_per_gas: Some(1_000_000_000),
+            max_priority_fee_per_gas: Some(1_000_000),
+            gas_limit: None,
+            simulate: false,
+        };
+
+        // Mock eth_call for allowance: return amount > requested (allowance sufficient).
+        let mut allowance_bytes = [0u8; 32];
+        // Encode 1_000_000 as big-endian uint256 (same as the amount we will request).
+        allowance_bytes[24..32].copy_from_slice(&1_000_000u64.to_be_bytes());
+        asserter.push_success(&alloy::primitives::Bytes::copy_from_slice(&allowance_bytes));
+
+        let token = bytes::Bytes::copy_from_slice(&[0xdd; 20]);
+        // Request 500_000, but allowance is 1_000_000 — sufficient.
+        let amount = num_bigint::BigUint::from(500_000u64);
+
+        let payload = client
+            .approval(token, amount, &hints, &ApprovalOptions { check_allowance: true })
+            .await
+            .expect("approval with sufficient allowance check should succeed");
+
+        assert_eq!(
+            payload.is_needed(),
+            Some(false),
+            "sufficient allowance should mean approval not needed"
+        );
     }
 
     // ========================================================================

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -22,7 +22,7 @@ use crate::{
     mapping::dto_to_batch_quote,
     signing::{
         compute_settled_amount, ApprovalPayload, ExecutionReceipt, FyndPayload, MinedTx,
-        SettledOrder, SignablePayload, SignedApproval, SignedOrder, TxReceipt,
+        SettledOrder, SignedApproval, SignedSwap, SwapPayload, TxReceipt,
     },
     types::{BackendKind, HealthStatus, InstanceInfo, Quote, QuoteParams},
 };
@@ -85,7 +85,7 @@ impl Default for RetryConfig {
 /// Optional hints to override auto-resolved transaction parameters.
 ///
 /// All fields default to `None` / `false`. Unset fields are resolved automatically from the
-/// RPC node during [`FyndClient::signable_payload`].
+/// RPC node during [`FyndClient::swap_payload`].
 ///
 /// Build via the setter methods; all options are unset by default.
 #[derive(Default)]
@@ -252,22 +252,21 @@ pub struct ExecutionOptions {
 }
 
 // ============================================================================
-// APPROVAL OPTIONS
+// APPROVAL PARAMS
 // ============================================================================
 
-/// Options controlling the behaviour of [`FyndClient::approval`].
-#[derive(Default)]
-pub struct ApprovalOptions {
+/// Parameters for [`FyndClient::approval`].
+pub struct ApprovalParams {
+    /// ERC-20 token to approve (20 raw bytes).
+    pub token: bytes::Bytes,
+    /// Amount to approve (token units).
+    pub amount: num_bigint::BigUint,
     /// When `true`, check the current ERC-20 allowance before building the transaction.
     ///
     /// If the allowance is already sufficient, [`ApprovalPayload::is_needed`] returns
     /// `Some(false)`; otherwise `Some(true)`. When `false`, `is_needed` is always `None`.
     pub check_allowance: bool,
 }
-
-/// Options controlling the behaviour of [`FyndClient::submit`].
-#[derive(Default)]
-pub struct SubmitOptions {}
 
 // ============================================================================
 // ERC-20 ABI
@@ -348,7 +347,7 @@ impl FyndClientBuilder {
     /// Build a [`FyndClient`] without connecting to an Ethereum RPC node.
     ///
     /// Suitable for [`FyndClient::quote`] and [`FyndClient::health`] calls only.
-    /// [`FyndClient::signable_payload`] and [`FyndClient::execute`] require a live RPC URL and
+    /// [`FyndClient::swap_payload`] and [`FyndClient::execute`] require a live RPC URL and
     /// will fail if called on a client built this way.
     ///
     /// Returns [`FyndError::Config`] if `base_url` is invalid.
@@ -578,7 +577,7 @@ where
         Err(FyndError::Protocol(format!("unexpected health response ({status}): {body}")))
     }
 
-    /// Build a signable payload for a given order quote.
+    /// Build a swap payload for a given order quote, ready for signing.
     ///
     /// For [`BackendKind::Fynd`] quotes, this resolves the sender nonce and EIP-1559 fee
     /// parameters from the RPC node (unless overridden via `hints`), then constructs an
@@ -589,14 +588,14 @@ where
     ///
     /// `token_out` and `receiver` are read directly from the `quote` (populated during
     /// `quote()`). Pass `&SigningHints::default()` to auto-resolve all transaction parameters.
-    pub async fn signable_payload(
+    pub async fn swap_payload(
         &self,
         quote: Quote,
         hints: &SigningHints,
-    ) -> Result<SignablePayload, FyndError> {
+    ) -> Result<SwapPayload, FyndError> {
         match quote.backend() {
             BackendKind::Fynd => {
-                self.fynd_signable_payload(quote, hints)
+                self.fynd_swap_payload(quote, hints)
                     .await
             }
             BackendKind::Turbine => {
@@ -605,11 +604,11 @@ where
         }
     }
 
-    async fn fynd_signable_payload(
+    async fn fynd_swap_payload(
         &self,
         quote: Quote,
         hints: &SigningHints,
-    ) -> Result<SignablePayload, FyndError> {
+    ) -> Result<SwapPayload, FyndError> {
         // Resolve sender.
         let sender = hints
             .sender()
@@ -682,10 +681,10 @@ where
         }
 
         let tx = TypedTransaction::Eip1559(tx_eip1559);
-        Ok(SignablePayload::Fynd(Box::new(FyndPayload::new(quote, tx))))
+        Ok(SwapPayload::Fynd(Box::new(FyndPayload::new(quote, tx))))
     }
 
-    /// Broadcast a signed order and return an [`ExecutionReceipt`] that resolves once the
+    /// Broadcast a signed swap and return an [`ExecutionReceipt`] that resolves once the
     /// transaction is mined.
     ///
     /// Pass [`ExecutionOptions::default`] for standard on-chain submission. Set
@@ -695,9 +694,9 @@ where
     /// For real submissions, this method returns **immediately** after broadcasting. The inner
     /// future polls every 2 seconds and has no built-in timeout; wrap with
     /// [`tokio::time::timeout`] to bound the wait.
-    pub async fn execute(
+    pub async fn execute_swap(
         &self,
-        order: SignedOrder,
+        order: SignedSwap,
         options: &ExecutionOptions,
     ) -> Result<ExecutionReceipt, FyndError> {
         let (payload, signature) = order.into_parts();
@@ -767,22 +766,20 @@ where
         mapping::dto_to_instance_info(dto_info)
     }
 
-    /// Build an unsigned EIP-1559 `approve(spender, amount)` transaction.
+    /// Build an unsigned EIP-1559 `approve(router, amount)` transaction for the given token.
     ///
     /// 1. Calls [`info()`](Self::info) to resolve the router address (used as spender).
     /// 2. Resolves nonce and EIP-1559 fees via `hints` (same semantics as
-    ///    [`signable_payload`](Self::signable_payload)).
+    ///    [`swap_payload`](Self::swap_payload)).
     /// 3. Encodes the `approve(router, amount)` calldata using the ERC-20 ABI.
-    /// 4. Optionally checks the current allowance if `options.check_allowance` is `true` and sets
+    /// 4. Optionally checks the current allowance if `params.check_allowance` is `true` and sets
     ///    [`ApprovalPayload::is_needed`] accordingly.
     ///
     /// Gas defaults to `hints.gas_limit().unwrap_or(65_000)`.
     pub async fn approval(
         &self,
-        token: bytes::Bytes,
-        amount: num_bigint::BigUint,
+        params: &ApprovalParams,
         hints: &SigningHints,
-        options: &ApprovalOptions,
     ) -> Result<ApprovalPayload, FyndError> {
         let info = self.info().await?;
         let router_addr = mapping::bytes_to_alloy_address(info.router_address())?;
@@ -818,8 +815,8 @@ where
             };
 
         let gas_limit = hints.gas_limit().unwrap_or(65_000);
-        let token_addr = mapping::bytes_to_alloy_address(&token)?;
-        let amount_u256 = mapping::biguint_to_u256(&amount);
+        let token_addr = mapping::bytes_to_alloy_address(&params.token)?;
+        let amount_u256 = mapping::biguint_to_u256(&params.amount);
 
         // Encode approve(router, amount).
         use alloy::sol_types::SolCall;
@@ -839,7 +836,7 @@ where
         };
 
         // Optionally check current allowance.
-        let is_needed = if options.check_allowance {
+        let is_needed = if params.check_allowance {
             use alloy::sol_types::SolCall;
             let call_data =
                 erc20::allowanceCall { owner: sender, spender: router_addr }.abi_encode();
@@ -864,7 +861,13 @@ where
         };
 
         let spender = bytes::Bytes::copy_from_slice(router_addr.as_slice());
-        Ok(ApprovalPayload { tx, token, spender, amount, is_needed })
+        Ok(ApprovalPayload {
+            tx,
+            token: params.token.clone(),
+            spender,
+            amount: params.amount.clone(),
+            is_needed,
+        })
     }
 
     /// Broadcast a signed approval transaction and return a [`TxReceipt`] that resolves once
@@ -872,11 +875,7 @@ where
     ///
     /// This method returns immediately after broadcasting. The inner future polls every 2 seconds
     /// and has no built-in timeout; wrap with [`tokio::time::timeout`] to bound the wait.
-    pub async fn submit(
-        &self,
-        approval: SignedApproval,
-        _options: &SubmitOptions,
-    ) -> Result<TxReceipt, FyndError> {
+    pub async fn execute_approval(&self, approval: SignedApproval) -> Result<TxReceipt, FyndError> {
         let (payload, signature) = approval.into_parts();
         let tx_hash = self
             .send_raw(payload.tx, signature)
@@ -1314,11 +1313,11 @@ mod tests {
     }
 
     // ========================================================================
-    // signable_payload() tests
+    // swap_payload() tests
     // ========================================================================
 
     #[tokio::test]
-    async fn signable_payload_uses_hints_when_all_provided() {
+    async fn swap_payload_uses_hints_when_all_provided() {
         let sender = Address::with_last_byte(0xab);
         let (client, _asserter) =
             make_test_client("http://localhost".to_string(), RetryConfig::default(), None);
@@ -1334,11 +1333,11 @@ mod tests {
         };
 
         let payload = client
-            .signable_payload(quote, &hints)
+            .swap_payload(quote, &hints)
             .await
-            .expect("signable_payload should succeed");
+            .expect("swap_payload should succeed");
 
-        let SignablePayload::Fynd(fynd) = payload else {
+        let SwapPayload::Fynd(fynd) = payload else {
             panic!("expected Fynd payload");
         };
         let TypedTransaction::Eip1559(tx) = fynd.tx() else {
@@ -1351,7 +1350,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn signable_payload_fetches_nonce_and_fees_when_hints_absent() {
+    async fn swap_payload_fetches_nonce_and_fees_when_hints_absent() {
         let sender = Address::with_last_byte(0xde);
         let (client, asserter) =
             make_test_client("http://localhost".to_string(), RetryConfig::default(), Some(sender));
@@ -1373,11 +1372,11 @@ mod tests {
         let hints = SigningHints::default();
 
         let payload = client
-            .signable_payload(quote, &hints)
+            .swap_payload(quote, &hints)
             .await
-            .expect("signable_payload should succeed");
+            .expect("swap_payload should succeed");
 
-        let SignablePayload::Fynd(fynd) = payload else {
+        let SwapPayload::Fynd(fynd) = payload else {
             panic!("expected Fynd payload");
         };
         let TypedTransaction::Eip1559(tx) = fynd.tx() else {
@@ -1387,7 +1386,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn signable_payload_returns_config_error_when_no_sender() {
+    async fn swap_payload_returns_config_error_when_no_sender() {
         // No sender on client, no sender in hints.
         let (client, _asserter) =
             make_test_client("http://localhost".to_string(), RetryConfig::default(), None);
@@ -1396,7 +1395,7 @@ mod tests {
         let hints = SigningHints::default(); // no sender
 
         let err = client
-            .signable_payload(quote, &hints)
+            .swap_payload(quote, &hints)
             .await
             .unwrap_err();
 
@@ -1404,7 +1403,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn signable_payload_with_simulate_true_calls_eth_call_successfully() {
+    async fn swap_payload_with_simulate_true_calls_eth_call_successfully() {
         let sender = Address::with_last_byte(0xab);
         let (client, asserter) =
             make_test_client("http://localhost".to_string(), RetryConfig::default(), None);
@@ -1423,15 +1422,15 @@ mod tests {
         asserter.push_success(&alloy::primitives::Bytes::new());
 
         let payload = client
-            .signable_payload(quote, &hints)
+            .swap_payload(quote, &hints)
             .await
-            .expect("signable_payload with simulate=true should succeed");
+            .expect("swap_payload with simulate=true should succeed");
 
-        assert!(matches!(payload, SignablePayload::Fynd(_)));
+        assert!(matches!(payload, SwapPayload::Fynd(_)));
     }
 
     #[tokio::test]
-    async fn signable_payload_with_simulate_true_returns_simulation_failed_on_revert() {
+    async fn swap_payload_with_simulate_true_returns_simulation_failed_on_revert() {
         let sender = Address::with_last_byte(0xab);
         let (client, asserter) =
             make_test_client("http://localhost".to_string(), RetryConfig::default(), None);
@@ -1450,7 +1449,7 @@ mod tests {
         asserter.push_failure_msg("execution reverted");
 
         let err = client
-            .signable_payload(quote, &hints)
+            .swap_payload(quote, &hints)
             .await
             .unwrap_err();
 
@@ -1461,14 +1460,14 @@ mod tests {
     }
 
     // ========================================================================
-    // execute() dry-run tests
+    // execute_swap() dry-run tests
     // ========================================================================
 
-    /// Build a [`SignedOrder`] from a minimal [`Quote`] and a dummy transaction.
+    /// Build a [`SignedSwap`] from a minimal [`Quote`] and a dummy transaction.
     ///
     /// Suitable for dry-run tests where neither the signature nor the transaction
     /// contents are validated on-chain.
-    fn make_signed_order() -> SignedOrder {
+    fn make_signed_swap() -> SignedSwap {
         use alloy::{
             eips::eip2930::AccessList,
             primitives::{Bytes as AlloyBytes, Signature, TxKind, U256},
@@ -1489,8 +1488,8 @@ mod tests {
             access_list: AccessList::default(),
         };
         let payload =
-            SignablePayload::Fynd(Box::new(FyndPayload::new(quote, TypedTransaction::Eip1559(tx))));
-        SignedOrder::assemble(payload, Signature::test_signature())
+            SwapPayload::Fynd(Box::new(FyndPayload::new(quote, TypedTransaction::Eip1559(tx))));
+        SignedSwap::assemble(payload, Signature::test_signature())
     }
 
     #[tokio::test]
@@ -1505,10 +1504,10 @@ mod tests {
         asserter.push_success(&alloy::primitives::Bytes::copy_from_slice(&amount_bytes));
         asserter.push_success(&50_000u64); // estimate_gas response
 
-        let order = make_signed_order();
+        let order = make_signed_swap();
         let opts = ExecutionOptions { dry_run: true, storage_overrides: None };
         let receipt = client
-            .execute(order, &opts)
+            .execute_swap(order, &opts)
             .await
             .expect("execute should succeed");
         let settled = receipt
@@ -1539,10 +1538,10 @@ mod tests {
         asserter.push_success(&alloy::primitives::Bytes::copy_from_slice(&amount_bytes));
         asserter.push_success(&21_000u64);
 
-        let order = make_signed_order();
+        let order = make_signed_swap();
         let opts = ExecutionOptions { dry_run: true, storage_overrides: Some(overrides) };
         let receipt = client
-            .execute(order, &opts)
+            .execute_swap(order, &opts)
             .await
             .expect("execute with overrides should succeed");
         receipt.await.expect("should resolve");
@@ -1556,9 +1555,9 @@ mod tests {
 
         asserter.push_failure_msg("execution reverted");
 
-        let order = make_signed_order();
+        let order = make_signed_swap();
         let opts = ExecutionOptions { dry_run: true, storage_overrides: None };
-        let result = client.execute(order, &opts).await;
+        let result = client.execute_swap(order, &opts).await;
         let err = match result {
             Err(e) => e,
             Ok(_) => panic!("expected SimulationFailed error"),
@@ -1579,10 +1578,10 @@ mod tests {
         asserter.push_success(&alloy::primitives::Bytes::new());
         asserter.push_success(&21_000u64);
 
-        let order = make_signed_order();
+        let order = make_signed_swap();
         let opts = ExecutionOptions { dry_run: true, storage_overrides: None };
         let receipt = client
-            .execute(order, &opts)
+            .execute_swap(order, &opts)
             .await
             .expect("execute should succeed");
         let settled = receipt.await.expect("should resolve");
@@ -1594,7 +1593,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn signable_payload_returns_protocol_error_when_no_transaction() {
+    async fn swap_payload_returns_protocol_error_when_no_transaction() {
         use crate::types::{BackendKind, BlockInfo, QuoteStatus};
 
         let sender = Address::with_last_byte(0xab);
@@ -1628,7 +1627,7 @@ mod tests {
         };
 
         let err = client
-            .signable_payload(quote, &hints)
+            .swap_payload(quote, &hints)
             .await
             .unwrap_err();
 
@@ -1744,11 +1743,14 @@ mod tests {
         // allowance check)
         let _ = &asserter; // suppress unused warning
 
-        let token = bytes::Bytes::copy_from_slice(&[0xdd; 20]);
-        let amount = num_bigint::BigUint::from(1_000_000u64);
+        let params = ApprovalParams {
+            token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
+            amount: num_bigint::BigUint::from(1_000_000u64),
+            check_allowance: false,
+        };
 
         let payload = client
-            .approval(token, amount, &hints, &ApprovalOptions::default())
+            .approval(&params, &hints)
             .await
             .expect("approval should succeed");
 
@@ -1793,11 +1795,14 @@ mod tests {
         let zero_allowance = alloy::primitives::Bytes::copy_from_slice(&[0u8; 32]);
         asserter.push_success(&zero_allowance);
 
-        let token = bytes::Bytes::copy_from_slice(&[0xdd; 20]);
-        let amount = num_bigint::BigUint::from(500_000u64);
+        let params = ApprovalParams {
+            token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
+            amount: num_bigint::BigUint::from(500_000u64),
+            check_allowance: true,
+        };
 
         let payload = client
-            .approval(token, amount, &hints, &ApprovalOptions { check_allowance: true })
+            .approval(&params, &hints)
             .await
             .expect("approval with allowance check should succeed");
 
@@ -1839,12 +1844,15 @@ mod tests {
         allowance_bytes[24..32].copy_from_slice(&1_000_000u64.to_be_bytes());
         asserter.push_success(&alloy::primitives::Bytes::copy_from_slice(&allowance_bytes));
 
-        let token = bytes::Bytes::copy_from_slice(&[0xdd; 20]);
         // Request 500_000, but allowance is 1_000_000 — sufficient.
-        let amount = num_bigint::BigUint::from(500_000u64);
+        let params = ApprovalParams {
+            token: bytes::Bytes::copy_from_slice(&[0xdd; 20]),
+            amount: num_bigint::BigUint::from(500_000u64),
+            check_allowance: true,
+        };
 
         let payload = client
-            .approval(token, amount, &hints, &ApprovalOptions { check_allowance: true })
+            .approval(&params, &hints)
             .await
             .expect("approval with sufficient allowance check should succeed");
 
@@ -1856,7 +1864,7 @@ mod tests {
     }
 
     // ========================================================================
-    // submit() tests
+    // execute_approval() tests
     // ========================================================================
 
     fn make_signed_approval() -> crate::signing::SignedApproval {
@@ -1886,7 +1894,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_broadcasts_and_polls() {
+    async fn execute_approval_broadcasts_and_polls() {
         let sender = Address::with_last_byte(0xab);
         let (client, asserter) =
             make_test_client("http://localhost".to_string(), RetryConfig::default(), Some(sender));
@@ -1922,9 +1930,9 @@ mod tests {
 
         let approval = make_signed_approval();
         let tx_receipt = client
-            .submit(approval, &SubmitOptions::default())
+            .execute_approval(approval)
             .await
-            .expect("submit should succeed");
+            .expect("execute_approval should succeed");
 
         let mined = tx_receipt
             .await

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -280,7 +280,7 @@ impl ApprovalParams {
     ///
     /// `UserTransferType::TransferFrom` → router (default).
     /// `UserTransferType::TransferFromPermit2` → Permit2.
-    /// `UserTransferType::None` → [`FyndClient::approval`] returns `None` immediately.
+    /// `UserTransferType::UseVaultsFunds` → [`FyndClient::approval`] returns `None` immediately.
     pub fn with_transfer_type(mut self, transfer_type: UserTransferType) -> Self {
         self.transfer_type = transfer_type;
         self
@@ -803,10 +803,6 @@ where
     ) -> Result<Option<ApprovalPayload>, FyndError> {
         use alloy::sol_types::SolCall;
 
-        if params.transfer_type == UserTransferType::None {
-            return Ok(None);
-        }
-
         let info = self.info().await?;
         let spender_addr = match params.transfer_type {
             UserTransferType::TransferFrom => {
@@ -815,7 +811,7 @@ where
             UserTransferType::TransferFromPermit2 => {
                 mapping::bytes_to_alloy_address(info.permit2_address())?
             }
-            UserTransferType::None => unreachable!(),
+            UserTransferType::UseVaultsFunds => return Ok(None),
         };
 
         let sender = hints

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -105,6 +105,11 @@ pub enum FyndError {
     #[error("simulation failed: {0}")]
     SimulationFailed(String),
 
+    /// An on-chain transaction was mined but reverted. The message contains the revert reason
+    /// decoded from replaying the transaction via `eth_call`.
+    #[error("transaction reverted: {0}")]
+    TransactionReverted(String),
+
     /// Invalid client configuration (e.g. unparseable URL, missing sender address).
     #[error("configuration error: {0}")]
     Config(String),
@@ -121,6 +126,11 @@ impl FyndError {
             Self::Api { code, .. } => code.is_retryable(),
             _ => false,
         }
+    }
+
+    /// Returns `true` if this error represents an on-chain transaction revert.
+    pub fn is_revert(&self) -> bool {
+        matches!(self, Self::TransactionReverted(_))
     }
 }
 

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -50,13 +50,13 @@
 //! ```
 
 pub use client::{
-    ApprovalOptions, ExecutionOptions, FyndClient, FyndClientBuilder, RetryConfig, SigningHints,
-    StorageOverrides, SubmitOptions,
+    ApprovalParams, ExecutionOptions, FyndClient, FyndClientBuilder, RetryConfig, SigningHints,
+    StorageOverrides,
 };
 pub use error::{ErrorCode, FyndError};
 pub use signing::{
-    ApprovalPayload, ExecutionReceipt, FyndPayload, MinedTx, SettledOrder, SignablePayload,
-    SignedApproval, SignedOrder, TxReceipt,
+    ApprovalPayload, ExecutionReceipt, FyndPayload, MinedTx, SettledOrder, SignedApproval,
+    SignedSwap, SwapPayload, TxReceipt,
 };
 pub use types::{
     BackendKind, BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown, HealthStatus,

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -50,14 +50,18 @@
 //! ```
 
 pub use client::{
-    ExecutionOptions, FyndClient, FyndClientBuilder, RetryConfig, SigningHints, StorageOverrides,
+    ApprovalOptions, ExecutionOptions, FyndClient, FyndClientBuilder, RetryConfig, SigningHints,
+    StorageOverrides, SubmitOptions,
 };
 pub use error::{ErrorCode, FyndError};
-pub use signing::{ExecutionReceipt, FyndPayload, SettledOrder, SignablePayload, SignedOrder};
+pub use signing::{
+    ApprovalPayload, ExecutionReceipt, FyndPayload, MinedTx, SettledOrder, SignablePayload,
+    SignedApproval, SignedOrder, TxReceipt,
+};
 pub use types::{
-    BackendKind, BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown, HealthStatus, Order,
-    OrderSide, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteParams, QuoteStatus, Route,
-    Swap, Transaction, UserTransferType,
+    BackendKind, BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown, HealthStatus,
+    InstanceInfo, Order, OrderSide, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteParams,
+    QuoteStatus, Route, Swap, Transaction, UserTransferType,
 };
 
 mod client;

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -297,24 +297,26 @@ impl From<dto::BlockInfo> for BlockInfo {
     }
 }
 
-pub(crate) fn dto_to_instance_info(
-    dto: fynd_rpc_types::InstanceInfo,
-) -> Result<crate::types::InstanceInfo, FyndError> {
-    let router = bytes::Bytes::copy_from_slice(dto.router_address().as_ref());
-    let permit2 = bytes::Bytes::copy_from_slice(dto.permit2_address().as_ref());
-    if router.len() != 20 {
-        return Err(FyndError::Protocol(format!(
-            "router_address must be 20 bytes, got {}",
-            router.len()
-        )));
+impl TryFrom<fynd_rpc_types::InstanceInfo> for crate::types::InstanceInfo {
+    type Error = FyndError;
+
+    fn try_from(dto: fynd_rpc_types::InstanceInfo) -> Result<Self, Self::Error> {
+        let router = bytes::Bytes::copy_from_slice(dto.router_address().as_ref());
+        let permit2 = bytes::Bytes::copy_from_slice(dto.permit2_address().as_ref());
+        if router.len() != 20 {
+            return Err(FyndError::Protocol(format!(
+                "router_address must be 20 bytes, got {}",
+                router.len()
+            )));
+        }
+        if permit2.len() != 20 {
+            return Err(FyndError::Protocol(format!(
+                "permit2_address must be 20 bytes, got {}",
+                permit2.len()
+            )));
+        }
+        Ok(crate::types::InstanceInfo::new(router, permit2, dto.chain_id()))
     }
-    if permit2.len() != 20 {
-        return Err(FyndError::Protocol(format!(
-            "permit2_address must be 20 bytes, got {}",
-            permit2.len()
-        )));
-    }
-    Ok(crate::types::InstanceInfo::new(router, permit2, dto.chain_id()))
 }
 
 impl From<dto::HealthStatus> for HealthStatus {

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -297,6 +297,26 @@ impl From<dto::BlockInfo> for BlockInfo {
     }
 }
 
+pub(crate) fn dto_to_instance_info(
+    dto: fynd_rpc_types::InstanceInfo,
+) -> Result<crate::types::InstanceInfo, FyndError> {
+    let router = bytes::Bytes::copy_from_slice(dto.router_address().as_ref());
+    let permit2 = bytes::Bytes::copy_from_slice(dto.permit2_address().as_ref());
+    if router.len() != 20 {
+        return Err(FyndError::Protocol(format!(
+            "router_address must be 20 bytes, got {}",
+            router.len()
+        )));
+    }
+    if permit2.len() != 20 {
+        return Err(FyndError::Protocol(format!(
+            "permit2_address must be 20 bytes, got {}",
+            permit2.len()
+        )));
+    }
+    Ok(crate::types::InstanceInfo::new(router, permit2, dto.chain_id()))
+}
+
 impl From<dto::HealthStatus> for HealthStatus {
     fn from(dh: dto::HealthStatus) -> Self {
         HealthStatus::new(

--- a/clients/rust/src/signing.rs
+++ b/clients/rust/src/signing.rs
@@ -196,9 +196,9 @@ impl SettledOrder {
 
 /// A future that resolves once the swap transaction is mined and settled.
 ///
-/// Returned by [`FyndClient::execute`](crate::FyndClient::execute). The inner future polls the
-/// RPC node every 2 seconds and **has no built-in timeout** — it will poll indefinitely if the
-/// transaction is never mined. Callers should wrap it with [`tokio::time::timeout`]:
+/// Returned by [`FyndClient::execute_swap`](crate::FyndClient::execute_swap). The inner future
+/// polls the RPC node every 2 seconds and **has no built-in timeout** — it will poll indefinitely
+/// if the transaction is never mined. Callers should wrap it with [`tokio::time::timeout`]:
 ///
 /// ```rust,no_run
 /// # use fynd_client::ExecutionReceipt;
@@ -285,7 +285,7 @@ impl ApprovalPayload {
 ///
 /// Construct via [`SignedApproval::assemble`] after signing the
 /// [`signing_hash`](ApprovalPayload::signing_hash). Pass to
-/// [`FyndClient::submit`](crate::FyndClient::submit).
+/// [`FyndClient::execute_approval`](crate::FyndClient::execute_approval).
 pub struct SignedApproval {
     payload: ApprovalPayload,
     signature: Signature,
@@ -341,8 +341,8 @@ impl MinedTx {
 
 /// A future that resolves once a submitted transaction is mined.
 ///
-/// Returned by [`FyndClient::submit`](crate::FyndClient::submit). Polls the RPC node every
-/// 2 seconds with no built-in timeout — wrap with [`tokio::time::timeout`] as needed.
+/// Returned by [`FyndClient::execute_approval`](crate::FyndClient::execute_approval). Polls the RPC
+/// node every 2 seconds with no built-in timeout — wrap with [`tokio::time::timeout`] as needed.
 pub enum TxReceipt {
     /// A pending on-chain transaction.
     Pending(Pin<Box<dyn Future<Output = Result<MinedTx, FyndError>> + Send + 'static>>),

--- a/clients/rust/src/signing.rs
+++ b/clients/rust/src/signing.rs
@@ -241,8 +241,6 @@ pub struct ApprovalPayload {
     pub(crate) spender: bytes::Bytes,
     /// Amount being approved (token units).
     pub(crate) amount: BigUint,
-    /// Whether an approval is actually needed (populated when `check_allowance` is `true`).
-    pub(crate) is_needed: Option<bool>,
 }
 
 impl ApprovalPayload {
@@ -270,14 +268,6 @@ impl ApprovalPayload {
     /// Amount to approve (token units).
     pub fn amount(&self) -> &BigUint {
         &self.amount
-    }
-
-    /// Whether the approval is still needed.
-    ///
-    /// `None` when `check_allowance` was `false`. `Some(true)` means the current allowance is
-    /// less than `amount`; `Some(false)` means the allowance is already sufficient.
-    pub fn is_needed(&self) -> Option<bool> {
-        self.is_needed
     }
 }
 

--- a/clients/rust/src/signing.rs
+++ b/clients/rust/src/signing.rs
@@ -15,7 +15,7 @@ use crate::{error::FyndError, Quote};
 
 /// A ready-to-sign EIP-1559 transaction produced by the Fynd execution path.
 ///
-/// Obtain one via [`FyndClient::signable_payload`](crate::FyndClient::signable_payload) when
+/// Obtain one via [`FyndClient::swap_payload`](crate::FyndClient::swap_payload) when
 /// the quote's backend is [`BackendKind::Fynd`](crate::BackendKind::Fynd).
 #[derive(Debug)]
 pub struct FyndPayload {
@@ -35,7 +35,7 @@ impl FyndPayload {
 
     /// The unsigned EIP-1559 transaction. Sign its
     /// [`signature_hash()`](alloy::consensus::SignableTransaction::signature_hash) and pass the
-    /// result to [`SignedOrder::assemble`].
+    /// result to [`SignedSwap::assemble`].
     pub fn tx(&self) -> &TypedTransaction {
         &self.tx
     }
@@ -54,22 +54,22 @@ pub struct TurbinePayload {
     _order_quote: (),
 }
 
-/// A payload that needs to be signed before it can be executed.
+/// A payload that needs to be signed before a swap can be executed.
 ///
 /// Use [`signing_hash`](Self::signing_hash) to obtain the bytes to sign, then pass the resulting
-/// [`alloy::primitives::Signature`] to [`SignedOrder::assemble`].
+/// [`alloy::primitives::Signature`] to [`SignedSwap::assemble`].
 ///
 /// Only the [`Fynd`](Self::Fynd) variant is currently executable; calling methods on the
 /// [`Turbine`](Self::Turbine) variant will panic with `unimplemented!`.
 #[derive(Debug)]
-pub enum SignablePayload {
+pub enum SwapPayload {
     /// Fynd execution path — an EIP-1559 transaction targeting the RouterV3 contract.
     Fynd(Box<FyndPayload>),
     /// Turbine execution path — not yet implemented.
     Turbine(TurbinePayload),
 }
 
-impl SignablePayload {
+impl SwapPayload {
     /// Returns the 32-byte hash that must be signed.
     ///
     /// For the Fynd path this is the EIP-1559 transaction's `signature_hash()`.
@@ -110,7 +110,7 @@ impl SignablePayload {
         }
     }
 
-    /// Consume the payload and return its inner parts for use in `execute()`.
+    /// Consume the payload and return its inner parts for use in `execute_swap()`.
     pub(crate) fn into_fynd_parts(
         self,
     ) -> Result<(Quote, TypedTransaction), crate::error::FyndError> {
@@ -127,25 +127,25 @@ impl SignablePayload {
 // SIGNED ORDER
 // ============================================================================
 
-/// A [`SignablePayload`] paired with its cryptographic signature.
+/// A [`SwapPayload`] paired with its cryptographic signature.
 ///
-/// Construct via [`SignedOrder::assemble`] after signing the
-/// [`signing_hash`](SignablePayload::signing_hash). Pass to
-/// [`FyndClient::execute`](crate::FyndClient::execute) to broadcast and settle.
-pub struct SignedOrder {
-    payload: SignablePayload,
+/// Construct via [`SignedSwap::assemble`] after signing the
+/// [`signing_hash`](SwapPayload::signing_hash). Pass to
+/// [`FyndClient::execute_swap`](crate::FyndClient::execute_swap) to broadcast and settle.
+pub struct SignedSwap {
+    payload: SwapPayload,
     signature: Signature,
 }
 
-impl SignedOrder {
+impl SignedSwap {
     /// Pair a payload with the signature produced by signing its
-    /// [`signing_hash`](SignablePayload::signing_hash).
-    pub fn assemble(payload: SignablePayload, signature: Signature) -> Self {
+    /// [`signing_hash`](SwapPayload::signing_hash).
+    pub fn assemble(payload: SwapPayload, signature: Signature) -> Self {
         Self { payload, signature }
     }
 
-    /// The underlying signable payload.
-    pub fn payload(&self) -> &SignablePayload {
+    /// The underlying swap payload.
+    pub fn payload(&self) -> &SwapPayload {
         &self.payload
     }
 
@@ -154,7 +154,7 @@ impl SignedOrder {
         &self.signature
     }
 
-    pub(crate) fn into_parts(self) -> (SignablePayload, Signature) {
+    pub(crate) fn into_parts(self) -> (SwapPayload, Signature) {
         (self.payload, self.signature)
     }
 }

--- a/clients/rust/src/signing.rs
+++ b/clients/rust/src/signing.rs
@@ -1,7 +1,7 @@
 use std::{future::Future, pin::Pin};
 
 use alloy::{
-    consensus::TypedTransaction,
+    consensus::{TxEip1559, TypedTransaction},
     dyn_abi::TypedData,
     primitives::{Address, Signature, B256},
 };
@@ -221,6 +221,142 @@ impl Future for ExecutionReceipt {
     ) -> std::task::Poll<Self::Output> {
         match self.get_mut() {
             Self::Transaction(fut) => fut.as_mut().poll(cx),
+        }
+    }
+}
+
+// ============================================================================
+// APPROVAL PAYLOAD
+// ============================================================================
+
+/// An unsigned EIP-1559 `approve(spender, amount)` transaction.
+///
+/// Obtain via [`FyndClient::approval`](crate::FyndClient::approval). Sign its
+/// [`signing_hash`](Self::signing_hash) and pass the result to [`SignedApproval::assemble`].
+pub struct ApprovalPayload {
+    pub(crate) tx: TxEip1559,
+    /// ERC-20 token contract address (20 raw bytes).
+    pub(crate) token: bytes::Bytes,
+    /// Spender address being approved (20 raw bytes).
+    pub(crate) spender: bytes::Bytes,
+    /// Amount being approved (token units).
+    pub(crate) amount: BigUint,
+    /// Whether an approval is actually needed (populated when `check_allowance` is `true`).
+    pub(crate) is_needed: Option<bool>,
+}
+
+impl ApprovalPayload {
+    /// The 32-byte hash to sign.
+    pub fn signing_hash(&self) -> B256 {
+        use alloy::consensus::SignableTransaction;
+        self.tx.signature_hash()
+    }
+
+    /// The unsigned EIP-1559 transaction.
+    pub fn tx(&self) -> &TxEip1559 {
+        &self.tx
+    }
+
+    /// ERC-20 token address (20 raw bytes).
+    pub fn token(&self) -> &bytes::Bytes {
+        &self.token
+    }
+
+    /// Spender address (20 raw bytes).
+    pub fn spender(&self) -> &bytes::Bytes {
+        &self.spender
+    }
+
+    /// Amount to approve (token units).
+    pub fn amount(&self) -> &BigUint {
+        &self.amount
+    }
+
+    /// Whether the approval is still needed.
+    ///
+    /// `None` when `check_allowance` was `false`. `Some(true)` means the current allowance is
+    /// less than `amount`; `Some(false)` means the allowance is already sufficient.
+    pub fn is_needed(&self) -> Option<bool> {
+        self.is_needed
+    }
+}
+
+/// An [`ApprovalPayload`] paired with its cryptographic signature.
+///
+/// Construct via [`SignedApproval::assemble`] after signing the
+/// [`signing_hash`](ApprovalPayload::signing_hash). Pass to
+/// [`FyndClient::submit`](crate::FyndClient::submit).
+pub struct SignedApproval {
+    payload: ApprovalPayload,
+    signature: Signature,
+}
+
+impl SignedApproval {
+    /// Pair a payload with the signature produced by signing its
+    /// [`signing_hash`](ApprovalPayload::signing_hash).
+    pub fn assemble(payload: ApprovalPayload, signature: Signature) -> Self {
+        Self { payload, signature }
+    }
+
+    /// The underlying approval payload.
+    pub fn payload(&self) -> &ApprovalPayload {
+        &self.payload
+    }
+
+    /// The signature over the payload's signing hash.
+    pub fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    pub(crate) fn into_parts(self) -> (ApprovalPayload, Signature) {
+        (self.payload, self.signature)
+    }
+}
+
+// ============================================================================
+// MINED TX / TX RECEIPT
+// ============================================================================
+
+/// The result of a successfully mined transaction (non-swap).
+pub struct MinedTx {
+    tx_hash: B256,
+    gas_cost: BigUint,
+}
+
+impl MinedTx {
+    pub(crate) fn new(tx_hash: B256, gas_cost: BigUint) -> Self {
+        Self { tx_hash, gas_cost }
+    }
+
+    /// Transaction hash.
+    pub fn tx_hash(&self) -> B256 {
+        self.tx_hash
+    }
+
+    /// Actual gas cost in wei (`gas_used * effective_gas_price`).
+    pub fn gas_cost(&self) -> &BigUint {
+        &self.gas_cost
+    }
+}
+
+/// A future that resolves once a submitted transaction is mined.
+///
+/// Returned by [`FyndClient::submit`](crate::FyndClient::submit). Polls the RPC node every
+/// 2 seconds with no built-in timeout — wrap with [`tokio::time::timeout`] as needed.
+pub enum TxReceipt {
+    /// A pending on-chain transaction.
+    Pending(Pin<Box<dyn Future<Output = Result<MinedTx, FyndError>> + Send + 'static>>),
+}
+
+impl Future for TxReceipt {
+    type Output = Result<MinedTx, FyndError>;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        match self.get_mut() {
+            Self::Pending(fut) => fut.as_mut().poll(cx),
         }
     }
 }

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -868,6 +868,41 @@ impl BatchQuote {
     }
 }
 
+/// Static metadata about this Fynd instance, returned by `GET /v1/info`.
+pub struct InstanceInfo {
+    /// Router contract address (20 raw bytes).
+    pub router_address: bytes::Bytes,
+    /// Permit2 contract address (20 raw bytes).
+    pub permit2_address: bytes::Bytes,
+    /// Chain ID of the network this instance is deployed on.
+    pub chain_id: u64,
+}
+
+impl InstanceInfo {
+    pub(crate) fn new(
+        router_address: bytes::Bytes,
+        permit2_address: bytes::Bytes,
+        chain_id: u64,
+    ) -> Self {
+        Self { router_address, permit2_address, chain_id }
+    }
+
+    /// Router contract address (20 raw bytes).
+    pub fn router_address(&self) -> &bytes::Bytes {
+        &self.router_address
+    }
+
+    /// Permit2 contract address (20 raw bytes).
+    pub fn permit2_address(&self) -> &bytes::Bytes {
+        &self.permit2_address
+    }
+
+    /// Chain ID of the network this instance is deployed on.
+    pub fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+}
+
 /// Health information from the Fynd RPC server's `/v1/health` endpoint.
 #[derive(Debug)]
 pub struct HealthStatus {

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -871,11 +871,11 @@ impl BatchQuote {
 /// Static metadata about this Fynd instance, returned by `GET /v1/info`.
 pub struct InstanceInfo {
     /// Router contract address (20 raw bytes).
-    pub router_address: bytes::Bytes,
+    router_address: bytes::Bytes,
     /// Permit2 contract address (20 raw bytes).
-    pub permit2_address: bytes::Bytes,
+    permit2_address: bytes::Bytes,
     /// Chain ID of the network this instance is deployed on.
-    pub chain_id: u64,
+    chain_id: u64,
 }
 
 impl InstanceInfo {

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -777,7 +777,7 @@ impl Quote {
     /// The `token_out` address from the originating [`Order`] (20 raw bytes).
     ///
     /// Populated by [`FyndClient::quote`](crate::FyndClient::quote) and used by
-    /// [`FyndClient::execute`](crate::FyndClient::execute) to parse the settlement log.
+    /// [`FyndClient::execute_swap`](crate::FyndClient::execute_swap) to parse the settlement log.
     pub fn token_out(&self) -> &Bytes {
         &self.token_out
     }
@@ -786,7 +786,8 @@ impl Quote {
     ///
     /// Defaults to `sender` when the order had no explicit receiver. Populated by
     /// [`FyndClient::quote`](crate::FyndClient::quote) and used by
-    /// [`FyndClient::execute`](crate::FyndClient::execute) to verify the Transfer log recipient.
+    /// [`FyndClient::execute_swap`](crate::FyndClient::execute_swap) to verify the Transfer log
+    /// recipient.
     pub fn receiver(&self) -> &Bytes {
         &self.receiver
     }

--- a/clients/rust/tests/integration.rs
+++ b/clients/rust/tests/integration.rs
@@ -468,6 +468,7 @@ async fn full_quote_then_swap_payload_resolves_from_provider() {
         "reward": [["0xf4240", "0x1e8480"]]
     });
     asserter.push_success(&fee_history); // eth_feeHistory
+    asserter.push_success(&180_000u64); // eth_estimateGas
 
     let hints = SigningHints::default(); // no overrides — resolved from provider
 

--- a/clients/rust/tests/integration.rs
+++ b/clients/rust/tests/integration.rs
@@ -16,7 +16,7 @@ use alloy::{
 };
 use fynd_client::{
     ErrorCode, FyndClient, FyndError, Order, OrderSide, QuoteOptions, QuoteParams, RetryConfig,
-    SignablePayload, SigningHints,
+    SigningHints, SwapPayload,
 };
 use num_bigint::BigUint;
 use wiremock::{
@@ -385,14 +385,14 @@ async fn quote_receiver_defaults_to_sender_when_none() {
     server.verify().await;
 }
 
-/// Full round-trip: quote, then signable_payload with all hints — no RPC calls needed.
+/// Full round-trip: quote, then swap_payload with all hints — no RPC calls needed.
 ///
 /// This test exercises the complete flow that a real user would follow:
 /// 1. Call quote() to get an OrderQuote.
-/// 2. Call signable_payload() on the quote with explicit hints.
+/// 2. Call swap_payload() on the quote with explicit hints.
 /// 3. Verify the returned EIP-1559 tx has the expected fields.
 #[tokio::test]
-async fn full_quote_then_signable_payload_with_all_hints() {
+async fn full_quote_then_swap_payload_with_all_hints() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -418,11 +418,11 @@ async fn full_quote_then_signable_payload_with_all_hints() {
         .with_gas_limit(80_000);
 
     let payload = client
-        .signable_payload(quote, &hints)
+        .swap_payload(quote, &hints)
         .await
-        .expect("signable_payload should succeed");
+        .expect("swap_payload should succeed");
 
-    let SignablePayload::Fynd(fynd) = payload else {
+    let SwapPayload::Fynd(fynd) = payload else {
         panic!("expected Fynd payload");
     };
 
@@ -439,9 +439,9 @@ async fn full_quote_then_signable_payload_with_all_hints() {
     server.verify().await;
 }
 
-/// Full round-trip: quote, signable_payload resolving nonce/fees from mock provider.
+/// Full round-trip: quote, swap_payload resolving nonce/fees from mock provider.
 #[tokio::test]
-async fn full_quote_then_signable_payload_resolves_from_provider() {
+async fn full_quote_then_swap_payload_resolves_from_provider() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -472,11 +472,11 @@ async fn full_quote_then_signable_payload_resolves_from_provider() {
     let hints = SigningHints::default(); // no overrides — resolved from provider
 
     let payload = client
-        .signable_payload(quote, &hints)
+        .swap_payload(quote, &hints)
         .await
-        .expect("signable_payload should succeed");
+        .expect("swap_payload should succeed");
 
-    let SignablePayload::Fynd(fynd) = payload else {
+    let SwapPayload::Fynd(fynd) = payload else {
         panic!("expected Fynd payload");
     };
 

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -139,57 +139,62 @@ The full tutorial (signing + on-chain execution) is at `clients/typescript/examp
 {% endtab %}
 
 {% tab title="Rust" %}
-From [`clients/rust/examples/quote.rs`](../../../clients/rust/examples/quote.rs):
+From [`clients/rust/examples/swap_erc20.rs`](../../../clients/rust/examples/swap_erc20.rs):
 
 ```rust
-    let client = FyndClientBuilder::new(FYND_URL, FYND_URL)
-        .build_quote_only()
-        .expect("valid URL");
+let client = FyndClientBuilder::new(FYND_URL, RPC_URL)
+    .with_sender(sender)
+    .build()
+    .await?;
 
-    // -----------------------------------------------------------------------
-    // Health check
-    // -----------------------------------------------------------------------
-    let health = client.health().await?;
-    println!("=== Health ===");
-    println!("  healthy:            {}", health.healthy());
-    println!("  last_update_ms:     {}", health.last_update_ms());
-    println!("  num_solver_pools:   {}", health.num_solver_pools());
-    println!("  derived_data_ready: {}", health.derived_data_ready());
-    println!();
+// 1. Quote
+let quote = client
+    .quote(QuoteParams::new(
+        Order::new(
+            Bytes::copy_from_slice(sell_token.as_slice()),
+            Bytes::copy_from_slice(buy_token.as_slice()),
+            BigUint::from(SELL_AMOUNT),
+            OrderSide::Sell,
+            Bytes::copy_from_slice(sender.as_slice()),
+            None,
+        ),
+        QuoteOptions::default()
+            .with_timeout_ms(5_000)
+            .with_encoding_options(EncodingOptions::new(SLIPPAGE)),
+    ))
+    .await?;
+println!("amount_out: {}", quote.amount_out());
 
-    // -----------------------------------------------------------------------
-    // Quote 1: sell 1 WETH for USDC
-    // -----------------------------------------------------------------------
-    let quote = client
-        .quote(QuoteParams::new(
-            Order::new(addr(WETH), addr(USDC), one_ether(), OrderSide::Sell, addr(VITALIK), None),
-            QuoteOptions::default(),
-        ))
+// 2. Approve if needed (checks on-chain allowance, skips if sufficient)
+if let Some(approval_payload) = client
+    .approval(
+        &ApprovalParams::new(
+            Bytes::copy_from_slice(sell_token.as_slice()),
+            BigUint::from(SELL_AMOUNT),
+            true,
+        ),
+        &SigningHints::default(),
+    )
+    .await?
+{
+    let sig = signer.sign_hash(&approval_payload.signing_hash()).await?;
+    client
+        .execute_approval(SignedApproval::assemble(approval_payload, sig))
+        .await?
         .await?;
+}
 
-    println!("=== Quote: 1 WETH → USDC ===");
-    println!("  order_id:      {}", quote.order_id());
-    println!("  status:        {:?}", quote.status());
-    println!("  amount_in:     {}", quote.amount_in());
-    println!("  amount_out:    {}", quote.amount_out());
-    println!("  gas_estimate:  {}", quote.gas_estimate());
-    println!("  solve_time_ms: {}", quote.solve_time_ms());
-    println!("  block:         #{} ({})", quote.block().number(), quote.block().hash());
-    if let Some(route) = quote.route() {
-        for (i, swap) in route.swaps().iter().enumerate() {
-            println!(
-                "  swap[{i}]: {} {} → {} (pool {})",
-                swap.protocol(),
-                swap.amount_in(),
-                swap.amount_out(),
-                swap.component_id(),
-            );
-        }
-    }
-    println!();
+// 3. Sign and execute swap
+let payload = client.swap_payload(quote, &SigningHints::default()).await?;
+let sig = signer.sign_hash(&payload.signing_hash()).await?;
+let receipt = client
+    .execute_swap(SignedSwap::assemble(payload, sig), &ExecutionOptions::default())
+    .await?
+    .await?;
+println!("gas: {}", receipt.gas_cost());
 ```
 
-Run with: `cargo run --example quote`
+Run with: `cargo run --example swap_erc20 -p fynd-client`
 {% endtab %}
 {% endtabs %}
 

--- a/docs/guides/client-fees.md
+++ b/docs/guides/client-fees.md
@@ -109,7 +109,7 @@ The fee receiver signs a typed data hash:
     );
 
     // Compute the EIP-712 signing hash and sign it with the fee receiver's key.
-    let hash = fee.eip712_signing_hash(1, &router_address)?; // chainId = Ethereum mainnet
+    let hash = fee.eip712_signing_hash(chain_id, &router_address)?;
     let sig = fee_signer
         .sign_hash(&B256::from(hash))
         .await?;

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -46,8 +46,7 @@ start_anvil() {
         --port 8545 \
         --mnemonic "$_MNEMONIC" \
         --balance 10000 \
-        --steps-tracing \
-        --silent &
+        --enable-trace-printing &
     _ANVIL_PID=$!
 
     local i

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -75,8 +75,8 @@ start_fynd() {
     local tycho_args=()
     [[ -n "${TYCHO_URL:-}" ]] && tycho_args+=(--tycho-url "$TYCHO_URL")
     echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL${TYCHO_URL:+, TYCHO_URL: $TYCHO_URL})..."
-    RUST_LOG="${RUST_LOG:-error}" cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
-        serve --rpc-url "$ANVIL_RPC_URL" --protocols uniswap_v3,uniswap_v2 --min-tvl 200 "${tycho_args[@]}" &
+    RUST_LOG="${RUST_LOG:-info}" cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
+        serve --rpc-url "$ANVIL_RPC_URL" --protocols uniswap_v2,uniswap_v3 --min-tvl 200 "${tycho_args[@]}" &
     _FYND_PID=$!
 
     echo "    Waiting for fynd to be healthy (this may take a minute on first run)..."

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -46,6 +46,7 @@ start_anvil() {
         --port 8545 \
         --mnemonic "$_MNEMONIC" \
         --balance 10000 \
+        --steps-tracing \
         --silent &
     _ANVIL_PID=$!
 
@@ -75,8 +76,8 @@ start_fynd() {
     local tycho_args=()
     [[ -n "${TYCHO_URL:-}" ]] && tycho_args+=(--tycho-url "$TYCHO_URL")
     echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL${TYCHO_URL:+, TYCHO_URL: $TYCHO_URL})..."
-    RUST_LOG="${RUST_LOG:-info}" cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
-        serve --rpc-url "$ANVIL_RPC_URL" "${tycho_args[@]}" &
+    RUST_LOG="${RUST_LOG:-error}" cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
+        serve --rpc-url "$ANVIL_RPC_URL" --protocols uniswap_v3,uniswap_v2 --min-tvl 200 "${tycho_args[@]}" &
     _FYND_PID=$!
 
     echo "    Waiting for fynd to be healthy (this may take a minute on first run)..."

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -79,9 +79,9 @@ start_fynd() {
         serve --rpc-url "$ANVIL_RPC_URL" --protocols uniswap_v2,uniswap_v3 --min-tvl 200 "${tycho_args[@]}" &
     _FYND_PID=$!
 
-    echo "    Waiting for fynd to be healthy (this may take a minute on first run)..."
+    echo "    Waiting for fynd to be healthy (Tycho sync can take a few minutes)..."
     local i
-    for i in $(seq 90); do
+    for i in $(seq 150); do
         if curl -sf "$FYND_URL/v1/health" &>/dev/null; then
             echo "    Ready at $FYND_URL"
             return
@@ -92,6 +92,6 @@ start_fynd() {
             exit 1
         fi
     done
-    echo "fynd failed to become healthy within 3 minutes"
+    echo "fynd failed to become healthy within 5 minutes"
     exit 1
 }

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -72,9 +72,9 @@ wrap_weth() {
 }
 
 start_fynd() {
-    echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL)..."
+    echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL, TYCHO_URL: $TYCHO_URL)..."
     cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
-        serve --rpc-url "$ANVIL_RPC_URL" &
+        serve --rpc-url "$ANVIL_RPC_URL" --tycho-url "$TYCHO_URL" &
     _FYND_PID=$!
 
     echo "    Waiting for fynd to be healthy (this may take a minute on first run)..."

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -1,0 +1,94 @@
+# shellcheck shell=bash
+# Shared setup for dev-env.sh and run-example.sh.
+# Source this file; do not run it directly.
+#
+# Defines: check_deps, start_anvil, wrap_weth, start_fynd
+# Sets:    REPO_ROOT, ANVIL_RPC_URL, FYND_URL, FORK_RPC_URL
+# Registers an EXIT trap to kill background processes on exit.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORK_RPC_URL="${FORK_RPC_URL:-https://reth-ethereum.ithaca.xyz/rpc}"
+ANVIL_RPC_URL="http://localhost:8545"
+FYND_URL="http://localhost:3000"
+
+_PRIVATE_KEY="0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5"
+_WETH="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+_ANVIL_PID=""
+_FYND_PID=""
+
+_cleanup() {
+    [[ -n "$_ANVIL_PID" ]] && kill "$_ANVIL_PID" 2>/dev/null || true
+    [[ -n "$_FYND_PID" ]] && kill "$_FYND_PID" 2>/dev/null || true
+    echo "Dev environment stopped."
+}
+trap _cleanup EXIT
+
+check_deps() {
+    local missing=()
+    command -v anvil &>/dev/null || missing+=("anvil")
+    command -v cast  &>/dev/null || missing+=("cast")
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        printf "Missing tools: %s\n" "${missing[*]}"
+        echo "Install Foundry: curl -L https://foundry.paradigm.xyz | bash && foundryup"
+        exit 1
+    fi
+    if [[ -z "${TYCHO_API_KEY:-}" ]]; then
+        echo "TYCHO_API_KEY is not set. Get one at: https://t.me/fynd_portal_bot"
+        exit 1
+    fi
+}
+
+start_anvil() {
+    echo "==> Starting Anvil (fork: $FORK_RPC_URL)..."
+    anvil \
+        --fork-url "$FORK_RPC_URL" \
+        --port 8545 \
+        --private-keys "$_PRIVATE_KEY" \
+        --balance 10000 \
+        --silent &
+    _ANVIL_PID=$!
+
+    local i
+    for i in $(seq 30); do
+        cast block-number --rpc-url "$ANVIL_RPC_URL" &>/dev/null && break
+        sleep 0.5
+        if [[ $i -eq 30 ]]; then
+            echo "Anvil failed to start within 15s"
+            exit 1
+        fi
+    done
+    echo "    Ready at $ANVIL_RPC_URL"
+}
+
+wrap_weth() {
+    echo "==> Wrapping 1000 ETH → WETH..."
+    cast send "$_WETH" "deposit()" \
+        --value 1000ether \
+        --private-key "$_PRIVATE_KEY" \
+        --rpc-url "$ANVIL_RPC_URL" \
+        --quiet
+    echo "    Done"
+}
+
+start_fynd() {
+    echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL)..."
+    cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
+        serve --rpc-url "$ANVIL_RPC_URL" &
+    _FYND_PID=$!
+
+    echo "    Waiting for fynd to be healthy (this may take a minute on first run)..."
+    local i
+    for i in $(seq 90); do
+        if curl -sf "$FYND_URL/v1/health" &>/dev/null; then
+            echo "    Ready at $FYND_URL"
+            return
+        fi
+        sleep 2
+        if ! kill -0 "$_FYND_PID" 2>/dev/null; then
+            echo "fynd process exited unexpectedly. Check TYCHO_API_KEY and logs."
+            exit 1
+        fi
+    done
+    echo "fynd failed to become healthy within 3 minutes"
+    exit 1
+}

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -11,7 +11,8 @@ FORK_RPC_URL="${FORK_RPC_URL:-https://reth-ethereum.ithaca.xyz/rpc}"
 ANVIL_RPC_URL="http://localhost:8545"
 FYND_URL="http://localhost:3000"
 
-_PRIVATE_KEY="0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5"
+_MNEMONIC="undo about satisfy liberty crime forget extra erode fever peasant ability cotton"
+_PRIVATE_KEY="0x02d483ff876e4d1d55ddc829a22df2707bd2574ba18d0d870ef9c9edd3c0fe29"
 _WETH="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 _ANVIL_PID=""
 _FYND_PID=""
@@ -43,7 +44,7 @@ start_anvil() {
     anvil \
         --fork-url "$FORK_RPC_URL" \
         --port 8545 \
-        --private-keys "$_PRIVATE_KEY" \
+        --mnemonic "$_MNEMONIC" \
         --balance 10000 \
         --silent &
     _ANVIL_PID=$!

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -75,7 +75,7 @@ start_fynd() {
     local tycho_args=()
     [[ -n "${TYCHO_URL:-}" ]] && tycho_args+=(--tycho-url "$TYCHO_URL")
     echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL${TYCHO_URL:+, TYCHO_URL: $TYCHO_URL})..."
-    RUST_LOG="${RUST_LOG:-info}" cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
+    RUST_LOG="${RUST_LOG:-warn}" cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
         serve --rpc-url "$ANVIL_RPC_URL" --protocols uniswap_v2,uniswap_v3 --min-tvl 200 "${tycho_args[@]}" &
     _FYND_PID=$!
 

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -72,9 +72,11 @@ wrap_weth() {
 }
 
 start_fynd() {
-    echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL, TYCHO_URL: $TYCHO_URL)..."
+    local tycho_args=()
+    [[ -n "${TYCHO_URL:-}" ]] && tycho_args+=(--tycho-url "$TYCHO_URL")
+    echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL${TYCHO_URL:+, TYCHO_URL: $TYCHO_URL})..."
     cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
-        serve --rpc-url "$ANVIL_RPC_URL" --tycho-url "$TYCHO_URL" &
+        serve --rpc-url "$ANVIL_RPC_URL" "${tycho_args[@]}" &
     _FYND_PID=$!
 
     echo "    Waiting for fynd to be healthy (this may take a minute on first run)..."

--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -75,7 +75,7 @@ start_fynd() {
     local tycho_args=()
     [[ -n "${TYCHO_URL:-}" ]] && tycho_args+=(--tycho-url "$TYCHO_URL")
     echo "==> Building and starting fynd serve (RPC: $ANVIL_RPC_URL${TYCHO_URL:+, TYCHO_URL: $TYCHO_URL})..."
-    cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
+    RUST_LOG="${RUST_LOG:-info}" cargo run --manifest-path "$REPO_ROOT/Cargo.toml" --release --quiet -- \
         serve --rpc-url "$ANVIL_RPC_URL" "${tycho_args[@]}" &
     _FYND_PID=$!
 

--- a/scripts/check-doc-snippets.sh
+++ b/scripts/check-doc-snippets.sh
@@ -8,7 +8,6 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Format: "source_file:anchor_name:doc_file"
 SNIPPETS=(
-    "clients/rust/examples/quote.rs:quote-rust:docs/get-started/quickstart/README.md"
     "clients/typescript/examples/tutorial/main.ts:quote-typescript:docs/get-started/quickstart/README.md"
     "fynd-core/examples/custom_algorithm.rs:custom-algo-impl:docs/guides/custom-algorithm.md"
     "fynd-core/examples/custom_algorithm.rs:custom-algo-wire:docs/guides/custom-algorithm.md"

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -23,7 +23,7 @@
 #   ./scripts/run-example.sh swap_erc20
 set -euo pipefail
 
-# shellcheck source=scripts/_env-setup.sh
+# shellcheck source=scripts/_env-setup.sh disable=SC1091
 source "$(dirname "$0")/_env-setup.sh"
 
 check_deps

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Start a local dev environment for running fynd-client examples.
+#
+# Starts a forked Anvil node with a funded account, wraps 1000 ETH to WETH,
+# then runs fynd serve. Runs until interrupted (Ctrl-C).
+#
+# Usage:
+#   ./scripts/dev-env.sh
+#
+# Options (env vars):
+#   FORK_RPC_URL   Ethereum node to fork from
+#                  (default: https://reth-ethereum.ithaca.xyz/rpc)
+#   TYCHO_API_KEY  Required. Get one at: https://t.me/fynd_portal_bot
+#
+# The funded account:
+#   Private key: 0x912a64d0474cbddb4afd9b1aa2e800c433a3e975fa858395e6134220cf2b4cd5
+#   Balance:     10 000 ETH + 1 000 WETH
+#
+# Once running, point examples at the local stack:
+#   RPC_URL=http://localhost:8545 cargo run --example swap_erc20 -p fynd-client
+#
+# Or use run-example.sh which handles this automatically:
+#   ./scripts/run-example.sh swap_erc20
+set -euo pipefail
+
+# shellcheck source=scripts/_env-setup.sh
+source "$(dirname "$0")/_env-setup.sh"
+
+check_deps
+start_anvil
+wrap_weth
+start_fynd
+
+echo ""
+echo "Dev environment ready."
+echo "  Anvil RPC : $ANVIL_RPC_URL"
+echo "  Fynd      : $FYND_URL"
+echo ""
+echo "Run an example:"
+echo "  RPC_URL=$ANVIL_RPC_URL cargo run --example swap_erc20 -p fynd-client"
+echo "  ./scripts/run-example.sh swap_erc20"
+echo ""
+echo "Press Ctrl-C to stop."
+
+wait "$_FYND_PID"

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -38,7 +38,6 @@ echo "  Fynd      : $FYND_URL"
 echo ""
 echo "Run an example:"
 echo "  RPC_URL=$ANVIL_RPC_URL cargo run --example swap_erc20 -p fynd-client"
-echo "  ./scripts/run-example.sh swap_erc20"
 echo ""
 echo "Press Ctrl-C to stop."
 

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # shellcheck source=scripts/_env-setup.sh disable=SC1091
 source "$(dirname "$0")/_env-setup.sh"
 
-EXAMPLES=(swap_erc20 swap_permit2 swap_client_fee quote)
+EXAMPLES=(swap_erc20)
 
 check_deps
 start_anvil

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # shellcheck source=scripts/_env-setup.sh disable=SC1091
 source "$(dirname "$0")/_env-setup.sh"
 
-EXAMPLES=(swap_erc20 swap_permit2)
+EXAMPLES=(swap_erc20 swap_permit2 swap_client_fee)
 
 check_deps
 start_anvil

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run all fynd-client examples against a single shared dev environment.
+#
+# Starts Anvil + fynd serve once, runs every example, then tears down.
+# Intended for CI; for running a single example interactively use
+# run-example.sh instead.
+#
+# Usage:
+#   ./scripts/run-all-examples.sh
+#
+# Options (env vars):
+#   FORK_RPC_URL   Ethereum node to fork from
+#                  (default: https://reth-ethereum.ithaca.xyz/rpc)
+#   TYCHO_API_KEY  Required. Get one at: https://t.me/fynd_portal_bot
+#   TYCHO_URL      Tycho endpoint (optional, uses fynd default if unset)
+set -euo pipefail
+
+# shellcheck source=scripts/_env-setup.sh disable=SC1091
+source "$(dirname "$0")/_env-setup.sh"
+
+EXAMPLES=(swap_erc20 swap_permit2 swap_client_fee quote)
+
+check_deps
+start_anvil
+wrap_weth
+start_fynd
+
+echo ""
+failed=()
+for example in "${EXAMPLES[@]}"; do
+    echo "==> Running: $example"
+    if cargo run \
+        --manifest-path "$REPO_ROOT/Cargo.toml" \
+        --example "$example" \
+        --package fynd-client \
+        --quiet 2>&1; then
+        echo "    PASS: $example"
+    else
+        echo "    FAIL: $example"
+        failed+=("$example")
+    fi
+    echo ""
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    printf "Failed examples: %s\n" "${failed[*]}"
+    exit 1
+fi
+
+echo "All examples passed."

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # shellcheck source=scripts/_env-setup.sh disable=SC1091
 source "$(dirname "$0")/_env-setup.sh"
 
-EXAMPLES=(swap_erc20)
+EXAMPLES=(swap_erc20 swap_permit2)
 
 check_deps
 start_anvil

--- a/scripts/run-all-examples.sh
+++ b/scripts/run-all-examples.sh
@@ -29,7 +29,7 @@ echo ""
 failed=()
 for example in "${EXAMPLES[@]}"; do
     echo "==> Running: $example"
-    if cargo run \
+    if RPC_URL="$ANVIL_RPC_URL" FYND_URL="$FYND_URL" cargo run \
         --manifest-path "$REPO_ROOT/Cargo.toml" \
         --example "$example" \
         --package fynd-client \

--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Run a fynd-client example against a fresh local dev environment.
+#
+# Starts a forked Anvil node, wraps 1000 ETH to WETH, starts fynd serve,
+# runs the example with RPC_URL pointed at Anvil, then tears everything down.
+#
+# Usage:
+#   ./scripts/run-example.sh <example-name>
+#
+# Examples:
+#   ./scripts/run-example.sh swap_erc20
+#   ./scripts/run-example.sh swap_permit2
+#   ./scripts/run-example.sh swap_client_fee
+#   ./scripts/run-example.sh quote
+#
+# Options (env vars):
+#   FORK_RPC_URL   Ethereum node to fork from
+#                  (default: https://reth-ethereum.ithaca.xyz/rpc)
+#   TYCHO_API_KEY  Required. Get one at: https://t.me/fynd_portal_bot
+set -euo pipefail
+
+EXAMPLE="${1:-}"
+if [[ -z "$EXAMPLE" ]]; then
+    echo "Usage: $0 <example-name>"
+    echo ""
+    echo "Available examples:"
+    echo "  swap_erc20       ERC-20 approve + swap"
+    echo "  swap_permit2     Permit2 approve + swap"
+    echo "  swap_client_fee  Swap with client fee"
+    echo "  quote            Quote only (no signing)"
+    exit 1
+fi
+
+# shellcheck source=scripts/_env-setup.sh
+source "$(dirname "$0")/_env-setup.sh"
+
+check_deps
+start_anvil
+wrap_weth
+start_fynd
+
+echo ""
+echo "==> Running example: $EXAMPLE"
+echo ""
+RPC_URL="$ANVIL_RPC_URL" \
+    cargo run \
+        --manifest-path "$REPO_ROOT/Cargo.toml" \
+        --example "$EXAMPLE" \
+        --package fynd-client \
+        --quiet

--- a/scripts/run-example.sh
+++ b/scripts/run-example.sh
@@ -31,7 +31,7 @@ if [[ -z "$EXAMPLE" ]]; then
     exit 1
 fi
 
-# shellcheck source=scripts/_env-setup.sh
+# shellcheck source=scripts/_env-setup.sh disable=SC1091
 source "$(dirname "$0")/_env-setup.sh"
 
 check_deps

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -28,7 +28,7 @@ use clap::Parser;
 use fynd_client::{
     EncodingOptions, ExecutionOptions, FyndClient, FyndClientBuilder, HealthStatus, Order,
     OrderSide, PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle, QuoteOptions,
-    QuoteParams, SignedOrder, SigningHints, StorageOverrides,
+    QuoteParams, SignedSwap, SigningHints, StorageOverrides,
 };
 use fynd_rpc::{
     builder::{parse_chain, FyndRPCBuilder},
@@ -543,12 +543,12 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Sign order payload ────────────────────────────────────────────────────
     let payload = client
-        .signable_payload(quote, &SigningHints::default())
+        .swap_payload(quote, &SigningHints::default())
         .await?;
     let order_sig = signer
         .sign_hash(&payload.signing_hash())
         .await?;
-    let signed = SignedOrder::assemble(payload, order_sig);
+    let signed = SignedSwap::assemble(payload, order_sig);
 
     // ── Build execution options ───────────────────────────────────────────────
     let exec_options = if cli.execute {
@@ -579,7 +579,7 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Execute ───────────────────────────────────────────────────────────────
     let receipt = client
-        .execute(signed, &exec_options)
+        .execute_swap(signed, &exec_options)
         .await?;
     let settled = if cli.execute {
         tokio::time::timeout(Duration::from_secs(120), receipt)

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -574,7 +574,7 @@ async fn main() -> anyhow::Result<()> {
             TransferType::UseVaultsFunds => None,
         };
         info!("Submitting dry-run execution...");
-        ExecutionOptions { dry_run: true, storage_overrides: overrides }
+        ExecutionOptions { dry_run: true, storage_overrides: overrides, fetch_revert_reason: true }
     };
 
     // ── Execute ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds an approval flow to `FyndClient` alongside a rename of the swap execution API for clarity.

### New methods

- **`info()`** — fetches and caches `GET /v1/info` (router address, permit2 address, chain ID). Cached via `OnceLock` after the first successful call.
- **`approval(params: &ApprovalParams, hints: &SigningHints)`** — builds an unsigned EIP-1559 `approve(router, amount)` transaction. On-chain allowance check is opt-in via `ApprovalParams::check_allowance` (off by default for latency-sensitive callers).
- **`execute_approval(signed: SignedApproval)`** — broadcasts a signed approval and polls for inclusion, returning `TxReceipt { tx_hash, gas_cost }`.

### Renamed for clarity

| Old | New |
|---|---|
| `signable_payload()` | `swap_payload()` |
| `SignablePayload` | `SwapPayload` |
| `SignedOrder` | `SignedSwap` |
| `execute()` | `execute_swap()` |

### New public types

`ApprovalParams`, `ApprovalPayload`, `SignedApproval`, `MinedTx`, `TxReceipt`, `InstanceInfo`

`execute_approval()` reuses the `send_raw()` private helper that was extracted from `execute_swap()`.

## Test plan

- `cargo nextest run -p fynd-client` — 75 tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- Tests cover: `info()` caching, calldata selector (`0x095ea7b3`), `check_allowance` both branches, `execute_approval` broadcast + poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)