### PR TITLE
refactor: reduce SharedMarketData read lock hold times

### DIFF
--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -427,30 +427,8 @@ impl Algorithm for MostLiquidAlgorithm {
             });
         }
 
-        // Acquire lock to read market data
-        let market = market.read().await;
-
-        // Early return if gas price is not found, we know this is required for simulation
-        if market.gas_price().is_none() {
-            return Err(AlgorithmError::DataNotFound { kind: "gas price", id: None });
-        }
-
-        // Debug: log edge weight status
-        let total_edges = graph.edge_count();
-        let edges_with_weights = graph
-            .edge_indices()
-            .filter(|&idx| {
-                graph
-                    .edge_weight(idx)
-                    .is_some_and(|e| e.data.is_some())
-            })
-            .count();
-        debug!(
-            total_edges,
-            edges_with_weights, paths_candidates, "graph edge weight status before scoring"
-        );
-
         // Step 2: Score and sort all paths by estimated output (higher score = better)
+        // No lock needed — scoring uses only local graph data.
         let mut scored_paths: Vec<(Path<DepthAndPrice>, f64)> = all_paths
             .into_iter()
             .filter_map(|path| {
@@ -490,8 +468,12 @@ impl Algorithm for MostLiquidAlgorithm {
             })
             .collect();
 
-        // Step 4: Extract market subset and release the lock over the main market data
+        // Step 4: Brief lock — check gas price + extract market subset for simulation
         let market = {
+            let market = market.read().await;
+            if market.gas_price().is_none() {
+                return Err(AlgorithmError::DataNotFound { kind: "gas price", id: None });
+            }
             let market_subset = market.extract_subset(&component_ids);
             drop(market);
             market_subset

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -609,8 +609,8 @@ mod tests {
 
             let reserve_in =
                 U256::from(case.reserve_in_human) * U256::from(10u64).pow(U256::from(decimals_in));
-            let reserve_out = U256::from(case.reserve_out_human)
-                * U256::from(10u64).pow(U256::from(decimals_out));
+            let reserve_out = U256::from(case.reserve_out_human) *
+                U256::from(10u64).pow(U256::from(decimals_out));
             let univ2 = UniswapV2State::new(reserve_in, reserve_out);
 
             let spot_price = univ2

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -83,19 +83,16 @@ impl DerivedComputation for PoolDepthComputation {
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<Self::Output, ComputationError> {
-        // Fetch all data needed for the computation under short-lived locks, then drop guards.
-        let (snapshot, spot_prices, mut pool_depths, components_to_compute) = {
-            let market_guard = market.read().await;
+        // Read derived data from store
+        let (spot_prices, mut pool_depths) = {
             let store_guard = store.read().await;
-
-            // Get precomputed spot prices (required dependency)
+            // Get precomputed spot prices (required dependency).
             let spot_prices = store_guard
                 .spot_prices()
                 .ok_or(ComputationError::MissingDependency(SpotPriceComputation::ID))?
                 .clone();
-
-            // Start with existing depths (or empty for full recompute)
-            let mut pool_depths = if changed.is_full_recompute {
+            // Start with existing depths (or empty for full recompute).
+            let pool_depths = if changed.is_full_recompute {
                 PoolDepths::new()
             } else {
                 store_guard
@@ -103,15 +100,20 @@ impl DerivedComputation for PoolDepthComputation {
                     .cloned()
                     .unwrap_or_default()
             };
+            (spot_prices, pool_depths)
+        };
 
-            // Remove pool depths for removed components
-            for component_id in &changed.removed {
-                pool_depths.retain(|key, _| &key.0 != component_id);
-            }
+        // Remove pool depths for removed components.
+        for component_id in &changed.removed {
+            pool_depths.retain(|key, _| &key.0 != component_id);
+        }
 
+        // Snapshot market data under brief lock.
+        let (snapshot, components_to_compute) = {
+            let market_guard = market.read().await;
             let topology = market_guard.component_topology();
 
-            // Determine which components to compute
+            // Determine which components need (re)computation.
             let components_to_compute: Vec<ComponentId> = if changed.is_full_recompute {
                 topology.keys().cloned().collect()
             } else {
@@ -129,7 +131,7 @@ impl DerivedComputation for PoolDepthComputation {
                 .collect();
             let snapshot: SharedMarketData = market_guard.extract_subset(&component_ids);
 
-            (snapshot, spot_prices, pool_depths, components_to_compute)
+            (snapshot, components_to_compute)
         };
 
         let topology = snapshot.component_topology();
@@ -607,8 +609,8 @@ mod tests {
 
             let reserve_in =
                 U256::from(case.reserve_in_human) * U256::from(10u64).pow(U256::from(decimals_in));
-            let reserve_out = U256::from(case.reserve_out_human) *
-                U256::from(10u64).pow(U256::from(decimals_out));
+            let reserve_out = U256::from(case.reserve_out_human)
+                * U256::from(10u64).pow(U256::from(decimals_out));
             let univ2 = UniswapV2State::new(reserve_in, reserve_out);
 
             let spot_price = univ2

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -2,6 +2,11 @@
 //!
 //! Computes spot prices for all pools in both directions using `ProtocolSim::spot_price()`.
 //! Spot prices are the instantaneous exchange rates without slippage.
+//!
+//! `ProtocolSim::spot_price()` is cheap for all pool types: VM pools return a pre-computed
+//! HashMap lookup, native pools do simple arithmetic. This means the read lock hold time is
+//! negligible (microseconds per pool), so we hold it for the full loop rather than paying the
+//! cost of cloning simulation states via `extract_subset()`.
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -46,9 +51,7 @@ impl DerivedComputation for SpotPriceComputation {
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<Self::Output, ComputationError> {
-        let market = market.read().await;
-
-        // Start with existing prices (or empty for full recompute)
+        // Start with existing prices (or empty for full recompute).
         let mut spot_prices = if changed.is_full_recompute {
             SpotPrices::new()
         } else {
@@ -58,43 +61,45 @@ impl DerivedComputation for SpotPriceComputation {
                 .spot_prices()
                 .cloned()
                 .unwrap_or_default();
-            // Remove spot prices for removed components
+            // Remove spot prices for removed components.
             for component_id in &changed.removed {
                 existing_prices.retain(|key, _| &key.0 != component_id);
             }
             existing_prices
         };
 
-        let topology = market.component_topology();
-        let tokens = market.token_registry_ref();
+        let market_guard = market.read().await;
+        let topology = market_guard.component_topology();
+        let tokens = market_guard.token_registry_ref();
 
-        // Determine which components to compute
+        // Determine which components need (re)computation.
         let components_to_compute: Vec<_> = if changed.is_full_recompute {
-            topology.keys().collect()
+            topology.keys().cloned().collect()
         } else {
             changed
                 .added
                 .keys()
                 .chain(changed.updated.iter())
+                .cloned()
                 .collect()
         };
+        let num_components_to_compute = components_to_compute.len();
 
         let mut succeeded = 0usize;
         let mut failed = 0usize;
-        let num_components_to_compute = components_to_compute.len();
 
-        for component_id in components_to_compute {
-            // Get token addresses: changed.added for new components, topology for existing
+        for component_id in &components_to_compute {
+            // Get token addresses: changed.added for new components, topology for existing.
             let token_addresses = changed
                 .added
                 .get(component_id)
                 .or_else(|| topology.get(component_id));
 
             let Some(token_addresses) = token_addresses else {
-                continue; // Component might have been removed in the meantime
+                continue;
             };
 
-            let Some(sim_state) = market.get_simulation_state(component_id) else {
+            let Some(sim_state) = market_guard.get_simulation_state(component_id) else {
                 warn!(component_id, "missing simulation state, skipping pool");
                 spot_prices.retain(|key, _| &key.0 != component_id);
                 continue;
@@ -135,11 +140,18 @@ impl DerivedComputation for SpotPriceComputation {
             }
         }
 
-        debug!(succeeded, failed, total = spot_prices.len(), "spot price computation complete");
+        drop(market_guard);
+
+        debug!(
+            succeeded,
+            failed,
+            total = spot_prices.len(),
+            "spot price computation complete"
+        );
         Span::current().record("updated_spot_prices", spot_prices.len());
 
-        // Return error if all calculations failed for a full recompute. Partial computations can
-        // fail for a small subset of components.
+        // Return error if all calculations failed for a full recompute.
+        // Partial (incremental) computations can fail for a small subset of components.
         if changed.is_full_recompute && succeeded == 0 && num_components_to_compute > 0 {
             return Err(ComputationError::TotalFailure {
                 computation_id: Self::ID,

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -142,12 +142,7 @@ impl DerivedComputation for SpotPriceComputation {
 
         drop(market_guard);
 
-        debug!(
-            succeeded,
-            failed,
-            total = spot_prices.len(),
-            "spot price computation complete"
-        );
+        debug!(succeeded, failed, total = spot_prices.len(), "spot price computation complete");
         Span::current().record("updated_spot_prices", spot_prices.len());
 
         // Return error if all calculations failed for a full recompute.

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -286,11 +286,11 @@ impl TokenGasPriceComputation {
         // denominator = 2 * (sim_amount + buy_gas_cost) * (sell_out - sell_gas_cost)
         let sell_out_net = &sell_out - &sell_gas_cost; // Safe: checked above
         let buy_price_precise = Price {
-            numerator: &buy_out * &sell_out_net +
-                &buy_out * (&self.simulation_amount + &buy_gas_cost),
-            denominator: BigUint::from(2u8) *
-                (&self.simulation_amount + &buy_gas_cost) *
-                sell_out_net,
+            numerator: &buy_out * &sell_out_net
+                + &buy_out * (&self.simulation_amount + &buy_gas_cost),
+            denominator: BigUint::from(2u8)
+                * (&self.simulation_amount + &buy_gas_cost)
+                * sell_out_net,
         };
 
         Ok((spread, buy_price_precise, path_components))
@@ -372,19 +372,28 @@ impl TokenGasPriceComputation {
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<Option<TokenGasPrices>, ComputationError> {
-        let store_guard = store.read().await;
+        // Read all needed data from store in a single lock acquisition.
+        let (existing_deps, existing_prices, spot_prices) = {
+            let store_guard = store.read().await;
 
-        // Need existing deps to do incremental computation
-        let Some(existing_deps) = store_guard.token_prices_deps() else {
-            return Ok(None); // No deps stored yet, need full compute
-        };
-        let Some(existing_prices) = store_guard.token_prices() else {
-            return Ok(None);
+            // Need existing deps to do incremental computation.
+            let Some(existing_deps) = store_guard.token_prices_deps().cloned() else {
+                return Ok(None); // No deps stored yet, need full compute
+            };
+            let Some(existing_prices) = store_guard.token_prices().cloned() else {
+                return Ok(None);
+            };
+            let spot_prices = store_guard
+                .spot_prices()
+                .ok_or(ComputationError::MissingDependency("spot_prices"))?
+                .clone();
+
+            (existing_deps, existing_prices, spot_prices)
         };
 
         let changed_components = changed.all_changed_ids();
 
-        // Find tokens whose paths intersect with changed components
+        // Find tokens whose paths intersect with changed components.
         let tokens_to_recompute: HashSet<Address> = existing_deps
             .iter()
             .filter(|(_, entry)| {
@@ -396,12 +405,8 @@ impl TokenGasPriceComputation {
             .collect();
 
         if tokens_to_recompute.is_empty() {
-            return Ok(Some(existing_prices.clone()));
+            return Ok(Some(existing_prices));
         }
-
-        let existing_prices = existing_prices.clone();
-        let existing_deps = existing_deps.clone();
-        drop(store_guard);
 
         debug!(
             affected_tokens = tokens_to_recompute.len(),
@@ -409,26 +414,32 @@ impl TokenGasPriceComputation {
             "incremental token price recomputation"
         );
 
-        let market = market.read().await;
-        let block = market
-            .last_updated()
-            .map(|b| b.number())
-            .unwrap_or(0);
+        // Snapshot market data under brief lock, then simulate on snapshot.
+        // simulate_token_prices calls get_amount_out (EVM simulation) which can take 100ms+.
+        let (snapshot, gas_price, block) = {
+            let market_guard = market.read().await;
+            let block = market_guard
+                .last_updated()
+                .map(|b| b.number())
+                .unwrap_or(0);
 
-        let store_guard = store.read().await;
-        let spot_prices = store_guard
-            .spot_prices()
-            .ok_or(ComputationError::MissingDependency("spot_prices"))?
-            .clone();
-        drop(store_guard);
+            let gas_price = market_guard
+                .gas_price()
+                .ok_or(ComputationError::MissingDependency("gas_price"))?
+                .effective_gas_price();
 
-        let gas_price = market
-            .gas_price()
-            .ok_or(ComputationError::MissingDependency("gas_price"))?
-            .effective_gas_price();
+            let component_ids: HashSet<ComponentId> = market_guard
+                .component_topology()
+                .keys()
+                .cloned()
+                .collect();
+            let snapshot = market_guard.extract_subset(&component_ids);
+
+            (snapshot, gas_price, block)
+        };
 
         let best_prices = self.simulate_token_prices(
-            &market,
+            &snapshot,
             &spot_prices,
             &gas_price,
             Some(&tokens_to_recompute),
@@ -487,26 +498,40 @@ impl DerivedComputation for TokenGasPriceComputation {
             // Fall through to full compute if incremental is not possible
         }
 
-        let market = market.read().await;
-        let store_guard = store.read().await;
-
-        let block = market
-            .last_updated()
-            .map(|b| b.number())
-            .unwrap_or(0);
-
-        let spot_prices = store_guard
+        // Read spot prices from store (independent of market lock).
+        let spot_prices = store
+            .read()
+            .await
             .spot_prices()
             .ok_or(ComputationError::MissingDependency("spot_prices"))?
             .clone();
-        drop(store_guard);
 
-        let gas_price = market
-            .gas_price()
-            .ok_or(ComputationError::MissingDependency("gas_price"))?
-            .effective_gas_price();
+        // Snapshot market data under brief lock, then simulate on snapshot.
+        // simulate_token_prices calls get_amount_out (EVM simulation) which can take 100ms+.
+        let (snapshot, gas_price, block) = {
+            let market_guard = market.read().await;
 
-        let best_prices = self.simulate_token_prices(&market, &spot_prices, &gas_price, None)?;
+            let block = market_guard
+                .last_updated()
+                .map(|b| b.number())
+                .unwrap_or(0);
+
+            let gas_price = market_guard
+                .gas_price()
+                .ok_or(ComputationError::MissingDependency("gas_price"))?
+                .effective_gas_price();
+
+            let component_ids: HashSet<ComponentId> = market_guard
+                .component_topology()
+                .keys()
+                .cloned()
+                .collect();
+            let snapshot = market_guard.extract_subset(&component_ids);
+
+            (snapshot, gas_price, block)
+        };
+
+        let best_prices = self.simulate_token_prices(&snapshot, &spot_prices, &gas_price, None)?;
 
         // Build token prices with dependencies for incremental computation
         let mut token_prices_with_deps = TokenPricesWithDeps::new();

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -286,11 +286,11 @@ impl TokenGasPriceComputation {
         // denominator = 2 * (sim_amount + buy_gas_cost) * (sell_out - sell_gas_cost)
         let sell_out_net = &sell_out - &sell_gas_cost; // Safe: checked above
         let buy_price_precise = Price {
-            numerator: &buy_out * &sell_out_net
-                + &buy_out * (&self.simulation_amount + &buy_gas_cost),
-            denominator: BigUint::from(2u8)
-                * (&self.simulation_amount + &buy_gas_cost)
-                * sell_out_net,
+            numerator: &buy_out * &sell_out_net +
+                &buy_out * (&self.simulation_amount + &buy_gas_cost),
+            denominator: BigUint::from(2u8) *
+                (&self.simulation_amount + &buy_gas_cost) *
+                sell_out_net,
         };
 
         Ok((spread, buy_price_precise, path_components))

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -297,21 +297,78 @@ impl TokenGasPriceComputation {
     }
 
     /// Core simulation logic: discovers paths, runs round-robin simulation,
-    /// returns best prices with dependency tracking.
+    /// returns best prices with dependency tracking and block number.
     ///
-    /// If `filter_tokens` is `Some`, only simulates those tokens (incremental mode).
-    /// If `None`, simulates all discovered tokens (full mode).
+    /// Takes two brief read locks on market:
+    /// 1. Clone topology + gas_price + block (cheap)
+    /// 2. `extract_subset` with only the components on candidate paths
+    ///
+    /// Path discovery (cheap DFS) runs twice to avoid holding borrows across await
+    /// points. The expensive part — EVM simulation — runs lock-free on the subset.
+    ///
+    /// # Arguments
+    ///
+    /// * `market`: The market data to simulate token prices on.
+    /// * `spot_prices`: The spot prices to use for the simulation.
+    /// * `filter_tokens`: An optional set of tokens to filter the simulation by. If None, all
+    ///   tokens are simulated.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing the best prices and the block number.
     #[allow(clippy::type_complexity)]
-    fn simulate_token_prices(
+    async fn simulate_token_prices(
         &self,
-        market: &SharedMarketData,
+        market: &SharedMarketDataRef,
         spot_prices: &SpotPrices,
-        gas_price: &BigUint,
         filter_tokens: Option<&HashSet<Address>>,
-    ) -> Result<HashMap<Address, (f64, Price, HashSet<ComponentId>)>, ComputationError> {
-        let mut graph_manager = PetgraphStableDiGraphManager::new();
-        graph_manager.initialize_graph(&market.component_topology());
+    ) -> Result<(HashMap<Address, (f64, Price, HashSet<ComponentId>)>, u64), ComputationError> {
+        // Brief lock 1: topology + gas_price + block (all cheap clones)
+        let (topology, gas_price, block) = {
+            let guard = market.read().await;
+            let topology = guard.component_topology();
+            let block = guard
+                .last_updated()
+                .map(|b| b.number())
+                .unwrap_or(0);
+            let gas_price = guard
+                .gas_price()
+                .ok_or(ComputationError::MissingDependency("gas_price"))?
+                .effective_gas_price();
+            (topology, gas_price, block)
+        };
 
+        // Discover paths to find which components candidate paths need (cheap DFS)
+        let needed_component_ids = {
+            let mut graph_manager = PetgraphStableDiGraphManager::new();
+            graph_manager.initialize_graph(&topology);
+            let mut paths = self.discover_paths(&graph_manager, spot_prices)?;
+            if let Some(tokens) = filter_tokens {
+                paths.retain(|token, _| tokens.contains(token));
+            }
+            paths
+                .values()
+                .flatten()
+                .flat_map(|c| {
+                    c.path
+                        .edge_data
+                        .iter()
+                        .map(|e| e.component_id.clone())
+                })
+                .collect::<HashSet<ComponentId>>()
+        };
+
+        // Brief lock 2: extract only the simulation states we need
+        let subset = {
+            market
+                .read()
+                .await
+                .extract_subset(&needed_component_ids)
+        };
+
+        // Rediscover paths from subset + simulate (no lock, expensive EVM simulation)
+        let mut graph_manager = PetgraphStableDiGraphManager::new();
+        graph_manager.initialize_graph(&subset.component_topology());
         let mut paths_by_token = self.discover_paths(&graph_manager, spot_prices)?;
 
         // Optionally filter to only requested tokens
@@ -337,7 +394,7 @@ impl TokenGasPriceComputation {
                 };
                 candidates_exhausted = false;
 
-                match self.compute_spread_and_mid_price(candidate.path, market, gas_price) {
+                match self.compute_spread_and_mid_price(candidate.path, &subset, &gas_price) {
                     Ok((spread, price, components)) => {
                         let is_better = best_prices
                             .get(token)
@@ -357,7 +414,7 @@ impl TokenGasPriceComputation {
             }
         }
 
-        Ok(best_prices)
+        Ok((best_prices, block))
     }
 
     /// Attempts incremental recomputation for state-only changes.
@@ -414,36 +471,9 @@ impl TokenGasPriceComputation {
             "incremental token price recomputation"
         );
 
-        // Snapshot market data under brief lock, then simulate on snapshot.
-        // simulate_token_prices calls get_amount_out (EVM simulation) which can take 100ms+.
-        let (snapshot, gas_price, block) = {
-            let market_guard = market.read().await;
-            let block = market_guard
-                .last_updated()
-                .map(|b| b.number())
-                .unwrap_or(0);
-
-            let gas_price = market_guard
-                .gas_price()
-                .ok_or(ComputationError::MissingDependency("gas_price"))?
-                .effective_gas_price();
-
-            let component_ids: HashSet<ComponentId> = market_guard
-                .component_topology()
-                .keys()
-                .cloned()
-                .collect();
-            let snapshot = market_guard.extract_subset(&component_ids);
-
-            (snapshot, gas_price, block)
-        };
-
-        let best_prices = self.simulate_token_prices(
-            &snapshot,
-            &spot_prices,
-            &gas_price,
-            Some(&tokens_to_recompute),
-        )?;
+        let (best_prices, block) = self
+            .simulate_token_prices(market, &spot_prices, Some(&tokens_to_recompute))
+            .await?;
 
         // Merge results into existing prices and deps
         let mut result = existing_prices;
@@ -506,32 +536,9 @@ impl DerivedComputation for TokenGasPriceComputation {
             .ok_or(ComputationError::MissingDependency("spot_prices"))?
             .clone();
 
-        // Snapshot market data under brief lock, then simulate on snapshot.
-        // simulate_token_prices calls get_amount_out (EVM simulation) which can take 100ms+.
-        let (snapshot, gas_price, block) = {
-            let market_guard = market.read().await;
-
-            let block = market_guard
-                .last_updated()
-                .map(|b| b.number())
-                .unwrap_or(0);
-
-            let gas_price = market_guard
-                .gas_price()
-                .ok_or(ComputationError::MissingDependency("gas_price"))?
-                .effective_gas_price();
-
-            let component_ids: HashSet<ComponentId> = market_guard
-                .component_topology()
-                .keys()
-                .cloned()
-                .collect();
-            let snapshot = market_guard.extract_subset(&component_ids);
-
-            (snapshot, gas_price, block)
-        };
-
-        let best_prices = self.simulate_token_prices(&snapshot, &spot_prices, &gas_price, None)?;
+        let (best_prices, block) = self
+            .simulate_token_prices(market, &spot_prices, None)
+            .await?;
 
         // Build token prices with dependencies for incremental computation
         let mut token_prices_with_deps = TokenPricesWithDeps::new();

--- a/fynd-core/src/derived/mod.rs
+++ b/fynd-core/src/derived/mod.rs
@@ -57,5 +57,7 @@ pub(crate) mod tracker;
 pub(crate) mod types;
 
 // Only export the public API: manager, config, store, and shared reference type
-pub use manager::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef};
+pub use manager::{
+    ChangedComponents, ComputationManager, ComputationManagerConfig, SharedDerivedDataRef,
+};
 pub use store::DerivedData;

--- a/fynd-core/src/derived/mod.rs
+++ b/fynd-core/src/derived/mod.rs
@@ -57,7 +57,5 @@ pub(crate) mod tracker;
 pub(crate) mod types;
 
 // Only export the public API: manager, config, store, and shared reference type
-pub use manager::{
-    ChangedComponents, ComputationManager, ComputationManagerConfig, SharedDerivedDataRef,
-};
+pub use manager::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef};
 pub use store::DerivedData;


### PR DESCRIPTION
The tokio::RwLock protecting SharedMarketData is write-preferring — queued writers block new readers. Several read paths held the lock during expensive computation (EVM simulation, route scoring), causing request drops during block updates.                                                                                                                                                                                        
                  
## Changes:                                                                                                                                                                                                            
-  find_best_route — Merged two separate lock acquisitions (gas price check + extract_subset) into a single brief lock. Route scoring now runs entirely on a local snapshot with no lock held.                       
- TokenGasPriceComputation — Both full and incremental paths now use snapshot-then-simulate: brief lock to call extract_subset, then simulate on the local copy. Store reads are no longer nested inside the market
  lock.                                                                                                                                                                                                               
- PoolDepthComputation — Unnested store reads from the market lock. Store data is read first, then a brief market lock acquires the simulation snapshot.
- SpotPriceComputation — Reordered store reads to happen before the market lock. Kept the lock held during computation since spot_price() is a HashMap lookup (microseconds per pool).                              
                                                                                                                                                                                                                      
## Benchmark
  Before → After (under load across 8 blocks):                                                                                                                                                                        
                                                                                                                     
<img width="500" height="135" alt="Screenshot 2026-03-24 at 12 38 07" src="https://github.com/user-attachments/assets/e6a6c5c2-e20d-41f6-a8e7-da9215062d68" />
                                                                                                 
