### PR TITLE
feat: harden public API across fynd-core, fynd-rpc, fynd-rpc-types, fynd-client

### DIFF
--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -362,6 +362,7 @@ impl Transaction {
 /// The direction of a swap order.
 ///
 /// Currently only [`Sell`](Self::Sell) (exact-input) is supported.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OrderSide {
     /// Sell exactly the specified `amount` of `token_in` for as much `token_out` as possible.

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 
 /// Configuration for an Algorithm instance.
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct AlgorithmConfig {
     /// Minimum hops to search (must be >= 1).

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -257,6 +257,7 @@ pub enum AlgorithmError {
 }
 
 /// Reason why no path was found between tokens.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NoPathReason {
     /// Source token not present in the routing graph.

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -7,9 +7,6 @@ use tycho_simulation::{tycho_core::traits::FeePriceGetter, tycho_ethereum::gas::
 use crate::feed::{market_data::SharedMarketDataRef, DataFeedError};
 
 // TODO: Refactor gas price fetching into a `DerivedComputation`.
-/// Dependency ID used to register gas price as a market data dependency.
-pub const GAS_PRICE_DEPENDENCY_ID: &str = "gas_price";
-
 pub(crate) struct GasPriceFetcher<C: FeePriceGetter<FeePrice = BlockGasPrice>> {
     client: C,
     signal_rx: mpsc::Receiver<oneshot::Sender<()>>,

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -3,12 +3,9 @@ use std::{collections::HashSet, time::Duration};
 use tycho_simulation::tycho_common::models::Chain;
 
 pub(crate) mod events;
-/// Gas price fetching and the `GAS_PRICE_DEPENDENCY_ID` constant.
-pub mod gas;
+pub(crate) mod gas;
 /// Shared market data store (`SharedMarketData`, `SharedMarketDataRef`).
 pub mod market_data;
-
-pub use gas::GAS_PRICE_DEPENDENCY_ID;
 /// Protocol system registry: maps protocol names to their Tycho identifiers.
 pub mod protocol_registry;
 /// Tycho WebSocket feed: connects to the Tycho data stream and populates `SharedMarketData`.

--- a/fynd-core/src/price_guard/config.rs
+++ b/fynd-core/src/price_guard/config.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// Controls tolerance thresholds, fail-open behavior, and whether validation
 /// is enabled at all. All fields have sensible defaults via [`Default`].
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PriceGuardConfig {
     /// Maximum allowed deviation when `amount_out < expected`, in basis points.

--- a/fynd-core/src/price_guard/provider.rs
+++ b/fynd-core/src/price_guard/provider.rs
@@ -11,6 +11,7 @@ use tycho_simulation::tycho_common::models::Address;
 use crate::feed::market_data::SharedMarketDataRef;
 
 /// Errors that can occur when fetching external prices.
+#[non_exhaustive]
 #[derive(Error, Debug, Clone)]
 pub enum PriceProviderError {
     /// External price source is unavailable.
@@ -18,6 +19,7 @@ pub enum PriceProviderError {
     Unavailable(String),
 
     /// Token address not found in the market data registry (Fynd's data).
+    #[non_exhaustive]
     #[error("token not found: {address}")]
     TokenNotFound {
         /// Hex-encoded address of the missing token.
@@ -25,6 +27,7 @@ pub enum PriceProviderError {
     },
 
     /// No price data from the provider found for the requested token pair.
+    #[non_exhaustive]
     #[error("price not found for pair {token_in} -> {token_out}")]
     PriceNotFound {
         /// Input token identifier.
@@ -34,6 +37,7 @@ pub enum PriceProviderError {
     },
 
     /// Price data is stale (e.g., feed hasn't updated recently).
+    #[non_exhaustive]
     #[error("price data stale: last update {age_ms}ms ago")]
     StaleData {
         /// Milliseconds since the last successful price update.

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -99,6 +99,7 @@ fn default_algo_timeout_ms() -> u64 {
 }
 
 /// Per-pool configuration for [`FyndBuilder::add_pool`].
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolConfig {
     /// Algorithm name for this pool (e.g., `"most_liquid"`).

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -598,6 +598,7 @@ impl Order {
 /// Specifies the side of an order: sell (exact input) or buy (exact output).
 ///
 /// Currently only `Sell` is supported. `Buy` will be added in a future version.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OrderSide {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -66,6 +66,7 @@ impl QuoteRequest {
 }
 
 /// Options to customize the solving behavior.
+#[must_use]
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct QuoteOptions {
@@ -261,6 +262,7 @@ impl FeeBreakdown {
 }
 
 /// Options to customize the encoding behavior.
+#[must_use]
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EncodingOptions {

--- a/fynd-core/src/worker_pool_router/config.rs
+++ b/fynd-core/src/worker_pool_router/config.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 /// Configuration for the WorkerPoolRouter.
+#[must_use]
 #[derive(Debug, Clone)]
 pub struct WorkerPoolRouterConfig {
     /// Default timeout per order (can be overridden per-request).

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -771,6 +771,7 @@ impl Order {
 /// Specifies the side of an order: sell (exact input) or buy (exact output).
 ///
 /// Currently only `Sell` is supported. `Buy` will be added in a future version.
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -111,6 +111,7 @@ pub type Address = Bytes;
 // ============================================================================
 
 /// Request to solve one or more swap orders.
+#[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct QuoteRequest {
@@ -145,6 +146,7 @@ impl QuoteRequest {
 }
 
 /// Options to customize the solving behavior.
+#[must_use]
 #[serde_as]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -441,6 +443,7 @@ impl FeeBreakdown {
 }
 
 /// Options to customize the encoding behavior.
+#[must_use]
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -661,6 +664,7 @@ impl Quote {
 /// A single swap order to be solved.
 ///
 /// An order specifies an intent to swap one token for another.
+#[must_use]
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
@@ -1220,6 +1224,7 @@ impl InstanceInfo {
 }
 
 /// Error response body.
+#[must_use]
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct ErrorResponse {

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -168,10 +168,11 @@ mod tests {
         let pool = &config.pools()["basic"];
         assert_eq!(pool.algorithm(), "most_liquid");
         assert_eq!(pool.num_workers(), num_cpus::get());
-        assert_eq!(pool.task_queue_capacity(), defaults::POOL_TASK_QUEUE_CAPACITY);
-        assert_eq!(pool.min_hops(), defaults::POOL_MIN_HOPS);
-        assert_eq!(pool.max_hops(), defaults::POOL_MAX_HOPS);
-        assert_eq!(pool.timeout_ms(), defaults::POOL_TIMEOUT_MS);
+        use fynd_core::solver::defaults as core_defaults;
+        assert_eq!(pool.task_queue_capacity(), core_defaults::POOL_TASK_QUEUE_CAPACITY);
+        assert_eq!(pool.min_hops(), core_defaults::POOL_MIN_HOPS);
+        assert_eq!(pool.max_hops(), core_defaults::POOL_MAX_HOPS);
+        assert_eq!(pool.timeout_ms(), core_defaults::POOL_TIMEOUT_MS);
         assert_eq!(pool.max_routes(), None);
     }
 
@@ -203,8 +204,7 @@ mod tests {
 pub mod defaults {
     // Re-export shared defaults from fynd-core as the single source of truth.
     pub use fynd_core::solver::defaults::{
-        GAS_REFRESH_INTERVAL, MIN_TOKEN_QUALITY, POOL_MAX_HOPS, POOL_MIN_HOPS,
-        POOL_TASK_QUEUE_CAPACITY, POOL_TIMEOUT_MS, RECONNECT_DELAY, ROUTER_MIN_RESPONSES,
+        GAS_REFRESH_INTERVAL, MIN_TOKEN_QUALITY, RECONNECT_DELAY, ROUTER_MIN_RESPONSES,
         TRADED_N_DAYS_AGO, TVL_BUFFER_RATIO,
     };
 

--- a/fynd-rpc/src/lib.rs
+++ b/fynd-rpc/src/lib.rs
@@ -23,9 +23,3 @@ pub mod builder;
 pub mod config;
 /// Protocol discovery via the Tycho RPC.
 pub mod protocols;
-
-// Re-export key RPC types
-pub use api::{ApiError, AppState, HealthStatus};
-// Re-export price guard types so users can implement custom providers
-// without depending on fynd-core directly.
-pub use fynd_core::price_guard::provider::{ExternalPrice, PriceProvider, PriceProviderError};


### PR DESCRIPTION
## Summary

Audited all four library crates for backwards-compatibility risks and applied
targeted hardening. Changes are grouped by type across crates.

- **`#[non_exhaustive]` on all `OrderSide` enums** — `Buy` is explicitly documented as coming; without this attribute adding it would be semver-breaking (3 crates: `fynd-core`, `fynd-rpc-types`, `fynd-client`)
- **`#[non_exhaustive]` on `NoPathReason` and `PriceProviderError`** — both are extensible error enums with no exhaustive downstream matches; `PriceProviderError` also gets variant-level attributes on its three struct variants (`fynd-core`)
- **`#[must_use]` on builder and config types** — silently discarding a consuming `with_*` return is always a bug; covers `PoolConfig`, `AlgorithmConfig`, `PriceGuardConfig`, `WorkerPoolRouterConfig`, `QuoteOptions`, `EncodingOptions` in `fynd-core` and `QuoteRequest`, `Order`, `EncodingOptions`, `QuoteOptions`, `ErrorResponse` in `fynd-rpc-types`
- **Remove dead `GAS_PRICE_DEPENDENCY_ID` constant** and narrow `feed::gas` to `pub(crate)` (`fynd-core`)
- **Remove unused crate-root re-exports** in `fynd-rpc` (`ApiError`, `AppState`, `HealthStatus`, `ExternalPrice`, `PriceProvider`, `PriceProviderError`) — none consumed by any dependent crate
- **Remove `POOL_*` constants from `fynd-rpc`'s public defaults** — only used in own tests; updated tests to import from `fynd_core::solver::defaults` directly

## Test plan

- [x] `./check.sh` — 503 tests pass, 3 skipped (pre-existing)
- [x] All 7 commits pass the pre-commit hook individually
- [x] No wildcard match arms added — all `OrderSide` matches are within their defining crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)