### PR TITLE
feat: Add support for ekubo_v3 exchange in protocol registry

### DIFF
--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -7,6 +7,7 @@ use tycho_simulation::{
         protocol::{
             aerodrome_slipstreams::state::AerodromeSlipstreamsState,
             ekubo::state::EkuboState,
+            ekubo_v3::{self, state::EkuboV3State},
             erc4626::state::ERC4626State,
             filters::{balancer_v2_pool_filter, erc4626_filter, fluid_v1_paused_pools_filter},
             fluid::FluidV1,
@@ -123,6 +124,13 @@ pub(crate) fn register_exchanges(
                     "velodrome_slipstreams",
                     tvl_filter.clone(),
                     None,
+                );
+            }
+            "ekubo_v3" => {
+                builder = builder.exchange::<EkuboV3State>(
+                    "ekubo_v3",
+                    tvl_filter.clone(),
+                    Some(ekubo_v3::filter_fn),
                 );
             }
             p if p.starts_with("rfq:") => {


### PR DESCRIPTION
This update introduces ekubo_v3 to the protocol registry, allowing for the registration of the ekubo_v3 exchange with its associated filter function.