### PR TITLE
chore(blacklist): update blacklist.toml with additional components

### DIFF
--- a/blacklist.toml
+++ b/blacklist.toml
@@ -3,14 +3,18 @@
 
 [blacklist]
 # Component IDs to exclude (pool addresses)
-# AMPL pools - AMPL is a rebasing token that breaks simulation assumptions
-# UniswapV3 AMPL/WETH
-# UniswapV2 AMPL/WETH
 components = [
+    # AMPL pools - AMPL is a rebasing token that breaks simulation assumptions
+    # UniswapV3 AMPL/WETH
+    # UniswapV2 AMPL/WETH
     "0x86d257cdb7bc9c0df10e84c8709697f92770b335",
     "0xc5be99a02c6857f9eac67bbce58df5572498f40c",
     # Fluid Lite pools with broken simulation (ENG-5696)
     # Off-chain sim claims 50-100x more output than on-chain reality
     "0x32aa6f5c6f771b39d383c6e36d7ef0702a28e32ad64671c059f41547b82ef0ef",
     "0x7f31b44f032f125bb465c161343fccfdc88fee8dc94c068f6430d2345d80f1d1",
+    # Curve yETH/WETH — exploited Nov 2025 ($9M), broken invariant, pool insolvent
+    "0x69accb968b19a53790f43e57558f5e443a91af22",
+    # Fluid syrupUSDC/USDC — ERC-4626 vault token, simulation can't track accumulating rate
+    "0x79eea4a1be86c43a9a9c4384b0b28a07af24ae29",
 ]


### PR DESCRIPTION
Added new entries to the blacklist for Curve yETH/WETH and Fluid syrupUSDC/USDC pools due to simulation issues and past exploits.