### PR TITLE
feat: publish fynd as library and add Docker build pipeline

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,55 @@
+name: Docker
+
+on:
+  pull_request:
+  release:
+    types: [created]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/fynd
+
+jobs:
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'release'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
+        with:
+          context: .
+          push: ${{ github.event_name == 'release' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,6 +42,9 @@ jobs:
       - name: Publish fynd-rpc
         run: cargo publish --locked --verbose --package fynd-rpc
 
+      - name: Publish fynd
+        run: cargo publish --locked --verbose --package fynd
+
   publish-npm:
     name: Publish TypeScript packages to npm
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.34.3"
 name = "fynd"
 version.workspace = true
 edition = "2021"
+description = "High-performance DeFi route-finding engine — embeddable library and CLI"
+license = "MIT"
 
 [dependencies]
 fynd-rpc = { workspace = true }

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,23 +12,36 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-# Dependency caching layer: copy manifests and build deps first
+# Dependency caching layer: copy all workspace manifests and build deps first
 COPY Cargo.toml Cargo.lock ./
 COPY fynd-core/Cargo.toml fynd-core/
 COPY fynd-rpc/Cargo.toml fynd-rpc/
-RUN mkdir -p src fynd-core/src fynd-rpc/src && \
+COPY fynd-rpc-types/Cargo.toml fynd-rpc-types/
+COPY clients/rust/Cargo.toml clients/rust/
+COPY tools/benchmark/Cargo.toml tools/benchmark/
+COPY tools/fynd-swap-cli/Cargo.toml tools/fynd-swap-cli/
+RUN mkdir -p src fynd-core/src fynd-rpc/src fynd-rpc-types/src \
+        clients/rust/src tools/benchmark/src tools/fynd-swap-cli/src && \
     echo "fn main() {}" > src/main.rs && \
     echo "" > src/lib.rs && \
     echo "" > fynd-core/src/lib.rs && \
     echo "" > fynd-rpc/src/lib.rs && \
-    cargo build --release && \
-    rm -rf src fynd-core/src fynd-rpc/src
+    echo "" > fynd-rpc-types/src/lib.rs && \
+    echo "" > clients/rust/src/lib.rs && \
+    echo "fn main() {}" > tools/benchmark/src/main.rs && \
+    echo "fn main() {}" > tools/fynd-swap-cli/src/main.rs && \
+    cargo build --release --package fynd && \
+    rm -rf src fynd-core/src fynd-rpc/src fynd-rpc-types/src \
+        clients/rust/src tools/benchmark/src tools/fynd-swap-cli/src
 
 # Copy real source and rebuild
 COPY src/ src/
 COPY fynd-core/src/ fynd-core/src/
 COPY fynd-rpc/src/ fynd-rpc/src/
-RUN touch src/main.rs src/lib.rs fynd-core/src/lib.rs fynd-rpc/src/lib.rs && cargo build --release
+COPY fynd-rpc-types/src/ fynd-rpc-types/src/
+RUN touch src/main.rs src/lib.rs fynd-core/src/lib.rs fynd-rpc/src/lib.rs \
+        fynd-rpc-types/src/lib.rs && \
+    cargo build --release --package fynd
 
 # Stage 2: Runtime
 FROM debian:bookworm-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,11 @@ COPY src/ src/
 COPY fynd-core/src/ fynd-core/src/
 COPY fynd-rpc/src/ fynd-rpc/src/
 COPY fynd-rpc-types/src/ fynd-rpc-types/src/
-RUN touch src/main.rs src/lib.rs fynd-core/src/lib.rs fynd-rpc/src/lib.rs \
+RUN mkdir -p clients/rust/src tools/benchmark/src tools/fynd-swap-cli/src && \
+    echo "" > clients/rust/src/lib.rs && \
+    echo "fn main() {}" > tools/benchmark/src/main.rs && \
+    echo "fn main() {}" > tools/fynd-swap-cli/src/main.rs && \
+    touch src/main.rs src/lib.rs fynd-core/src/lib.rs fynd-rpc/src/lib.rs \
         fynd-rpc-types/src/lib.rs && \
     cargo build --release --package fynd
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 //! Then use the re-exported crates directly:
 //!
 //! ```rust,ignore
-//! use fynd::fynd_rpc::builder::FyndRPCBuilder;
-//! use fynd::fynd_core::algorithm::Algorithm;
+//! use fynd::rpc::builder::FyndRPCBuilder;
+//! use fynd::core::algorithm::Algorithm;
 //! ```
 
-pub use fynd_core;
-pub use fynd_rpc;
+pub use fynd_core as core;
+pub use fynd_rpc as rpc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,19 @@
+//! Fynd library — re-exports [`fynd_core`] and [`fynd_rpc`] as a single dependency,
+//! letting you build a custom Fynd CLI or embed the solver directly into your own binary.
+//!
+//! # Usage
+//!
+//! ```toml
+//! [dependencies]
+//! fynd = "0.33"
+//! ```
+//!
+//! Then use the re-exported crates directly:
+//!
+//! ```rust,ignore
+//! use fynd::fynd_rpc::builder::FyndRPCBuilder;
+//! use fynd::fynd_core::algorithm::Algorithm;
+//! ```
+
+pub use fynd_core;
+pub use fynd_rpc;


### PR DESCRIPTION
## Summary

- Add `src/lib.rs` that re-exports `fynd_core` and `fynd_rpc`, making the `fynd` crate usable as a library dependency for anyone building a custom Fynd-based CLI
- Add `description` and `license` to the root `Cargo.toml` so the crate is publishable to crates.io
- Add `fynd` as the final publish step in `release.yaml` (after `fynd-rpc`, which it depends on)
- Add `.github/workflows/docker.yaml`: builds the Docker image on every PR, builds and pushes to `ghcr.io/propeller-heads/fynd` on release with semver and `latest` tags

## Test plan

- [x] CI passes on this PR (Docker build step runs without push)
- [ ] On next release, `cargo publish --package fynd` succeeds and the Docker image is pushed to `ghcr.io/propeller-heads/fynd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)