### PR TITLE
docs: remove stale tycho-beta references, force GitBook re-sync

### DIFF
--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -13,7 +13,7 @@
 //! ```bash
 //! export TYCHO_API_KEY="your-api-key"  # Get from https://tycho.propellerheads.xyz
 //! export RPC_URL="https://eth.llamarpc.com"
-//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to tycho-beta
+//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to chain-specific Fynd endpoint
 //! cargo run --package fynd-core --example custom_algorithm
 //! ```
 

--- a/fynd-core/examples/solve_order.rs
+++ b/fynd-core/examples/solve_order.rs
@@ -8,7 +8,7 @@
 //! ```bash
 //! export TYCHO_API_KEY="your-api-key"  # Get from https://tycho.propellerheads.xyz
 //! export RPC_URL="https://eth.llamarpc.com"
-//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to tycho-beta
+//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to chain-specific Fynd endpoint
 //! cargo run --package fynd-core --example solve_order
 //! ```
 use std::{env, str::FromStr, time::Duration};


### PR DESCRIPTION
## Summary

- Remove last remaining `tycho-beta` references from example file comments (`solve_order.rs`, `custom_algorithm.rs`)
- Merging to main will trigger GitBook to re-sync from git, fixing the stale internal state caused by a conflict resolution in GitBook changeset #13

### Context

GitBook's internal state reverted to an older snapshot during a merge conflict resolution. The published docs at docs.fynd.xyz were showing:
- Base and Unichain as "coming soon" (they're already live)
- `tycho-beta.propellerheads.xyz` URLs instead of the `tycho-fynd-*` endpoints

The git repo already has the correct content on `main`. Merging this PR forces GitBook to re-read all files and sync its state back to what's in git.

## Test plan

- [ ] After merge, verify docs.fynd.xyz overview shows Base and Unichain as supported (not "coming soon")
- [ ] Verify quickstart page uses correct Tycho URLs (no tycho-beta)