### PR TITLE
docs: restore encoding doc updates (revert 56f27f4)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,10 +60,10 @@ Fynd works with any protocol Tycho supports. See the [list of supported protocol
 
 1. **TychoFeed** connects to **Tycho Streams** ([on-chain protocols](https://docs.propellerheads.xyz/tycho/for-solvers/simulation#streaming-protocol-states) and [RFQs](https://docs.propellerheads.xyz/tycho/for-solvers/request-for-quote-protocols#stream-real-time-price-updates)) and processes market updates (added/removed components and state changes) every block.
 2. **SharedMarketData** stores all component states, tokens, and gas prices in a single shared structure.
-3. When a **quote request** arrives via HTTP, the **WorkerPoolRouter** fans it out to all worker pools in parallel.
+3. When a **quote request** arrives via HTTP, the **OrderManager** fans it out to all worker pools in parallel.
 4. Each **Worker Pool** runs a specific algorithm. Workers compete to pick up the task, find routes through their local graph, simulate swaps against shared market state, and return ranked results.
-5. The **WorkerPoolRouter** collects results, picks the best solution by `amount_out_net_gas`, optionally encodes it into an on-chain transaction, and returns it.
+5. The **OrderManager** collects results, picks the best solution by `amount_out_net_gas`, optionally encodes it for execution against the `TychoRouter`, and returns it.
 
 ## Try it out
 
-Head to the [quickstart.md](get-started/quickstart.md "mention") to get Fynd running.
+Head to the [quickstart](get-started/quickstart/ "mention") to get Fynd running.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,7 +6,7 @@
 
 * [Overview](README.md)
   * [API Specifications](get-started/overview/api-specifications.md)
-* [Quickstart](get-started/quickstart.md)
+* [Quickstart](get-started/quickstart/README.md)
 
 ## Guides
 

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -24,8 +24,8 @@ Get a quote from Fynd in three steps.
 
 ## Prerequisites
 
-* **Tycho API key** — set as `TYCHO_API_KEY` ([get one here](https://app.gitbook.com/s/jrIe0oInIEt65tHqWn2w/for-solvers/indexer/tycho-client#authentication))
-* **Rust 1.92+** — install via [rustup](https://rustup.rs/)
+* **Tycho API key** (set as `TYCHO_API_KEY`, [get one here](https://t.me/fynd_portal_bot))
+* **Rust 1.92+** ([install via rustup](https://rustup.rs/))
 
 ## Step 1 — Start Fynd
 

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -68,7 +68,7 @@ This quotes 1000 USDC (6 decimals → 1 000 000 000 atomic units) for WETH.
 {% endtab %}
 
 {% tab title="TypeScript" %}
-From [`clients/typescript/examples/tutorial/main.ts`](../../clients/typescript/examples/tutorial/main.ts):
+From [`clients/typescript/examples/tutorial/main.ts`](../../../clients/typescript/examples/tutorial/main.ts):
 
 ```typescript
   // FyndClient accepts a viemProvider adapter — no manual wrapping needed.
@@ -139,7 +139,7 @@ The full tutorial (signing + on-chain execution) is at `clients/typescript/examp
 {% endtab %}
 
 {% tab title="Rust" %}
-From [`clients/rust/examples/quote.rs`](../../clients/rust/examples/quote.rs):
+From [`clients/rust/examples/quote.rs`](../../../clients/rust/examples/quote.rs):
 
 ```rust
     let client = FyndClientBuilder::new(FYND_URL, FYND_URL)
@@ -195,7 +195,7 @@ Run with: `cargo run --example quote`
 
 ## Next steps
 
-* [Server configuration](../guides/server-configuration.md)
-* [Custom algorithm](../guides/custom-algorithm.md)
-* [Benchmarking](../guides/benchmarking.md)
-* [Swap CLI](../guides/swap-cli.md)
+* [Server configuration](../../guides/server-configuration.md)
+* [Custom algorithm](../../guides/custom-algorithm.md)
+* [Benchmarking](../../guides/benchmarking.md)
+* [Swap CLI](../../guides/swap-cli.md)

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -24,7 +24,7 @@ layout:
 Fynd ships with a benchmark tool (`fynd-benchmark`) for load-testing a solver and comparing output quality between two solver instances. Both features live in `tools/benchmark/` and run against live solver instances.
 
 {% hint style="info" %}
-**Prerequisite:** You need a running solver before using any benchmark command. See [quickstart.md](../get-started/quickstart.md "mention") for setup instructions.
+**Prerequisite:** You need a running solver before using any benchmark command. See [quickstart](../get-started/quickstart/ "mention") for setup instructions.
 {% endhint %}
 
 ## Load Testing

--- a/docs/guides/swap-cli.md
+++ b/docs/guides/swap-cli.md
@@ -40,7 +40,7 @@ The output prints the quote (amount\_in, amount\_out, gas estimate, route) follo
 
 ## Dry-run a swap (Permit2)
 
-Add `--transfer-type transfer-from-permit2` and supply the TychoRouter address with `--router`. The dry-run uses nonce 0 and maximum deadlines — no chain reads for Permit2 state are needed.
+Add `--transfer-type transfer-from-permit2` and supply the TychoRouter address with `--router`. The dry-run uses nonce 0 and maximum deadlines, so you don't need any chain reads for Permit2 state.
 
 ```bash
 export RPC_URL=https://your-rpc-provider.com/v1/your_key

--- a/docs/guides/swap-cli.md
+++ b/docs/guides/swap-cli.md
@@ -9,7 +9,7 @@ icon: rectangle-terminal
 
 ## Prerequisites
 
-1. **Running Fynd server** — start `fynd serve` first. See the [quickstart.md](../get-started/quickstart.md "mention") if you haven't.
+1. **Running Fynd server** — start `fynd serve` first. See the [quickstart](../get-started/quickstart/ "mention") if you haven't.
 2. **RPC URL** — required for simulation and on-chain execution. The default public endpoint (`https://eth.llamarpc.com`) does not support state overrides, so you must supply your own.
 
 ## Build

--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -13,7 +13,7 @@
 //! ```bash
 //! export TYCHO_API_KEY="your-api-key"  # Get from https://tycho.propellerheads.xyz
 //! export RPC_URL="https://eth.llamarpc.com"
-//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to tycho-beta
+//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to chain-specific Fynd endpoint
 //! cargo run --package fynd-core --example custom_algorithm
 //! ```
 

--- a/fynd-core/examples/solve_order.rs
+++ b/fynd-core/examples/solve_order.rs
@@ -8,7 +8,7 @@
 //! ```bash
 //! export TYCHO_API_KEY="your-api-key"  # Get from https://tycho.propellerheads.xyz
 //! export RPC_URL="https://eth.llamarpc.com"
-//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to tycho-beta
+//! export TYCHO_URL="tycho-fynd-ethereum.propellerheads.xyz"  # Optional, defaults to chain-specific Fynd endpoint
 //! cargo run --package fynd-core --example solve_order
 //! ```
 use std::{env, str::FromStr, time::Duration};

--- a/scripts/check-doc-snippets.sh
+++ b/scripts/check-doc-snippets.sh
@@ -8,8 +8,8 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # Format: "source_file:anchor_name:doc_file"
 SNIPPETS=(
-    "clients/rust/examples/quote.rs:quote-rust:docs/get-started/quickstart.md"
-    "clients/typescript/examples/tutorial/main.ts:quote-typescript:docs/get-started/quickstart.md"
+    "clients/rust/examples/quote.rs:quote-rust:docs/get-started/quickstart/README.md"
+    "clients/typescript/examples/tutorial/main.ts:quote-typescript:docs/get-started/quickstart/README.md"
     "fynd-core/examples/custom_algorithm.rs:custom-algo-impl:docs/guides/custom-algorithm.md"
     "fynd-core/examples/custom_algorithm.rs:custom-algo-wire:docs/guides/custom-algorithm.md"
 )


### PR DESCRIPTION
## Summary

A bad GitBook merge (`56f27f4`) reverted Diana's GITBOOK-13 encoding changes. This undoes that revert.

Restored changes:
- `WorkerPoolRouter` → `OrderManager` rename in overview
- Encoding description now references `TychoRouter`
- Quickstart moved to folder structure (`quickstart/README.md`) for sub-page support