### PR TITLE
fix: npm provenance repository URL and rename cargo secret

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATESIO_REGISTRY_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/clients/typescript/client/package.json
+++ b/clients/typescript/client/package.json
@@ -2,6 +2,10 @@
   "name": "@kayibal/fynd-client",
   "version": "0.34.1",
   "description": "TypeScript client for the Fynd DEX router",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/propeller-heads/fynd"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

- Adds `repository.url` to `clients/typescript/client/package.json` — npm provenance verification requires this to match the repo URL from the OIDC token; without it publish fails with `E422 Unprocessable Entity`
- Renames `CARGO_REGISTRY_TOKEN` secret reference to `CRATESIO_REGISTRY_TOKEN` in `release.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)