### PR TITLE
fix(config): inline worker_pools defaults to fix cargo publish

### DIFF
--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -12,7 +12,34 @@ use serde::{Deserialize, Serialize};
 ///
 /// Used as a fallback when the default `worker_pools.toml` path is not found at runtime,
 /// so the binary works out-of-the-box without a config file (e.g. `cargo install`, Docker).
-const DEFAULT_WORKER_POOLS_TOML: &str = include_str!("../../worker_pools.toml");
+///
+/// Keep in sync with the repo-root `worker_pools.toml` (the user-facing example config).
+/// Cannot use `include_str!` here because `cargo publish` verifies the crate in isolation,
+/// and the file lives outside the `fynd-rpc` package directory.
+const DEFAULT_WORKER_POOLS_TOML: &str = r#"
+[pools.most_liquid_2_hops_fast]
+algorithm = "most_liquid"
+num_workers = 5
+task_queue_capacity = 1000
+max_hops = 2
+timeout_ms = 100
+max_routes = 50
+
+[pools.most_liquid_3_hops]
+algorithm = "most_liquid"
+num_workers = 3
+task_queue_capacity = 1000
+min_hops = 2
+max_hops = 3
+timeout_ms = 5000
+
+[pools.bellman_ford_5_hops]
+algorithm = "bellman_ford"
+num_workers = 3
+task_queue_capacity = 1000
+max_hops = 5
+timeout_ms = 500
+"#;
 
 /// Worker pools configuration loaded from TOML file.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- Replaces `include_str!("../../worker_pools.toml")` with an inline string constant in `fynd-rpc/src/config.rs`

`cargo publish` verifies each crate in isolation in a temp directory. The `include_str!` path pointed outside the `fynd-rpc` package tree, so compilation failed with:
```
error: couldn't read `src/../../worker_pools.toml`: No such file or directory
```

The fix inlines the TOML content directly. The repo-root `worker_pools.toml` stays as the user-facing example config; a comment notes the two should be kept in sync.

## Test plan

- [ ] `cargo test -p fynd-rpc test_builtin_default` passes
- [ ] Re-run the release workflow and confirm `cargo publish --package fynd-rpc` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)