### PR TITLE
feat(config): embed worker_pools.toml defaults in binary

### DIFF
--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -8,6 +8,12 @@ use anyhow::{Context, Result};
 pub use fynd_core::PoolConfig;
 use serde::{Deserialize, Serialize};
 
+/// The default worker pools configuration embedded at compile time.
+///
+/// Used as a fallback when the default `worker_pools.toml` path is not found at runtime,
+/// so the binary works out-of-the-box without a config file (e.g. `cargo install`, Docker).
+const DEFAULT_WORKER_POOLS_TOML: &str = include_str!("../../worker_pools.toml");
+
 /// Worker pools configuration loaded from TOML file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerPoolsConfig {
@@ -29,6 +35,13 @@ impl WorkerPoolsConfig {
     /// Consumes the config and returns the pools map.
     pub fn into_pools(self) -> HashMap<String, PoolConfig> {
         self.pools
+    }
+
+    /// Returns the built-in default configuration embedded in the binary.
+    ///
+    /// This is the repo-root `worker_pools.toml` baked in at compile time.
+    pub fn builtin_default() -> Self {
+        toml::from_str(DEFAULT_WORKER_POOLS_TOML).expect("built-in worker_pools.toml is valid TOML")
     }
 
     /// Load worker pools configuration from a TOML file.
@@ -82,6 +95,12 @@ impl BlacklistConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_builtin_default_does_not_panic() {
+        let config = WorkerPoolsConfig::builtin_default();
+        assert!(!config.pools().is_empty(), "built-in config must have at least one pool");
+    }
 
     #[test]
     fn test_pool_config_minimal_uses_defaults() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,11 +179,21 @@ fn create_metrics_exporter() -> tokio::task::JoinHandle<()> {
 /// Sets up the solver (loads config, parses chain, builds solver).
 /// Returns setup errors if any step fails.
 async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRPC, SolverError> {
-    // Load worker pools config
+    // Load worker pools config, falling back to the built-in defaults when the default path is
+    // absent (e.g. `cargo install`, Docker). Custom paths that don't exist still fail fast.
+    let default_path = std::path::Path::new("worker_pools.toml");
     let pools_config =
-        WorkerPoolsConfig::load_from_file(&args.worker_pools_config).map_err(|e| {
-            SolverError::SetupError(format!("failed to load worker pools config: {}", e))
-        })?;
+        if args.worker_pools_config == default_path && !args.worker_pools_config.exists() {
+            warn!(
+                "worker_pools.toml not found; using built-in defaults. \
+             Set --worker-pools-config or WORKER_POOLS_CONFIG to use a custom config."
+            );
+            WorkerPoolsConfig::builtin_default()
+        } else {
+            WorkerPoolsConfig::load_from_file(&args.worker_pools_config).map_err(|e| {
+                SolverError::SetupError(format!("failed to load worker pools config: {}", e))
+            })?
+        };
 
     // Parse chain
     let chain = parse_chain(&args.chain)


### PR DESCRIPTION
## Summary

- Bakes `worker_pools.toml` into the binary at compile time via `include_str!()` in `fynd-rpc/src/config.rs`
- Adds `WorkerPoolsConfig::builtin_default()` that parses the embedded TOML
- Falls back to built-in defaults in `src/main.rs` when the default path (`worker_pools.toml`) is absent, with a `warn!` log; custom paths that don't exist still fail fast

Fixes `fynd serve` failing on startup after `cargo install fynd` or in Docker, where no `worker_pools.toml` exists next to the binary.

## Test plan

- [ ] Run `fynd serve --tycho-api-key test` in a directory without `worker_pools.toml` — confirm it warns and starts (rather than erroring)
- [ ] Run with `--worker-pools-config missing.toml` — confirm it still errors with a clear message
- [ ] Run with a valid custom `--worker-pools-config` — confirm it loads without the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)