### PR TITLE
fix: inject CARGO_REGISTRY_TOKEN into release publish job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ jobs:
     name: Publish Crates
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary

- The `publish-dry-run` job was calling `cargo publish` without `CARGO_REGISTRY_TOKEN`, causing auth failures on every release
- Add `CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}` to the job env
- Rename job from `publish-dry-run` / `Publish Crates (dry-run)` to `publish-crates` / `Publish Crates` since it was always doing a real publish (no `--dry-run` flag)

Fixes the failing run: https://github.com/propeller-heads/fynd/actions/runs/23605191983