### PR TITLE
feat: account for router and client fees in min_amount_out 

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Submit one or more swap orders and receive optimal routes.
 | `options.encoding_options.transfer_type` | string | No | Input token transfer method: `transfer_from` (default) or `transfer_from_permit2`                             |
 | `options.encoding_options.permit` | object | No | Permit2 single-token authorization. Required when using `transfer_from_permit2`                               |
 | `options.encoding_options.permit2_signature` | string | No | Permit2 signature (hex-encoded). Required when `permit` is set                                                |
+| `options.encoding_options.client_fee_params` | object | No | Client fee configuration. See [Client Fees](docs/guides/client-fees.md)                                       |
 
 **Response:**
 
@@ -173,6 +174,12 @@ Submit one or more swap orders and receive optimal routes.
         "to": "0x...",
         "value": "0",
         "data": "0x..."
+      },
+      "fee_breakdown": {
+        "router_fee": "320000",
+        "client_fee": "0",
+        "max_slippage": "31996800",
+        "min_amount_received": "3167683200"
       }
     }
   ],

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.25.2"
+    "version": "0.29.0"
   },
   "paths": {
     "/v1/health": {
@@ -267,6 +267,38 @@
           }
         }
       },
+      "FeeBreakdown": {
+        "type": "object",
+        "description": "Breakdown of fees applied to the swap output by the on-chain FeeCalculator.\n\nAll amounts are absolute values in output token units.",
+        "required": [
+          "router_fee",
+          "client_fee",
+          "max_slippage",
+          "min_amount_received"
+        ],
+        "properties": {
+          "client_fee": {
+            "type": "string",
+            "description": "Client's portion of the fee (after the router takes its share).",
+            "example": "2800000"
+          },
+          "max_slippage": {
+            "type": "string",
+            "description": "Maximum slippage: (amount_out - router_fee - client_fee) * slippage.",
+            "example": "3496850"
+          },
+          "min_amount_received": {
+            "type": "string",
+            "description": "Minimum amount the user receives on-chain.\nEqual to amount_out - router_fee - client_fee - max_slippage.",
+            "example": "3493353150"
+          },
+          "router_fee": {
+            "type": "string",
+            "description": "Router protocol fee (fee on output + router's share of client fee).",
+            "example": "350000"
+          }
+        }
+      },
       "HealthStatus": {
         "type": "object",
         "description": "Health check response.",
@@ -415,6 +447,17 @@
           "block": {
             "$ref": "#/components/schemas/BlockInfo",
             "description": "Block at which this quote was computed."
+          },
+          "fee_breakdown": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/FeeBreakdown",
+                "description": "Fee breakdown (populated when encoding options are provided)."
+              }
+            ]
           },
           "gas_estimate": {
             "type": "string",

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -838,6 +838,7 @@ mod tests {
             bytes::Bytes::copy_from_slice(&[0xbb; 20]),
             bytes::Bytes::copy_from_slice(&[0xcc; 20]),
             Some(tx),
+            None,
         )
     }
 
@@ -1405,6 +1406,7 @@ mod tests {
             BlockInfo::new(1, "0xabc".to_string(), 0),
             bytes::Bytes::copy_from_slice(&[0xbb; 20]),
             bytes::Bytes::copy_from_slice(&[0xcc; 20]),
+            None,
             None,
         );
         let hints = SigningHints {

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -55,9 +55,9 @@ pub use client::{
 pub use error::{ErrorCode, FyndError};
 pub use signing::{ExecutionReceipt, FyndPayload, SettledOrder, SignablePayload, SignedOrder};
 pub use types::{
-    BackendKind, BlockInfo, ClientFeeParams, EncodingOptions, HealthStatus, Order, OrderSide,
-    PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteParams, QuoteStatus, Route, Swap,
-    Transaction, UserTransferType,
+    BackendKind, BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown, HealthStatus, Order,
+    OrderSide, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteParams, QuoteStatus, Route,
+    Swap, Transaction, UserTransferType,
 };
 
 mod client;

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -10,9 +10,9 @@ use tycho_simulation::tycho_common::models::Address as TychoAddress;
 use crate::{
     error::{ErrorCode, FyndError},
     types::{
-        BackendKind, BatchQuote, BlockInfo, EncodingOptions, HealthStatus, Order, OrderSide,
-        PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteParams, QuoteStatus, Route, Swap,
-        Transaction, UserTransferType,
+        BackendKind, BatchQuote, BlockInfo, EncodingOptions, FeeBreakdown, HealthStatus, Order,
+        OrderSide, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteParams, QuoteStatus,
+        Route, Swap, Transaction, UserTransferType,
     },
 };
 // ============================================================================
@@ -197,6 +197,14 @@ pub(crate) fn dto_to_quote(
         .transaction()
         .cloned()
         .map(Transaction::from);
+    let fee_breakdown = ds.fee_breakdown().map(|fb| {
+        FeeBreakdown::new(
+            fb.router_fee().clone(),
+            fb.client_fee().clone(),
+            fb.max_slippage().clone(),
+            fb.min_amount_received().clone(),
+        )
+    });
     Ok(Quote::new(
         ds.order_id().to_string(),
         status,
@@ -211,6 +219,7 @@ pub(crate) fn dto_to_quote(
         token_out,
         receiver,
         transaction,
+        fee_breakdown,
     ))
 }
 

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -647,6 +647,49 @@ impl Route {
     }
 }
 
+/// Breakdown of fees applied to the swap output by the on-chain FeeCalculator.
+///
+/// All amounts are absolute values in output token units.
+#[derive(Debug, Clone)]
+pub struct FeeBreakdown {
+    router_fee: BigUint,
+    client_fee: BigUint,
+    max_slippage: BigUint,
+    min_amount_received: BigUint,
+}
+
+impl FeeBreakdown {
+    pub(crate) fn new(
+        router_fee: BigUint,
+        client_fee: BigUint,
+        max_slippage: BigUint,
+        min_amount_received: BigUint,
+    ) -> Self {
+        Self { router_fee, client_fee, max_slippage, min_amount_received }
+    }
+
+    /// Router protocol fee (fee on output + router's share of client fee).
+    pub fn router_fee(&self) -> &BigUint {
+        &self.router_fee
+    }
+
+    /// Client's portion of the fee (after the router takes its share).
+    pub fn client_fee(&self) -> &BigUint {
+        &self.client_fee
+    }
+
+    /// Maximum slippage: (amount_out - router_fee - client_fee) * slippage.
+    pub fn max_slippage(&self) -> &BigUint {
+        &self.max_slippage
+    }
+
+    /// Minimum amount the user receives on-chain.
+    /// Equal to amount_out - router_fee - client_fee - max_slippage.
+    pub fn min_amount_received(&self) -> &BigUint {
+        &self.min_amount_received
+    }
+}
+
 /// The solver's response for a single order.
 #[derive(Debug, Clone)]
 pub struct Quote {
@@ -670,6 +713,8 @@ pub struct Quote {
     /// ABI-encoded on-chain transaction. Present only when [`EncodingOptions`] was set in the
     /// request via [`QuoteOptions::with_encoding_options`].
     transaction: Option<Transaction>,
+    /// Fee breakdown. Present only when [`EncodingOptions`] was set in the request.
+    fee_breakdown: Option<FeeBreakdown>,
     /// Wall-clock time the server spent solving this request, in milliseconds.
     /// Populated by [`FyndClient::quote`](crate::FyndClient::quote).
     pub(crate) solve_time_ms: u64,
@@ -754,6 +799,14 @@ impl Quote {
         self.transaction.as_ref()
     }
 
+    /// Fee breakdown, present when [`EncodingOptions`] was set in the request.
+    ///
+    /// Contains router fee, client fee, max slippage, and the minimum amount the user
+    /// will receive on-chain (the value used as `min_amount_out` in the transaction).
+    pub fn fee_breakdown(&self) -> Option<&FeeBreakdown> {
+        self.fee_breakdown.as_ref()
+    }
+
     /// Wall-clock time the server spent solving this request, in milliseconds.
     ///
     /// Populated by [`FyndClient::quote`](crate::FyndClient::quote). Returns `0` if not set.
@@ -776,6 +829,7 @@ impl Quote {
         token_out: Bytes,
         receiver: Bytes,
         transaction: Option<Transaction>,
+        fee_breakdown: Option<FeeBreakdown>,
     ) -> Self {
         Self {
             order_id,
@@ -791,6 +845,7 @@ impl Quote {
             token_out,
             receiver,
             transaction,
+            fee_breakdown,
             solve_time_ms: 0,
         }
     }

--- a/clients/typescript/autogen/src/schema.d.ts
+++ b/clients/typescript/autogen/src/schema.d.ts
@@ -158,6 +158,34 @@ export interface components {
             /** @example bad request: no orders provided */
             error: string;
         };
+        /**
+         * @description Breakdown of fees applied to the swap output by the on-chain FeeCalculator.
+         *
+         *     All amounts are absolute values in output token units.
+         */
+        FeeBreakdown: {
+            /**
+             * @description Client's portion of the fee (after the router takes its share).
+             * @example 2800000
+             */
+            client_fee: string;
+            /**
+             * @description Maximum slippage: (amount_out - router_fee - client_fee) * slippage.
+             * @example 3496850
+             */
+            max_slippage: string;
+            /**
+             * @description Minimum amount the user receives on-chain.
+             *     Equal to amount_out - router_fee - client_fee - max_slippage.
+             * @example 3493353150
+             */
+            min_amount_received: string;
+            /**
+             * @description Router protocol fee (fee on output + router's share of client fee).
+             * @example 350000
+             */
+            router_fee: string;
+        };
         /** @description Health check response. */
         HealthStatus: {
             /**
@@ -272,6 +300,7 @@ export interface components {
             amount_out_net_gas: string;
             /** @description Block at which this quote was computed. */
             block: components["schemas"]["BlockInfo"];
+            fee_breakdown?: null | components["schemas"]["FeeBreakdown"];
             /**
              * @description Estimated gas cost for executing this route (as decimal string).
              * @example 150000

--- a/clients/typescript/client/src/index.ts
+++ b/clients/typescript/client/src/index.ts
@@ -4,6 +4,7 @@ export type {
   BlockInfo,
   ClientFeeParams,
   EncodingOptions,
+  FeeBreakdown,
   Hex,
   HealthStatus,
   Order,

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -5,6 +5,7 @@ import type {
     BlockInfo,
     ClientFeeParams,
     EncodingOptions,
+    FeeBreakdown,
     HealthStatus,
     Hex,
     PermitDetails,
@@ -29,6 +30,7 @@ type WireTransaction = components["schemas"]["Transaction"];
 type WirePermitSingle = components["schemas"]["PermitSingle"];
 type WirePermitDetails = components["schemas"]["PermitDetails"];
 type WireClientFeeParams = components["schemas"]["ClientFeeParams"];
+type WireFeeBreakdown = components["schemas"]["FeeBreakdown"];
 
 
 export function toWireRequest(params: QuoteParams): WireSolutionRequest {
@@ -80,6 +82,9 @@ export function fromWireQuote(
         ? fromWireTransaction(orderSolution.transaction)
         : undefined;
     const priceImpactBps = orderSolution.price_impact_bps ?? undefined;
+    const feeBreakdown = orderSolution.fee_breakdown != null
+        ? fromWireFeeBreakdown(orderSolution.fee_breakdown)
+        : undefined;
     return {
         orderId: orderSolution.order_id,
         status: orderSolution.status,
@@ -94,6 +99,7 @@ export function fromWireQuote(
         ...(route !== undefined ? {route} : {}),
         ...(transaction !== undefined ? {transaction} : {}),
         ...(priceImpactBps !== undefined ? {priceImpactBps} : {}),
+        ...(feeBreakdown !== undefined ? {feeBreakdown} : {}),
     };
 }
 
@@ -160,6 +166,15 @@ function toWirePermitDetails(d: PermitDetails): WirePermitDetails {
         amount: d.amount.toString(),
         expiration: d.expiration.toString(),
         nonce: d.nonce.toString(),
+    };
+}
+
+function fromWireFeeBreakdown(wire: WireFeeBreakdown): FeeBreakdown {
+    return {
+        routerFee: BigInt(wire.router_fee),
+        clientFee: BigInt(wire.client_fee),
+        maxSlippage: BigInt(wire.max_slippage),
+        minAmountReceived: BigInt(wire.min_amount_received),
     };
 }
 

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -139,6 +139,18 @@ export interface Route {
   swaps: Swap[];
 }
 
+/** Breakdown of fees applied to the swap output by the on-chain FeeCalculator. */
+export interface FeeBreakdown {
+  /** Router protocol fee (fee on output + router's share of client fee). */
+  routerFee: bigint;
+  /** Client's portion of the fee (after the router takes its share). */
+  clientFee: bigint;
+  /** Maximum slippage: (amountOut - routerFee - clientFee) * slippage. */
+  maxSlippage: bigint;
+  /** Minimum amount the user receives on-chain (the min_amount_out in the tx). */
+  minAmountReceived: bigint;
+}
+
 /** A solver quote containing the best route, amounts, and optional encoded transaction. */
 export interface Quote {
   orderId: string;
@@ -157,6 +169,8 @@ export interface Quote {
   receiver: Address;
   /** Encoded transaction; present only when `encodingOptions` was set in the quote request. */
   transaction?: Transaction;
+  /** Fee breakdown; present only when `encodingOptions` was set in the quote request. */
+  feeBreakdown?: FeeBreakdown;
 }
 
 /** Solver health status and readiness information. */

--- a/docs/guides/client-fees.md
+++ b/docs/guides/client-fees.md
@@ -2,40 +2,85 @@
 icon: coins
 ---
 
-# Client Fees
+# Fees
 
-Fynd supports optional client fees — a percentage of the swap output charged on behalf of an integrator.
-Fees are configured per-request via `ClientFeeParams` in the encoding options.
+Every swap through the TychoRouter incurs two fees, deducted from the swap output:
 
-## How it works
+- **Router fee**: 10 bps (0.1%) on the swap output, always applied.
+- **Client fee**: optional integrator fee via `ClientFeeParams`. The router takes a 20% share; the integrator keeps 80%.
 
-1. The integrator chooses a fee in basis points (e.g. `50` = 0.5%), a receiver address, and a `maxClientContribution`.
-2. The fee receiver signs an EIP-712 `ClientFee` message authorizing the fee parameters.
-3. The signed params are attached to the quote request via `EncodingOptions.clientFeeParams`.
-4. The router contract verifies the signature on-chain and deducts the fee from the swap output. Fees are credited to
-   the receiver's vault balance (not transferred directly).
+When you request encoding, the quote response includes a `fee_breakdown` with the exact amounts.
 
-When no `ClientFeeParams` are provided, no client fee is charged.
+## Fee breakdown
+
+The on-chain `FeeCalculator` deducts fees from the raw swap output. Fynd mirrors this calculation (identical integer
+arithmetic) to set `minAmountOut` in the encoded transaction.
+
+Given `amount_out` (raw swap output), `client_fee_bps` (0 if none), and `slippage`:
+
+```
+1. client_fee        = amount_out * client_fee_bps / 10,000
+2. router_share      = amount_out * client_fee_bps * 2,000 / 100,000,000
+3. client_portion    = client_fee - router_share
+4. router_fee_output = amount_out * 10 / 10,000
+5. router_fee        = router_share + router_fee_output
+6. amount_after_fees = amount_out - client_portion - router_fee
+7. max_slippage      = amount_after_fees * slippage
+8. min_amount_received = amount_after_fees - max_slippage
+```
+
+The response fields (all absolute values in output token units):
+
+| Field                  | Description                                                   |
+|------------------------|---------------------------------------------------------------|
+| `router_fee`           | Router's total take (output fee + 20% of client fee)          |
+| `client_fee`           | Integrator's portion (80% of the client fee)                  |
+| `max_slippage`         | Slippage allowance on the post-fee amount                     |
+| `min_amount_received`  | On-chain minimum the user receives (`minAmountOut` in the tx) |
+
+Invariant: `amount_out = router_fee + client_fee + max_slippage + min_amount_received`
+
+### Example
+
+1,000,000 USDC output, 50 bps client fee, 1% slippage:
+
+```
+client_fee (total)   = 1,000,000 * 50 / 10,000         = 5,000
+router_share         = 1,000,000 * 50 * 2,000 / 1e8    = 1,000
+client_portion       = 5,000 - 1,000                    = 4,000
+router_fee_output    = 1,000,000 * 10 / 10,000          = 1,000
+router_fee           = 1,000 + 1,000                     = 2,000
+amount_after_fees    = 1,000,000 - 4,000 - 2,000        = 994,000
+max_slippage         = 994,000 * 0.01                    = 9,940
+min_amount_received  = 994,000 - 9,940                   = 984,060
+```
+
+## Setting up client fees
+
+1. Choose a fee in basis points (e.g. `50` = 0.5%), a receiver address, and a `maxClientContribution`.
+2. The fee receiver signs an EIP-712 `ClientFee` message authorizing these parameters.
+3. Attach the signed params to `EncodingOptions.clientFeeParams`.
+4. The router verifies the signature on-chain and deducts the fee. Fees go to the receiver's vault balance.
+
+No `ClientFeeParams`? No client fee. The 10 bps router fee still applies.
 
 ### maxClientContribution
 
-`maxClientContribution` is the maximum amount (in output token units) the client is willing to subsidize from their
-vault balance if slippage causes the swap output to fall below `minAmountOut`. If the shortfall exceeds this limit, the
-transaction reverts.
+The maximum amount (in output token units) the client will subsidize from their vault balance if slippage pushes the
+output below `minAmountOut`. If the shortfall exceeds this limit, the transaction reverts.
 
-Set to `0` if you don't want to subsidize slippage. This is the common case — the client collects fees but doesn't cover
-losses.
+Set to `0` to collect fees without covering slippage losses. This is the common case.
 
-See [Tycho encoding docs](https://docs.propellerheads.xyz/tycho/for-solvers/execution/encoding#encode) for more details
-on the vault mechanism.
+See [Tycho encoding docs](https://docs.propellerheads.xyz/tycho/for-solvers/execution/encoding#encode) for vault
+details.
 
 ## EIP-712 signing
 
-The fee receiver must sign a typed data hash with the following structure:
+The fee receiver signs a typed data hash:
 
 | Field                   | Type      | Description                       |
 |-------------------------|-----------|-----------------------------------|
-| `clientFeeBps`          | `uint16`  | Fee in basis points (0–10,000)    |
+| `clientFeeBps`          | `uint16`  | Fee in basis points (0-10,000)    |
 | `clientFeeReceiver`     | `address` | Address receiving the fee         |
 | `maxClientContribution` | `uint256` | Maximum subsidy from client vault |
 | `deadline`              | `uint256` | Signature expiry (Unix timestamp) |
@@ -50,8 +95,6 @@ The fee receiver must sign a typed data hash with the following structure:
 | `verifyingContract` | TychoRouter contract address |
 
 ## Code examples
-
-Both the Rust and TypeScript clients provide helper functions to compute the signing hash.
 
 {% tabs %}
 {% tab title="Rust" %}
@@ -85,18 +128,18 @@ example: [`clients/rust/examples/swap_client_fee.rs`](https://github.com/propell
 ```typescript
 // Build fee params (without signature).
 const feeParams: ClientFeeParams = {
-  bps: 50,              // 0.5% fee
-  receiver: feeReceiver,
-  maxContribution: 0n,  // no vault subsidy
-  deadline: 1893456000, // Unix timestamp
+    bps: 50,              // 0.5% fee
+    receiver: feeReceiver,
+    maxContribution: 0n,  // no vault subsidy
+    deadline: 1893456000, // Unix timestamp
 };
 
 // Compute the EIP-712 hash and sign with the fee receiver's wallet.
 const hash = clientFeeSigningHash(feeParams, 1, routerAddress);
-const signature = await account.signMessage({ message: { raw: hash } });
+const signature = await account.signMessage({message: {raw: hash}});
 
 // Attach signature and wire into encoding options.
-const opts = withClientFee(encodingOptions(0.005), { ...feeParams, signature });
+const opts = withClientFee(encodingOptions(0.005), {...feeParams, signature});
 ```
 
 {% endtab %}

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -15,8 +15,8 @@ applications.
 | `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `PoolDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
 | `graph/`              | `pub(crate)` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `EdgeWeightUpdaterWithDerived`, `Path` type                                 |
 | `price_guard/`        | Price guard: external price validation for quotes. Provider registry, config, utilities                                                                                            |
-| `encoding/`           | `Encoder` wraps `tycho-execution` to produce ABI-encoded calldata (singleSwap, sequentialSwap, Permit2 variants)                                                                   |
-| `types/`              | Core types: `Order`, `Route`, `Swap`, `Quote`, `QuoteRequest`, `BlockInfo`, `EncodingOptions`, error types                                                                         |
+| `encoding/`           | `Encoder` wraps `tycho-execution` to produce ABI-encoded calldata (singleSwap, sequentialSwap, Permit2 variants). Computes `FeeBreakdown` mirroring on-chain `FeeCalculator` logic |
+| `types/`              | Core types: `Order`, `Route`, `Swap`, `Quote`, `QuoteRequest`, `BlockInfo`, `EncodingOptions`, `FeeBreakdown`, error types                                                         |
 
 ## Key Traits
 

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -97,8 +97,8 @@ impl TryFrom<&OrderQuote> for Solution {
             .collect();
 
         Ok(Solution::new(
-            quote.sender.clone(),
-            quote.receiver.clone(),
+            quote.sender().clone(),
+            quote.receiver().clone(),
             Bytes::from(token_in.as_ref()),
             Bytes::from(token_out.as_ref()),
             quote.amount_in().clone(),
@@ -207,8 +207,8 @@ impl Encoder {
         {
             let (transaction, fee_breakdown) =
                 self.encode_tycho_router_call(encoded_solution, &solution, &encoding_options)?;
-            quotes[idx].transaction = Some(transaction);
-            quotes[idx].fee_breakdown = Some(fee_breakdown);
+            quotes[idx].set_transaction(transaction);
+            quotes[idx].set_fee_breakdown(fee_breakdown);
         }
 
         Ok(quotes)

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -19,10 +19,15 @@ use tycho_execution::encoding::{
 };
 use tycho_simulation::tycho_common::{models::Chain, Bytes};
 
-use crate::{EncodingOptions, OrderQuote, QuoteStatus, SolveError, Transaction};
+use crate::{EncodingOptions, FeeBreakdown, OrderQuote, QuoteStatus, SolveError, Transaction};
 
 /// Canonical Permit2 contract address — identical on all EVM chains.
 pub const PERMIT2_ADDRESS: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
+
+/// Router fee on swap output amount: 10 basis points (0.1%).
+const ROUTER_FEE_ON_OUTPUT_BPS: u64 = 10;
+/// Router's share of the client fee: 2000 basis points (20%).
+const ROUTER_FEE_ON_CLIENT_FEE_BPS: u64 = 2000;
 
 /// Encodes solution into tycho compatible transactions.
 ///
@@ -200,9 +205,10 @@ impl Encoder {
             .into_iter()
             .zip(to_encode)
         {
-            let transaction =
+            let (transaction, fee_breakdown) =
                 self.encode_tycho_router_call(encoded_solution, &solution, &encoding_options)?;
             quotes[idx].transaction = Some(transaction);
+            quotes[idx].fee_breakdown = Some(fee_breakdown);
         }
 
         Ok(quotes)
@@ -213,19 +219,25 @@ impl Encoder {
     /// Selects the appropriate router function based on the function signature in
     /// `encoded_solution` (single/sequential/split, with optional Permit2 or Vault variants),
     /// prepends the 4-byte selector, and returns a `Transaction` ready for submission.
+    ///
+    /// Fee calculation mirrors the on-chain `FeeCalculator.calculateFee` using identical
+    /// integer arithmetic so `min_amount_out` passes the router's post-fee check.
     fn encode_tycho_router_call(
         &self,
         encoded_solution: EncodedSolution,
         solution: &Solution,
         encoding_options: &EncodingOptions,
-    ) -> Result<Transaction, EncodingError> {
+    ) -> Result<(Transaction, FeeBreakdown), EncodingError> {
         let amount_in = biguint_to_u256(solution.amount_in());
-        let precision = BigUint::from(1_000_000u64);
-        let slippage_amount = solution.min_amount_out().clone() *
-            BigUint::from((encoding_options.slippage() * 1_000_000.0) as u64) /
-            &precision;
-        let min_amount_out =
-            biguint_to_u256(&(solution.min_amount_out().clone() - slippage_amount));
+        let swap_output = solution.min_amount_out();
+        let fee_breakdown = Self::calculate_fee_breakdown(
+            swap_output,
+            encoding_options
+                .client_fee_params()
+                .map_or(0, |f| f.bps()),
+            encoding_options.slippage(),
+        );
+        let min_amount_out = biguint_to_u256(fee_breakdown.min_amount_received());
         let token_in = bytes_to_address(solution.token_in())?;
         let token_out = bytes_to_address(solution.token_out())?;
         let receiver = bytes_to_address(solution.receiver())?;
@@ -329,13 +341,14 @@ impl Encoder {
         } else {
             BigUint::ZERO
         };
-        Ok(Transaction::new(
+        let transaction = Transaction::new(
             encoded_solution
                 .interacting_with()
                 .clone(),
             value,
             contract_interaction,
-        ))
+        );
+        Ok((transaction, fee_breakdown))
     }
 
     /// Prepends the 4-byte Keccak selector for `selector` to the ABI-encoded args.
@@ -358,6 +371,43 @@ impl Encoder {
         }
         call_data.extend(encoded_args);
         call_data
+    }
+
+    /// Mirrors the on-chain `FeeCalculator.calculateFee` using identical integer arithmetic.
+    ///
+    /// Given the raw swap output, client fee in bps, and slippage tolerance, computes
+    /// the exact fee amounts and the minimum amount the user will receive.
+    fn calculate_fee_breakdown(
+        swap_output: &BigUint,
+        client_fee_bps: u16,
+        slippage: f64,
+    ) -> FeeBreakdown {
+        let client_bps = client_fee_bps as u64;
+
+        let mut router_fee_on_client = BigUint::ZERO;
+        let mut client_portion = BigUint::ZERO;
+
+        if client_bps > 0 {
+            let fee_numerator = swap_output * client_bps;
+            let total_client_fee = &fee_numerator / 10_000u64;
+
+            router_fee_on_client = &fee_numerator * ROUTER_FEE_ON_CLIENT_FEE_BPS / 100_000_000u64;
+
+            client_portion = total_client_fee - &router_fee_on_client;
+        }
+
+        let router_fee_on_output = swap_output * ROUTER_FEE_ON_OUTPUT_BPS / 10_000u64;
+        let total_router_fee = router_fee_on_client + router_fee_on_output;
+
+        let amount_after_fees = swap_output - &client_portion - &total_router_fee;
+
+        let precision = BigUint::from(1_000_000u64);
+        let slippage_amount =
+            &amount_after_fees * BigUint::from((slippage * 1_000_000.0) as u64) / &precision;
+
+        let min_amount_received = &amount_after_fees - &slippage_amount;
+
+        FeeBreakdown::new(total_router_fee, client_portion, slippage_amount, min_amount_received)
     }
 }
 

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -38,18 +38,18 @@ pub struct Encoder {
     /// Dedicated multi-threaded runtime so that swap encoders using
     /// `block_in_place` (e.g. Bebop RFQ) work even when the caller
     /// runs on a current-thread runtime (actix-web workers).
-    encoding_rt: Arc<tokio::runtime::Runtime>,
+    encoding_rt: Option<Arc<tokio::runtime::Runtime>>,
 }
 
 impl Drop for Encoder {
     fn drop(&mut self) {
-        // If dropped from within a tokio runtime (e.g. test teardown),
-        // move the runtime to a background thread so its shutdown doesn't
-        // panic with "cannot drop a runtime in a context where blocking
-        // is not allowed".
-        if tokio::runtime::Handle::try_current().is_ok() {
-            let rt = Arc::clone(&self.encoding_rt);
-            std::thread::spawn(move || drop(rt));
+        // Take ownership so the field auto-drop is a no-op.
+        // If inside an async context, move shutdown to a background
+        // thread to avoid the "cannot drop a runtime" panic.
+        if let Some(rt) = self.encoding_rt.take() {
+            if tokio::runtime::Handle::try_current().is_ok() {
+                std::thread::spawn(move || drop(rt));
+            }
         }
     }
 }
@@ -133,7 +133,7 @@ impl Encoder {
                 .build()?,
             chain,
             router_address,
-            encoding_rt: Arc::new(encoding_rt),
+            encoding_rt: Some(Arc::new(encoding_rt)),
         })
     }
 
@@ -180,10 +180,14 @@ impl Encoder {
             .iter()
             .map(|(_, s)| s.clone())
             .collect();
+        let rt = self
+            .encoding_rt
+            .as_ref()
+            .ok_or_else(|| SolveError::FailedEncoding("encoding runtime was dropped".into()))?;
         let encoded_solutions = std::thread::scope(|scope| {
             scope
                 .spawn(|| {
-                    self.encoding_rt.block_on(async {
+                    rt.block_on(async {
                         self.tycho_encoder
                             .encode_solutions(solutions)
                     })
@@ -448,13 +452,13 @@ mod tests {
             tycho_encoder: Box::new(MockTychoEncoder),
             chain,
             router_address: Bytes::from([0u8; 20].as_ref()),
-            encoding_rt: Arc::new(
+            encoding_rt: Some(Arc::new(
                 tokio::runtime::Builder::new_multi_thread()
                     .worker_threads(1)
                     .enable_all()
                     .build()
                     .unwrap(),
-            ),
+            )),
         }
     }
 

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -39,10 +39,10 @@ pub use algorithm::{Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgori
 pub use derived::computation::ComputationRequirements;
 pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
 pub use types::{
-    BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, Order, OrderQuote, OrderSide,
-    OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteRequest,
-    QuoteStatus, Route, RouteValidationError, SingleOrderQuote, SolveError, SolveResult, Swap,
-    TaskId, Transaction, UserTransferType,
+    BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, FeeBreakdown, Order, OrderQuote,
+    OrderSide, OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions,
+    QuoteRequest, QuoteStatus, Route, RouteValidationError, SingleOrderQuote, SolveError,
+    SolveResult, Swap, TaskId, Transaction, UserTransferType,
 };
 pub use worker_pool::{
     pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig},

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -18,7 +18,7 @@ pub use internal::{SolveError, SolveResult, SolveTask, TaskId};
 pub use primitives::*;
 // Re-export public quote types
 pub use quote::{
-    BlockInfo, ClientFeeParams, EncodingOptions, Order, OrderQuote, OrderSide,
+    BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown, Order, OrderQuote, OrderSide,
     OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteRequest,
     QuoteStatus, Route, RouteResult, RouteValidationError, SingleOrderQuote, Swap, Transaction,
     UserTransferType,

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -192,6 +192,60 @@ impl ClientFeeParams {
     }
 }
 
+/// Breakdown of fees applied to the swap output by the on-chain FeeCalculator.
+///
+/// All amounts are absolute values in output token units.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FeeBreakdown {
+    /// Router protocol fee (fee on output + router's share of client fee).
+    #[serde_as(as = "DisplayFromStr")]
+    router_fee: BigUint,
+    /// Client's portion of the fee (after the router takes its share).
+    #[serde_as(as = "DisplayFromStr")]
+    client_fee: BigUint,
+    /// Maximum slippage amount: (amount_out - router_fee - client_fee) * slippage.
+    #[serde_as(as = "DisplayFromStr")]
+    max_slippage: BigUint,
+    /// Minimum amount the user receives on-chain.
+    /// Equal to amount_out - router_fee - client_fee - max_slippage.
+    /// This is the value encoded as min_amount_out in the transaction.
+    #[serde_as(as = "DisplayFromStr")]
+    min_amount_received: BigUint,
+}
+
+impl FeeBreakdown {
+    /// Creates a new fee breakdown.
+    pub fn new(
+        router_fee: BigUint,
+        client_fee: BigUint,
+        max_slippage: BigUint,
+        min_amount_received: BigUint,
+    ) -> Self {
+        Self { router_fee, client_fee, max_slippage, min_amount_received }
+    }
+
+    /// Router protocol fee amount.
+    pub fn router_fee(&self) -> &BigUint {
+        &self.router_fee
+    }
+
+    /// Client fee amount.
+    pub fn client_fee(&self) -> &BigUint {
+        &self.client_fee
+    }
+
+    /// Maximum slippage amount.
+    pub fn max_slippage(&self) -> &BigUint {
+        &self.max_slippage
+    }
+
+    /// Minimum amount the user receives on-chain.
+    pub fn min_amount_received(&self) -> &BigUint {
+        &self.min_amount_received
+    }
+}
+
 /// Options to customize the encoding behavior.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -615,6 +669,9 @@ pub struct OrderQuote {
     gas_price: Option<BigUint>,
     /// An encoded EVM transaction ready to be submitted on-chain.
     pub(crate) transaction: Option<Transaction>,
+    /// Fee breakdown (populated when encoding options are provided).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) fee_breakdown: Option<FeeBreakdown>,
     /// Address of the sender.
     pub(crate) sender: Bytes,
     /// Address of the receiver.
@@ -648,6 +705,7 @@ impl OrderQuote {
             algorithm,
             gas_price: None,
             transaction: None,
+            fee_breakdown: None,
             sender,
             receiver,
         }
@@ -742,6 +800,18 @@ impl OrderQuote {
     /// Returns the encoded EVM transaction, if available.
     pub fn transaction(&self) -> Option<&Transaction> {
         self.transaction.as_ref()
+    }
+
+    /// Returns the fee breakdown, if encoding was requested.
+    pub fn fee_breakdown(&self) -> Option<&FeeBreakdown> {
+        self.fee_breakdown.as_ref()
+    }
+
+    /// Sets the fee breakdown.
+    #[allow(dead_code)]
+    pub(crate) fn with_fee_breakdown(mut self, fb: FeeBreakdown) -> Self {
+        self.fee_breakdown = Some(fb);
+        self
     }
 
     /// Returns the sender address.

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -668,14 +668,14 @@ pub struct OrderQuote {
     #[serde_as(as = "Option<DisplayFromStr>")]
     gas_price: Option<BigUint>,
     /// An encoded EVM transaction ready to be submitted on-chain.
-    pub(crate) transaction: Option<Transaction>,
+    transaction: Option<Transaction>,
     /// Fee breakdown (populated when encoding options are provided).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) fee_breakdown: Option<FeeBreakdown>,
+    fee_breakdown: Option<FeeBreakdown>,
     /// Address of the sender.
-    pub(crate) sender: Bytes,
+    sender: Bytes,
     /// Address of the receiver.
-    pub(crate) receiver: Bytes,
+    receiver: Bytes,
 }
 
 impl OrderQuote {
@@ -730,11 +730,9 @@ impl OrderQuote {
         self
     }
 
-    /// Sets the encoded EVM transaction.
-    #[allow(dead_code)]
-    pub(crate) fn with_transaction(mut self, transaction: Transaction) -> Self {
+    /// Sets the encoded EVM transaction in place.
+    pub fn set_transaction(&mut self, transaction: Transaction) {
         self.transaction = Some(transaction);
-        self
     }
 
     /// Returns the order ID.
@@ -807,11 +805,9 @@ impl OrderQuote {
         self.fee_breakdown.as_ref()
     }
 
-    /// Sets the fee breakdown.
-    #[allow(dead_code)]
-    pub(crate) fn with_fee_breakdown(mut self, fb: FeeBreakdown) -> Self {
+    /// Sets the fee breakdown in place.
+    pub fn set_fee_breakdown(&mut self, fb: FeeBreakdown) {
         self.fee_breakdown = Some(fb);
-        self
     }
 
     /// Returns the sender address.

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -335,8 +335,8 @@ impl WorkerPoolRouter {
                 BigUint::ZERO,
                 any_q.block().clone(),
                 String::new(),
-                any_q.sender.clone(),
-                any_q.receiver.clone(),
+                any_q.sender().clone(),
+                any_q.receiver().clone(),
             )
         } else {
             // No responses at all - determine status from failure types

--- a/fynd-rpc-types/CLAUDE.md
+++ b/fynd-rpc-types/CLAUDE.md
@@ -27,7 +27,8 @@ Single file: `src/lib.rs`. All types derive `Serialize + Deserialize`.
 ## Response Types
 
 - `Quote` — orders (Vec<OrderQuote>), total_gas_estimate, solve_time_ms
-- `OrderQuote` — order_id, status, route, amount_in/out, gas_estimate, price_impact_bps, amount_out_net_gas, block, gas_price, transaction
+- `OrderQuote` — order_id, status, route, amount_in/out, gas_estimate, price_impact_bps, amount_out_net_gas, block, gas_price, transaction, fee_breakdown
+- `FeeBreakdown` — router_fee, client_fee, max_slippage, min_amount_received (all absolute token-out amounts, populated when encoding_options is set)
 - `QuoteStatus` — Success, NoRouteFound, InsufficientLiquidity, Timeout, NotReady
 - `Route` — Vec<Swap>
 - `Swap` — component_id, protocol, token_in/out, amount_in/out, gas_estimate, split

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -203,6 +203,54 @@ impl ClientFeeParams {
     }
 }
 
+/// Breakdown of fees applied to the swap output by the on-chain FeeCalculator.
+///
+/// All amounts are absolute values in output token units.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct FeeBreakdown {
+    /// Router protocol fee (fee on output + router's share of client fee).
+    #[serde_as(as = "DisplayFromStr")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "350000"))]
+    router_fee: BigUint,
+    /// Client's portion of the fee (after the router takes its share).
+    #[serde_as(as = "DisplayFromStr")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "2800000"))]
+    client_fee: BigUint,
+    /// Maximum slippage: (amount_out - router_fee - client_fee) * slippage.
+    #[serde_as(as = "DisplayFromStr")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "3496850"))]
+    max_slippage: BigUint,
+    /// Minimum amount the user receives on-chain.
+    /// Equal to amount_out - router_fee - client_fee - max_slippage.
+    #[serde_as(as = "DisplayFromStr")]
+    #[cfg_attr(feature = "openapi", schema(value_type = String, example = "3493353150"))]
+    min_amount_received: BigUint,
+}
+
+impl FeeBreakdown {
+    /// Router protocol fee amount.
+    pub fn router_fee(&self) -> &BigUint {
+        &self.router_fee
+    }
+
+    /// Client fee amount.
+    pub fn client_fee(&self) -> &BigUint {
+        &self.client_fee
+    }
+
+    /// Maximum slippage amount.
+    pub fn max_slippage(&self) -> &BigUint {
+        &self.max_slippage
+    }
+
+    /// Minimum amount the user receives on-chain.
+    pub fn min_amount_received(&self) -> &BigUint {
+        &self.min_amount_received
+    }
+}
+
 /// Options to customize the encoding behavior.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -591,6 +639,9 @@ pub struct OrderQuote {
     gas_price: Option<BigUint>,
     /// An encoded EVM transaction ready to be submitted on-chain.
     transaction: Option<Transaction>,
+    /// Fee breakdown (populated when encoding options are provided).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fee_breakdown: Option<FeeBreakdown>,
 }
 
 impl OrderQuote {
@@ -647,6 +698,11 @@ impl OrderQuote {
     /// Encoded EVM transaction, if encoding options were provided in the request.
     pub fn transaction(&self) -> Option<&Transaction> {
         self.transaction.as_ref()
+    }
+
+    /// Fee breakdown, if encoding options were provided in the request.
+    pub fn fee_breakdown(&self) -> Option<&FeeBreakdown> {
+        self.fee_breakdown.as_ref()
     }
 }
 
@@ -1247,6 +1303,10 @@ mod conversions {
                 .transaction()
                 .cloned()
                 .map(Into::into);
+            let fee_breakdown = core
+                .fee_breakdown()
+                .cloned()
+                .map(Into::into);
             let route = core.into_route().map(Into::into);
             Self {
                 order_id,
@@ -1260,6 +1320,7 @@ mod conversions {
                 block,
                 gas_price,
                 transaction,
+                fee_breakdown,
             }
         }
     }
@@ -1318,6 +1379,17 @@ mod conversions {
     impl From<fynd_core::Transaction> for Transaction {
         fn from(core: fynd_core::Transaction) -> Self {
             Self { to: core.to().clone(), value: core.value().clone(), data: core.data().to_vec() }
+        }
+    }
+
+    impl From<fynd_core::FeeBreakdown> for FeeBreakdown {
+        fn from(core: fynd_core::FeeBreakdown) -> Self {
+            Self {
+                router_fee: core.router_fee().clone(),
+                client_fee: core.client_fee().clone(),
+                max_slippage: core.max_slippage().clone(),
+                min_amount_received: core.min_amount_received().clone(),
+            }
         }
     }
 


### PR DESCRIPTION
The encoder now mirrors the on-chain FeeCalculator.calculateFee logic
(integer arithmetic) so min_amount_out is the post-fee value the router
checks. Previously slippage was applied to the raw swap output, ignoring
fee deductions, which would cause reverts.

Hardcoded fee parameters (matching current on-chain config):
- 10 bps router fee on output
- 20% router share of client fee

Adds FeeBreakdown (router_fee, client_fee, max_slippage,
min_amount_received) to the quote response across all layers:
fynd-core, fynd-rpc-types, Rust client, TypeScript client.

Updates docs/guides/client-fees.md with fee calculation walkthrough,
field reference table, and worked example. Updates README API reference
with fee_breakdown in the response and client_fee_params in the request.

Regenerated OpenAPI spec and autogen TS types.

Bonus fix:
Prevent race in Encoder runtime drop: The Drop impl cloned the Arc and spawned a thread to drop it, but the field auto-drop could still destroy the Runtime in the async context if the spawned thread finished first. Use Option::take to move ownership out of the field before spawning.