### PR TITLE
fix(config): embed default configs in binary to fix cargo publish

### DIFF
--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -91,7 +91,43 @@ pub struct BlacklistConfig {
     components: HashSet<String>,
 }
 
+/// The default blacklist configuration embedded at compile time.
+///
+/// Keep in sync with the repo-root `blacklist.toml` (the user-facing example config).
+/// Cannot use `include_str!` here because `cargo publish` verifies the crate in isolation,
+/// and the file lives outside the `fynd-rpc` package directory.
+const DEFAULT_BLACKLIST_TOML: &str = r#"
+[blacklist]
+components = [
+    # AMPL pools - AMPL is a rebasing token that breaks simulation assumptions
+    # UniswapV3 AMPL/WETH
+    "0x86d257cdb7bc9c0df10e84c8709697f92770b335",
+    # UniswapV2 AMPL/WETH
+    "0xc5be99a02c6857f9eac67bbce58df5572498f40c",
+    # Fluid Lite pools with broken simulation (ENG-5696)
+    "0x32aa6f5c6f771b39d383c6e36d7ef0702a28e32ad64671c059f41547b82ef0ef",
+    "0x7f31b44f032f125bb465c161343fccfdc88fee8dc94c068f6430d2345d80f1d1",
+    # Curve yETH/WETH — exploited Nov 2025 ($9M), broken invariant, pool insolvent
+    "0x69accb968b19a53790f43e57558f5e443a91af22",
+    # Fluid syrupUSDC/USDC — ERC-4626 vault token, simulation can't track accumulating rate
+    "0x79eea4a1be86c43a9a9c4384b0b28a07af24ae29",
+]
+"#;
+
 impl BlacklistConfig {
+    /// Returns the built-in default blacklist embedded in the binary.
+    ///
+    /// This is the repo-root `blacklist.toml` baked in at compile time.
+    pub fn builtin_default() -> Self {
+        #[derive(Deserialize)]
+        struct Wrapper {
+            blacklist: BlacklistConfig,
+        }
+        let wrapper: Wrapper =
+            toml::from_str(DEFAULT_BLACKLIST_TOML).expect("built-in blacklist.toml is valid TOML");
+        wrapper.blacklist
+    }
+
     /// Load blacklist configuration from a TOML file.
     ///
     /// The TOML file should have a `[blacklist]` section:
@@ -127,6 +163,15 @@ mod tests {
     fn test_builtin_default_does_not_panic() {
         let config = WorkerPoolsConfig::builtin_default();
         assert!(!config.pools().is_empty(), "built-in config must have at least one pool");
+    }
+
+    #[test]
+    fn test_blacklist_builtin_default_does_not_panic() {
+        let config = BlacklistConfig::builtin_default();
+        assert!(
+            !config.components.is_empty(),
+            "built-in blacklist must have at least one component"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,9 +282,19 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
         builder = builder.tycho_api_key(api_key.clone());
     }
     if let Some(blacklist_path) = &args.blacklist_config {
-        let blacklist = BlacklistConfig::load_from_file(blacklist_path).map_err(|e| {
-            SolverError::SetupError(format!("failed to load blacklist config: {}", e))
-        })?;
+        let default_blacklist_path = std::path::Path::new("blacklist.toml");
+        let blacklist =
+            if blacklist_path.as_path() == default_blacklist_path && !blacklist_path.exists() {
+                warn!(
+                    "blacklist.toml not found; using built-in defaults. \
+                     Set --blacklist-config or BLACKLIST_CONFIG to use a custom config."
+                );
+                BlacklistConfig::builtin_default()
+            } else {
+                BlacklistConfig::load_from_file(blacklist_path).map_err(|e| {
+                    SolverError::SetupError(format!("failed to load blacklist config: {}", e))
+                })?
+            };
         builder = builder.blacklist(blacklist);
     }
 


### PR DESCRIPTION
## Summary

- Fixes `cargo publish` failure for `fynd-rpc`: `include_str!("../../worker_pools.toml")` resolved correctly in the workspace but failed during crate verification (the file is outside the package tree)
- Inlines both `worker_pools.toml` and `blacklist.toml` as string constants in `fynd-rpc/src/config.rs`
- Adds `WorkerPoolsConfig::builtin_default()` and `BlacklistConfig::builtin_default()`
- Falls back to built-in defaults in `src/main.rs` when the default path is missing, with a `warn!` log; custom paths that don't exist still fail fast
- Adds unit tests for both `builtin_default()` methods

The repo-root `.toml` files stay as the user-facing example configs; a comment in each constant notes they should be kept in sync.

Verified with `cargo publish --dry-run --package fynd-rpc`.

## Test plan

- [ ] `cargo test -p fynd-rpc` passes
- [ ] Re-run the release workflow and confirm `cargo publish --package fynd-rpc` succeeds
- [ ] Start `fynd serve` in a directory without either `.toml` file — confirm it warns and starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)