### PR TITLE
fix: polish crate docs, add READMEs, enforce missing_docs

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -119,6 +119,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 - `cargo nextest run --workspace --all-targets --all-features` — full test suite
 - `cargo +nightly clippy --workspace --all-targets --all-features` — lint
 - `cargo +nightly fmt --all --check` — format check
+- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --locked --package fynd-core --package fynd-rpc-types --package fynd-rpc --package fynd-client` — doc build (broken links, missing docs)
 - OpenAPI drift: `cargo run -- openapi | jq 'del(.info.version)'` vs `clients/openapi.json`
 - TypeScript: `pnpm --dir clients/typescript install && pnpm --dir clients/typescript --filter @fynd/client run test`
 

--- a/.claude/knowledge/rust.md
+++ b/.claude/knowledge/rust.md
@@ -12,6 +12,12 @@ cargo clippy --all-features
 
 After a task is done, run `./check.sh` (the same script runs as a precommit hook).
 
+`check.sh` runs, in order:
+1. `cargo +nightly fmt -- --check`
+2. `cargo +nightly clippy --locked --all --all-features --all-targets -- -D warnings`
+3. `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --locked --package fynd-core --package fynd-rpc-types --package fynd-rpc --package fynd-client`
+4. `cargo nextest run --workspace --locked --all-targets --all-features --bin fynd`
+
 ## Coding Style
 
 ### General Rust guidelines

--- a/check.sh
+++ b/check.sh
@@ -1,5 +1,6 @@
-set -e 
+set -e
 
 cargo +nightly fmt -- --check
 cargo +nightly clippy --locked --all --all-features --all-targets -- -D warnings
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --locked --package fynd-core --package fynd-rpc-types --package fynd-rpc --package fynd-client
 cargo nextest run --workspace --locked --all-targets --all-features --bin fynd

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 description = "Rust client for the Fynd DEX router"
 license = "MIT"
+readme = "README.md"
 
 [dependencies]
 # Shared RPC wire types

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -26,7 +26,7 @@ use num_bigint::BigUint;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start a local Fynd instance first: https://docs.fynd.xyz/get-started/quickstart
-    let client = FyndClientBuilder::new("http://localhost:3000", "http://localhost:8545")
+    let client = FyndClientBuilder::new("http://localhost:3000", "https://reth-ethereum.ithaca.xyz/rpc")
         .build()
         .await?;
 

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -6,9 +6,8 @@ For documentation, guides, and API reference visit **<https://docs.fynd.xyz/>**.
 
 ## Installation
 
-```toml
-[dependencies]
-fynd-client = "0"  # see crates.io for the latest version
+```sh
+cargo add fynd-client
 ```
 
 ## Quick start

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -2,10 +2,7 @@
 
 Rust client for the [Fynd](https://fynd.xyz) DEX router.
 
-Request swap quotes, build signable transaction payloads, and broadcast signed orders through
-the Fynd RPC API — all from a single typed interface.
-
-For documentation, guides, and API reference, visit **<https://docs.fynd.xyz/>**.
+For documentation, guides, and API reference visit **<https://docs.fynd.xyz/>**.
 
 ## Installation
 
@@ -16,48 +13,5 @@ fynd-client = "0.35"
 
 ## Quick start
 
-```rust,no_run
-use fynd_client::{
-    FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams,
-};
-use bytes::Bytes;
-use num_bigint::BigUint;
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Start a local Fynd instance first: https://docs.fynd.xyz/get-started/quickstart
-    let client = FyndClientBuilder::new("http://localhost:3000", "https://reth-ethereum.ithaca.xyz/rpc")
-        .build()
-        .await?;
-
-    let weth = Bytes::copy_from_slice(
-        alloy::primitives::address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").as_slice(),
-    );
-    let usdc = Bytes::copy_from_slice(
-        alloy::primitives::address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").as_slice(),
-    );
-    let sender = Bytes::copy_from_slice(
-        alloy::primitives::address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").as_slice(),
-    );
-
-    let quote = client
-        .quote(QuoteParams::new(
-            Order::new(
-                weth,
-                usdc,
-                BigUint::from(1_000_000_000_000_000_000u64), // 1 WETH
-                OrderSide::Sell,
-                sender,
-                None,
-            ),
-            QuoteOptions::default(),
-        ))
-        .await?;
-
-    println!("amount out: {}", quote.amount_out());
-    Ok(())
-}
-```
-
-See the [`examples/`](examples/) directory for complete, runnable programs covering ERC-20
-approvals, Permit2 transfers, and client fees.
+See the [quickstart guide](https://docs.fynd.xyz/get-started/quickstart) and the
+[`examples/`](examples/) directory for complete, runnable programs.

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -1,0 +1,63 @@
+# fynd-client
+
+Rust client for the [Fynd](https://fynd.xyz) DEX router.
+
+Request swap quotes, build signable transaction payloads, and broadcast signed orders through
+the Fynd RPC API — all from a single typed interface.
+
+For documentation, guides, and API reference, visit **<https://docs.fynd.xyz/>**.
+
+## Installation
+
+```toml
+[dependencies]
+fynd-client = "0.35"
+```
+
+## Quick start
+
+```rust,no_run
+use fynd_client::{
+    FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams,
+};
+use bytes::Bytes;
+use num_bigint::BigUint;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Start a local Fynd instance first: https://docs.fynd.xyz/get-started/quickstart
+    let client = FyndClientBuilder::new("http://localhost:3000", "http://localhost:8545")
+        .build()
+        .await?;
+
+    let weth = Bytes::copy_from_slice(
+        alloy::primitives::address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").as_slice(),
+    );
+    let usdc = Bytes::copy_from_slice(
+        alloy::primitives::address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").as_slice(),
+    );
+    let sender = Bytes::copy_from_slice(
+        alloy::primitives::address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").as_slice(),
+    );
+
+    let quote = client
+        .quote(QuoteParams::new(
+            Order::new(
+                weth,
+                usdc,
+                BigUint::from(1_000_000_000_000_000_000u64), // 1 WETH
+                OrderSide::Sell,
+                sender,
+                None,
+            ),
+            QuoteOptions::default(),
+        ))
+        .await?;
+
+    println!("amount out: {}", quote.amount_out());
+    Ok(())
+}
+```
+
+See the [`examples/`](examples/) directory for complete, runnable programs covering ERC-20
+approvals, Permit2 transfers, and client fees.

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -8,7 +8,7 @@ For documentation, guides, and API reference visit **<https://docs.fynd.xyz/>**.
 
 ```toml
 [dependencies]
-fynd-client = "0.35"
+fynd-client = "0"  # see crates.io for the latest version
 ```
 
 ## Quick start

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -93,7 +93,12 @@ pub enum FyndError {
     /// A structured error response from the Fynd RPC API. Check `code` to distinguish permanent
     /// failures (e.g. `NoRouteFound`) from transient ones (e.g. `SolveTimeout`).
     #[error("API error ({code:?}): {message}")]
-    Api { code: ErrorCode, message: String },
+    Api {
+        /// The structured error code identifying the failure kind.
+        code: ErrorCode,
+        /// The human-readable error message returned by the server.
+        message: String,
+    },
 
     /// Malformed or unexpected data in the API response (e.g. an address with the wrong byte
     /// length, an unrecognised enum variant).

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -19,8 +19,7 @@
 //! ```rust,no_run
 //! # use fynd_client::FyndClientBuilder;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! // Fynd default: http://localhost:3000  RPC default (Anvil): https://reth-ethereum.ithaca.xyz/rpc
-//! let client = FyndClientBuilder::new(
+//! //! let client = FyndClientBuilder::new(
 //!     "http://localhost:3000",
 //!     "https://reth-ethereum.ithaca.xyz/rpc",
 //! )

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -19,7 +19,7 @@
 //! ```rust,no_run
 //! # use fynd_client::FyndClientBuilder;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! //! let client = FyndClientBuilder::new(
+//! let client = FyndClientBuilder::new(
 //!     "http://localhost:3000",
 //!     "https://reth-ethereum.ithaca.xyz/rpc",
 //! )

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,14 +1,16 @@
 #![deny(missing_docs)]
-//! Rust client for the [Fynd](https://fynd.exchange) DEX router.
+//! Rust client for the [Fynd](https://fynd.xyz) DEX router.
 //!
 //! `fynd-client` lets you request swap quotes, build signable transaction payloads, and
 //! broadcast signed orders through the Fynd RPC API — all from a single typed interface.
 //!
+//! For guides, API reference, and setup instructions see **<https://docs.fynd.xyz/>**.
+//!
 //! # Workflow
 //!
 //! A complete swap runs in three steps: **quote → approve → sign and execute**.
-//! See `clients/rust/examples/swap_erc20.rs` for a full walkthrough, or run it against a
-//! local Fynd instance with `./scripts/run-example.sh swap_erc20`.
+//! See `clients/rust/examples/swap_erc20.rs` for a full walkthrough, or follow the
+//! [quickstart](https://docs.fynd.xyz/get-started/quickstart) to run a local Fynd instance.
 //!
 //! # Constructing a client
 //!
@@ -17,9 +19,10 @@
 //! ```rust,no_run
 //! # use fynd_client::FyndClientBuilder;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Fynd default: http://localhost:3000  RPC default (Anvil): http://localhost:8545
 //! let client = FyndClientBuilder::new(
-//!     "https://rpc.fynd.exchange",
-//!     "https://mainnet.infura.io/v3/YOUR_KEY",
+//!     "http://localhost:3000",
+//!     "http://localhost:8545",
 //! )
 //! .build()
 //! .await?;
@@ -31,7 +34,7 @@
 //!
 //! ```rust,no_run
 //! # use fynd_client::FyndClientBuilder;
-//! let client = FyndClientBuilder::new("https://rpc.fynd.exchange", "https://rpc.fynd.exchange")
+//! let client = FyndClientBuilder::new("http://localhost:3000", "http://localhost:3000")
 //!     .build_quote_only()?;
 //! ```
 //!
@@ -42,7 +45,7 @@
 //! # use bytes::Bytes;
 //! # use num_bigint::BigUint;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let client = FyndClientBuilder::new("https://rpc.fynd.exchange", "https://rpc.fynd.exchange")
+//! # let client = FyndClientBuilder::new("http://localhost:3000", "http://localhost:3000")
 //! #     .build_quote_only()?;
 //! // WETH → USDC on mainnet (Vitalik's address as sender).
 //! let weth = Bytes::copy_from_slice(

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -3,12 +3,18 @@
 //! `fynd-client` lets you request swap quotes, build signable transaction payloads, and
 //! broadcast signed orders through the Fynd RPC API — all from a single typed interface.
 //!
+//! # Workflow
+//!
+//! A complete swap runs in three steps: **quote → approve → sign and execute**.
+//! See `clients/rust/examples/swap_erc20.rs` for a full walkthrough, or run it against a
+//! local Fynd instance with `./scripts/run-example.sh swap_erc20`.
+//!
 //! # Constructing a client
 //!
 //! Use [`FyndClientBuilder`] to configure and build a [`FyndClient`]:
 //!
 //! ```rust,no_run
-//! # use fynd_client::{FyndClient, FyndClientBuilder};
+//! # use fynd_client::FyndClientBuilder;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = FyndClientBuilder::new(
 //!     "https://rpc.fynd.exchange",
@@ -19,30 +25,47 @@
 //! # Ok(()) }
 //! ```
 //!
-//! # Minimal quote example
+//! For quote-only use (no on-chain transactions), skip the RPC connection with
+//! [`FyndClientBuilder::build_quote_only`]:
+//!
+//! ```rust,no_run
+//! # use fynd_client::FyndClientBuilder;
+//! let client = FyndClientBuilder::new("https://rpc.fynd.exchange", "https://rpc.fynd.exchange")
+//!     .build_quote_only()?;
+//! ```
+//!
+//! # Requesting a quote
 //!
 //! ```rust,no_run
 //! # use fynd_client::{FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams};
 //! # use bytes::Bytes;
 //! # use num_bigint::BigUint;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! # let client = FyndClientBuilder::new("https://rpc.fynd.exchange", "https://example.com")
-//! #     .build().await?;
-//! let weth: Bytes = Bytes::copy_from_slice(&[0xC0; 20]); // placeholder
-//! let usdc: Bytes = Bytes::copy_from_slice(&[0xA0; 20]); // placeholder
-//! let sender: Bytes = Bytes::copy_from_slice(&[0xd8; 20]); // placeholder
-//!
-//! let order = Order::new(
-//!     weth,
-//!     usdc,
-//!     BigUint::from(1_000_000_000_000_000_000u64), // 1 WETH (18 decimals)
-//!     OrderSide::Sell,
-//!     sender,
-//!     None,
+//! # let client = FyndClientBuilder::new("https://rpc.fynd.exchange", "https://rpc.fynd.exchange")
+//! #     .build_quote_only()?;
+//! // WETH → USDC on mainnet (Vitalik's address as sender).
+//! let weth = Bytes::copy_from_slice(
+//!     alloy::primitives::address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").as_slice(),
+//! );
+//! let usdc = Bytes::copy_from_slice(
+//!     alloy::primitives::address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").as_slice(),
+//! );
+//! let sender = Bytes::copy_from_slice(
+//!     alloy::primitives::address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").as_slice(),
 //! );
 //!
 //! let quote = client
-//!     .quote(QuoteParams::new(order, QuoteOptions::default()))
+//!     .quote(QuoteParams::new(
+//!         Order::new(
+//!             weth,
+//!             usdc,
+//!             BigUint::from(1_000_000_000_000_000_000u64), // 1 WETH (18 decimals)
+//!             OrderSide::Sell,
+//!             sender,
+//!             None,
+//!         ),
+//!         QuoteOptions::default(),
+//!     ))
 //!     .await?;
 //!
 //! println!("amount out: {}", quote.amount_out());

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! Rust client for the [Fynd](https://fynd.exchange) DEX router.
 //!
 //! `fynd-client` lets you request swap quotes, build signable transaction payloads, and

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -9,7 +9,7 @@
 //! # Workflow
 //!
 //! A complete swap runs in three steps: **quote → approve → sign and execute**.
-//! See `clients/rust/examples/swap_erc20.rs` for a full walkthrough, or follow the
+//! See `examples/swap_erc20.rs` for a full walkthrough, or follow the
 //! [quickstart](https://docs.fynd.xyz/get-started/quickstart) to run a local Fynd instance.
 //!
 //! # Constructing a client
@@ -34,29 +34,26 @@
 //!
 //! ```rust,no_run
 //! # use fynd_client::FyndClientBuilder;
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = FyndClientBuilder::new("http://localhost:3000", "http://localhost:3000")
 //!     .build_quote_only()?;
+//! # Ok(()) }
 //! ```
 //!
 //! # Requesting a quote
 //!
 //! ```rust,no_run
 //! # use fynd_client::{FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams};
+//! # use alloy::primitives::address;
 //! # use bytes::Bytes;
 //! # use num_bigint::BigUint;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # let client = FyndClientBuilder::new("http://localhost:3000", "http://localhost:3000")
 //! #     .build_quote_only()?;
 //! // WETH → USDC on mainnet (Vitalik's address as sender).
-//! let weth = Bytes::copy_from_slice(
-//!     alloy::primitives::address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").as_slice(),
-//! );
-//! let usdc = Bytes::copy_from_slice(
-//!     alloy::primitives::address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").as_slice(),
-//! );
-//! let sender = Bytes::copy_from_slice(
-//!     alloy::primitives::address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").as_slice(),
-//! );
+//! let weth: Bytes = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2").to_vec().into();
+//! let usdc: Bytes = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48").to_vec().into();
+//! let sender: Bytes = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045").to_vec().into();
 //!
 //! let quote = client
 //!     .quote(QuoteParams::new(

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -19,10 +19,10 @@
 //! ```rust,no_run
 //! # use fynd_client::FyndClientBuilder;
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! // Fynd default: http://localhost:3000  RPC default (Anvil): http://localhost:8545
+//! // Fynd default: http://localhost:3000  RPC default (Anvil): https://reth-ethereum.ithaca.xyz/rpc
 //! let client = FyndClientBuilder::new(
 //!     "http://localhost:3000",
-//!     "http://localhost:8545",
+//!     "https://reth-ethereum.ithaca.xyz/rpc",
 //! )
 //! .build()
 //! .await?;

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -33,6 +33,13 @@ pub struct PermitDetails {
 }
 
 impl PermitDetails {
+    /// Construct a Permit2 token details entry.
+    ///
+    /// - `token`: 20-byte ERC-20 token address.
+    /// - `amount`: allowance cap (must fit in `uint160`).
+    /// - `expiration`: Unix timestamp in seconds at which the permit expires (must fit in
+    ///   `uint48`).
+    /// - `nonce`: Permit2 per-token nonce (must fit in `uint48`).
     pub fn new(
         token: bytes::Bytes,
         amount: num_bigint::BigUint,
@@ -52,6 +59,11 @@ pub struct PermitSingle {
 }
 
 impl PermitSingle {
+    /// Construct a single-token Permit2 authorisation.
+    ///
+    /// - `details`: per-token allowance parameters (see [`PermitDetails::new`]).
+    /// - `spender`: 20-byte address authorised to transfer the token.
+    /// - `sig_deadline`: Unix timestamp in seconds at which the signature expires.
     pub fn new(
         details: PermitDetails,
         spender: bytes::Bytes,

--- a/clients/typescript/client/README.md
+++ b/clients/typescript/client/README.md
@@ -2,59 +2,15 @@
 
 TypeScript client for the [Fynd](https://fynd.xyz) DEX router.
 
-Request swap quotes, build signable transaction payloads, and broadcast signed orders through
-the Fynd RPC API — all from a single typed interface.
-
 For documentation, guides, and API reference visit **<https://docs.fynd.xyz/>**.
 
 ## Installation
 
 ```bash
 npm install @kayibal/fynd-client
-# or
-pnpm add @kayibal/fynd-client
 ```
 
 ## Quick start
 
-```typescript
-import { FyndClient, encodingOptions } from "@kayibal/fynd-client";
-import { createPublicClient, http } from "viem";
-import { mainnet } from "viem/chains";
-
-// Start a local Fynd instance first: https://docs.fynd.xyz/get-started/quickstart
-const client = new FyndClient({
-  baseUrl: "http://localhost:3000",
-  chainId: mainnet.id,
-  sender: "0xYourAddress",
-  rpcUrl: "https://reth-ethereum.ithaca.xyz/rpc",
-});
-
-// 1. Quote
-const quote = await client.quote({
-  order: {
-    tokenIn:  "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
-    tokenOut: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
-    amount:   1_000_000_000_000_000_000n,                    // 1 WETH
-    side:     "sell",
-    sender:   "0xYourAddress",
-  },
-  options: { encodingOptions: encodingOptions(0.005) },
-});
-console.log("amount out:", quote.amountOut);
-
-// 2. Approve if needed
-const approval = await client.approval({
-  token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-  amount: 1_000_000_000_000_000_000n,
-  checkAllowance: true,
-});
-
-// 3. Sign and execute
-const payload  = await client.swapPayload(quote);
-const sig      = await wallet.sign({ hash: swapSigningHash(payload) });
-const settled  = await (await client.executeSwap(assembleSignedSwap(payload, sig))).settle();
-console.log("settled:", settled.settledAmount, "gas:", settled.gasCost);
-```
-
-See the [full example](examples/tutorial/main.ts) for the complete flow including approvals.
+See the [quickstart guide](https://docs.fynd.xyz/get-started/quickstart) and the
+[full example](examples/tutorial/main.ts).

--- a/clients/typescript/client/README.md
+++ b/clients/typescript/client/README.md
@@ -2,4 +2,59 @@
 
 TypeScript client for the [Fynd](https://fynd.xyz) DEX router.
 
-For documentation, guides, and API reference, visit **https://docs.fynd.xyz/**
+Request swap quotes, build signable transaction payloads, and broadcast signed orders through
+the Fynd RPC API — all from a single typed interface.
+
+For documentation, guides, and API reference visit **<https://docs.fynd.xyz/>**.
+
+## Installation
+
+```bash
+npm install @kayibal/fynd-client
+# or
+pnpm add @kayibal/fynd-client
+```
+
+## Quick start
+
+```typescript
+import { FyndClient, encodingOptions } from "@kayibal/fynd-client";
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
+
+// Start a local Fynd instance first: https://docs.fynd.xyz/get-started/quickstart
+const client = new FyndClient({
+  baseUrl: "http://localhost:3000",
+  chainId: mainnet.id,
+  sender: "0xYourAddress",
+  rpcUrl: "https://reth-ethereum.ithaca.xyz/rpc",
+});
+
+// 1. Quote
+const quote = await client.quote({
+  order: {
+    tokenIn:  "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+    tokenOut: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+    amount:   1_000_000_000_000_000_000n,                    // 1 WETH
+    side:     "sell",
+    sender:   "0xYourAddress",
+  },
+  options: { encodingOptions: encodingOptions(0.005) },
+});
+console.log("amount out:", quote.amountOut);
+
+// 2. Approve if needed
+const approval = await client.approval({
+  token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+  amount: 1_000_000_000_000_000_000n,
+  checkAllowance: true,
+});
+
+// 3. Sign and execute
+const payload  = await client.swapPayload(quote);
+const sig      = await wallet.sign({ hash: swapSigningHash(payload) });
+const settled  = await (await client.executeSwap(assembleSignedSwap(payload, sig))).settle();
+console.log("settled:", settled.settledAmount, "gas:", settled.gasCost);
+```
+
+See the [full example](examples/tutorial/main.ts) for the complete flow including approvals.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -29,6 +29,13 @@
 * [Architecture](ARCHITECTURE.md)
 * [Performance](benchmark-results.md)
 
+## Rust API Reference
+
+* [fynd-client](https://docs.rs/fynd-client)
+* [fynd-core](https://docs.rs/fynd-core)
+* [fynd-rpc](https://docs.rs/fynd-rpc)
+* [fynd-rpc-types](https://docs.rs/fynd-rpc-types)
+
 ## MEDIA KIT
 
 * [Brand Assets](https://drive.google.com/drive/folders/1AZzrF_3r9lVMRUZJbNNNaPiDM7GJ4ySc?usp=sharing)

--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 description = "Core solving logic for Fynd DEX router"
 license = "MIT"
+readme = "README.md"
 
 [dependencies]
 tycho-simulation.workspace = true

--- a/fynd-core/README.md
+++ b/fynd-core/README.md
@@ -1,0 +1,42 @@
+# fynd-core
+
+Pure solving logic for the [Fynd](https://fynd.xyz) DEX router.
+
+Contains the route-finding algorithms, market-data pipeline, and on-chain encoder that power
+Fynd. **No HTTP dependencies** — embed directly in any application or use the
+[`fynd-rpc`](https://crates.io/crates/fynd-rpc) crate to expose it as an HTTP service.
+
+For documentation, configuration guides, and API reference see **<https://docs.fynd.xyz/>**.
+
+## Use cases
+
+- **Standalone routing** — call `Solver::quote()` directly from your application.
+- **Custom algorithms** — implement the `Algorithm` trait and plug in via `FyndBuilder::with_algorithm`.
+- **HTTP server** — use `fynd-rpc`, which wraps this crate with Actix Web.
+
+## Quick start
+
+```rust,no_run
+use fynd_core::{FyndBuilder, types::Order};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // See https://docs.fynd.xyz/get-started/quickstart for prerequisites.
+    let solver = FyndBuilder::new(
+        "ethereum".parse()?,
+        "tycho-fynd-ethereum.propellerheads.xyz".into(),
+        "https://reth-ethereum.ithaca.xyz/rpc".into(),
+        vec!["uniswap_v3".into(), "uniswap_v2".into()],
+        10.0, // minimum pool TVL
+    )
+    .build()?
+    .wait_until_ready()
+    .await?;
+
+    // solver.quote(request).await?;
+    Ok(())
+}
+```
+
+See the [custom algorithm guide](https://docs.fynd.xyz/guides/custom-algorithm) to implement
+your own routing strategy.

--- a/fynd-core/README.md
+++ b/fynd-core/README.md
@@ -3,40 +3,13 @@
 Pure solving logic for the [Fynd](https://fynd.xyz) DEX router.
 
 Contains the route-finding algorithms, market-data pipeline, and on-chain encoder that power
-Fynd. **No HTTP dependencies** — embed directly in any application or use the
-[`fynd-rpc`](https://crates.io/crates/fynd-rpc) crate to expose it as an HTTP service.
+Fynd. No HTTP dependencies — embed directly or use
+[`fynd-rpc`](https://crates.io/crates/fynd-rpc) to expose it as an HTTP service.
 
-For documentation, configuration guides, and API reference see **<https://docs.fynd.xyz/>**.
-
-## Use cases
-
-- **Standalone routing** — call `Solver::quote()` directly from your application.
-- **Custom algorithms** — implement the `Algorithm` trait and plug in via `FyndBuilder::with_algorithm`.
-- **HTTP server** — use `fynd-rpc`, which wraps this crate with Actix Web.
+For documentation, guides, and API reference visit **<https://docs.fynd.xyz/>**.
 
 ## Quick start
 
-```rust,no_run
-use fynd_core::{FyndBuilder, types::Order};
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    // See https://docs.fynd.xyz/get-started/quickstart for prerequisites.
-    let solver = FyndBuilder::new(
-        "ethereum".parse()?,
-        "tycho-fynd-ethereum.propellerheads.xyz".into(),
-        "https://reth-ethereum.ithaca.xyz/rpc".into(),
-        vec!["uniswap_v3".into(), "uniswap_v2".into()],
-        10.0, // minimum pool TVL (chain native token)
-    )
-    .build()?
-    .wait_until_ready()
-    .await?;
-
-    // solver.quote(request).await?;
-    Ok(())
-}
-```
-
-See the [custom algorithm guide](https://docs.fynd.xyz/guides/custom-algorithm) to implement
-your own routing strategy.
+See the [quickstart guide](https://docs.fynd.xyz/get-started/quickstart) and the
+[custom algorithm guide](https://docs.fynd.xyz/guides/custom-algorithm).
+The [`examples/`](examples/) directory contains complete, runnable programs.

--- a/fynd-core/README.md
+++ b/fynd-core/README.md
@@ -27,7 +27,7 @@ async fn main() -> anyhow::Result<()> {
         "tycho-fynd-ethereum.propellerheads.xyz".into(),
         "https://reth-ethereum.ithaca.xyz/rpc".into(),
         vec!["uniswap_v3".into(), "uniswap_v2".into()],
-        10.0, // minimum pool TVL
+        10.0, // minimum pool TVL (chain native token)
     )
     .build()?
     .wait_until_ready()

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -43,6 +43,11 @@ use crate::{
 type Subgraph =
     (HashMap<NodeIndex, Vec<(NodeIndex, ComponentId)>>, HashSet<NodeIndex>, HashSet<ComponentId>);
 
+/// Bellman-Ford algorithm with SPFA optimisation for simulation-driven DEX routing.
+///
+/// Finds optimal A→B routes by running actual pool simulations during edge relaxation,
+/// accounting for slippage, fees, and pool mechanics at the requested trade size.
+/// Gas costs are subtracted when price data is available.
 pub struct BellmanFordAlgorithm {
     max_hops: usize,
     timeout: Duration,

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -198,12 +198,22 @@ pub enum AlgorithmError {
     /// Invalid algorithm configuration (programmer error).
     #[non_exhaustive]
     #[error("invalid configuration: {reason}")]
-    InvalidConfiguration { reason: String },
+    InvalidConfiguration {
+        /// Human-readable description of the invalid configuration.
+        reason: String,
+    },
 
     /// No path exists between the tokens.
     #[non_exhaustive]
     #[error("no path from {from:?} to {to:?}: {reason}")]
-    NoPath { from: Address, to: Address, reason: NoPathReason },
+    NoPath {
+        /// Input token address.
+        from: Address,
+        /// Output token address.
+        to: Address,
+        /// Detailed reason why no path was found.
+        reason: NoPathReason,
+    },
 
     /// Paths exist but none have sufficient liquidity.
     #[error("insufficient liquidity on all paths")]
@@ -212,7 +222,10 @@ pub enum AlgorithmError {
     /// Route finding timed out.
     #[non_exhaustive]
     #[error("timeout after {elapsed_ms}ms")]
-    Timeout { elapsed_ms: u64 },
+    Timeout {
+        /// Elapsed time in milliseconds when the timeout fired.
+        elapsed_ms: u64,
+    },
 
     /// Exact-out not supported by this algorithm.
     #[error("exact-out orders not supported")]
@@ -221,12 +234,22 @@ pub enum AlgorithmError {
     /// Simulation failed for a specific component.
     #[non_exhaustive]
     #[error("simulation failed for {component_id}: {error}")]
-    SimulationFailed { component_id: String, error: String },
+    SimulationFailed {
+        /// ID of the pool component that failed.
+        component_id: String,
+        /// Underlying simulation error message.
+        error: String,
+    },
 
     /// Required data not found in market.
     #[non_exhaustive]
     #[error("{kind} not found{}", id.as_ref().map(|i| format!(": {i}")).unwrap_or_default())]
-    DataNotFound { kind: &'static str, id: Option<String> },
+    DataNotFound {
+        /// Category of the missing data (e.g. `"token"`, `"component"`).
+        kind: &'static str,
+        /// Optional identifier of the missing item.
+        id: Option<String>,
+    },
 
     /// Other algorithm-specific error.
     #[error("{0}")]

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -47,7 +47,7 @@ pub struct MostLiquidAlgorithm {
 pub struct DepthAndPrice {
     /// Spot price (token_out per token_in) for this edge direction.
     pub spot_price: f64,
-    /// Liquidity depth in USD (or native token terms).
+    /// Liquidity depth denominated in the chain's native token.
     pub depth: f64,
 }
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -58,6 +58,7 @@ impl DepthAndPrice {
         Self { spot_price, depth }
     }
 
+    /// Compute depth and spot price from a live protocol simulation.
     #[cfg(test)]
     pub fn from_protocol_sim(
         sim: &impl ProtocolSim,

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -47,7 +47,7 @@ pub struct MostLiquidAlgorithm {
 pub struct DepthAndPrice {
     /// Spot price (token_out per token_in) for this edge direction.
     pub spot_price: f64,
-    /// Liquidity depth denominated in the chain's native token.
+    /// Liquidity depth in raw units of the sell token.
     pub depth: f64,
 }
 

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -57,30 +57,36 @@ pub struct MockProtocolSim {
 }
 
 impl MockProtocolSim {
+    /// Create a mock with the given spot price and all other fields at default.
     pub fn new(spot_price: f64) -> Self {
         Self { spot_price, ..Default::default() }
     }
 
+    /// Override the spot price.
     pub fn with_spot_price(mut self, spot_price: f64) -> Self {
         self.spot_price = spot_price;
         self
     }
 
+    /// Override the gas estimate.
     pub fn with_gas(mut self, gas: u64) -> Self {
         self.gas = gas;
         self
     }
 
+    /// Override the available liquidity.
     pub fn with_liquidity(mut self, liquidity: u128) -> Self {
         self.liquidity = liquidity;
         self
     }
 
+    /// Override the fee.
     pub fn with_fee(mut self, fee: f64) -> Self {
         self.fee = fee;
         self
     }
 
+    /// Register token decimals for the given tokens.
     pub fn with_tokens(mut self, tokens: &[Token]) -> Self {
         for token in tokens {
             self.token_decimals
@@ -261,6 +267,7 @@ pub fn token(addr_b: u8, symbol: &str) -> Token {
     token_with_decimals(addr_b, symbol, 18)
 }
 
+/// Construct a test `Token` with a single-byte address, symbol, and decimal count.
 pub fn token_with_decimals(addr_b: u8, symbol: &str, decimals: u32) -> Token {
     Token {
         address: addr(addr_b),

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -119,24 +119,36 @@ impl ComputationRequirements {
 /// Typed error for a failed computation item.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum FailedItemError {
+    /// The pool's simulation state was not available in shared market data.
     #[error("missing simulation state")]
     MissingSimulationState,
 
+    /// Token metadata (decimals, symbol) was not found for the pool's tokens.
     #[error("missing token metadata")]
     MissingTokenMetadata,
 
+    /// A required spot price was not yet computed for this edge.
     #[error("missing spot price")]
     MissingSpotPrice,
 
+    /// The decimal difference between two tokens is too large for a meaningful price.
     #[error("extreme decimal mismatch ({from}\u{2192}{to})")]
-    ExtremeDecimalMismatch { from: u32, to: u32 },
+    ExtremeDecimalMismatch {
+        /// Source token decimals.
+        from: u32,
+        /// Target token decimals.
+        to: u32,
+    },
 
+    /// The computed spot price is below the minimum threshold.
     #[error("spot price too small: {0}")]
     SpotPriceTooSmall(f64),
 
+    /// Protocol simulation returned an error.
     #[error("simulation failed: {0}")]
     SimulationFailed(String),
 
+    /// Every simulation path for this pool failed.
     #[error("all simulation paths failed")]
     AllSimulationPathsFailed,
 }

--- a/fynd-core/src/encoding/mod.rs
+++ b/fynd-core/src/encoding/mod.rs
@@ -1,1 +1,2 @@
+/// Route encoder: converts solver output into ABI-encoded on-chain calldata.
 pub mod encoder;

--- a/fynd-core/src/encoding/mod.rs
+++ b/fynd-core/src/encoding/mod.rs
@@ -1,7 +1,8 @@
 /// Route encoder: converts solver output into ABI-encoded on-chain calldata.
 ///
 /// Wraps [tycho-execution](https://docs.propellerheads.xyz/tycho/for-solvers/execution) to
-/// produce ABI-encoded calldata for single and sequential swaps, with and without Permit2. See
+/// produce ABI-encoded calldata for single, sequential, and split swaps, with and without
+/// Permit2. See
 /// the [Fynd encoding guide](https://docs.fynd.xyz/guides/encoding-options) for supported
 /// encoding options and how to configure them.
 pub mod encoder;

--- a/fynd-core/src/encoding/mod.rs
+++ b/fynd-core/src/encoding/mod.rs
@@ -1,2 +1,7 @@
 /// Route encoder: converts solver output into ABI-encoded on-chain calldata.
+///
+/// Wraps [tycho-execution](https://docs.propellerheads.xyz/tycho/for-solvers/execution) to
+/// produce ABI-encoded calldata for single and sequential swaps, with and without Permit2. See
+/// the [Fynd encoding guide](https://docs.fynd.xyz/guides/encoding-options) for supported
+/// encoding options and how to configure them.
 pub mod encoder;

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -7,6 +7,7 @@ use tycho_simulation::{tycho_core::traits::FeePriceGetter, tycho_ethereum::gas::
 use crate::feed::{market_data::SharedMarketDataRef, DataFeedError};
 
 // TODO: Refactor gas price fetching into a `DerivedComputation`.
+/// Dependency ID used to register gas price as a market data dependency.
 pub const GAS_PRICE_DEPENDENCY_ID: &str = "gas_price";
 
 pub(crate) struct GasPriceFetcher<C: FeePriceGetter<FeePrice = BlockGasPrice>> {

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -3,11 +3,15 @@ use std::{collections::HashSet, time::Duration};
 use tycho_simulation::tycho_common::models::Chain;
 
 pub(crate) mod events;
+/// Gas price fetching and the `GAS_PRICE_DEPENDENCY_ID` constant.
 pub mod gas;
+/// Shared market data store (`SharedMarketData`, `SharedMarketDataRef`).
 pub mod market_data;
 
 pub use gas::GAS_PRICE_DEPENDENCY_ID;
+/// Protocol system registry: maps protocol names to their Tycho identifiers.
 pub mod protocol_registry;
+/// Tycho WebSocket feed: connects to the Tycho data stream and populates `SharedMarketData`.
 pub mod tycho_feed;
 
 /// Configuration for the TychoFeed.

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -1,36 +1,46 @@
-//! Fynd Core - Pure solving logic for DEX routing
+#![deny(missing_docs)]
+//! Pure solving logic for the [Fynd](https://fynd.xyz) DEX router.
 //!
-//! This crate provides the core solving algorithms and types for finding optimal
-//! swap routes across multiple DEX protocols. It contains **no HTTP or UI dependencies**,
-//! making it suitable for standalone use in any application.
+//! This crate contains the route-finding algorithms, market-data pipeline, and encoder that
+//! powers Fynd. It has **no HTTP dependencies** and can be embedded directly in any application.
 //!
-//! # Use Cases
+//! For documentation, guides, and API reference see **<https://docs.fynd.xyz/>**.
 //!
-//! - **Standalone routing**: Integrate Fynd's routing algorithms into your own application
-//! - **Custom solvers**: Build specialized routing solutions without HTTP overhead
-//! - **Research & testing**: Experiment with routing algorithms in isolation
+//! # Use cases
 //!
-//! # Main Components
+//! - **Standalone routing** — embed Fynd's algorithms directly without running an HTTP server.
+//! - **Custom algorithms** — implement the [`Algorithm`] trait and plug in via
+//!   [`FyndBuilder::with_algorithm`](solver::FyndBuilder).
+//! - **HTTP server** — use the [`fynd-rpc`](https://crates.io/crates/fynd-rpc) crate, which wraps
+//!   this crate with Actix Web.
 //!
-//! - **algorithm**: Route-finding algorithms (e.g., `MostLiquidAlgorithm`)
-//! - **graph**: Graph management and pathfinding utilities
-//! - **derived**: Derived data computations (spot prices, pool depths, gas prices)
-//! - **types**: Core type definitions (`Order`, `Route`, `Swap`, `OrderQuote`)
-//! - **feed**: Market data structures and event handling
-//! - **encoding**: Encodes solved routes into on-chain transactions via Tycho's router contracts
-//! - **worker_pool**: Multi-threaded solver pool management with algorithm registry
-//! - **worker_pool_router**: Request orchestration across multiple solver pools
+//! # Quick start
+//!
+//! See the [Fynd quickstart](https://docs.fynd.xyz/get-started/quickstart) to run a local
+//! instance, or the [custom algorithm guide](https://docs.fynd.xyz/guides/custom-algorithm)
+//! to implement your own routing strategy.
 
-// Public modules
+/// Route-finding algorithms. Includes [`MostLiquidAlgorithm`] and the
+/// pluggable [`Algorithm`] trait.
 pub mod algorithm;
+/// Derived data computations: spot prices, pool depths, and gas prices.
 pub mod derived;
+/// Encodes solved routes into ABI-encoded on-chain calldata via Tycho's router contracts.
 pub mod encoding;
+/// Market data feed: Tycho WebSocket integration, gas price fetching, and protocol registry.
 pub mod feed;
 pub(crate) mod graph;
+/// External price validation for quotes.
 pub mod price_guard;
+/// [`FyndBuilder`](solver::FyndBuilder) assembles the full pipeline and returns a
+/// [`Solver`](solver::Solver).
 pub mod solver;
+/// Core domain types: [`Order`](types::Order), [`Route`](types::Route), [`Quote`](types::Quote),
+/// etc.
 pub mod types;
+/// Multi-threaded solver pool management with pluggable algorithm registry.
 pub mod worker_pool;
+/// Request orchestration: fans out orders to all solver pools and selects the best result.
 pub mod worker_pool_router;
 
 // Re-export commonly used types for convenience

--- a/fynd-core/src/price_guard/config.rs
+++ b/fynd-core/src/price_guard/config.rs
@@ -47,46 +47,56 @@ impl Default for PriceGuardConfig {
 }
 
 impl PriceGuardConfig {
+    /// Maximum allowed negative deviation in basis points (user gets less than expected).
     pub fn lower_tolerance_bps(&self) -> u32 {
         self.lower_tolerance_bps
     }
 
+    /// Maximum allowed positive deviation in basis points (output exceeds expectation).
     pub fn upper_tolerance_bps(&self) -> u32 {
         self.upper_tolerance_bps
     }
 
+    /// Whether solutions pass through when all providers are unreachable.
     pub fn allow_on_provider_error(&self) -> bool {
         self.allow_on_provider_error
     }
 
+    /// Whether solutions pass through when no provider has a price for the pair.
     pub fn allow_on_token_price_not_found(&self) -> bool {
         self.allow_on_token_price_not_found
     }
 
+    /// Whether price-guard validation is enabled.
     pub fn enabled(&self) -> bool {
         self.enabled
     }
 
+    /// Set the lower tolerance threshold in basis points.
     pub fn with_lower_tolerance_bps(mut self, bps: u32) -> Self {
         self.lower_tolerance_bps = bps;
         self
     }
 
+    /// Set the upper tolerance threshold in basis points.
     pub fn with_upper_tolerance_bps(mut self, bps: u32) -> Self {
         self.upper_tolerance_bps = bps;
         self
     }
 
+    /// Set whether solutions pass through when all providers error.
     pub fn with_allow_on_provider_error(mut self, allow: bool) -> Self {
         self.allow_on_provider_error = allow;
         self
     }
 
+    /// Set whether solutions pass through when no provider has a price.
     pub fn with_allow_on_token_price_not_found(mut self, allow: bool) -> Self {
         self.allow_on_token_price_not_found = allow;
         self
     }
 
+    /// Enable or disable price-guard validation.
     pub fn with_enabled(mut self, enabled: bool) -> Self {
         self.enabled = enabled;
         self

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -43,6 +43,7 @@ impl Drop for PriceGuard {
 }
 
 impl PriceGuard {
+    /// Creates a new price guard with the given provider registry and background worker handles.
     pub fn new(registry: PriceProviderRegistry, worker_handles: Vec<JoinHandle<()>>) -> Self {
         Self { registry, worker_handles }
     }

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -1,7 +1,9 @@
 //! Hyperliquid oracle price provider.
 //!
 //! Polls the Hyperliquid REST API for oracle prices (weighted median across 8 CEXs) and caches them
-//! in memory. The [`HyperliquidProvider`] reads from this cache to validate solution prices.
+//! in memory. The
+//! [`HyperliquidProvider`](crate::price_guard::hyperliquid::HyperliquidProvider) reads from this
+//! cache to validate solution prices.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -87,6 +87,7 @@ pub struct HyperliquidProvider {
 }
 
 impl HyperliquidProvider {
+    /// Creates a new Hyperliquid provider that polls prices at the given interval.
     pub fn new(poll_interval: Duration) -> Self {
         Self {
             price_cache: Arc::new(RwLock::new(HashMap::new())),

--- a/fynd-core/src/price_guard/mod.rs
+++ b/fynd-core/src/price_guard/mod.rs
@@ -12,9 +12,16 @@
 //! - **[`config`]**: [`PriceGuardConfig`](config::PriceGuardConfig) for tolerance thresholds and
 //!   fail-open behavior
 
+/// Tolerance thresholds and fail-open configuration for the price guard.
 pub mod config;
+/// [`PriceGuard`](guard::PriceGuard) struct that orchestrates validation of solver solutions.
 pub mod guard;
+/// Hyperliquid price provider implementation.
 pub mod hyperliquid;
+/// [`PriceProvider`](provider::PriceProvider) trait and supporting error types.
 pub mod provider;
+/// Registry that manages and queries multiple [`PriceProvider`](provider::PriceProvider)s
+/// concurrently.
 pub mod provider_registry;
+/// Shared utilities: symbol normalisation, token resolution, and staleness checks.
 pub mod utils;

--- a/fynd-core/src/price_guard/mod.rs
+++ b/fynd-core/src/price_guard/mod.rs
@@ -2,26 +2,28 @@
 //!
 //! This module provides the infrastructure for external price validation:
 //!
-//! - **[`guard`]**: [`PriceGuard`](guard::PriceGuard) struct that orchestrates validation of solver
-//!   solutions
-//! - **[`provider`]**: [`PriceProvider`](provider::PriceProvider) trait and supporting types
-//! - **[`provider_registry`]**: [`PriceProviderRegistry`](provider_registry::PriceProviderRegistry)
-//!   for managing multiple providers concurrently
-//! - **[`utils`]**: Shared utilities for symbol normalization, token resolution, staleness checks,
-//!   and amount computation
-//! - **[`config`]**: [`PriceGuardConfig`](config::PriceGuardConfig) for tolerance thresholds and
-//!   fail-open behavior
+//! - **guard**: [`PriceGuard`](crate::price_guard::guard::PriceGuard) struct that orchestrates
+//!   validation of solver solutions
+//! - **provider**: [`PriceProvider`](crate::price_guard::provider::PriceProvider) trait and
+//!   supporting types
+//! - **provider\_registry**:
+//!   [`PriceProviderRegistry`](crate::price_guard::provider_registry::PriceProviderRegistry) for
+//!   managing multiple providers concurrently
+//! - **utils**: Shared utilities for symbol normalization, token resolution, staleness checks, and
+//!   amount computation
+//! - **config**: [`PriceGuardConfig`](crate::price_guard::config::PriceGuardConfig) for tolerance
+//!   thresholds and fail-open behavior
 
 /// Tolerance thresholds and fail-open configuration for the price guard.
 pub mod config;
-/// [`PriceGuard`](guard::PriceGuard) struct that orchestrates validation of solver solutions.
+/// Orchestrates validation of solver solutions against external prices.
 pub mod guard;
 /// Hyperliquid price provider implementation.
 pub mod hyperliquid;
-/// [`PriceProvider`](provider::PriceProvider) trait and supporting error types.
+/// [`PriceProvider`](crate::price_guard::provider::PriceProvider) trait and supporting error types.
 pub mod provider;
-/// Registry that manages and queries multiple [`PriceProvider`](provider::PriceProvider)s
-/// concurrently.
+/// Registry that manages and queries multiple
+/// [`PriceProvider`](crate::price_guard::provider::PriceProvider)s concurrently.
 pub mod provider_registry;
 /// Shared utilities: symbol normalisation, token resolution, and staleness checks.
 pub mod utils;

--- a/fynd-core/src/price_guard/provider.rs
+++ b/fynd-core/src/price_guard/provider.rs
@@ -19,15 +19,26 @@ pub enum PriceProviderError {
 
     /// Token address not found in the market data registry (Fynd's data).
     #[error("token not found: {address}")]
-    TokenNotFound { address: String },
+    TokenNotFound {
+        /// Hex-encoded address of the missing token.
+        address: String,
+    },
 
     /// No price data from the provider found for the requested token pair.
     #[error("price not found for pair {token_in} -> {token_out}")]
-    PriceNotFound { token_in: String, token_out: String },
+    PriceNotFound {
+        /// Input token identifier.
+        token_in: String,
+        /// Output token identifier.
+        token_out: String,
+    },
 
     /// Price data is stale (e.g., feed hasn't updated recently).
     #[error("price data stale: last update {age_ms}ms ago")]
-    StaleData { age_ms: u64 },
+    StaleData {
+        /// Milliseconds since the last successful price update.
+        age_ms: u64,
+    },
 }
 
 /// A price quote from an external source.
@@ -42,18 +53,22 @@ pub struct ExternalPrice {
 }
 
 impl ExternalPrice {
+    /// Create a new external price quote.
     pub fn new(expected_amount_out: BigUint, source: String, timestamp_ms: u64) -> Self {
         Self { expected_amount_out, source, timestamp_ms }
     }
 
+    /// Expected output amount in raw output token units.
     pub fn expected_amount_out(&self) -> &BigUint {
         &self.expected_amount_out
     }
 
+    /// Name of the price source (e.g. `"hyperliquid"`, `"binance_ws"`).
     pub fn source(&self) -> &str {
         &self.source
     }
 
+    /// Timestamp of the price data in Unix milliseconds.
     pub fn timestamp_ms(&self) -> u64 {
         self.timestamp_ms
     }

--- a/fynd-core/src/price_guard/provider.rs
+++ b/fynd-core/src/price_guard/provider.rs
@@ -1,7 +1,7 @@
 //! Price provider trait and types.
 //!
-//! Defines the [`PriceProvider`] trait for fetching external token prices
-//! and supporting error and result types.
+//! Defines the [`provider::PriceProvider`](crate::price_guard::provider::PriceProvider) trait for
+//! fetching external token prices and supporting error and result types.
 
 use num_bigint::BigUint;
 use thiserror::Error;

--- a/fynd-core/src/price_guard/provider_registry.rs
+++ b/fynd-core/src/price_guard/provider_registry.rs
@@ -14,6 +14,7 @@ pub struct PriceProviderRegistry {
 }
 
 impl PriceProviderRegistry {
+    /// Create an empty registry with no providers registered.
     pub fn new() -> Self {
         Self { providers: Vec::new() }
     }

--- a/fynd-core/src/price_guard/provider_registry.rs
+++ b/fynd-core/src/price_guard/provider_registry.rs
@@ -1,4 +1,4 @@
-//! Registry for managing multiple [`PriceProvider`]s.
+//! Registry for managing multiple [PriceProvider](crate::price_guard::provider::PriceProvider)s.
 
 use num_bigint::BigUint;
 use tycho_simulation::tycho_common::models::Address;

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -50,15 +50,26 @@ use crate::{
 pub mod defaults {
     use std::time::Duration;
 
+    /// Minimum token quality score required for a token to be included in routing.
     pub const MIN_TOKEN_QUALITY: i32 = 100;
+    /// Maximum age (in days) of trading history required for a token to be considered liquid.
     pub const TRADED_N_DAYS_AGO: u64 = 3;
+    /// Multiplier applied to a pool's TVL when estimating available liquidity.
     pub const TVL_BUFFER_RATIO: f64 = 1.1;
+    /// How often the gas price is refreshed from the RPC node.
     pub const GAS_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+    /// Delay before reconnecting to the Tycho feed after a disconnect.
     pub const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+    /// Minimum number of solver pool responses required before returning a quote (`0` = wait for
+    /// all).
     pub const ROUTER_MIN_RESPONSES: usize = 0;
+    /// Capacity of the task queue for each worker pool.
     pub const POOL_TASK_QUEUE_CAPACITY: usize = 1000;
+    /// Minimum number of hops allowed in a route.
     pub const POOL_MIN_HOPS: usize = 1;
+    /// Maximum number of hops allowed in a route.
     pub const POOL_MAX_HOPS: usize = 3;
+    /// Per-pool solve timeout in milliseconds.
     pub const POOL_TIMEOUT_MS: u64 = 100;
 }
 
@@ -314,6 +325,7 @@ impl FyndBuilder {
         }
     }
 
+    /// The blockchain this builder is configured for.
     pub fn chain(&self) -> Chain {
         self.chain
     }

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -127,7 +127,10 @@ pub enum SolveError {
 
     /// Price check against external source failed.
     #[error("price check failed for order {order_id}")]
-    PriceCheckFailed { order_id: String },
+    PriceCheckFailed {
+        /// Identifier of the order that failed the price check.
+        order_id: String,
+    },
 }
 
 impl SolveError {

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -62,17 +62,28 @@ pub enum SolveError {
     /// No route found between the tokens.
     #[non_exhaustive]
     #[error("no route found for order {order_id}")]
-    NoRouteFound { order_id: String },
+    NoRouteFound {
+        /// ID of the order for which no route was found.
+        order_id: String,
+    },
 
     /// Insufficient liquidity for the requested amount.
     #[non_exhaustive]
     #[error("insufficient liquidity: need {required}, have {available}")]
-    InsufficientLiquidity { required: BigUint, available: BigUint },
+    InsufficientLiquidity {
+        /// Amount the user requested.
+        required: BigUint,
+        /// Maximum amount available in the pool.
+        available: BigUint,
+    },
 
     /// Solving timed out.
     #[non_exhaustive]
     #[error("solve timeout after {elapsed_ms}ms")]
-    Timeout { elapsed_ms: u64 },
+    Timeout {
+        /// Wall-clock time elapsed before the timeout fired, in milliseconds.
+        elapsed_ms: u64,
+    },
 
     /// Algorithm-specific error.
     #[error("algorithm error: {0}")]
@@ -81,7 +92,10 @@ pub enum SolveError {
     /// Market data is too old.
     #[non_exhaustive]
     #[error("market data stale: last update {age_ms}ms ago")]
-    MarketDataStale { age_ms: u64 },
+    MarketDataStale {
+        /// Milliseconds since the last successful market-data update.
+        age_ms: u64,
+    },
 
     /// Task queue is full.
     #[error("task queue full")]

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -1,10 +1,11 @@
 //! Core type definitions for Fynd.
 //!
 //! This module contains all shared types used across the solver:
-//! - [`quote`] - Public API types (requests, responses, routes, swaps)
-//! - [`primitives`] - Basic types like ComponentId, ProtocolSystem, GasPrice
-//! - [`internal`] - Internal task and error types
-//! - [`constants`] - Protocol gas costs and native token addresses
+//! - [`types::quote`](crate::types::quote) - Public API types (requests, responses, routes, swaps)
+//! - [`types::primitives`](crate::types::primitives) - Basic types like ComponentId,
+//!   ProtocolSystem, GasPrice
+//! - [`types::internal`](crate::types::internal) - Internal task and error types
+//! - [`types::constants`](crate::types::constants) - Protocol gas costs and native token addresses
 
 /// Protocol gas costs and native token addresses per chain.
 pub mod constants;

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -6,9 +6,13 @@
 //! - [`internal`] - Internal task and error types
 //! - [`constants`] - Protocol gas costs and native token addresses
 
+/// Protocol gas costs and native token addresses per chain.
 pub mod constants;
+/// Internal task and solve-error types used between the worker pool and router.
 pub mod internal;
+/// Primitive types: `ComponentId`, `ProtocolSystem`, `GasPrice`, `TaskId`.
 pub mod primitives;
+/// Public API types: `Order`, `Quote`, `Route`, `Swap`, `QuoteRequest`, etc.
 pub mod quote;
 
 // Re-export constants

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -38,7 +38,7 @@ use crate::{price_guard::config::PriceGuardConfig, AlgorithmError};
 // REQUEST TYPES
 // ============================================================================
 
-// Request to solve one or more swap orders.
+/// Request to solve one or more swap orders.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QuoteRequest {
     /// Orders to solve.
@@ -607,8 +607,10 @@ pub enum OrderSide {
 #[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum OrderValidationError {
+    /// `token_in` and `token_out` are the same address.
     #[error("token_in and token_out must be different")]
     SameTokens,
+    /// The requested swap amount is zero.
     #[error("amount must be non-zero")]
     ZeroAmount,
 }
@@ -1097,17 +1099,32 @@ impl Route {
 #[non_exhaustive]
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum RouteValidationError {
+    /// Route contains no swaps.
     #[error("route must contain at least one swap")]
     EmptyRoute,
+    /// Adjacent swaps in the route do not share a token.
     #[non_exhaustive]
     #[error("swaps are not connected: {first_out} != {second_in}")]
-    DisconnectedSwaps { first_out: Address, second_in: Address },
+    DisconnectedSwaps {
+        /// Output token of the first swap.
+        first_out: Address,
+        /// Input token of the second swap.
+        second_in: Address,
+    },
+    /// Route contains a cycle involving a token that is not start == end.
     #[non_exhaustive]
     #[error(
         "unsupported cycle: token {token} appears more than once in route \
          {first} -> ... -> {last} (only first == last cycles are supported)"
     )]
-    UnsupportedCycle { token: Address, first: Address, last: Address },
+    UnsupportedCycle {
+        /// Token that appears more than once.
+        token: Address,
+        /// First token in the route.
+        first: Address,
+        /// Last token in the route.
+        last: Address,
+    },
 }
 
 /// A single swap within a route.

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -191,6 +191,7 @@ pub struct WorkerPoolBuilder {
 }
 
 impl WorkerPoolBuilder {
+    /// Create a builder with default configuration values.
     pub fn new() -> Self {
         Self { config: WorkerPoolConfig::default() }
     }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -13,7 +13,8 @@
 //! 3. **Collection**: Wait for N responses OR timeout per order
 //! 4. **Selection**: Choose best quote (max `amount_out_net_gas`)
 //! 5. **Encoding**: If [`EncodingOptions`](crate::EncodingOptions) are provided in the request,
-//!    encode winning solutions into executable on-chain transactions via the [`Encoder`]
+//!    encode winning solutions into executable on-chain transactions via the
+//!    [`encoding::encoder::Encoder`](crate::encoding::encoder::Encoder)
 
 pub mod config;
 

--- a/fynd-rpc-types/Cargo.toml
+++ b/fynd-rpc-types/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 description = "Shared DTO types for the Fynd RPC API (request/response wire format)"
 license = "MIT"
+readme = "README.md"
 
 [features]
 openapi = ["dep:utoipa"]

--- a/fynd-rpc-types/README.md
+++ b/fynd-rpc-types/README.md
@@ -1,0 +1,26 @@
+# fynd-rpc-types
+
+Wire-format types for the [Fynd](https://fynd.xyz) RPC HTTP API.
+
+This crate contains only the serialisation types (`QuoteRequest`, `Quote`, `Order`, …) shared
+between the Fynd RPC server (`fynd-rpc`) and its clients (`fynd-client`). It has no HTTP or
+server-side dependencies.
+
+For documentation and API reference see **<https://docs.fynd.xyz/>**.
+
+## Features
+
+| Feature | Purpose |
+|---------|---------|
+| `openapi` | Derives `utoipa::ToSchema` on all types for OpenAPI spec generation |
+| `core` | Enables `Into` conversions between wire DTOs and `fynd-core` domain types |
+
+## Usage
+
+This crate is typically pulled in transitively via `fynd-client` or `fynd-rpc`. Direct use is
+only needed when implementing a custom server or client against the Fynd wire format.
+
+```toml
+[dependencies]
+fynd-rpc-types = "0.35"
+```

--- a/fynd-rpc-types/README.md
+++ b/fynd-rpc-types/README.md
@@ -2,25 +2,14 @@
 
 Wire-format types for the [Fynd](https://fynd.xyz) RPC HTTP API.
 
-This crate contains only the serialisation types (`QuoteRequest`, `Quote`, `Order`, …) shared
-between the Fynd RPC server (`fynd-rpc`) and its clients (`fynd-client`). It has no HTTP or
+Shared between the Fynd RPC server (`fynd-rpc`) and its clients (`fynd-client`). No HTTP or
 server-side dependencies.
 
-For documentation and API reference see **<https://docs.fynd.xyz/>**.
+For documentation and API reference visit **<https://docs.fynd.xyz/>**.
 
 ## Features
 
 | Feature | Purpose |
 |---------|---------|
-| `openapi` | Derives `utoipa::ToSchema` on all types for OpenAPI spec generation |
-| `core` | Enables `Into` conversions between wire DTOs and `fynd-core` domain types |
-
-## Usage
-
-This crate is typically pulled in transitively via `fynd-client` or `fynd-rpc`. Direct use is
-only needed when implementing a custom server or client against the Fynd wire format.
-
-```toml
-[dependencies]
-fynd-rpc-types = "0.35"
-```
+| `openapi` | Derives `utoipa::ToSchema` for OpenAPI spec generation |
+| `core` | Enables conversions between wire DTOs and `fynd-core` domain types |

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1,11 +1,16 @@
-//! Data Transfer Objects (DTOs) for the Fynd RPC HTTP API.
+#![deny(missing_docs)]
+//! Wire-format types for the [Fynd](https://fynd.xyz) RPC HTTP API.
 //!
-//! This crate contains only the wire-format types shared between the Fynd RPC server
+//! This crate contains only the serialisation types shared between the Fynd RPC server
 //! (`fynd-rpc`) and its clients (`fynd-client`). It has no server-side infrastructure
 //! dependencies (no actix-web, no server logic).
 //!
-//! Enable the `openapi` feature to derive `utoipa::ToSchema` on all types for use in
-//! API documentation generation.
+//! For documentation and API reference see **<https://docs.fynd.xyz/>**.
+//!
+//! ## Features
+//!
+//! - **`openapi`** — derives `utoipa::ToSchema` on all types for OpenAPI spec generation.
+//! - **`core`** — enables `Into` conversions between wire DTOs and `fynd-core` domain types.
 
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -56,10 +56,12 @@ mod hex_bytes_serde {
 pub struct Bytes(#[serde(with = "hex_bytes_serde")] pub bytes::Bytes);
 
 impl Bytes {
+    /// Returns the number of bytes.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// Returns `true` if the byte sequence is empty.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/fynd-rpc/Cargo.toml
+++ b/fynd-rpc/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 description = "HTTP RPC server for Fynd DEX router"
 license = "MIT"
+readme = "README.md"
 
 [dependencies]
 fynd-core.workspace = true

--- a/fynd-rpc/README.md
+++ b/fynd-rpc/README.md
@@ -1,0 +1,42 @@
+# fynd-rpc
+
+HTTP RPC server for the [Fynd](https://fynd.xyz) DEX router.
+
+Wraps [`fynd-core`](https://crates.io/crates/fynd-core) with Actix Web and exposes swap routing
+as a REST service on `http://0.0.0.0:3000` by default.
+
+For documentation, configuration guides, and API reference see **<https://docs.fynd.xyz/>**.
+
+## Endpoints
+
+| Endpoint | Description |
+|---|---|
+| `POST /v1/quote` | Request an optimal swap route |
+| `GET /v1/health` | Data freshness and solver readiness |
+| `GET /v1/info` | Static instance metadata (chain ID, contract addresses) |
+
+## Quick start
+
+```rust,no_run
+use std::collections::HashMap;
+use fynd_rpc::{builder::FyndRPCBuilder, config::WorkerPoolsConfig};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // See https://docs.fynd.xyz/get-started/quickstart for prerequisites.
+    let server = FyndRPCBuilder::new(
+        "ethereum".parse()?,
+        HashMap::new(),                          // pool configs
+        "tycho-fynd-ethereum.propellerheads.xyz".into(),
+        "https://reth-ethereum.ithaca.xyz/rpc".into(),
+        vec!["uniswap_v3".into(), "uniswap_v2".into()],
+    )
+    .build()?;
+
+    server.run().await?;
+    Ok(())
+}
+```
+
+See the [server configuration guide](https://docs.fynd.xyz/guides/server-configuration) for all
+available options.

--- a/fynd-rpc/README.md
+++ b/fynd-rpc/README.md
@@ -5,7 +5,8 @@ HTTP RPC server for the [Fynd](https://fynd.xyz) DEX router.
 Wraps [`fynd-core`](https://crates.io/crates/fynd-core) with Actix Web and exposes swap routing
 as a REST service on `http://0.0.0.0:3000` by default.
 
-For documentation, configuration guides, and API reference visit **<https://docs.fynd.xyz/>**.
+For documentation and configuration guides visit **<https://docs.fynd.xyz/>**.
+For the full API reference visit **<https://docs.fynd.xyz/reference/api>**.
 
 ## Endpoints
 

--- a/fynd-rpc/README.md
+++ b/fynd-rpc/README.md
@@ -5,7 +5,7 @@ HTTP RPC server for the [Fynd](https://fynd.xyz) DEX router.
 Wraps [`fynd-core`](https://crates.io/crates/fynd-core) with Actix Web and exposes swap routing
 as a REST service on `http://0.0.0.0:3000` by default.
 
-For documentation, configuration guides, and API reference see **<https://docs.fynd.xyz/>**.
+For documentation, configuration guides, and API reference visit **<https://docs.fynd.xyz/>**.
 
 ## Endpoints
 
@@ -17,26 +17,5 @@ For documentation, configuration guides, and API reference see **<https://docs.f
 
 ## Quick start
 
-```rust,no_run
-use std::collections::HashMap;
-use fynd_rpc::{builder::FyndRPCBuilder, config::WorkerPoolsConfig};
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    // See https://docs.fynd.xyz/get-started/quickstart for prerequisites.
-    let server = FyndRPCBuilder::new(
-        "ethereum".parse()?,
-        HashMap::new(),                          // pool configs
-        "tycho-fynd-ethereum.propellerheads.xyz".into(),
-        "https://reth-ethereum.ithaca.xyz/rpc".into(),
-        vec!["uniswap_v3".into(), "uniswap_v2".into()],
-    )
-    .build()?;
-
-    server.run().await?;
-    Ok(())
-}
-```
-
-See the [server configuration guide](https://docs.fynd.xyz/guides/server-configuration) for all
-available options.
+See the [server configuration guide](https://docs.fynd.xyz/guides/server-configuration) and the
+[quickstart](https://docs.fynd.xyz/get-started/quickstart).

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -28,7 +28,10 @@ pub enum ApiError {
     /// Market data is stale.
     #[error("market data stale: last update {age_ms}ms ago")]
     #[non_exhaustive]
-    StaleData { age_ms: u64 },
+    StaleData {
+        /// Milliseconds since the last successful market-data update.
+        age_ms: u64,
+    },
 }
 
 impl ResponseError for ApiError {

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -1,13 +1,13 @@
-//! HTTP API layer using Actix Web.
-//!
-//! This module provides the HTTP endpoints for the solver:
-//! - POST /quote - Submit solve requests
-//! - GET /health - Health check endpoint
+//! HTTP API layer: endpoint handlers, OpenAPI docs, and shared application state.
 
+/// Re-exports of wire-format DTO types from `fynd-rpc-types`.
 pub mod dto;
+/// [`ApiError`] type with HTTP status code mapping.
 pub mod error;
+/// Request handlers for `/v1/quote`, `/v1/health`, and `/v1/info`.
 pub mod handlers;
 #[cfg(feature = "experimental")]
+/// Response types and handler for `GET /v1/prices` (experimental).
 pub mod prices;
 
 use std::{
@@ -31,6 +31,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api::error::ErrorResponse;
 
+/// OpenAPI documentation bundle for the stable Fynd RPC endpoints.
 #[derive(OpenApi)]
 #[openapi(
     paths(handlers::quote, handlers::health, handlers::info),
@@ -54,6 +55,7 @@ use crate::api::error::ErrorResponse;
 pub struct ApiDoc;
 
 #[cfg(feature = "experimental")]
+/// OpenAPI documentation bundle for experimental endpoints (`GET /v1/prices`).
 #[derive(OpenApi)]
 #[openapi(
     paths(handlers::get_prices),

--- a/fynd-rpc/src/api/prices.rs
+++ b/fynd-rpc/src/api/prices.rs
@@ -22,7 +22,9 @@ pub struct PricesQuery {
 /// Parsed variant of the `include` query parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IncludeField {
+    /// Include pool depth data.
     Depths,
+    /// Include spot price data.
     SpotPrices,
 }
 

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -158,6 +158,10 @@ impl FyndRPCBuilder {
         self
     }
 
+    /// Assemble all components and return a running [`FyndRPC`] server handle.
+    ///
+    /// Starts all worker pools and binds the HTTP listener. Returns an error if any component
+    /// fails to initialise.
     pub fn build(self) -> Result<FyndRPC> {
         info!(
             host = %self.http_host,
@@ -339,6 +343,10 @@ impl FyndRPC {
     }
 }
 
+/// Parse a chain name string into a [`Chain`] value.
+///
+/// Accepts case-insensitive names like `"Ethereum"`, `"ethereum"`.
+/// Returns an error for unrecognised chains.
 pub fn parse_chain(chain: &str) -> Result<Chain> {
     let candidate = format!("\"{}\"", chain.to_ascii_lowercase());
     serde_json::from_str::<Chain>(&candidate)

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -216,7 +216,8 @@ pub mod defaults {
     /// Default Ethereum JSON-RPC URL used when none is provided.
     pub const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
 
-    /// Minimum USD TVL a pool must have to be included in routing.
+    /// Minimum TVL a pool must have to be included in routing, denominated in the chain's native
+    /// token.
     pub const MIN_TVL: f64 = 10.0;
 
     /// Worker-router timeout in milliseconds.

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -199,6 +199,7 @@ mod tests {
     }
 }
 
+/// Default values for all `fynd-rpc` configuration parameters.
 pub mod defaults {
     // Re-export shared defaults from fynd-core as the single source of truth.
     pub use fynd_core::solver::defaults::{
@@ -207,18 +208,21 @@ pub mod defaults {
         TRADED_N_DAYS_AGO, TVL_BUFFER_RATIO,
     };
 
-    // HTTP server — fynd-rpc specific.
+    /// Default HTTP bind host (`"0.0.0.0"` — all interfaces).
     pub const HTTP_HOST: &str = "0.0.0.0";
+    /// Default HTTP port (`3000`).
     pub const HTTP_PORT: u16 = 3000;
 
-    // RPC — fynd-rpc specific.
+    /// Default Ethereum JSON-RPC URL used when none is provided.
     pub const DEFAULT_RPC_URL: &str = "https://eth.llamarpc.com";
 
-    // Minimum TVL passed to FyndBuilder::new — fynd-rpc's opinion of a sensible floor.
+    /// Minimum USD TVL a pool must have to be included in routing.
     pub const MIN_TVL: f64 = 10.0;
 
-    // Router timeout — intentionally tighter than FyndBuilder's generous 10 s standalone
-    // default; an HTTP service must respond within its request deadline.
+    /// Worker-router timeout in milliseconds.
+    ///
+    /// Intentionally tighter than `FyndBuilder`'s generous 10 s standalone default; an HTTP
+    /// service must respond within its request deadline.
     pub const WORKER_ROUTER_TIMEOUT_MS: u64 = 100;
 
     /// Returns the default Tycho Fynd endpoint URL for the given chain.

--- a/fynd-rpc/src/lib.rs
+++ b/fynd-rpc/src/lib.rs
@@ -1,25 +1,26 @@
-//! Fynd RPC - HTTP server for DEX routing
+#![deny(missing_docs)]
+//! HTTP RPC server for the [Fynd](https://fynd.xyz) DEX router.
 //!
-//! This crate provides an HTTP RPC server that exposes Fynd's solving capabilities
-//! via REST API endpoints. It builds on [`fynd-core`](https://docs.rs/fynd-core) and adds
-//! HTTP infrastructure, worker pool management, and customizable middleware support.
+//! Wraps [`fynd-core`] with Actix Web to expose swap-routing as a REST service.
+//! Use [`FyndRPCBuilder`](builder::FyndRPCBuilder) to assemble and start the server.
 //!
-//! # Use Cases
+//! For documentation, configuration guides, and API reference see **<https://docs.fynd.xyz/>**.
 //!
-//! - **Turnkey HTTP server**: Use `FyndRPCBuilder` to quickly deploy a routing service
-//! - **Custom middleware**: Add authentication, rate limiting, or custom logic to the HTTP layer
-//! - **Microservices**: Integrate Fynd as an HTTP microservice in your infrastructure
+//! ## Endpoints
 //!
-//! # Main Components
-//!
-//! - **builder**: `FyndRPCBuilder` for assembling and configuring the HTTP server
-//! - **api**: HTTP endpoint handlers (`/v1/quote`, `/v1/health`) and OpenAPI documentation
-//! - **config**: Configuration types for pools, algorithms, and blacklists
+//! | Endpoint | Description |
+//! |---|---|
+//! | `POST /v1/quote` | Request an optimal swap route |
+//! | `GET /v1/health` | Data freshness and solver readiness |
+//! | `GET /v1/info` | Static instance metadata (chain ID, contract addresses) |
 
-// Public modules
+/// HTTP endpoint handlers, OpenAPI docs, and shared application state.
 pub mod api;
+/// Server builder and runner.
 pub mod builder;
+/// TOML-based pool configuration and server defaults.
 pub mod config;
+/// Protocol discovery via the Tycho RPC.
 pub mod protocols;
 
 // Re-export key RPC types

--- a/fynd-rpc/src/lib.rs
+++ b/fynd-rpc/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 //! HTTP RPC server for the [Fynd](https://fynd.xyz) DEX router.
 //!
-//! Wraps [`fynd-core`] with Actix Web to expose swap-routing as a REST service.
+//! Wraps [fynd-core](fynd_core) with Actix Web to expose swap-routing as a REST service.
 //! Use [`FyndRPCBuilder`](builder::FyndRPCBuilder) to assemble and start the server.
 //!
 //! For documentation, configuration guides, and API reference see **<https://docs.fynd.xyz/>**.

--- a/fynd-rpc/src/lib.rs
+++ b/fynd-rpc/src/lib.rs
@@ -4,7 +4,8 @@
 //! Wraps [fynd-core](fynd_core) with Actix Web to expose swap-routing as a REST service.
 //! Use [`FyndRPCBuilder`](builder::FyndRPCBuilder) to assemble and start the server.
 //!
-//! For documentation, configuration guides, and API reference see **<https://docs.fynd.xyz/>**.
+//! For documentation and configuration guides see **<https://docs.fynd.xyz/>**.
+//! For the full API reference see **<https://docs.fynd.xyz/reference/api>**.
 //!
 //! ## Endpoints
 //!


### PR DESCRIPTION
All four Rust crates now have complete, navigable docs on docs.rs. Previously, `missing_docs` was not enforced, intra-doc links were broken, and the example code in `fynd-client` used a verbose address instantiation pattern and had a broken doctest.

**What changed:**
- Enforce `#![deny(missing_docs)]` across all crates; fill every gap
- Fix broken intra-doc links in `fynd-core` and `fynd-rpc`
- Expand the `encoding` module doc with links to the tycho-execution and Fynd encoding guide
- Add direct link to the API reference (`docs.fynd.xyz/reference/api`) in `fynd-rpc`
- Fix `fynd-client` doctest: succinct address instantiation, correct `Result` return context, crate-relative example path
- Unpin `fynd-client` README version (`"0.35"` → `"0"`)
- Add a Rust API Reference section to the GitBook sidebar linking to docs.rs for all four crates

Users integrating the Rust crates get accurate, fully linked API docs on docs.rs and can navigate from the GitBook site directly to crate-level reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)