### PR TITLE
docs: add split swap limitation warning for large trades

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,16 @@ Fynd puts you in control:
 
 Fynd currently supports **sell orders** only (exact input amount). You specify the amount of the input token, and Fynd finds the best output. Buy orders (exact output) are not yet supported.
 
+### Known Limitations
+
+{% hint style="warning" %}
+**Large trades — split swaps coming soon**
+
+Fynd currently routes each order through a single path. For large trades (e.g. >$100k), this can result in significant price impact compared to aggregators that split orders across multiple pools in parallel. Split swap support is on the roadmap and will substantially improve pricing for high-volume orders.
+
+For the best results today, test with trade sizes typical for your use case rather than extreme values.
+{% endhint %}
+
 ### Supported Chains
 
 * Ethereum Mainnet

--- a/docs/algorithms/README.md
+++ b/docs/algorithms/README.md
@@ -16,6 +16,8 @@ Three properties make this harder than classical shortest-path routing:
 
 These properties rule out off-the-shelf graph algorithms that rely on precomputed, additive, size-independent edge weights. Both of Fynd's algorithms handle this by simulating the actual swap math at every step.
 
+> **Note:** Fynd currently finds the single best path for each order. Order splitting across parallel paths is planned and will improve output for large trades where a single path exhausts pool liquidity.
+
 ## How Fynd uses algorithms
 
 Each algorithm runs inside a **worker pool**: a group of dedicated OS threads that process quote requests. Multiple worker pools can run in parallel with different algorithms and configurations (e.g., a fast 2-hop Most Liquid pool alongside a deeper 5-hop Bellman-Ford pool). The **WorkerPoolRouter** fans out each request to all pools and returns the best result.


### PR DESCRIPTION
## Summary
- Add a "Known Limitations" section to the overview page (`docs/README.md`) warning that large trades may see worse pricing due to single-path routing
- Add a note to the algorithms overview (`docs/algorithms/README.md`) connecting the limitation to the routing problem context
- Both mention split swaps are on the roadmap

## Test plan
- [ ] Verify GitBook renders the `{% hint %}` block correctly on the overview page
- [ ] Verify the blockquote renders on the algorithms page

🤖 Generated with [Claude Code](https://claude.com/claude-code)