### PR TITLE
chore: fix run example ci

### DIFF
--- a/scripts/_env-setup.sh
+++ b/scripts/_env-setup.sh
@@ -74,8 +74,8 @@ wrap_weth() {
 build_ts() {
     echo "==> Building TypeScript packages..."
     pnpm --dir "$REPO_ROOT/clients/typescript" install --frozen-lockfile --silent
-    pnpm --dir "$REPO_ROOT/clients/typescript" --filter @fynd/autogen run build --silent
-    pnpm --dir "$REPO_ROOT/clients/typescript" --filter @fynd/client run build --silent
+    pnpm --dir "$REPO_ROOT/clients/typescript" --filter @fynd/autogen --silent run build
+    pnpm --dir "$REPO_ROOT/clients/typescript" --filter @fynd/client --silent run build
     echo "    Done"
 }
 


### PR DESCRIPTION
## Summary

- `--silent` placed after the script name (`pnpm run build --silent`) is forwarded to `tsc`, which rejects it as an unknown flag
- Moved to before the subcommand (`pnpm --silent run build`) so it is consumed by pnpm, not passed through

## Test plan

- [ ] Re-run the `Run client examples` workflow and confirm `build_ts` completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)