### PR TITLE
docs: add alpha disclosure to README for unaudited contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 A high-performance DeFi route-finding engine built on [Tycho](https://www.propellerheads.xyz/tycho). Finds optimal swap
 routes across multiple DeFi protocols in real-time.
 
+> [!CAUTION]
+  > **Alpha Software — Unaudited Contracts**
+  >
+  > Fynd's smart contracts ([TychoRouter V3](https://docs.propellerheads.xyz/tycho/for-solvers/execution#security-and-audits), Vault, Executors) are still undergoing a security audit. Funds stored in the router (including vault deposits) may be lost. Use at your own
+   discretion.
+
 ## Features
 
 - **Multi-protocol routing** - Routes through your favorite on-chain liquidity protocol, like Uniswap, Balancer, Curve,


### PR DESCRIPTION
## Summary
- Adds a `[!CAUTION]` block to the README with an alpha/unaudited contracts disclosure
- Links TychoRouter V3 to the execution security docs
- Matches disclosures already added to docs.fynd.xyz (Overview, Quickstart, Client Fees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)