### PR TITLE
feat: add Binance WebSocket price provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "tycho-execution",
  "tycho-simulation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ num_cpus = "1.16"
 lazy_static = { version = "1.5.0", default-features = false }
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio-stream = "0.1.18"
+tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
 async-channel = "2.5.0"
 async-trait = "0.1"
 chrono = "0.4"

--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -30,6 +30,7 @@ metrics.workspace = true
 typetag.workspace = true
 tycho-execution.workspace = true
 reqwest.workspace = true
+tokio-tungstenite.workspace = true
 alloy = { workspace = true, features = ["sol-types"] }
 
 [dev-dependencies]

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -7,7 +7,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, RwLock},
+    sync::{Arc, LazyLock, RwLock},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -47,6 +47,11 @@ const DEFAULT_EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchange
 
 /// Quote assets used for intermediate price routing.
 const INTERMEDIATE_ASSETS: &[&str] = &["USDT", "USDC", "ETH", "BTC"];
+
+/// USD-pegged stablecoins. Loaded from `stable_usd.json` — shared across providers.
+static USD_STABLECOINS: LazyLock<HashSet<String>> = LazyLock::new(|| {
+    serde_json::from_str(include_str!("stable_usd.json")).expect("stable_usd.json is valid")
+});
 
 /// How often to check for new tokens and subscribe to additional streams.
 const RESYNC_INTERVAL: Duration = Duration::from_secs(60);
@@ -387,6 +392,11 @@ impl BinanceWsWorker {
             return;
         };
         cache.insert(symbol.clone(), TickerData { bid, ask, timestamp_ms });
+
+        // When a ticker quotes against USDT or USDC, inject synthetic entries for
+        // all USD stablecoins so unlisted stablecoins (DAI, GHO, …) get priced
+        // as if they were USDT/USDC.
+        inject_stablecoin_tickers(&mut cache, symbol, bid, ask, timestamp_ms);
     }
 
     /// Fetches valid TRADING symbols from Binance exchange info.
@@ -534,6 +544,44 @@ fn discover_pairs(
     }
 
     pairs.into_iter().collect()
+}
+
+/// For a ticker like `ETHUSDT`, injects synthetic entries `ETHDAI`, `ETHGHO`, etc. for every
+/// USD stablecoin in `stable_usd.json` that doesn't already have a real Binance pair cached.
+/// Similarly handles `USDTETH`-style pairs (quote asset is a stablecoin).
+fn inject_stablecoin_tickers(
+    cache: &mut HashMap<String, TickerData>,
+    symbol: &str,
+    bid: f64,
+    ask: f64,
+    timestamp_ms: u64,
+) {
+    for quote in ["USDT", "USDC"] {
+        if let Some(base) = symbol.strip_suffix(quote) {
+            for stable in USD_STABLECOINS.iter() {
+                if stable == quote {
+                    continue;
+                }
+                let synthetic = format!("{base}{stable}");
+                cache
+                    .entry(synthetic)
+                    .or_insert(TickerData { bid, ask, timestamp_ms });
+            }
+            return;
+        }
+        if let Some(base) = symbol.strip_prefix(quote) {
+            for stable in USD_STABLECOINS.iter() {
+                if stable == quote {
+                    continue;
+                }
+                let synthetic = format!("{stable}{base}");
+                cache
+                    .entry(synthetic)
+                    .or_insert(TickerData { bid, ask, timestamp_ms });
+            }
+            return;
+        }
+    }
 }
 
 fn now_ms() -> u64 {
@@ -916,6 +964,141 @@ mod tests {
         assert!(pairs.contains(&"LINKETH".to_string()));
         assert!(pairs.contains(&"AAVEUSDT".to_string()));
         assert!(!pairs.contains(&"XYZUSDT".to_string()));
+    }
+
+    // -- Stablecoin cache injection tests --
+
+    #[test]
+    fn inject_creates_synthetic_stablecoin_tickers() {
+        let mut cache = HashMap::new();
+        let now = now_ms();
+
+        // Receiving ETHUSDT should create ETHDAI, ETHGHO, etc.
+        inject_stablecoin_tickers(&mut cache, "ETHUSDT", 2000.0, 2000.5, now);
+
+        assert!(cache.contains_key("ETHDAI"));
+        assert!(cache.contains_key("ETHGHO"));
+        assert!(cache.contains_key("ETHUSDC"));
+        // Should not create ETHUSDT — that's the original, already in cache via the caller.
+        assert!(!cache.contains_key("ETHUSDT"));
+    }
+
+    #[test]
+    fn inject_does_not_overwrite_real_ticker() {
+        let mut cache = HashMap::new();
+        let now = now_ms();
+
+        // Pre-populate a real ETHUSDC ticker with a different price.
+        cache.insert(
+            "ETHUSDC".to_string(),
+            TickerData { bid: 1999.0, ask: 1999.5, timestamp_ms: now },
+        );
+
+        inject_stablecoin_tickers(&mut cache, "ETHUSDT", 2000.0, 2000.5, now);
+
+        // Real ticker should be preserved.
+        let real = cache
+            .get("ETHUSDC")
+            .expect("should exist");
+        assert!((real.bid - 1999.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn inject_handles_quote_prefix_pair() {
+        let mut cache = HashMap::new();
+        let now = now_ms();
+
+        // USDCETH → strip "USDC" prefix, remainder is "ETH", create "DAITH", "GHOETH", etc.
+        inject_stablecoin_tickers(&mut cache, "USDCETH", 0.0005, 0.00051, now);
+
+        assert!(cache.contains_key("DAIETH"));
+        assert!(cache.contains_key("GHOETH"));
+        assert!(cache.contains_key("USDTETH"));
+    }
+
+    #[test]
+    fn unlisted_stablecoin_resolves_via_cache() {
+        let provider = seeded_provider();
+
+        let dai_address: Address = "6B175474E89094C44Da98b954EedeAC495271d0F"
+            .parse()
+            .expect("valid address");
+        {
+            let mut cache = provider
+                .token_cache
+                .write()
+                .expect("lock");
+            let dai = make_token(dai_address.clone(), "DAI", 18);
+            cache.insert(dai.address.clone(), dai);
+        }
+
+        // Simulate what update_price_cache does: inject stablecoin tickers from ETHUSDT.
+        {
+            let mut cache = provider
+                .price_cache
+                .write()
+                .expect("lock");
+            inject_stablecoin_tickers(&mut cache, "ETHUSDT", 2000.0, 2000.5, now_ms());
+        }
+
+        let one_eth = BigUint::from(10u64).pow(18);
+        let result = provider
+            .get_expected_out(&weth_address(), &dai_address, &one_eth)
+            .expect("should resolve ETH/DAI via synthetic ticker");
+
+        // ETH/DAI uses the ETHUSDT bid (2000.0)
+        let expected = BigUint::from(2000u64) * BigUint::from(10u64).pow(18);
+        let diff = if *result.expected_amount_out() > expected {
+            result.expected_amount_out() - &expected
+        } else {
+            &expected - result.expected_amount_out()
+        };
+        let tolerance = &expected / BigUint::from(100u64); // 1%
+        assert!(diff < tolerance, "result={}, expected ~{expected}", result.expected_amount_out());
+    }
+
+    #[test]
+    fn ws_message_creates_synthetic_stablecoin_ticker() {
+        // End-to-end: a raw ETHUSDT WebSocket message arrives, the worker processes
+        // it, and we can price ETH/GHO through the synthetic cache entry.
+        let provider = BinanceWsProvider::default();
+        let price_cache = Arc::clone(&provider.price_cache);
+        let worker = make_worker(&price_cache);
+
+        let gho_address: Address = "40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f"
+            .parse()
+            .expect("valid address");
+        {
+            let mut cache = provider
+                .token_cache
+                .write()
+                .expect("lock");
+            let weth = make_token(weth_address(), "WETH", 18);
+            cache.insert(weth.address.clone(), weth);
+            let gho = make_token(gho_address.clone(), "GHO", 18);
+            cache.insert(gho.address.clone(), gho);
+        }
+
+        // Simulate a bookTicker message arriving from Binance (no event time → uses now).
+        let msg = Message::Text(r#"{"s":"ETHUSDT","b":"2000.00","a":"2000.50"}"#.into());
+        worker.handle_message(&msg);
+
+        // The cache should now contain a synthetic ETHGHO entry.
+        {
+            let cache = price_cache.read().expect("lock");
+            assert!(cache.contains_key("ETHGHO"), "synthetic ETHGHO ticker missing");
+        }
+
+        // Price 1 ETH → GHO (both 18 decimals).
+        let one_eth = BigUint::from(10u64).pow(18);
+        let result = provider
+            .get_expected_out(&weth_address(), &gho_address, &one_eth)
+            .expect("should resolve ETH/GHO via synthetic ticker");
+
+        // Sell-side uses bid = 2000.0 → 2000 GHO (18 decimals)
+        let expected = BigUint::from(2000u64) * BigUint::from(10u64).pow(18);
+        assert_eq!(*result.expected_amount_out(), expected);
+        assert_eq!(result.source(), "binance_ws");
     }
 
     // -- Live integration test --

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -106,6 +106,7 @@ pub struct BinanceWsProvider {
 }
 
 impl BinanceWsProvider {
+    /// Creates a new `BinanceWsProvider` with default Binance WebSocket and exchange info URLs.
     pub fn new() -> Self {
         Self {
             price_cache: Arc::new(RwLock::new(HashMap::new())),

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -1,0 +1,942 @@
+//! Binance WebSocket price provider.
+//!
+//! Connects to the Binance `bookTicker` WebSocket stream, dynamically discovers trading pairs
+//! from [`SharedMarketData`](crate::feed::market_data::SharedMarketData), and caches real-time
+//! bid/ask prices. Price resolution supports direct pairs, reverse pairs, and intermediate
+//! routing through common quote assets (USDT, USDC, ETH, BTC).
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, RwLock},
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use futures::{SinkExt, StreamExt};
+use num_bigint::BigUint;
+use reqwest::Client;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::{connect_async, tungstenite::Message};
+use tracing::{debug, info, warn};
+use tycho_simulation::tycho_common::models::Address;
+
+use super::{
+    provider::{ExternalPrice, PriceProvider, PriceProviderError},
+    utils::{check_staleness, expected_out_from_price, normalize_symbol},
+};
+use crate::feed::market_data::SharedMarketDataRef;
+
+const DEFAULT_WS_URL: &str = "wss://stream.binance.com:9443/ws";
+const DEFAULT_EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
+
+/// Quote assets used for intermediate price routing.
+const INTERMEDIATE_ASSETS: &[&str] = &["USDT", "USDC", "ETH", "BTC"];
+
+/// How often to check for new tokens and subscribe to additional streams.
+const RESYNC_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Initial reconnect delay, doubles up to `MAX_BACKOFF`.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(5);
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Cached ticker data from the bookTicker stream.
+#[derive(Debug, Clone)]
+struct TickerData {
+    bid: f64,
+    ask: f64,
+    timestamp_ms: u64,
+}
+
+/// Resolved price lookup result.
+#[derive(Debug)]
+struct PriceLookup {
+    price: f64,
+    timestamp_ms: u64,
+}
+
+/// Shared ticker cache. Key is the uppercase Binance symbol (e.g. "ETHUSDT").
+type TickerCache = Arc<RwLock<HashMap<String, TickerData>>>;
+
+/// Shared token metadata cache.
+type TokenCache = Arc<RwLock<HashMap<Address, TokenInfo>>>;
+
+#[derive(Debug, Clone)]
+struct TokenInfo {
+    symbol: String,
+    decimals: u32,
+}
+
+/// Binance WebSocket price provider.
+///
+/// Subscribes to `bookTicker` streams for pairs discovered by cross-referencing
+/// Binance exchange info with tokens in [`SharedMarketData`]. Prices are resolved
+/// via direct pair (bid), reverse pair (1/ask), or intermediate routing through
+/// USDT/USDC/ETH/BTC.
+pub struct BinanceWsProvider {
+    ticker_cache: TickerCache,
+    token_cache: TokenCache,
+    ws_url: String,
+    exchange_info_url: String,
+}
+
+impl BinanceWsProvider {
+    pub fn new() -> Self {
+        Self {
+            ticker_cache: Arc::new(RwLock::new(HashMap::new())),
+            token_cache: Arc::new(RwLock::new(HashMap::new())),
+            ws_url: DEFAULT_WS_URL.to_string(),
+            exchange_info_url: DEFAULT_EXCHANGE_INFO_URL.to_string(),
+        }
+    }
+
+    /// Overrides the Binance WebSocket and exchange info endpoint URLs.
+    pub fn new_with_urls(ws_url: impl Into<String>, exchange_info_url: impl Into<String>) -> Self {
+        Self {
+            ticker_cache: Arc::new(RwLock::new(HashMap::new())),
+            token_cache: Arc::new(RwLock::new(HashMap::new())),
+            ws_url: ws_url.into(),
+            exchange_info_url: exchange_info_url.into(),
+        }
+    }
+
+    /// Resolves a token address to (normalized_symbol, decimals) from the local token cache.
+    fn resolve_token(&self, address: &Address) -> Result<(String, u32), PriceProviderError> {
+        let cache = self
+            .token_cache
+            .read()
+            .map_err(|e| PriceProviderError::Unavailable(format!("token cache poisoned: {e}")))?;
+        let info = cache
+            .get(address)
+            .ok_or_else(|| PriceProviderError::TokenNotFound { address: address.to_string() })?;
+        let symbol = normalize_symbol(&info.symbol);
+        Ok((symbol, info.decimals))
+    }
+
+    /// Looks up a sell-side price for `base` in terms of `quote`.
+    ///
+    /// Direct pair: uses bid (what you get when selling).
+    /// Reverse pair: uses 1/ask (what you pay when buying the reverse).
+    fn lookup_sell_price(
+        cache: &HashMap<String, TickerData>,
+        base: &str,
+        quote: &str,
+    ) -> Option<PriceLookup> {
+        let direct_symbol = format!("{base}{quote}");
+        if let Some(ticker) = cache.get(&direct_symbol) {
+            if ticker.bid > 0.0 {
+                return Some(PriceLookup { price: ticker.bid, timestamp_ms: ticker.timestamp_ms });
+            }
+        }
+
+        let reverse_symbol = format!("{quote}{base}");
+        if let Some(ticker) = cache.get(&reverse_symbol) {
+            if ticker.ask > 0.0 {
+                return Some(PriceLookup {
+                    price: 1.0 / ticker.ask,
+                    timestamp_ms: ticker.timestamp_ms,
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Looks up a buy-side price for `base` in terms of `quote`.
+    ///
+    /// Direct pair: uses ask (what you pay when buying).
+    /// Reverse pair: uses 1/bid (what you get when selling the reverse).
+    fn lookup_buy_price(
+        cache: &HashMap<String, TickerData>,
+        base: &str,
+        quote: &str,
+    ) -> Option<PriceLookup> {
+        let direct_symbol = format!("{base}{quote}");
+        if let Some(ticker) = cache.get(&direct_symbol) {
+            if ticker.ask > 0.0 {
+                return Some(PriceLookup { price: ticker.ask, timestamp_ms: ticker.timestamp_ms });
+            }
+        }
+
+        let reverse_symbol = format!("{quote}{base}");
+        if let Some(ticker) = cache.get(&reverse_symbol) {
+            if ticker.bid > 0.0 {
+                return Some(PriceLookup {
+                    price: 1.0 / ticker.bid,
+                    timestamp_ms: ticker.timestamp_ms,
+                });
+            }
+        }
+
+        None
+    }
+
+    /// Resolves a price between two symbols, trying direct/reverse first,
+    /// then routing through intermediate assets.
+    ///
+    /// For intermediate routing: sells `sym_in` for intermediate (bid),
+    /// then buys `sym_out` with intermediate (ask), accounting for spreads.
+    fn resolve_price(
+        cache: &HashMap<String, TickerData>,
+        sym_in: &str,
+        sym_out: &str,
+    ) -> Option<PriceLookup> {
+        if let Some(lookup) = Self::lookup_sell_price(cache, sym_in, sym_out) {
+            return Some(lookup);
+        }
+
+        for intermediate in INTERMEDIATE_ASSETS {
+            if *intermediate == sym_in || *intermediate == sym_out {
+                continue;
+            }
+            let leg_in = Self::lookup_sell_price(cache, sym_in, intermediate);
+            let leg_out = Self::lookup_buy_price(cache, sym_out, intermediate);
+            if let (Some(sell_price), Some(buy_price)) = (leg_in, leg_out) {
+                if buy_price.price > 0.0 {
+                    let price = sell_price.price / buy_price.price;
+                    let ts = sell_price
+                        .timestamp_ms
+                        .min(buy_price.timestamp_ms);
+                    return Some(PriceLookup { price, timestamp_ms: ts });
+                }
+            }
+        }
+
+        None
+    }
+}
+
+impl Default for BinanceWsProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PriceProvider for BinanceWsProvider {
+    fn start(&mut self, market_data: SharedMarketDataRef) -> JoinHandle<()> {
+        let worker = BinanceWsWorker {
+            ticker_cache: Arc::clone(&self.ticker_cache),
+            token_cache: Arc::clone(&self.token_cache),
+            market_data,
+            client: Client::new(),
+            ws_url: self.ws_url.clone(),
+            exchange_info_url: self.exchange_info_url.clone(),
+            subscribed_symbols: HashSet::new(),
+            next_subscription_id: 1,
+        };
+        tokio::spawn(async move { worker.run().await })
+    }
+
+    fn get_expected_out(
+        &self,
+        token_in: &Address,
+        token_out: &Address,
+        amount_in: &BigUint,
+    ) -> Result<ExternalPrice, PriceProviderError> {
+        let (sym_in, dec_in) = self.resolve_token(token_in)?;
+        let (sym_out, dec_out) = self.resolve_token(token_out)?;
+
+        let cache = self
+            .ticker_cache
+            .read()
+            .map_err(|e| PriceProviderError::Unavailable(format!("ticker cache poisoned: {e}")))?;
+
+        let lookup = Self::resolve_price(&cache, &sym_in, &sym_out).ok_or_else(|| {
+            PriceProviderError::PriceNotFound {
+                token_in: sym_in.clone(),
+                token_out: sym_out.clone(),
+            }
+        })?;
+
+        check_staleness(lookup.timestamp_ms)?;
+
+        let expected_out = expected_out_from_price(amount_in, lookup.price, dec_in, dec_out);
+        Ok(ExternalPrice::new(expected_out, "binance_ws".to_string(), lookup.timestamp_ms))
+    }
+}
+
+/// Background worker that manages the Binance WebSocket connection lifecycle.
+struct BinanceWsWorker {
+    ticker_cache: TickerCache,
+    token_cache: TokenCache,
+    market_data: SharedMarketDataRef,
+    client: Client,
+    ws_url: String,
+    exchange_info_url: String,
+    subscribed_symbols: HashSet<String>,
+    next_subscription_id: u64,
+}
+
+impl BinanceWsWorker {
+    async fn run(mut self) {
+        let mut backoff = INITIAL_BACKOFF;
+
+        loop {
+            self.refresh_token_cache().await;
+
+            match self.connect_and_stream().await {
+                Ok(()) => {
+                    info!("Binance WebSocket disconnected normally, reconnecting");
+                    backoff = INITIAL_BACKOFF;
+                }
+                Err(e) => {
+                    warn!(error = %e, backoff_secs = backoff.as_secs(), "Binance WebSocket error");
+                }
+            }
+
+            tokio::time::sleep(backoff).await;
+            backoff = (backoff * 2).min(MAX_BACKOFF);
+        }
+    }
+
+    /// Establishes a WebSocket connection, subscribes to bookTicker streams,
+    /// and processes messages until disconnection.
+    async fn connect_and_stream(&mut self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let binance_symbols = self.fetch_binance_symbols().await?;
+        let token_symbols = self.get_token_symbols();
+        let pairs = discover_pairs(&token_symbols, &binance_symbols);
+
+        if pairs.is_empty() {
+            return Err("no valid Binance pairs discovered".into());
+        }
+
+        let (ws_stream, _) = connect_async(&self.ws_url).await?;
+        let (mut write, mut read) = ws_stream.split();
+
+        // Subscribe to bookTicker streams for all discovered pairs.
+        self.subscribed_symbols = pairs.iter().cloned().collect();
+        let streams: Vec<String> = pairs
+            .iter()
+            .map(|s| format!("{}@bookTicker", s.to_lowercase()))
+            .collect();
+
+        let sub_id = self.next_subscription_id;
+        self.next_subscription_id += 1;
+        let subscribe_msg = serde_json::json!({
+            "method": "SUBSCRIBE",
+            "params": streams,
+            "id": sub_id
+        });
+        write
+            .send(Message::Text(subscribe_msg.to_string().into()))
+            .await?;
+
+        info!(pair_count = pairs.len(), id = sub_id, "subscribed to Binance bookTicker streams");
+
+        let mut resync_interval = tokio::time::interval(RESYNC_INTERVAL);
+        resync_interval.tick().await; // consume the first immediate tick
+
+        loop {
+            tokio::select! {
+                msg = read.next() => {
+                    let Some(msg) = msg else {
+                        return Ok(());
+                    };
+                    let msg = msg?;
+                    self.handle_message(&msg);
+                }
+                _ = resync_interval.tick() => {
+                    self.refresh_token_cache().await;
+                    if let Err(e) = self.resync_subscriptions(&mut write).await {
+                        warn!(error = %e, "failed to resync Binance subscriptions");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handles a single WebSocket message.
+    fn handle_message(&self, msg: &Message) {
+        match msg {
+            Message::Text(text) => self.handle_ticker(text),
+            Message::Close(frame) => {
+                let reason = frame
+                    .as_ref()
+                    .map(|f| format!("code={}, reason={}", f.code, f.reason))
+                    .unwrap_or_else(|| "no reason".to_string());
+                debug!(reason, "Binance WebSocket close frame received");
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_ticker(&self, text: &str) {
+        let Ok(ticker) = serde_json::from_str::<BookTickerMsg>(text) else {
+            return;
+        };
+
+        let Some(symbol) = &ticker.s else {
+            return;
+        };
+
+        let bid = ticker.b.parse::<f64>().unwrap_or(0.0);
+        let ask = ticker.a.parse::<f64>().unwrap_or(0.0);
+        if bid <= 0.0 || ask <= 0.0 {
+            return;
+        }
+
+        let timestamp_ms = ticker.event_time.unwrap_or_else(now_ms);
+
+        let Ok(mut cache) = self.ticker_cache.write() else {
+            warn!("ticker cache lock poisoned, dropping update");
+            return;
+        };
+        cache.insert(symbol.clone(), TickerData { bid, ask, timestamp_ms });
+    }
+
+    /// Fetches valid TRADING symbols from Binance exchange info.
+    async fn fetch_binance_symbols(
+        &self,
+    ) -> Result<HashSet<String>, Box<dyn std::error::Error + Send + Sync>> {
+        let resp: ExchangeInfoResponse = self
+            .client
+            .get(&self.exchange_info_url)
+            .send()
+            .await?
+            .json()
+            .await?;
+        let symbols: HashSet<String> = resp
+            .symbols
+            .into_iter()
+            .filter(|s| s.status == "TRADING")
+            .map(|s| s.symbol)
+            .collect();
+        debug!(count = symbols.len(), "fetched Binance exchange symbols");
+        Ok(symbols)
+    }
+
+    /// Gets all unique normalized token symbols from the token cache.
+    fn get_token_symbols(&self) -> HashSet<String> {
+        let Ok(cache) = self.token_cache.read() else {
+            return HashSet::new();
+        };
+        cache
+            .values()
+            .map(|info| normalize_symbol(&info.symbol))
+            .collect()
+    }
+
+    /// Snapshots the token registry from SharedMarketData into the local token cache.
+    async fn refresh_token_cache(&self) {
+        let token_entries: Vec<(Address, String, u32)> = {
+            let data = self.market_data.read().await;
+            data.token_registry_ref()
+                .iter()
+                .map(|(address, token)| (address.clone(), token.symbol.clone(), token.decimals))
+                .collect()
+        };
+
+        let mut new_cache: HashMap<Address, TokenInfo> = HashMap::new();
+        for (address, symbol, decimals) in token_entries {
+            new_cache.insert(address, TokenInfo { symbol, decimals });
+        }
+
+        let Ok(mut cache) = self.token_cache.write() else {
+            warn!("token cache lock poisoned");
+            return;
+        };
+        *cache = new_cache;
+    }
+
+    /// Checks for new token pairs and subscribes to additional streams.
+    async fn resync_subscriptions<S>(
+        &mut self,
+        write: &mut S,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    where
+        S: futures::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+    {
+        let binance_symbols = self.fetch_binance_symbols().await?;
+        let token_symbols = self.get_token_symbols();
+        let all_pairs = discover_pairs(&token_symbols, &binance_symbols);
+
+        let new_pairs: Vec<String> = all_pairs
+            .into_iter()
+            .filter(|p| !self.subscribed_symbols.contains(p))
+            .collect();
+
+        if new_pairs.is_empty() {
+            return Ok(());
+        }
+
+        let streams: Vec<String> = new_pairs
+            .iter()
+            .map(|s| format!("{}@bookTicker", s.to_lowercase()))
+            .collect();
+
+        let sub_id = self.next_subscription_id;
+        self.next_subscription_id += 1;
+        let subscribe_msg = serde_json::json!({
+            "method": "SUBSCRIBE",
+            "params": streams,
+            "id": sub_id
+        });
+        write
+            .send(Message::Text(subscribe_msg.to_string().into()))
+            .await?;
+
+        info!(new_pairs = new_pairs.len(), id = sub_id, "subscribed to additional Binance streams");
+        self.subscribed_symbols
+            .extend(new_pairs);
+        Ok(())
+    }
+}
+
+/// Discovers candidate Binance pairs by cross-referencing token symbols with available pairs.
+///
+/// For each token symbol, generates candidate pairs with every intermediate asset
+/// and checks if Binance lists them (in either order). Also generates pairs between
+/// all token symbols directly.
+fn discover_pairs(
+    token_symbols: &HashSet<String>,
+    binance_symbols: &HashSet<String>,
+) -> Vec<String> {
+    let mut pairs = HashSet::new();
+
+    for symbol in token_symbols {
+        for quote in INTERMEDIATE_ASSETS {
+            let direct = format!("{symbol}{quote}");
+            if binance_symbols.contains(&direct) {
+                pairs.insert(direct);
+            }
+            let reverse = format!("{quote}{symbol}");
+            if binance_symbols.contains(&reverse) {
+                pairs.insert(reverse);
+            }
+        }
+    }
+
+    // Also try direct pairs between tracked tokens.
+    let symbols: Vec<&String> = token_symbols.iter().collect();
+    for (i, a) in symbols.iter().enumerate() {
+        for b in &symbols[i + 1..] {
+            let pair_ab = format!("{a}{b}");
+            if binance_symbols.contains(&pair_ab) {
+                pairs.insert(pair_ab);
+            }
+            let pair_ba = format!("{b}{a}");
+            if binance_symbols.contains(&pair_ba) {
+                pairs.insert(pair_ba);
+            }
+        }
+    }
+
+    pairs.into_iter().collect()
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+// -- Binance API/WS response types --
+
+/// BookTicker WebSocket message.
+#[derive(serde::Deserialize)]
+struct BookTickerMsg {
+    /// Symbol (e.g. "ETHUSDT").
+    s: Option<String>,
+    /// Best bid price.
+    b: String,
+    /// Best ask price.
+    a: String,
+    /// Event time in milliseconds.
+    #[serde(rename = "E")]
+    event_time: Option<u64>,
+}
+
+/// Response from GET /api/v3/exchangeInfo.
+#[derive(serde::Deserialize)]
+struct ExchangeInfoResponse {
+    symbols: Vec<SymbolInfo>,
+}
+
+/// Per-symbol metadata from exchange info.
+#[derive(serde::Deserialize)]
+struct SymbolInfo {
+    symbol: String,
+    status: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::RwLock;
+    use tycho_simulation::{evm::tycho_models::Chain, tycho_common::models::token::Token};
+
+    use super::*;
+    use crate::feed::market_data::SharedMarketData;
+
+    fn make_token(address: Address, symbol: &str, decimals: u32) -> Token {
+        Token {
+            address,
+            symbol: symbol.to_string(),
+            decimals,
+            tax: Default::default(),
+            gas: vec![],
+            chain: Chain::Ethereum,
+            quality: 100,
+        }
+    }
+
+    fn weth_address() -> Address {
+        "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            .parse()
+            .expect("valid address")
+    }
+
+    fn usdc_address() -> Address {
+        "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            .parse()
+            .expect("valid address")
+    }
+
+    fn link_address() -> Address {
+        "514910771AF9Ca656af840dff83E8264EcF986CA"
+            .parse()
+            .expect("valid address")
+    }
+
+    fn usdt_address() -> Address {
+        "dAC17F958D2ee523a2206206994597C13D831ec7"
+            .parse()
+            .expect("valid address")
+    }
+
+    /// Returns a provider pre-seeded with ETH, BTC, LINK tickers and
+    /// WETH, USDC, LINK token metadata.
+    fn seeded_provider() -> BinanceWsProvider {
+        let provider = BinanceWsProvider::default();
+        let now = now_ms();
+
+        {
+            let mut cache = provider
+                .ticker_cache
+                .write()
+                .expect("lock");
+            cache.insert(
+                "ETHUSDT".to_string(),
+                TickerData { bid: 2000.0, ask: 2000.5, timestamp_ms: now },
+            );
+            cache.insert(
+                "ETHUSDC".to_string(),
+                TickerData { bid: 2000.0, ask: 2000.5, timestamp_ms: now },
+            );
+            cache.insert(
+                "BTCUSDT".to_string(),
+                TickerData { bid: 60000.0, ask: 60010.0, timestamp_ms: now },
+            );
+            cache.insert(
+                "LINKUSDT".to_string(),
+                TickerData { bid: 15.0, ask: 15.01, timestamp_ms: now },
+            );
+            cache.insert(
+                "ETHBTC".to_string(),
+                TickerData { bid: 0.0333, ask: 0.0334, timestamp_ms: now },
+            );
+        }
+
+        {
+            let mut cache = provider
+                .token_cache
+                .write()
+                .expect("lock");
+            cache.insert(weth_address(), TokenInfo { symbol: "WETH".to_string(), decimals: 18 });
+            cache.insert(usdc_address(), TokenInfo { symbol: "USDC".to_string(), decimals: 6 });
+            cache.insert(link_address(), TokenInfo { symbol: "LINK".to_string(), decimals: 18 });
+        }
+
+        provider
+    }
+
+    /// Creates a `BinanceWsWorker` that writes to the given ticker cache.
+    fn make_worker(ticker_cache: &TickerCache) -> BinanceWsWorker {
+        let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
+        BinanceWsWorker {
+            ticker_cache: Arc::clone(ticker_cache),
+            token_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
+            market_data,
+            client: Client::new(),
+            ws_url: DEFAULT_WS_URL.to_string(),
+            exchange_info_url: DEFAULT_EXCHANGE_INFO_URL.to_string(),
+            subscribed_symbols: HashSet::new(),
+            next_subscription_id: 1,
+        }
+    }
+
+    // -- Price resolution tests --
+
+    #[test]
+    fn direct_pair_price() {
+        let provider = seeded_provider();
+        let one_eth = BigUint::from(10u64).pow(18);
+
+        let result = provider
+            .get_expected_out(&weth_address(), &usdc_address(), &one_eth)
+            .expect("should get price");
+
+        // 1 ETH at bid 2000 USDC → 2_000_000_000 (6 decimals)
+        assert_eq!(*result.expected_amount_out(), BigUint::from(2_000_000_000u64));
+        assert_eq!(result.source(), "binance_ws");
+    }
+
+    #[test]
+    fn price_via_intermediate_usdt() {
+        let provider = seeded_provider();
+        let ten_link = BigUint::from(10u64) * BigUint::from(10u64).pow(18);
+
+        let result = provider
+            .get_expected_out(&link_address(), &weth_address(), &ten_link)
+            .expect("should get price");
+
+        // 10 LINK → ETH via USDT:
+        //   sell LINK: bid=15.0, buy ETH: ask=2000.5
+        //   10 * (15.0 / 2000.5) ≈ 0.07498 ETH
+        let expected_price = 15.0 / 2000.5;
+        let expected_raw = (10.0 * expected_price * 1e18) as u128;
+        let expected = BigUint::from(expected_raw);
+        let diff = if *result.expected_amount_out() > expected {
+            result.expected_amount_out() - &expected
+        } else {
+            &expected - result.expected_amount_out()
+        };
+        let tolerance = &expected / BigUint::from(100u64); // 1%
+        assert!(diff < tolerance, "result={}, expected ~{expected}", result.expected_amount_out());
+    }
+
+    #[test]
+    fn reverse_pair_price() {
+        let provider = BinanceWsProvider::default();
+        let now = now_ms();
+
+        {
+            let mut cache = provider
+                .ticker_cache
+                .write()
+                .expect("lock");
+            cache.insert(
+                "BTCETH".to_string(),
+                TickerData { bid: 30.0, ask: 30.01, timestamp_ms: now },
+            );
+        }
+
+        let cache = provider
+            .ticker_cache
+            .read()
+            .expect("lock");
+        // ETH→BTC via reverse BTCETH: sell-side uses 1/ask
+        let lookup = BinanceWsProvider::lookup_sell_price(&cache, "ETH", "BTC");
+        assert!(lookup.is_some());
+        let lookup = lookup.expect("should have price");
+        let expected = 1.0 / 30.01;
+        assert!((lookup.price - expected).abs() < 1e-10);
+
+        // Buy-side uses 1/bid
+        let buy = BinanceWsProvider::lookup_buy_price(&cache, "ETH", "BTC");
+        let buy = buy.expect("should have buy price");
+        let expected_buy = 1.0 / 30.0;
+        assert!((buy.price - expected_buy).abs() < 1e-10);
+    }
+
+    #[test]
+    fn unknown_token_returns_error() {
+        let provider = seeded_provider();
+        let unknown: Address = "0000000000000000000000000000000000000001"
+            .parse()
+            .expect("valid");
+        let one = BigUint::from(10u64).pow(18);
+
+        let result = provider.get_expected_out(&unknown, &usdc_address(), &one);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(PriceProviderError::TokenNotFound { .. })));
+    }
+
+    #[test]
+    fn stale_price_returns_error() {
+        let provider = BinanceWsProvider::default();
+        let stale_ts = 1_000u64;
+
+        {
+            let mut cache = provider
+                .ticker_cache
+                .write()
+                .expect("lock");
+            cache.insert(
+                "ETHUSDT".to_string(),
+                TickerData { bid: 2000.0, ask: 2000.5, timestamp_ms: stale_ts },
+            );
+        }
+        {
+            let mut cache = provider
+                .token_cache
+                .write()
+                .expect("lock");
+            cache.insert(weth_address(), TokenInfo { symbol: "WETH".to_string(), decimals: 18 });
+            cache.insert(usdt_address(), TokenInfo { symbol: "USDT".to_string(), decimals: 6 });
+        }
+
+        let one_eth = BigUint::from(10u64).pow(18);
+        let result = provider.get_expected_out(&weth_address(), &usdt_address(), &one_eth);
+        assert!(result.is_err());
+        assert!(matches!(result, Err(PriceProviderError::StaleData { .. })));
+    }
+
+    // -- handle_message / handle_ticker tests (M4) --
+
+    #[test]
+    fn handle_ticker_writes_to_cache() {
+        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&ticker_cache);
+
+        let msg = Message::Text(
+            r#"{"s":"ETHUSDT","b":"2000.00","a":"2000.50","E":1700000000000}"#.into(),
+        );
+        worker.handle_message(&msg);
+
+        let cache = ticker_cache.read().expect("lock");
+        let ticker = cache
+            .get("ETHUSDT")
+            .expect("should be cached");
+        assert!((ticker.bid - 2000.0).abs() < f64::EPSILON);
+        assert!((ticker.ask - 2000.5).abs() < f64::EPSILON);
+        assert_eq!(ticker.timestamp_ms, 1_700_000_000_000);
+    }
+
+    #[test]
+    fn handle_ticker_rejects_zero_bid() {
+        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&ticker_cache);
+
+        let msg = Message::Text(r#"{"s":"ETHUSDT","b":"0","a":"2000.50"}"#.into());
+        worker.handle_message(&msg);
+
+        let cache = ticker_cache.read().expect("lock");
+        assert!(cache.get("ETHUSDT").is_none());
+    }
+
+    #[test]
+    fn handle_ticker_rejects_zero_ask() {
+        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&ticker_cache);
+
+        let msg = Message::Text(r#"{"s":"ETHUSDT","b":"2000.00","a":"0"}"#.into());
+        worker.handle_message(&msg);
+
+        let cache = ticker_cache.read().expect("lock");
+        assert!(cache.get("ETHUSDT").is_none());
+    }
+
+    #[test]
+    fn handle_ticker_uses_now_ms_when_no_event_time() {
+        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&ticker_cache);
+
+        let before = now_ms();
+        let msg = Message::Text(r#"{"s":"ETHUSDT","b":"2000.00","a":"2000.50"}"#.into());
+        worker.handle_message(&msg);
+        let after = now_ms();
+
+        let cache = ticker_cache.read().expect("lock");
+        let ticker = cache
+            .get("ETHUSDT")
+            .expect("should be cached");
+        assert!(ticker.timestamp_ms >= before && ticker.timestamp_ms <= after);
+    }
+
+    #[test]
+    fn handle_message_ignores_non_text() {
+        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&ticker_cache);
+
+        worker.handle_message(&Message::Ping(vec![].into()));
+        worker.handle_message(&Message::Pong(vec![].into()));
+        worker.handle_message(&Message::Binary(vec![].into()));
+
+        let cache = ticker_cache.read().expect("lock");
+        assert!(cache.is_empty());
+    }
+
+    // -- Deserialization tests --
+
+    #[test]
+    fn parse_book_ticker_msg() {
+        let json = r#"{"e":"bookTicker","u":123,"s":"ETHUSDT","b":"2000.00","B":"10.5","a":"2000.50","A":"5.2","E":1700000000000}"#;
+        let msg: BookTickerMsg = serde_json::from_str(json).expect("should parse");
+        assert_eq!(msg.s.as_deref(), Some("ETHUSDT"));
+        assert_eq!(msg.b, "2000.00");
+        assert_eq!(msg.a, "2000.50");
+        assert_eq!(msg.event_time, Some(1_700_000_000_000));
+    }
+
+    #[test]
+    fn parse_exchange_info_response() {
+        let json = r#"{"symbols":[{"symbol":"ETHUSDT","status":"TRADING"},{"symbol":"ETHBTC","status":"BREAK"}]}"#;
+        let resp: ExchangeInfoResponse = serde_json::from_str(json).expect("should parse");
+        assert_eq!(resp.symbols.len(), 2);
+        assert_eq!(resp.symbols[0].symbol, "ETHUSDT");
+        assert_eq!(resp.symbols[0].status, "TRADING");
+    }
+
+    // -- Pair discovery tests --
+
+    #[test]
+    fn discover_pairs_filters_correctly() {
+        let tokens: HashSet<String> = ["ETH", "LINK", "AAVE"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let binance: HashSet<String> =
+            ["ETHUSDT", "ETHBTC", "LINKUSDT", "LINKETH", "AAVEUSDT", "XYZUSDT"]
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+
+        let pairs = discover_pairs(&tokens, &binance);
+        assert!(pairs.contains(&"ETHUSDT".to_string()));
+        assert!(pairs.contains(&"ETHBTC".to_string()));
+        assert!(pairs.contains(&"LINKUSDT".to_string()));
+        assert!(pairs.contains(&"LINKETH".to_string()));
+        assert!(pairs.contains(&"AAVEUSDT".to_string()));
+        assert!(!pairs.contains(&"XYZUSDT".to_string()));
+    }
+
+    // -- Live integration test --
+
+    #[tokio::test]
+    #[ignore] // requires network access
+    async fn binance_ws_live_weth_usdc() {
+        let weth = make_token(weth_address(), "WETH", 18);
+        let usdc = make_token(usdc_address(), "USDC", 6);
+
+        let mut market_data = SharedMarketData::new();
+        market_data.upsert_tokens([weth, usdc]);
+        let market_data = Arc::new(RwLock::new(market_data));
+
+        let mut provider = BinanceWsProvider::default();
+        let _handle = provider.start(market_data);
+
+        // Retry: WebSocket connection + initial tickers may take a few seconds.
+        let one_eth = BigUint::from(10u64).pow(18);
+        let mut price = None;
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+            match provider.get_expected_out(&weth_address(), &usdc_address(), &one_eth) {
+                Ok(p) => {
+                    price = Some(p);
+                    break;
+                }
+                Err(e) => debug!(error = %e, "waiting for Binance WS price"),
+            }
+        }
+
+        let price = price.expect("should get a price from Binance WS within 20s");
+
+        // 1 ETH should be worth between $1,000 and $10,000 USDC (6 decimals)
+        let min = BigUint::from(1_000_000_000u64); // $1,000
+        let max = BigUint::from(10_000_000_000u64); // $10,000
+        let amount = price.expected_amount_out();
+        assert!(
+            *amount >= min && *amount <= max,
+            "expected amount_out in [{min}, {max}], got {amount}"
+        );
+    }
+}

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -17,7 +17,7 @@ use reqwest::Client;
 use tokio::task::JoinHandle;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, info, warn};
-use tycho_simulation::tycho_common::models::Address;
+use tycho_simulation::tycho_common::models::{token::Token, Address};
 
 use super::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
@@ -73,14 +73,8 @@ struct PriceLookup {
 /// Shared ticker cache. Key is the uppercase Binance symbol (e.g. "ETHUSDT").
 type TickerCache = Arc<RwLock<HashMap<String, TickerData>>>;
 
-/// Shared token metadata cache.
-type TokenCache = Arc<RwLock<HashMap<Address, TokenInfo>>>;
-
-#[derive(Debug, Clone)]
-struct TokenInfo {
-    symbol: String,
-    decimals: u32,
-}
+/// Cached token metadata resolved from on-chain addresses.
+type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
 
 /// Binance WebSocket price provider.
 ///
@@ -430,18 +424,13 @@ impl BinanceWsWorker {
 
     /// Snapshots the token registry from SharedMarketData into the local token cache.
     async fn refresh_token_cache(&self) {
-        let token_entries: Vec<(Address, String, u32)> = {
+        let new_cache: HashMap<Address, Token> = {
             let data = self.market_data.read().await;
             data.token_registry_ref()
                 .iter()
-                .map(|(address, token)| (address.clone(), token.symbol.clone(), token.decimals))
+                .map(|(address, token)| (address.clone(), token.clone()))
                 .collect()
         };
-
-        let mut new_cache: HashMap<Address, TokenInfo> = HashMap::new();
-        for (address, symbol, decimals) in token_entries {
-            new_cache.insert(address, TokenInfo { symbol, decimals });
-        }
 
         let Ok(mut cache) = self.token_cache.write() else {
             warn!("token cache lock poisoned");
@@ -575,7 +564,7 @@ struct SymbolInfo {
 #[cfg(test)]
 mod tests {
     use tokio::sync::RwLock;
-    use tycho_simulation::{evm::tycho_models::Chain, tycho_common::models::token::Token};
+    use tycho_simulation::evm::tycho_models::Chain;
 
     use super::*;
     use crate::feed::market_data::SharedMarketData;
@@ -654,9 +643,12 @@ mod tests {
                 .token_cache
                 .write()
                 .expect("lock");
-            cache.insert(weth_address(), TokenInfo { symbol: "WETH".to_string(), decimals: 18 });
-            cache.insert(usdc_address(), TokenInfo { symbol: "USDC".to_string(), decimals: 6 });
-            cache.insert(link_address(), TokenInfo { symbol: "LINK".to_string(), decimals: 18 });
+            let weth = make_token(weth_address(), "WETH", 18);
+            cache.insert(weth.address.clone(), weth);
+            let usdc = make_token(usdc_address(), "USDC", 6);
+            cache.insert(usdc.address.clone(), usdc);
+            let link = make_token(link_address(), "LINK", 18);
+            cache.insert(link.address.clone(), link);
         }
 
         provider
@@ -784,8 +776,10 @@ mod tests {
                 .token_cache
                 .write()
                 .expect("lock");
-            cache.insert(weth_address(), TokenInfo { symbol: "WETH".to_string(), decimals: 18 });
-            cache.insert(usdt_address(), TokenInfo { symbol: "USDT".to_string(), decimals: 6 });
+            let weth = make_token(weth_address(), "WETH", 18);
+            cache.insert(weth.address.clone(), weth);
+            let usdt = make_token(usdt_address(), "USDT", 6);
+            cache.insert(usdt.address.clone(), usdt);
         }
 
         let one_eth = BigUint::from(10u64).pow(18);

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -71,7 +71,7 @@ struct PriceLookup {
 }
 
 /// Shared ticker cache. Key is the uppercase Binance symbol (e.g. "ETHUSDT").
-type TickerCache = Arc<RwLock<HashMap<String, TickerData>>>;
+type PriceCache = Arc<RwLock<HashMap<String, TickerData>>>;
 
 /// Cached token metadata resolved from on-chain addresses.
 type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
@@ -83,7 +83,7 @@ type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
 /// [`SharedMarketData`](crate::feed::market_data::SharedMarketData). Prices are resolved via direct
 /// pair (bid), reverse pair (1/ask), or intermediate routing through USDT/USDC/ETH/BTC.
 pub struct BinanceWsProvider {
-    ticker_cache: TickerCache,
+    price_cache: PriceCache,
     token_cache: TokenCache,
     ws_url: String,
     exchange_info_url: String,
@@ -92,7 +92,7 @@ pub struct BinanceWsProvider {
 impl BinanceWsProvider {
     pub fn new() -> Self {
         Self {
-            ticker_cache: Arc::new(RwLock::new(HashMap::new())),
+            price_cache: Arc::new(RwLock::new(HashMap::new())),
             token_cache: Arc::new(RwLock::new(HashMap::new())),
             ws_url: DEFAULT_WS_URL.to_string(),
             exchange_info_url: DEFAULT_EXCHANGE_INFO_URL.to_string(),
@@ -102,7 +102,7 @@ impl BinanceWsProvider {
     /// Overrides the Binance WebSocket and exchange info endpoint URLs.
     pub fn new_with_urls(ws_url: impl Into<String>, exchange_info_url: impl Into<String>) -> Self {
         Self {
-            ticker_cache: Arc::new(RwLock::new(HashMap::new())),
+            price_cache: Arc::new(RwLock::new(HashMap::new())),
             token_cache: Arc::new(RwLock::new(HashMap::new())),
             ws_url: ws_url.into(),
             exchange_info_url: exchange_info_url.into(),
@@ -224,7 +224,7 @@ impl Default for BinanceWsProvider {
 impl PriceProvider for BinanceWsProvider {
     fn start(&mut self, market_data: SharedMarketDataRef) -> JoinHandle<()> {
         let worker = BinanceWsWorker {
-            ticker_cache: Arc::clone(&self.ticker_cache),
+            price_cache: Arc::clone(&self.price_cache),
             token_cache: Arc::clone(&self.token_cache),
             market_data,
             client: Client::new(),
@@ -246,7 +246,7 @@ impl PriceProvider for BinanceWsProvider {
         let (sym_out, dec_out) = self.resolve_token(token_out)?;
 
         let cache = self
-            .ticker_cache
+            .price_cache
             .read()
             .map_err(|e| PriceProviderError::Unavailable(format!("ticker cache poisoned: {e}")))?;
 
@@ -263,7 +263,7 @@ impl PriceProvider for BinanceWsProvider {
 
 /// Background worker that manages the Binance WebSocket connection lifecycle.
 struct BinanceWsWorker {
-    ticker_cache: TickerCache,
+    price_cache: PriceCache,
     token_cache: TokenCache,
     market_data: SharedMarketDataRef,
     client: Client,
@@ -338,23 +338,20 @@ impl BinanceWsWorker {
                     let Some(msg) = msg else {
                         return Ok(());
                     };
-                    let msg = msg?;
-                    self.handle_message(&msg);
+                    self.handle_message(&msg?);
                 }
                 _ = resync_interval.tick() => {
-                    self.refresh_token_cache().await;
-                    if let Err(e) = self.resync_subscriptions(&mut write).await {
-                        warn!(error = %e, "failed to resync Binance subscriptions");
-                    }
+                    self.discover_new_pairs(&mut write).await;
                 }
             }
         }
     }
 
-    /// Handles a single WebSocket message.
+    /// Routes a WebSocket message by type: text frames are parsed as bookTicker
+    /// updates, close frames are logged, and everything else is ignored.
     fn handle_message(&self, msg: &Message) {
         match msg {
-            Message::Text(text) => self.handle_ticker(text),
+            Message::Text(text) => self.update_price_cache(text),
             Message::Close(frame) => {
                 let reason = frame
                     .as_ref()
@@ -366,7 +363,9 @@ impl BinanceWsWorker {
         }
     }
 
-    fn handle_ticker(&self, text: &str) {
+    /// Parses a bookTicker JSON message and upserts the bid/ask into the ticker cache.
+    /// Silently drops messages that fail to parse or have non-positive prices.
+    fn update_price_cache(&self, text: &str) {
         let Ok(ticker) = serde_json::from_str::<BookTickerMsg>(text) else {
             return;
         };
@@ -383,7 +382,7 @@ impl BinanceWsWorker {
 
         let timestamp_ms = ticker.event_time.unwrap_or_else(now_ms);
 
-        let Ok(mut cache) = self.ticker_cache.write() else {
+        let Ok(mut cache) = self.price_cache.write() else {
             warn!("ticker cache lock poisoned, dropping update");
             return;
         };
@@ -437,6 +436,18 @@ impl BinanceWsWorker {
             return;
         };
         *cache = new_cache;
+    }
+
+    /// Re-reads tokens from SharedMarketData and subscribes to any new Binance
+    /// pairs that appeared since the last sync.
+    async fn discover_new_pairs<S>(&mut self, write: &mut S)
+    where
+        S: futures::Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+    {
+        self.refresh_token_cache().await;
+        if let Err(e) = self.resync_subscriptions(write).await {
+            warn!(error = %e, "failed to resync Binance subscriptions");
+        }
     }
 
     /// Checks for new token pairs and subscribes to additional streams.
@@ -613,7 +624,7 @@ mod tests {
 
         {
             let mut cache = provider
-                .ticker_cache
+                .price_cache
                 .write()
                 .expect("lock");
             cache.insert(
@@ -655,10 +666,10 @@ mod tests {
     }
 
     /// Creates a `BinanceWsWorker` that writes to the given ticker cache.
-    fn make_worker(ticker_cache: &TickerCache) -> BinanceWsWorker {
+    fn make_worker(price_cache: &PriceCache) -> BinanceWsWorker {
         let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
         BinanceWsWorker {
-            ticker_cache: Arc::clone(ticker_cache),
+            price_cache: Arc::clone(price_cache),
             token_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
             market_data,
             client: Client::new(),
@@ -716,7 +727,7 @@ mod tests {
 
         {
             let mut cache = provider
-                .ticker_cache
+                .price_cache
                 .write()
                 .expect("lock");
             cache.insert(
@@ -726,7 +737,7 @@ mod tests {
         }
 
         let cache = provider
-            .ticker_cache
+            .price_cache
             .read()
             .expect("lock");
         // ETH→BTC via reverse BTCETH: sell-side uses 1/ask
@@ -763,7 +774,7 @@ mod tests {
 
         {
             let mut cache = provider
-                .ticker_cache
+                .price_cache
                 .write()
                 .expect("lock");
             cache.insert(
@@ -788,19 +799,19 @@ mod tests {
         assert!(matches!(result, Err(PriceProviderError::StaleData { .. })));
     }
 
-    // -- handle_message / handle_ticker tests (M4) --
+    // -- handle_message / update_price_cache tests (M4) --
 
     #[test]
-    fn handle_ticker_writes_to_cache() {
-        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
-        let worker = make_worker(&ticker_cache);
+    fn update_price_cache_writes_to_cache() {
+        let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&price_cache);
 
         let msg = Message::Text(
             r#"{"s":"ETHUSDT","b":"2000.00","a":"2000.50","E":1700000000000}"#.into(),
         );
         worker.handle_message(&msg);
 
-        let cache = ticker_cache.read().expect("lock");
+        let cache = price_cache.read().expect("lock");
         let ticker = cache
             .get("ETHUSDT")
             .expect("should be cached");
@@ -810,40 +821,40 @@ mod tests {
     }
 
     #[test]
-    fn handle_ticker_rejects_zero_bid() {
-        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
-        let worker = make_worker(&ticker_cache);
+    fn update_price_cache_rejects_zero_bid() {
+        let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&price_cache);
 
         let msg = Message::Text(r#"{"s":"ETHUSDT","b":"0","a":"2000.50"}"#.into());
         worker.handle_message(&msg);
 
-        let cache = ticker_cache.read().expect("lock");
+        let cache = price_cache.read().expect("lock");
         assert!(cache.get("ETHUSDT").is_none());
     }
 
     #[test]
-    fn handle_ticker_rejects_zero_ask() {
-        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
-        let worker = make_worker(&ticker_cache);
+    fn update_price_cache_rejects_zero_ask() {
+        let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&price_cache);
 
         let msg = Message::Text(r#"{"s":"ETHUSDT","b":"2000.00","a":"0"}"#.into());
         worker.handle_message(&msg);
 
-        let cache = ticker_cache.read().expect("lock");
+        let cache = price_cache.read().expect("lock");
         assert!(cache.get("ETHUSDT").is_none());
     }
 
     #[test]
-    fn handle_ticker_uses_now_ms_when_no_event_time() {
-        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
-        let worker = make_worker(&ticker_cache);
+    fn update_price_cache_uses_now_ms_when_no_event_time() {
+        let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&price_cache);
 
         let before = now_ms();
         let msg = Message::Text(r#"{"s":"ETHUSDT","b":"2000.00","a":"2000.50"}"#.into());
         worker.handle_message(&msg);
         let after = now_ms();
 
-        let cache = ticker_cache.read().expect("lock");
+        let cache = price_cache.read().expect("lock");
         let ticker = cache
             .get("ETHUSDT")
             .expect("should be cached");
@@ -852,14 +863,14 @@ mod tests {
 
     #[test]
     fn handle_message_ignores_non_text() {
-        let ticker_cache: TickerCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
-        let worker = make_worker(&ticker_cache);
+        let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
+        let worker = make_worker(&price_cache);
 
         worker.handle_message(&Message::Ping(vec![].into()));
         worker.handle_message(&Message::Pong(vec![].into()));
         worker.handle_message(&Message::Binary(vec![].into()));
 
-        let cache = ticker_cache.read().expect("lock");
+        let cache = price_cache.read().expect("lock");
         assert!(cache.is_empty());
     }
 

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -1,7 +1,7 @@
 //! Binance WebSocket price provider.
 //!
 //! Connects to the Binance `bookTicker` WebSocket stream, dynamically discovers trading pairs
-//! from [`SharedMarketData`](crate::feed::market_data::SharedMarketData), and caches real-time
+//! from [`SharedMarketData`](crate::feed::market_data::SharedMarketData)(crate::feed::market_data::SharedMarketData), and caches real-time
 //! bid/ask prices. Price resolution supports direct pairs, reverse pairs, and intermediate
 //! routing through common quote assets (USDT, USDC, ETH, BTC).
 
@@ -79,9 +79,9 @@ type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
 /// Binance WebSocket price provider.
 ///
 /// Subscribes to `bookTicker` streams for pairs discovered by cross-referencing
-/// Binance exchange info with tokens in [`SharedMarketData`]. Prices are resolved
-/// via direct pair (bid), reverse pair (1/ask), or intermediate routing through
-/// USDT/USDC/ETH/BTC.
+/// Binance exchange info with tokens in
+/// [`SharedMarketData`](crate::feed::market_data::SharedMarketData). Prices are resolved via direct
+/// pair (bid), reverse pair (1/ask), or intermediate routing through USDT/USDC/ETH/BTC.
 pub struct BinanceWsProvider {
     ticker_cache: TickerCache,
     token_cache: TokenCache,

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -21,9 +21,26 @@ use tycho_simulation::tycho_common::models::Address;
 
 use super::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
-    utils::{check_staleness, expected_out_from_price, normalize_symbol},
+    utils::{check_staleness, expected_out_from_price},
 };
 use crate::feed::market_data::SharedMarketDataRef;
+
+/// Maps on-chain token symbols to their Binance spot trading names.
+///
+/// On-chain tokens use wrapped ("W"-prefixed) names for native gas tokens, but Binance
+/// lists the unwrapped base asset.
+///
+/// Binance-specific: MATIC was renamed to POL (Polygon rebrand).
+fn normalize_symbol(symbol: &str) -> String {
+    match symbol.to_uppercase().as_str() {
+        "WETH" => "ETH".to_string(),
+        "WBTC" => "BTC".to_string(),
+        "WBNB" => "BNB".to_string(),
+        "WMATIC" | "MATIC" => "POL".to_string(),
+        "WAVAX" => "AVAX".to_string(),
+        other => other.to_string(),
+    }
+}
 
 const DEFAULT_WS_URL: &str = "wss://stream.binance.com:9443/ws";
 const DEFAULT_EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
@@ -240,10 +257,7 @@ impl PriceProvider for BinanceWsProvider {
             .map_err(|e| PriceProviderError::Unavailable(format!("ticker cache poisoned: {e}")))?;
 
         let lookup = Self::resolve_price(&cache, &sym_in, &sym_out).ok_or_else(|| {
-            PriceProviderError::PriceNotFound {
-                token_in: sym_in.clone(),
-                token_out: sym_out.clone(),
-            }
+            PriceProviderError::TokenNotFound { address: format!("{sym_in}/{sym_out}") }
         })?;
 
         check_staleness(lookup.timestamp_ms)?;

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -43,6 +43,34 @@ const RESYNC_INTERVAL: Duration = Duration::from_secs(60);
 const INITIAL_BACKOFF: Duration = Duration::from_secs(5);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
 
+/// Maps on-chain token symbols to their Binance spot trading names.
+///
+/// Returns `(binance_symbol, price_scale)` where `price_scale` adjusts the oracle price
+/// to a per-token basis. For most tokens this is `1.0`. Curated from the Binance perp
+/// universe across three categories:
+///
+/// 1. **Wrapped native tokens** — on-chain "W"-prefixed wrappers of chain gas tokens. Tokens like
+///    WLD/WIF whose names happen to start with W are NOT included.
+/// 2. **1000-prefix tokens** — Binance quotes these per 1,000 tokens to avoid tiny decimals.
+///    `price_scale` is `0.001` so callers get the per-token price.
+/// 3. **Binance-specific**: MATIC was renamed to POL (Polygon rebrand).
+fn normalize_symbol(symbol: &str) -> (String, f64) {
+    match symbol.to_uppercase().as_str() {
+        // Wrapped native tokens
+        "WETH" => ("ETH".to_string(), 1.0),
+        "WBTC" => ("BTC".to_string(), 1.0),
+        "WBNB" => ("BNB".to_string(), 1.0),
+        "WAVAX" => ("AVAX".to_string(), 1.0),
+        // 1000-prefixed: Binance quotes per 1,000 tokens
+        "CHEEMS" => ("1000CHEEMS".to_string(), 0.001),
+        "SATS" => ("1000SATS".to_string(), 0.001),
+        "CAT" => ("1000CAT".to_string(), 0.001),
+        // Binance specific
+        "WMATIC" | "MATIC" => ("POL".to_string(), 1.0),
+        other => (other.to_string(), 1.0),
+    }
+}
+
 /// Cached ticker data from the bookTicker stream.
 #[derive(Debug, Clone)]
 struct TickerData {
@@ -98,7 +126,7 @@ impl BinanceWsProvider {
     }
 
     /// Resolves a token address to (normalized_symbol, decimals) from the local token cache.
-    fn resolve_token(&self, address: &Address) -> Result<(String, u32), PriceProviderError> {
+    fn resolve_token(&self, address: &Address) -> Result<(String, u32, f64), PriceProviderError> {
         let cache = self
             .token_cache
             .read()
@@ -106,8 +134,8 @@ impl BinanceWsProvider {
         let info = cache
             .get(address)
             .ok_or_else(|| PriceProviderError::TokenNotFound { address: address.to_string() })?;
-        let symbol = normalize_symbol(&info.symbol);
-        Ok((symbol, info.decimals))
+        let (symbol, price_scale) = normalize_symbol(&info.symbol);
+        Ok((symbol, info.decimals, price_scale))
     }
 
     /// Looks up a sell-side price for `base` in terms of `quote`.
@@ -230,8 +258,8 @@ impl PriceProvider for BinanceWsProvider {
         token_out: &Address,
         amount_in: &BigUint,
     ) -> Result<ExternalPrice, PriceProviderError> {
-        let (sym_in, dec_in) = self.resolve_token(token_in)?;
-        let (sym_out, dec_out) = self.resolve_token(token_out)?;
+        let (sym_in, dec_in, scale_in) = self.resolve_token(token_in)?;
+        let (sym_out, dec_out, scale_out) = self.resolve_token(token_out)?;
 
         let cache = self
             .price_cache
@@ -244,7 +272,8 @@ impl PriceProvider for BinanceWsProvider {
 
         check_staleness(lookup.timestamp_ms)?;
 
-        let expected_out = expected_out_from_price(amount_in, lookup.price, dec_in, dec_out);
+        let price = lookup.price * scale_in / scale_out;
+        let expected_out = expected_out_from_price(amount_in, price, dec_in, dec_out);
         Ok(ExternalPrice::new(expected_out, "binance_ws".to_string(), lookup.timestamp_ms))
     }
 }
@@ -410,7 +439,7 @@ impl BinanceWsWorker {
         };
         cache
             .values()
-            .map(|info| normalize_symbol(&info.symbol))
+            .map(|info| normalize_symbol(&info.symbol).0)
             .collect()
     }
 
@@ -621,6 +650,8 @@ struct SymbolInfo {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use tokio::sync::RwLock;
     use tycho_simulation::evm::tycho_models::Chain;
 
@@ -663,6 +694,12 @@ mod tests {
             .expect("valid address")
     }
 
+    fn cheems_address() -> Address {
+        "0x41b1f9dcd5923c9542b6957b9b72169595acbc5c"
+            .parse()
+            .expect("valid address")
+    }
+
     /// Returns a provider pre-seeded with ETH, BTC, LINK tickers and
     /// WETH, USDC, LINK token metadata.
     fn seeded_provider() -> BinanceWsProvider {
@@ -694,6 +731,10 @@ mod tests {
                 "ETHBTC".to_string(),
                 TickerData { bid: 0.0333, ask: 0.0334, timestamp_ms: now },
             );
+            cache.insert(
+                "1000CHEEMSUSDC".to_string(),
+                TickerData { bid: 0.000433, ask: 0.000434, timestamp_ms: now },
+            );
         }
 
         {
@@ -707,6 +748,8 @@ mod tests {
             cache.insert(usdc.address.clone(), usdc);
             let link = make_token(link_address(), "LINK", 18);
             cache.insert(link.address.clone(), link);
+            let cheems = make_token(cheems_address(), "CHEEMS", 18);
+            cache.insert(cheems.address.clone(), cheems);
         }
 
         provider
@@ -799,6 +842,62 @@ mod tests {
         let buy = buy.expect("should have buy price");
         let expected_buy = 1.0 / 30.0;
         assert!((buy.price - expected_buy).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_direct_pair_price_1000_token() {
+        // Testing for pairs that are quoted in 1000 tokens
+        // 1000CHEEMSUSDC price is 0.000433 USDC per 1000 CHEEMS
+        // which means the real price is 0.000000433 USDC per 1 CHEEMS (bid)
+        // and 1 USDC is ~23041474 CHEEMS (ask)
+        let provider = seeded_provider();
+        let amount = BigUint::from(10u64).pow(22);
+
+        let result = provider
+            .get_expected_out(&cheems_address(), &usdc_address(), &amount)
+            .expect("should get price");
+
+        // 10_000 * 10**18 CHEEMS → 4330 USDC (6 decimals)
+        assert_eq!(*result.expected_amount_out(), BigUint::from(4330u64));
+
+        // let's test the reverse price
+        let amount = BigUint::from(10u64).pow(7);
+
+        let result = provider
+            .get_expected_out(&usdc_address(), &cheems_address(), &amount)
+            .expect("should get price");
+
+        // 10 * 10**6 USDC  → ~23094680 * 10**18 CHEEMS
+        assert_eq!(
+            *result.expected_amount_out(),
+            BigUint::from_str("23041474_654377879797760000").unwrap()
+        );
+    }
+    #[test]
+    fn test_pair_price_1000_token_intermediate_usdc() {
+        // Testing for pairs that are quoted in 1000 tokens
+        let provider = seeded_provider();
+        let amount = BigUint::from(10u64).pow(22);
+
+        let result = provider
+            .get_expected_out(&cheems_address(), &weth_address(), &amount)
+            .expect("should get price");
+
+        // 10_000 * 10**18 CHEEMS → 4330 USDC -> 2164458880000 ETH
+        assert_eq!(*result.expected_amount_out(), BigUint::from(2164458880000u64));
+
+        // let's test the reverse price
+        let amount = BigUint::from(10u64).pow(18);
+
+        let result = provider
+            .get_expected_out(&weth_address(), &cheems_address(), &amount)
+            .expect("should get price");
+
+        // 1 * 10**18 ETH -> 2000 * 10**6 USDC  → ~4608294930 * 10**18 CHEEMS
+        assert_eq!(
+            *result.expected_amount_out(),
+            BigUint::from_str("4608294930_875576062631215104").unwrap()
+        );
     }
 
     #[test]

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -25,23 +25,6 @@ use super::{
 };
 use crate::feed::market_data::SharedMarketDataRef;
 
-/// Maps on-chain token symbols to their Binance spot trading names.
-///
-/// On-chain tokens use wrapped ("W"-prefixed) names for native gas tokens, but Binance
-/// lists the unwrapped base asset.
-///
-/// Binance-specific: MATIC was renamed to POL (Polygon rebrand).
-fn normalize_symbol(symbol: &str) -> String {
-    match symbol.to_uppercase().as_str() {
-        "WETH" => "ETH".to_string(),
-        "WBTC" => "BTC".to_string(),
-        "WBNB" => "BNB".to_string(),
-        "WMATIC" | "MATIC" => "POL".to_string(),
-        "WAVAX" => "AVAX".to_string(),
-        other => other.to_string(),
-    }
-}
-
 const DEFAULT_WS_URL: &str = "wss://stream.binance.com:9443/ws";
 const DEFAULT_EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
 
@@ -432,19 +415,35 @@ impl BinanceWsWorker {
     }
 
     /// Snapshots the token registry from SharedMarketData into the local token cache.
+    /// Skips the clone when the registry size hasn't changed, since tokens are only
+    /// ever added — never removed or replaced.
     async fn refresh_token_cache(&self) {
+        let current_len = self
+            .token_cache
+            .read()
+            .map(|c| c.len())
+            .unwrap_or(0);
+
         let new_cache: HashMap<Address, Token> = {
             let data = self.market_data.read().await;
-            data.token_registry_ref()
+            let registry = data.token_registry_ref();
+            if registry.len() == current_len {
+                return;
+            }
+            registry
                 .iter()
                 .map(|(address, token)| (address.clone(), token.clone()))
                 .collect()
         };
 
-        let Ok(mut cache) = self.token_cache.write() else {
-            warn!("token cache lock poisoned");
-            return;
+        let mut cache = match self.token_cache.write() {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(error = %e, "token cache lock poisoned");
+                return;
+            }
         };
+
         *cache = new_cache;
     }
 
@@ -731,7 +730,7 @@ mod tests {
     // -- Price resolution tests --
 
     #[test]
-    fn direct_pair_price() {
+    fn test_direct_pair_price() {
         let provider = seeded_provider();
         let one_eth = BigUint::from(10u64).pow(18);
 
@@ -745,7 +744,7 @@ mod tests {
     }
 
     #[test]
-    fn price_via_intermediate_usdt() {
+    fn test_price_via_intermediate_usdt() {
         let provider = seeded_provider();
         let ten_link = BigUint::from(10u64) * BigUint::from(10u64).pow(18);
 
@@ -769,7 +768,7 @@ mod tests {
     }
 
     #[test]
-    fn reverse_pair_price() {
+    fn test_reverse_pair_price() {
         let provider = BinanceWsProvider::default();
         let now = now_ms();
 
@@ -803,7 +802,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_token_returns_error() {
+    fn test_unknown_token_returns_error() {
         let provider = seeded_provider();
         let unknown: Address = "0000000000000000000000000000000000000001"
             .parse()
@@ -816,7 +815,7 @@ mod tests {
     }
 
     #[test]
-    fn stale_price_returns_error() {
+    fn test_stale_price_returns_error() {
         let provider = BinanceWsProvider::default();
         let stale_ts = 1_000u64;
 
@@ -850,7 +849,7 @@ mod tests {
     // -- handle_message / update_price_cache tests (M4) --
 
     #[test]
-    fn update_price_cache_writes_to_cache() {
+    fn test_update_price_cache_writes_to_cache() {
         let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
         let worker = make_worker(&price_cache);
 
@@ -869,7 +868,7 @@ mod tests {
     }
 
     #[test]
-    fn update_price_cache_rejects_zero_bid() {
+    fn test_update_price_cache_rejects_zero_bid() {
         let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
         let worker = make_worker(&price_cache);
 
@@ -881,7 +880,7 @@ mod tests {
     }
 
     #[test]
-    fn update_price_cache_rejects_zero_ask() {
+    fn test_update_price_cache_rejects_zero_ask() {
         let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
         let worker = make_worker(&price_cache);
 
@@ -893,7 +892,7 @@ mod tests {
     }
 
     #[test]
-    fn update_price_cache_uses_now_ms_when_no_event_time() {
+    fn test_update_price_cache_uses_now_ms_when_no_event_time() {
         let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
         let worker = make_worker(&price_cache);
 
@@ -910,7 +909,7 @@ mod tests {
     }
 
     #[test]
-    fn handle_message_ignores_non_text() {
+    fn test_handle_message_ignores_non_text() {
         let price_cache: PriceCache = Arc::new(std::sync::RwLock::new(HashMap::new()));
         let worker = make_worker(&price_cache);
 
@@ -925,7 +924,7 @@ mod tests {
     // -- Deserialization tests --
 
     #[test]
-    fn parse_book_ticker_msg() {
+    fn test_parse_book_ticker_msg() {
         let json = r#"{"e":"bookTicker","u":123,"s":"ETHUSDT","b":"2000.00","B":"10.5","a":"2000.50","A":"5.2","E":1700000000000}"#;
         let msg: BookTickerMsg = serde_json::from_str(json).expect("should parse");
         assert_eq!(msg.s.as_deref(), Some("ETHUSDT"));
@@ -935,7 +934,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_exchange_info_response() {
+    fn test_parse_exchange_info_response() {
         let json = r#"{"symbols":[{"symbol":"ETHUSDT","status":"TRADING"},{"symbol":"ETHBTC","status":"BREAK"}]}"#;
         let resp: ExchangeInfoResponse = serde_json::from_str(json).expect("should parse");
         assert_eq!(resp.symbols.len(), 2);
@@ -946,7 +945,7 @@ mod tests {
     // -- Pair discovery tests --
 
     #[test]
-    fn discover_pairs_filters_correctly() {
+    fn test_discover_pairs_filters_correctly() {
         let tokens: HashSet<String> = ["ETH", "LINK", "AAVE"]
             .iter()
             .map(|s| s.to_string())
@@ -969,7 +968,7 @@ mod tests {
     // -- Stablecoin cache injection tests --
 
     #[test]
-    fn inject_creates_synthetic_stablecoin_tickers() {
+    fn test_inject_creates_synthetic_stablecoin_tickers() {
         let mut cache = HashMap::new();
         let now = now_ms();
 
@@ -984,7 +983,7 @@ mod tests {
     }
 
     #[test]
-    fn inject_does_not_overwrite_real_ticker() {
+    fn test_inject_does_not_overwrite_real_ticker() {
         let mut cache = HashMap::new();
         let now = now_ms();
 
@@ -1004,7 +1003,7 @@ mod tests {
     }
 
     #[test]
-    fn inject_handles_quote_prefix_pair() {
+    fn test_inject_handles_quote_prefix_pair() {
         let mut cache = HashMap::new();
         let now = now_ms();
 
@@ -1017,7 +1016,7 @@ mod tests {
     }
 
     #[test]
-    fn unlisted_stablecoin_resolves_via_cache() {
+    fn test_unlisted_stablecoin_resolves_via_cache() {
         let provider = seeded_provider();
 
         let dai_address: Address = "6B175474E89094C44Da98b954EedeAC495271d0F"
@@ -1058,7 +1057,7 @@ mod tests {
     }
 
     #[test]
-    fn ws_message_creates_synthetic_stablecoin_ticker() {
+    fn test_ws_message_creates_synthetic_stablecoin_ticker() {
         // End-to-end: a raw ETHUSDT WebSocket message arrives, the worker processes
         // it, and we can price ETH/GHO through the synthetic cache entry.
         let provider = BinanceWsProvider::default();
@@ -1105,7 +1104,7 @@ mod tests {
 
     #[tokio::test]
     #[ignore] // requires network access
-    async fn binance_ws_live_weth_usdc() {
+    async fn test_binance_ws_live_weth_usdc() {
         let weth = make_token(weth_address(), "WETH", 18);
         let usdc = make_token(usdc_address(), "USDC", 6);
 

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -154,7 +154,7 @@ impl PriceProvider for HyperliquidProvider {
                 token_in: sym_in.clone(),
                 token_out: sym_out.clone(),
             })?;
-        let price_out = cache
+            let price_out = cache
             .get(&sym_out)
             .ok_or(PriceProviderError::PriceNotFound { token_in: sym_in, token_out: sym_out })?;
 

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -31,17 +31,11 @@ static USD_STABLECOINS: LazyLock<HashSet<String>> = LazyLock::new(|| {
     serde_json::from_str(include_str!("stable_usd.json")).expect("stable_usd.json is valid")
 });
 
-/// Shared price cache. Key is the Hyperliquid asset name (e.g. "ETH").
-type PriceCache = Arc<RwLock<HashMap<String, OraclePrice>>>;
-
-/// Cached token metadata resolved from on-chain addresses.
-type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
-
 /// Maps on-chain token symbols to their Hyperliquid asset names.
 ///
 /// Returns `(hyperliquid_symbol, price_scale)` where `price_scale` adjusts the oracle price
 /// to a per-token basis. For most tokens this is `1.0`. Curated from the Hyperliquid perp
-/// universe across three categories:
+/// universe across two categories:
 ///
 /// 1. **Wrapped native tokens** — on-chain "W"-prefixed wrappers of chain gas tokens. Tokens like
 ///    WLD/WIF whose names happen to start with W are NOT included.
@@ -74,6 +68,12 @@ struct OraclePrice {
     usd_price: f64,
     timestamp_ms: u64,
 }
+
+/// Shared price cache. Key is the Hyperliquid asset name (e.g. "ETH").
+type PriceCache = Arc<RwLock<HashMap<String, OraclePrice>>>;
+
+/// Cached token metadata resolved from on-chain addresses.
+type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
 
 /// Hyperliquid oracle price provider.
 ///
@@ -154,7 +154,7 @@ impl PriceProvider for HyperliquidProvider {
                 token_in: sym_in.clone(),
                 token_out: sym_out.clone(),
             })?;
-            let price_out = cache
+        let price_out = cache
             .get(&sym_out)
             .ok_or(PriceProviderError::PriceNotFound { token_in: sym_in, token_out: sym_out })?;
 

--- a/fynd-core/src/price_guard/mod.rs
+++ b/fynd-core/src/price_guard/mod.rs
@@ -14,6 +14,8 @@
 //! - **config**: [`PriceGuardConfig`](crate::price_guard::config::PriceGuardConfig) for tolerance
 //!   thresholds and fail-open behavior
 
+/// Binance price provider implementation
+pub mod binance_ws;
 /// Tolerance thresholds and fail-open configuration for the price guard.
 pub mod config;
 /// Orchestrates validation of solver solutions against external prices.

--- a/fynd-core/src/price_guard/provider_registry.rs
+++ b/fynd-core/src/price_guard/provider_registry.rs
@@ -4,6 +4,7 @@ use num_bigint::BigUint;
 use tycho_simulation::tycho_common::models::Address;
 
 use super::{
+    binance_ws::BinanceWsProvider,
     hyperliquid::HyperliquidProvider,
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
@@ -27,8 +28,8 @@ impl PriceProviderRegistry {
 
     /// Registers the built-in providers (Hyperliquid + Binance).
     pub fn with_default_providers(self) -> Self {
-        // TODO: register BinanceWsProvider here once implemented (ENG-5605).
         self.register(Box::new(HyperliquidProvider::default()))
+            .register(Box::new(BinanceWsProvider::default()))
     }
 
     /// Returns `true` if no providers are registered.

--- a/fynd-core/src/price_guard/utils.rs
+++ b/fynd-core/src/price_guard/utils.rs
@@ -11,6 +11,22 @@ use crate::feed::market_data::SharedMarketDataRef;
 /// Maximum age of price data before it is considered stale.
 pub const STALENESS_THRESHOLD: Duration = Duration::from_secs(30);
 
+/// Maps wrapped on-chain token symbols to their uppercase offchain exchange
+/// equivalents.
+///
+/// On-chain tokens like WETH, WBTC are listed as ETH, BTC on offchain
+/// exchanges. Non-wrapped symbols are uppercased to match exchange conventions.
+pub fn normalize_symbol(symbol: &str) -> String {
+    match symbol.to_uppercase().as_str() {
+        "WETH" => "ETH".to_string(),
+        "WBTC" => "BTC".to_string(),
+        "WBNB" => "BNB".to_string(),
+        "WMATIC" => "MATIC".to_string(),
+        "WAVAX" => "AVAX".to_string(),
+        _ => symbol.to_uppercase(),
+    }
+}
+
 /// Resolves an on-chain address to a (symbol, decimals) pair via the
 /// [`SharedMarketData`](crate::feed::market_data::SharedMarketData) token registry.
 pub async fn resolve_token(

--- a/fynd-core/src/price_guard/utils.rs
+++ b/fynd-core/src/price_guard/utils.rs
@@ -3,42 +3,11 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use num_bigint::BigUint;
-use tycho_simulation::tycho_common::models::Address;
 
 use super::provider::PriceProviderError;
-use crate::feed::market_data::SharedMarketDataRef;
 
 /// Maximum age of price data before it is considered stale.
 pub const STALENESS_THRESHOLD: Duration = Duration::from_secs(30);
-
-/// Maps wrapped on-chain token symbols to their uppercase offchain exchange
-/// equivalents.
-///
-/// On-chain tokens like WETH, WBTC are listed as ETH, BTC on offchain
-/// exchanges. Non-wrapped symbols are uppercased to match exchange conventions.
-pub fn normalize_symbol(symbol: &str) -> String {
-    match symbol.to_uppercase().as_str() {
-        "WETH" => "ETH".to_string(),
-        "WBTC" => "BTC".to_string(),
-        "WBNB" => "BNB".to_string(),
-        "WMATIC" => "MATIC".to_string(),
-        "WAVAX" => "AVAX".to_string(),
-        _ => symbol.to_uppercase(),
-    }
-}
-
-/// Resolves an on-chain address to a (symbol, decimals) pair via the
-/// [`SharedMarketData`](crate::feed::market_data::SharedMarketData) token registry.
-pub async fn resolve_token(
-    market_data: &SharedMarketDataRef,
-    address: &Address,
-) -> Result<(String, u32), PriceProviderError> {
-    let data = market_data.read().await;
-    let token = data
-        .get_token(address)
-        .ok_or_else(|| PriceProviderError::TokenNotFound { address: address.to_string() })?;
-    Ok((token.symbol.clone(), token.decimals))
-}
 
 /// Returns `Err(StaleData)` if `ticker_ts` is older than [`STALENESS_THRESHOLD`].
 pub fn check_staleness(ticker_ts: u64) -> Result<(), PriceProviderError> {


### PR DESCRIPTION
  ## Summary
                                                                                                                                                                                                                      
  - Add `BinanceWsProvider` that subscribes to Binance `bookTicker` WebSocket streams for real-time bid/ask prices                                                                                                    
  - Pair discovery cross-references `SharedMarketData` tokens with Binance `/api/v3/exchangeInfo`, re-syncs every 60s
  - Price resolution: direct pair (bid) → reverse pair (1/ask) → intermediate routing through USDT/USDC/ETH/BTC, using ask prices on the buy-side leg
  - Reconnects with exponential backoff (5s → 60s max)                                            
  - Register as second default provider alongside Hyperliquid                                           