### PR TITLE
fix: remove runtime workaround for tycho-execution encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7551,9 +7551,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.170.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e63bfe29aee2d12e1e49674056bfb94a264dd8d7bb66ca70200de0ab58eea06"
+version = "0.171.0"
+source = "git+https://github.com/propeller-heads/tycho-contracts.git?branch=dc%2Fimprove-block-inplace#08061a9a2b80f67f7ef26c46e3a9704f8d7d5c6d"
 dependencies = [
  "alloy",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7551,8 +7551,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.171.0"
-source = "git+https://github.com/propeller-heads/tycho-contracts.git?branch=dc%2Fimprove-block-inplace#08061a9a2b80f67f7ef26c46e3a9704f8d7d5c6d"
+version = "0.171.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db780787dcc27ea6550a89b5811ad6a6b000d608a52bc6529f525b3934631dc"
 dependencies = [
  "alloy",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Tycho
 tycho-simulation = ">=0.251.1"
-tycho-execution = { version = ">=0.170.0", features = ["evm"] }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-contracts.git", branch = "dc/improve-block-inplace", features = ["evm"] }
 typetag = "0.2"
 
 # Graph algorithms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Tycho
 tycho-simulation = ">=0.251.1"
-tycho-execution = { git = "https://github.com/propeller-heads/tycho-contracts.git", branch = "dc/improve-block-inplace", features = ["evm"] }
+tycho-execution = ">=0.171.1"
 typetag = "0.2"
 
 # Graph algorithms

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -40,23 +40,6 @@ pub struct Encoder {
     tycho_encoder: Box<dyn TychoEncoder>,
     chain: Chain,
     router_address: Bytes,
-    /// Dedicated multi-threaded runtime so that swap encoders using
-    /// `block_in_place` (e.g. Bebop RFQ) work even when the caller
-    /// runs on a current-thread runtime (actix-web workers).
-    encoding_rt: Option<Arc<tokio::runtime::Runtime>>,
-}
-
-impl Drop for Encoder {
-    fn drop(&mut self) {
-        // Take ownership so the field auto-drop is a no-op.
-        // If inside an async context, move shutdown to a background
-        // thread to avoid the "cannot drop a runtime" panic.
-        if let Some(rt) = self.encoding_rt.take() {
-            if tokio::runtime::Handle::try_current().is_ok() {
-                std::thread::spawn(move || drop(rt));
-            }
-        }
-    }
 }
 
 impl TryFrom<&OrderQuote> for Solution {
@@ -124,13 +107,6 @@ impl Encoder {
         let router_address = get_router_address(&chain)
             .map_err(|e| SolveError::FailedEncoding(e.to_string()))?
             .clone();
-        let encoding_rt = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .build()
-            .map_err(|e| {
-                SolveError::FailedEncoding(format!("failed to create encoding runtime: {e}"))
-            })?;
         Ok(Self {
             tycho_encoder: TychoRouterEncoderBuilder::new()
                 .chain(chain)
@@ -138,7 +114,6 @@ impl Encoder {
                 .build()?,
             chain,
             router_address,
-            encoding_rt: Some(Arc::new(encoding_rt)),
         })
     }
 
@@ -185,21 +160,9 @@ impl Encoder {
             .iter()
             .map(|(_, s)| s.clone())
             .collect();
-        let rt = self
-            .encoding_rt
-            .as_ref()
-            .ok_or_else(|| SolveError::FailedEncoding("encoding runtime was dropped".into()))?;
-        let encoded_solutions = std::thread::scope(|scope| {
-            scope
-                .spawn(|| {
-                    rt.block_on(async {
-                        self.tycho_encoder
-                            .encode_solutions(solutions)
-                    })
-                })
-                .join()
-                .expect("encoding thread panicked")
-        })?;
+        let encoded_solutions = self
+            .tycho_encoder
+            .encode_solutions(solutions)?;
 
         for (encoded_solution, (idx, solution)) in encoded_solutions
             .into_iter()
@@ -502,13 +465,6 @@ mod tests {
             tycho_encoder: Box::new(MockTychoEncoder),
             chain,
             router_address: Bytes::from([0u8; 20].as_ref()),
-            encoding_rt: Some(Arc::new(
-                tokio::runtime::Builder::new_multi_thread()
-                    .worker_threads(1)
-                    .enable_all()
-                    .build()
-                    .unwrap(),
-            )),
         }
     }
 


### PR DESCRIPTION
tycho-execution no longer uses block_in_place, so callers don't need to provide a dedicated multi-thread runtime for encoding. This removes the encoding_rt field, the custom Drop impl, and the std::thread::scope dispatch from Encoder -- encode_solutions is now called directly.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
