### PR TITLE
feat: Enable using PriceGuard in FyndBuilder

### DIFF
--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.35.0"
+    "version": "0.49.1"
   },
   "paths": {
     "/v1/health": {
@@ -236,6 +236,17 @@
             ],
             "description": "Permit2 signature (65 bytes, hex-encoded). Required when `permit` is set.",
             "example": "0xabcd..."
+          },
+          "price_guard": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PriceGuardConfig",
+                "description": "Per-request price guard overrides. If `None`, uses server defaults."
+              }
+            ]
           },
           "slippage": {
             "type": "number",
@@ -581,6 +592,13 @@
         "type": "object",
         "description": "Per-request overrides for price guard validation.\n\nAll fields are optional. When `None`, the server's configured defaults are used.",
         "properties": {
+          "enabled": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "description": "Whether price guard validation is enabled."
+          },
           "fail_on_provider_error": {
             "type": [
               "boolean",
@@ -594,13 +612,6 @@
               "null"
             ],
             "description": "Whether to reject solutions when no provider returns price for token pair."
-          },
-          "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ],
-            "description": "Whether price guard validation is enabled."
           },
           "lower_tolerance_bps": {
             "type": [
@@ -684,17 +695,6 @@
             ],
             "description": "Minimum number of solver responses to wait for before returning.\nIf `None` or `0`, waits for all solvers to respond (or timeout).\n\nUse the `/health` endpoint to check `num_solver_pools` before setting this value.\nValues exceeding the number of active solver pools are clamped internally.",
             "minimum": 0
-          },
-          "price_guard": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/PriceGuardConfig",
-                "description": "Per-request price guard overrides. If `None`, uses server defaults."
-              }
-            ]
           },
           "timeout_ms": {
             "type": [

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -581,19 +581,19 @@
         "type": "object",
         "description": "Per-request overrides for price guard validation.\n\nAll fields are optional. When `None`, the server's configured defaults are used.",
         "properties": {
-          "allow_on_provider_error": {
+          "fail_on_provider_error": {
             "type": [
               "boolean",
               "null"
             ],
-            "description": "Whether to let solutions pass when no provider can return a price."
+            "description": "Whether to reject solutions when no provider can return a price."
           },
-          "allow_on_token_price_not_found": {
+          "fail_on_token_price_not_found": {
             "type": [
               "boolean",
               "null"
             ],
-            "description": "Whether to let solutions pass when no provider returns price for token pair."
+            "description": "Whether to reject solutions when no provider returns price for token pair."
           },
           "enabled": {
             "type": [

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -60,7 +60,9 @@ impl ErrorCode {
             "QUEUE_FULL" | "SERVICE_OVERLOADED" | "STALE_DATA" | "NOT_READY" => {
                 Self::ServiceUnavailable
             }
-            "ALGORITHM_ERROR" | "INTERNAL_ERROR" | "FAILED_ENCODING" => Self::ServerError,
+            "ALGORITHM_ERROR" | "INTERNAL_ERROR" | "FAILED_ENCODING" | "PRICE_CHECK_FAILED" => {
+                Self::ServerError
+            }
             "NOT_FOUND" => Self::NotFound,
             other => Self::Unknown(other.to_string()),
         }

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -83,8 +83,8 @@ pub use signing::{
 };
 pub use types::{
     BackendKind, BatchQuoteParams, BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown,
-    HealthStatus, InstanceInfo, Order, OrderSide, PermitDetails, PermitSingle, Quote, QuoteOptions,
-    QuoteParams, QuoteStatus, Route, Swap, Transaction, UserTransferType,
+    HealthStatus, InstanceInfo, Order, OrderSide, PermitDetails, PermitSingle, PriceGuardConfig,
+    Quote, QuoteOptions, QuoteParams, QuoteStatus, Route, Swap, Transaction, UserTransferType,
 };
 
 mod client;

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -137,6 +137,9 @@ impl TryFrom<QuoteOptions> for dto::QuoteOptions {
         if let Some(enc) = opts.encoding_options {
             dto_opts = dto_opts.with_encoding_options(dto::EncodingOptions::try_from(enc)?);
         }
+        if let Some(pg) = opts.price_guard {
+            dto_opts = dto_opts.with_price_guard(pg);
+        }
         Ok(dto_opts)
     }
 }
@@ -295,7 +298,8 @@ impl From<dto::QuoteStatus> for QuoteStatus {
             dto::QuoteStatus::InsufficientLiquidity => Self::InsufficientLiquidity,
             dto::QuoteStatus::Timeout => Self::Timeout,
             dto::QuoteStatus::NotReady => Self::NotReady,
-            _ => unreachable!("unexpected QuoteStatus variant"),
+            dto::QuoteStatus::PriceCheckFailed => Self::PriceCheckFailed,
+            _ => Self::NotReady,
         }
     }
 }
@@ -514,6 +518,7 @@ mod tests {
         ));
         assert!(matches!(QuoteStatus::from(Dto::Timeout), QuoteStatus::Timeout));
         assert!(matches!(QuoteStatus::from(Dto::NotReady), QuoteStatus::NotReady));
+        assert!(matches!(QuoteStatus::from(Dto::PriceCheckFailed), QuoteStatus::PriceCheckFailed));
     }
 
     // -----------------------------------------------------------------------

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -137,9 +137,6 @@ impl TryFrom<QuoteOptions> for dto::QuoteOptions {
         if let Some(enc) = opts.encoding_options {
             dto_opts = dto_opts.with_encoding_options(dto::EncodingOptions::try_from(enc)?);
         }
-        if let Some(pg) = opts.price_guard {
-            dto_opts = dto_opts.with_price_guard(pg);
-        }
         Ok(dto_opts)
     }
 }
@@ -171,6 +168,9 @@ impl TryFrom<EncodingOptions> for dto::EncodingOptions {
                         .as_ref(),
                 ),
             ));
+        }
+        if let Some(pg) = opts.price_guard {
+            dto_opts = dto_opts.with_price_guard(pg);
         }
         Ok(dto_opts)
     }

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -269,6 +269,7 @@ pub struct EncodingOptions {
     pub(crate) permit: Option<PermitSingle>,
     pub(crate) permit2_signature: Option<Bytes>,
     pub(crate) client_fee_params: Option<ClientFeeParams>,
+    pub(crate) price_guard: Option<PriceGuardConfig>,
 }
 
 impl EncodingOptions {
@@ -283,6 +284,7 @@ impl EncodingOptions {
             permit: None,
             permit2_signature: None,
             client_fee_params: None,
+            price_guard: None,
         }
     }
 
@@ -320,6 +322,14 @@ impl EncodingOptions {
     /// Attach client fee configuration with a pre-signed EIP-712 signature.
     pub fn with_client_fee(mut self, params: ClientFeeParams) -> Self {
         self.client_fee_params = Some(params);
+        self
+    }
+
+    /// Override server-side price guard defaults for this request.
+    ///
+    /// Fields left as `None` in [`PriceGuardConfig`] inherit the server defaults.
+    pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
+        self.price_guard = Some(config);
         self
     }
 }
@@ -454,7 +464,6 @@ pub struct QuoteOptions {
     pub(crate) min_responses: Option<usize>,
     pub(crate) max_gas: Option<BigUint>,
     pub(crate) encoding_options: Option<EncodingOptions>,
-    pub(crate) price_guard: Option<PriceGuardConfig>,
 }
 
 impl QuoteOptions {
@@ -486,16 +495,6 @@ impl QuoteOptions {
         self
     }
 
-    /// Override server-side price guard defaults for this request.
-    ///
-    /// When the server has the price guard enabled, this allows per-request
-    /// tuning of tolerance thresholds and fail-open behavior. Fields left as
-    /// `None` in [`PriceGuardConfig`] inherit the server defaults.
-    pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
-        self.price_guard = Some(config);
-        self
-    }
-
     /// The configured timeout in milliseconds, or `None` if using the server default.
     pub fn timeout_ms(&self) -> Option<u64> {
         self.timeout_ms
@@ -511,10 +510,6 @@ impl QuoteOptions {
         self.max_gas.as_ref()
     }
 
-    /// Per-request price guard overrides, or `None` if using server defaults.
-    pub fn price_guard(&self) -> Option<&PriceGuardConfig> {
-        self.price_guard.as_ref()
-    }
 }
 
 /// All inputs needed to call [`FyndClient::quote`](crate::FyndClient::quote).

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -439,6 +439,12 @@ impl Order {
     }
 }
 
+/// Per-request overrides for price guard validation.
+///
+/// All fields are optional. When `None`, the server's configured defaults are used.
+/// Re-exported from `fynd-rpc-types` for wire compatibility.
+pub use fynd_rpc_types::PriceGuardConfig;
+
 /// Optional parameters that tune solving behaviour for a [`QuoteParams`] request.
 ///
 /// Build via the builder methods; unset options use server defaults.
@@ -448,6 +454,7 @@ pub struct QuoteOptions {
     pub(crate) min_responses: Option<usize>,
     pub(crate) max_gas: Option<BigUint>,
     pub(crate) encoding_options: Option<EncodingOptions>,
+    pub(crate) price_guard: Option<PriceGuardConfig>,
 }
 
 impl QuoteOptions {
@@ -479,6 +486,16 @@ impl QuoteOptions {
         self
     }
 
+    /// Override server-side price guard defaults for this request.
+    ///
+    /// When the server has the price guard enabled, this allows per-request
+    /// tuning of tolerance thresholds and fail-open behavior. Fields left as
+    /// `None` in [`PriceGuardConfig`] inherit the server defaults.
+    pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
+        self.price_guard = Some(config);
+        self
+    }
+
     /// The configured timeout in milliseconds, or `None` if using the server default.
     pub fn timeout_ms(&self) -> Option<u64> {
         self.timeout_ms
@@ -492,6 +509,11 @@ impl QuoteOptions {
     /// The configured gas cap, or `None` if no cap was set.
     pub fn max_gas(&self) -> Option<&BigUint> {
         self.max_gas.as_ref()
+    }
+
+    /// Per-request price guard overrides, or `None` if using server defaults.
+    pub fn price_guard(&self) -> Option<&PriceGuardConfig> {
+        self.price_guard.as_ref()
     }
 }
 
@@ -555,6 +577,8 @@ pub enum QuoteStatus {
     Timeout,
     /// No solver workers are initialised yet (e.g. market data not loaded).
     NotReady,
+    /// The solution failed external price validation.
+    PriceCheckFailed,
 }
 
 /// Ethereum block at which a quote was computed.

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -509,7 +509,6 @@ impl QuoteOptions {
     pub fn max_gas(&self) -> Option<&BigUint> {
         self.max_gas.as_ref()
     }
-
 }
 
 /// All inputs needed to call [`FyndClient::quote`](crate::FyndClient::quote).

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -142,6 +142,7 @@ export interface components {
              * @example 0xabcd...
              */
             permit2_signature?: string | null;
+            price_guard?: null | components["schemas"]["PriceGuardConfig"];
             /**
              * Format: double
              * @example 0.001
@@ -377,12 +378,12 @@ export interface components {
          *     All fields are optional. When `None`, the server's configured defaults are used.
          */
         PriceGuardConfig: {
+            /** @description Whether price guard validation is enabled. */
+            enabled?: boolean | null;
             /** @description Whether to reject solutions when no provider can return a price. */
             fail_on_provider_error?: boolean | null;
             /** @description Whether to reject solutions when no provider returns price for token pair. */
             fail_on_token_price_not_found?: boolean | null;
-            /** @description Whether price guard validation is enabled. */
-            enabled?: boolean | null;
             /**
              * Format: int32
              * @description Maximum allowed deviation when `amount_out < expected`, in basis points.
@@ -433,7 +434,6 @@ export interface components {
              *     Values exceeding the number of active solver pools are clamped internally.
              */
             min_responses?: number | null;
-            price_guard?: null | components["schemas"]["PriceGuardConfig"];
             /**
              * Format: int64
              * @description Timeout in milliseconds. If `None`, uses server default.

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -377,10 +377,10 @@ export interface components {
          *     All fields are optional. When `None`, the server's configured defaults are used.
          */
         PriceGuardConfig: {
-            /** @description Whether to let solutions pass when no provider can return a price. */
-            allow_on_provider_error?: boolean | null;
-            /** @description Whether to let solutions pass when no provider returns price for token pair. */
-            allow_on_token_price_not_found?: boolean | null;
+            /** @description Whether to reject solutions when no provider can return a price. */
+            fail_on_provider_error?: boolean | null;
+            /** @description Whether to reject solutions when no provider returns price for token pair. */
+            fail_on_token_price_not_found?: boolean | null;
             /** @description Whether price guard validation is enabled. */
             enabled?: boolean | null;
             /**

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -47,7 +47,10 @@ pub mod worker_pool_router;
 pub use algorithm::{Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgorithm};
 // Required for implementing the Algorithm trait externally
 pub use derived::computation::ComputationRequirements;
-pub use price_guard::config::PriceGuardConfig;
+pub use price_guard::{
+    config::PriceGuardConfig,
+    provider::{ExternalPrice, PriceProvider, PriceProviderError},
+};
 pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
 pub use types::{
     BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, FeeBreakdown, Order, OrderQuote,

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -25,23 +25,6 @@ use super::{
 };
 use crate::feed::market_data::SharedMarketDataRef;
 
-/// Maps on-chain token symbols to their Binance spot trading names.
-///
-/// On-chain tokens use wrapped ("W"-prefixed) names for native gas tokens, but Binance
-/// lists the unwrapped base asset.
-///
-/// Binance-specific: MATIC was renamed to POL (Polygon rebrand).
-fn normalize_symbol(symbol: &str) -> String {
-    match symbol.to_uppercase().as_str() {
-        "WETH" => "ETH".to_string(),
-        "WBTC" => "BTC".to_string(),
-        "WBNB" => "BNB".to_string(),
-        "WMATIC" | "MATIC" => "POL".to_string(),
-        "WAVAX" => "AVAX".to_string(),
-        other => other.to_string(),
-    }
-}
-
 const DEFAULT_WS_URL: &str = "wss://stream.binance.com:9443/ws";
 const DEFAULT_EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
 

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -25,6 +25,23 @@ use super::{
 };
 use crate::feed::market_data::SharedMarketDataRef;
 
+/// Maps on-chain token symbols to their Binance spot trading names.
+///
+/// On-chain tokens use wrapped ("W"-prefixed) names for native gas tokens, but Binance
+/// lists the unwrapped base asset.
+///
+/// Binance-specific: MATIC was renamed to POL (Polygon rebrand).
+fn normalize_symbol(symbol: &str) -> String {
+    match symbol.to_uppercase().as_str() {
+        "WETH" => "ETH".to_string(),
+        "WBTC" => "BTC".to_string(),
+        "WBNB" => "BNB".to_string(),
+        "WMATIC" | "MATIC" => "POL".to_string(),
+        "WAVAX" => "AVAX".to_string(),
+        other => other.to_string(),
+    }
+}
+
 const DEFAULT_WS_URL: &str = "wss://stream.binance.com:9443/ws";
 const DEFAULT_EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
 

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -267,8 +267,8 @@ impl PriceProvider for BinanceWsProvider {
             .read()
             .map_err(|e| PriceProviderError::Unavailable(format!("ticker cache poisoned: {e}")))?;
 
-        let lookup = Self::resolve_price(&cache, &sym_in, &sym_out).ok_or_else(|| {
-            PriceProviderError::TokenNotFound { address: format!("{sym_in}/{sym_out}") }
+        let lookup = Self::resolve_price(&cache, &sym_in, &sym_out).ok_or({
+            PriceProviderError::PriceNotFound { token_in: sym_in, token_out: sym_out }
         })?;
 
         check_staleness(lookup.timestamp_ms)?;

--- a/fynd-core/src/price_guard/config.rs
+++ b/fynd-core/src/price_guard/config.rs
@@ -31,7 +31,7 @@ pub struct PriceGuardConfig {
     allow_on_token_price_not_found: bool,
 
     /// Whether the price guard is enabled.
-    /// Default: `true`.
+    /// Default: `false`.
     enabled: bool,
 }
 

--- a/fynd-core/src/price_guard/config.rs
+++ b/fynd-core/src/price_guard/config.rs
@@ -20,15 +20,15 @@ pub struct PriceGuardConfig {
 
     /// Controls behavior when all providers error for reasons unrelated to pricing
     /// (network issues, API down).
-    /// `false` (default): reject solutions when no provider can return a price.
-    /// `true`: let solutions pass through when no provider can be reached.
-    allow_on_provider_error: bool,
+    /// `true`: reject solutions when no provider can return a price.
+    /// `false` (default): let solutions pass through when no provider can be reached.
+    fail_on_provider_error: bool,
 
     /// Controls behavior when every provider returns `PriceNotFound` for the
     /// requested token pair.
-    /// `false` (default): reject solutions for unknown token pairs.
-    /// `true`: let solutions pass through when no provider has a price.
-    allow_on_token_price_not_found: bool,
+    /// `true`: reject solutions for unknown token pairs.
+    /// `false` (default): let solutions pass through when no provider has a price.
+    fail_on_token_price_not_found: bool,
 
     /// Whether the price guard is enabled.
     /// Default: `false`.
@@ -40,8 +40,8 @@ impl Default for PriceGuardConfig {
         Self {
             lower_tolerance_bps: 300,
             upper_tolerance_bps: 10_000,
-            allow_on_provider_error: false,
-            allow_on_token_price_not_found: false,
+            fail_on_provider_error: false,
+            fail_on_token_price_not_found: false,
             enabled: false,
         }
     }
@@ -58,14 +58,14 @@ impl PriceGuardConfig {
         self.upper_tolerance_bps
     }
 
-    /// Whether solutions pass through when all providers are unreachable.
-    pub fn allow_on_provider_error(&self) -> bool {
-        self.allow_on_provider_error
+    /// Whether solutions are rejected when all providers are unreachable.
+    pub fn fail_on_provider_error(&self) -> bool {
+        self.fail_on_provider_error
     }
 
-    /// Whether solutions pass through when no provider has a price for the pair.
-    pub fn allow_on_token_price_not_found(&self) -> bool {
-        self.allow_on_token_price_not_found
+    /// Whether solutions are rejected when no provider has a price for the pair.
+    pub fn fail_on_token_price_not_found(&self) -> bool {
+        self.fail_on_token_price_not_found
     }
 
     /// Whether price-guard validation is enabled.
@@ -85,15 +85,15 @@ impl PriceGuardConfig {
         self
     }
 
-    /// Set whether solutions pass through when all providers error.
-    pub fn with_allow_on_provider_error(mut self, allow: bool) -> Self {
-        self.allow_on_provider_error = allow;
+    /// Set whether solutions are rejected when all providers error.
+    pub fn with_fail_on_provider_error(mut self, fail: bool) -> Self {
+        self.fail_on_provider_error = fail;
         self
     }
 
-    /// Set whether solutions pass through when no provider has a price.
-    pub fn with_allow_on_token_price_not_found(mut self, allow: bool) -> Self {
-        self.allow_on_token_price_not_found = allow;
+    /// Set whether solutions are rejected when no provider has a price.
+    pub fn with_fail_on_token_price_not_found(mut self, fail: bool) -> Self {
+        self.fail_on_token_price_not_found = fail;
         self
     }
 

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -126,7 +126,7 @@ impl PriceGuard {
                     price_out_of_tolerance = true;
                 }
                 Err(e) => {
-                    if let PriceProviderError::TokenNotFound { .. } = e {
+                    if let PriceProviderError::PriceNotFound { .. } = e {
                     } else {
                         has_provider_error = true;
                     }

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -126,7 +126,7 @@ impl PriceGuard {
                     price_out_of_tolerance = true;
                 }
                 Err(e) => {
-                    if let PriceProviderError::PriceNotFound { .. } = e {
+                    if let PriceProviderError::TokenNotFound { .. } = e {
                     } else {
                         has_provider_error = true;
                     }

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -138,9 +138,9 @@ impl PriceGuard {
             return false;
         }
         if has_provider_error {
-            config.fail_on_provider_error()
+            !config.fail_on_provider_error()
         } else {
-            config.fail_on_token_price_not_found()
+            !config.fail_on_token_price_not_found()
         }
     }
 

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -138,9 +138,9 @@ impl PriceGuard {
             return false;
         }
         if has_provider_error {
-            config.allow_on_provider_error()
+            config.fail_on_provider_error()
         } else {
-            config.allow_on_token_price_not_found()
+            config.fail_on_token_price_not_found()
         }
     }
 
@@ -364,13 +364,13 @@ mod tests {
     }
 
     #[rstest]
-    #[case::all_error_allow(true, true)]
-    #[case::all_error_deny(false, false)]
+    #[case::all_error_allow(false, true)]
+    #[case::all_error_deny(true, false)]
     #[test]
-    fn test_all_providers_error(#[case] allow_on_error: bool, #[case] should_pass: bool) {
+    fn test_all_providers_error(#[case] fail_on_error: bool, #[case] should_pass: bool) {
         let config = PriceGuardConfig::default()
             .with_enabled(true)
-            .with_allow_on_provider_error(allow_on_error);
+            .with_fail_on_provider_error(fail_on_error);
         let guard = price_guard(vec![Box::new(FailingProvider), Box::new(FailingProvider)]);
 
         let result = guard
@@ -474,13 +474,13 @@ mod tests {
     }
 
     #[rstest]
-    #[case::allow(true, QuoteStatus::Success)]
-    #[case::deny(false, QuoteStatus::PriceCheckFailed)]
+    #[case::allow(false, QuoteStatus::Success)]
+    #[case::deny(true, QuoteStatus::PriceCheckFailed)]
     #[test]
-    fn test_all_price_not_found(#[case] allow: bool, #[case] result_status: QuoteStatus) {
+    fn test_all_price_not_found(#[case] fail: bool, #[case] result_status: QuoteStatus) {
         let config = PriceGuardConfig::default()
             .with_enabled(true)
-            .with_allow_on_token_price_not_found(allow);
+            .with_fail_on_token_price_not_found(fail);
         let guard =
             price_guard(vec![Box::new(PriceNotFoundProvider), Box::new(PriceNotFoundProvider)]);
 
@@ -495,11 +495,11 @@ mod tests {
     fn test_mixed_price_not_found_and_error() {
         // When at least one provider has an infrastructure error, the token
         // might be supported but the provider is just down — fall back to
-        // allow_on_provider_error.
+        // fail_on_provider_error.
         let config = PriceGuardConfig::default()
             .with_enabled(true)
-            .with_allow_on_token_price_not_found(true)
-            .with_allow_on_provider_error(false);
+            .with_fail_on_token_price_not_found(false)
+            .with_fail_on_provider_error(true);
         let guard = price_guard(vec![Box::new(PriceNotFoundProvider), Box::new(FailingProvider)]);
 
         let result = guard
@@ -517,7 +517,7 @@ mod tests {
         let config = PriceGuardConfig::default()
             .with_enabled(true)
             .with_lower_tolerance_bps(300)
-            .with_allow_on_token_price_not_found(false);
+            .with_fail_on_token_price_not_found(true);
         let guard = price_guard(vec![mock_provider(1000), Box::new(PriceNotFoundProvider)]);
 
         let result = guard
@@ -535,7 +535,7 @@ mod tests {
         let config = PriceGuardConfig::default()
             .with_enabled(true)
             .with_lower_tolerance_bps(300)
-            .with_allow_on_token_price_not_found(true);
+            .with_fail_on_token_price_not_found(false);
         let guard = price_guard(vec![mock_provider(1000), Box::new(PriceNotFoundProvider)]);
 
         let result = guard
@@ -547,11 +547,11 @@ mod tests {
 
     #[test]
     fn test_price_not_found_ignores_provider_error() {
-        // allow_on_provider_error should not allow price-not-found cases.
+        // fail_on_provider_error=false should not affect price-not-found cases.
         let config = PriceGuardConfig::default()
             .with_enabled(true)
-            .with_allow_on_provider_error(true)
-            .with_allow_on_token_price_not_found(false);
+            .with_fail_on_provider_error(false)
+            .with_fail_on_token_price_not_found(true);
         let guard =
             price_guard(vec![Box::new(PriceNotFoundProvider), Box::new(PriceNotFoundProvider)]);
 

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -150,7 +150,10 @@ impl PriceProvider for HyperliquidProvider {
 
         let price_in = cache
             .get(&sym_in)
-            .ok_or(PriceProviderError::TokenNotFound { address: sym_in.clone() })?;
+            .ok_or(PriceProviderError::PriceNotFound {
+                token_in: sym_in.clone(),
+                token_out: sym_out.clone(),
+            })?;
         let price_out = cache
             .get(&sym_out)
             .ok_or(PriceProviderError::PriceNotFound { token_in: sym_in, token_out: sym_out })?;

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -150,10 +150,7 @@ impl PriceProvider for HyperliquidProvider {
 
         let price_in = cache
             .get(&sym_in)
-            .ok_or(PriceProviderError::PriceNotFound {
-                token_in: sym_in.clone(),
-                token_out: sym_out.clone(),
-            })?;
+            .ok_or(PriceProviderError::TokenNotFound { address: sym_in.clone() })?;
         let price_out = cache
             .get(&sym_out)
             .ok_or(PriceProviderError::PriceNotFound { token_in: sym_in, token_out: sym_out })?;

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -33,6 +33,10 @@ use crate::{
         TychoFeedConfig,
     },
     graph::EdgeWeightUpdaterWithDerived,
+    price_guard::{
+        config::PriceGuardConfig, guard::PriceGuard, provider::PriceProvider,
+        provider_registry::PriceProviderRegistry,
+    },
     types::constants::native_token,
     worker_pool::{
         pool::{WorkerPool, WorkerPoolBuilder},
@@ -294,6 +298,8 @@ pub struct FyndBuilder {
     router_min_responses: usize,
     encoder: Option<Encoder>,
     pools: Vec<PoolEntry>,
+    price_guard_config: PriceGuardConfig,
+    price_providers: Vec<Box<dyn PriceProvider>>,
 }
 
 impl FyndBuilder {
@@ -323,6 +329,8 @@ impl FyndBuilder {
             router_min_responses: defaults::ROUTER_MIN_RESPONSES,
             encoder: None,
             pools: Vec::new(),
+            price_guard_config: PriceGuardConfig::default(),
+            price_providers: Vec::new(),
         }
     }
 
@@ -446,6 +454,39 @@ impl FyndBuilder {
         self
     }
 
+    /// Registers the built-in price providers (Hyperliquid + Binance).
+    ///
+    /// Called automatically during [`build`](Self::build) if no providers have been
+    /// registered and the price guard is not disabled. To use only custom
+    /// providers, call [`register_price_provider`](Self::register_price_provider)
+    /// before `build()` and the defaults will be skipped.
+    pub fn add_default_price_providers(self) -> Self {
+        self.register_price_provider(Box::new(
+            crate::price_guard::hyperliquid::HyperliquidProvider::default(),
+        ))
+        .register_price_provider(Box::new(
+            crate::price_guard::binance_ws::BinanceWsProvider::default(),
+        ))
+    }
+
+    /// Registers a custom price provider for the price guard.
+    ///
+    /// The provider's [`start`](PriceProvider::start) method is called during
+    /// [`build`](Self::build) with the shared market data.
+    pub fn register_price_provider(mut self, provider: Box<dyn PriceProvider>) -> Self {
+        self.price_providers.push(provider);
+        self
+    }
+
+    /// Sets the server-side default [`PriceGuardConfig`].
+    ///
+    /// This config is used when a quote request does not include per-request
+    /// price guard overrides. Defaults to [`PriceGuardConfig::default`].
+    pub fn price_guard_config(mut self, config: PriceGuardConfig) -> Self {
+        self.price_guard_config = config;
+        self
+    }
+
     /// Adds a named pool using the given [`PoolConfig`].
     pub fn add_pool(mut self, name: impl Into<String>, config: &PoolConfig) -> Self {
         self.pools.push(PoolEntry::BuiltIn {
@@ -466,9 +507,14 @@ impl FyndBuilder {
     /// # Errors
     ///
     /// Returns [`SolverBuildError`] if any component fails to initialize.
-    pub fn build(self) -> Result<Solver, SolverBuildError> {
+    pub fn build(mut self) -> Result<Solver, SolverBuildError> {
         if self.pools.is_empty() {
             return Err(SolverBuildError::NoPools);
+        }
+
+        // Add built-in providers if none were explicitly registered.
+        if self.price_providers.is_empty() {
+            self = self.add_default_price_providers();
         }
 
         let market_data = Arc::new(tokio::sync::RwLock::new(SharedMarketData::new()));
@@ -591,10 +637,24 @@ impl FyndBuilder {
         let chain = self.chain;
         let router_address = encoder.router_address().clone();
 
+        // Start price providers and construct the guard.
+        // Providers are started even when `enabled: false` so caches stay warm
+        // for per-request opt-in. The `enabled` flag only controls whether
+        // validation runs at request time.
         let router_config = WorkerPoolRouterConfig::default()
             .with_timeout(self.router_timeout)
             .with_min_responses(self.router_min_responses);
-        let router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
+        let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
+        if !self.price_providers.is_empty() {
+            let mut registry = PriceProviderRegistry::new();
+            let mut worker_handles = Vec::new();
+            for mut provider in self.price_providers {
+                worker_handles.push(provider.start(Arc::clone(&market_data)));
+                registry = registry.register(provider);
+            }
+            let price_guard = PriceGuard::new(registry, worker_handles);
+            router = router.with_price_guard(price_guard, self.price_guard_config);
+        }
 
         let feed_handle = tokio::spawn(async move {
             if let Err(e) = tycho_feed.run().await {

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -645,16 +645,15 @@ impl FyndBuilder {
             .with_timeout(self.router_timeout)
             .with_min_responses(self.router_min_responses);
         let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
-        if !self.price_providers.is_empty() {
-            let mut registry = PriceProviderRegistry::new();
-            let mut worker_handles = Vec::new();
-            for mut provider in self.price_providers {
-                worker_handles.push(provider.start(Arc::clone(&market_data)));
-                registry = registry.register(provider);
-            }
-            let price_guard = PriceGuard::new(registry, worker_handles);
-            router = router.with_price_guard(price_guard, self.price_guard_config);
+
+        let mut registry = PriceProviderRegistry::new();
+        let mut worker_handles = Vec::new();
+        for mut provider in self.price_providers {
+            worker_handles.push(provider.start(Arc::clone(&market_data)));
+            registry = registry.register(provider);
         }
+        let price_guard = PriceGuard::new(registry, worker_handles);
+        router = router.with_price_guard(price_guard, self.price_guard_config);
 
         let feed_handle = tokio::spawn(async move {
             if let Err(e) = tycho_feed.run().await {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -132,7 +132,6 @@ impl QuoteOptions {
     pub fn encoding_options(&self) -> Option<&EncodingOptions> {
         self.encoding_options.as_ref()
     }
-
 }
 
 /// Client fee configuration for the Tycho Router.

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -86,9 +86,6 @@ pub struct QuoteOptions {
     /// Options for encoding the solution into an on-chain transaction.
     /// If `None`, the solution is returned without an encoded transaction.
     encoding_options: Option<EncodingOptions>,
-    /// Per-request price guard overrides. If `None`, uses server defaults.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    price_guard: Option<PriceGuardConfig>,
 }
 
 impl QuoteOptions {
@@ -136,16 +133,6 @@ impl QuoteOptions {
         self.encoding_options.as_ref()
     }
 
-    /// Sets per-request price guard config.
-    pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
-        self.price_guard = Some(config);
-        self
-    }
-
-    /// Returns the per-request price guard config.
-    pub fn price_guard(&self) -> Option<&PriceGuardConfig> {
-        self.price_guard.as_ref()
-    }
 }
 
 /// Client fee configuration for the Tycho Router.
@@ -279,6 +266,9 @@ pub struct EncodingOptions {
     /// Client fee configuration. When absent, no client fee is charged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     client_fee_params: Option<ClientFeeParams>,
+    /// Per-request price guard overrides. If `None`, uses server defaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    price_guard: Option<PriceGuardConfig>,
 }
 
 impl EncodingOptions {
@@ -290,6 +280,7 @@ impl EncodingOptions {
             permit: None,
             permit2_signature: None,
             client_fee_params: None,
+            price_guard: None,
         }
     }
 
@@ -340,6 +331,17 @@ impl EncodingOptions {
     /// Returns the client fee params, if set.
     pub fn client_fee_params(&self) -> Option<&ClientFeeParams> {
         self.client_fee_params.as_ref()
+    }
+
+    /// Sets per-request price guard config.
+    pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
+        self.price_guard = Some(config);
+        self
+    }
+
+    /// Returns the per-request price guard config.
+    pub fn price_guard(&self) -> Option<&PriceGuardConfig> {
+        self.price_guard.as_ref()
     }
 }
 

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -31,8 +31,10 @@ use tracing::{debug, warn};
 use tycho_simulation::tycho_common::Bytes;
 
 use crate::{
-    encoding::encoder::Encoder, worker_pool::task_queue::TaskQueueHandle, BlockInfo, Order,
-    OrderQuote, Quote, QuoteOptions, QuoteRequest, QuoteStatus, SolveError,
+    encoding::encoder::Encoder,
+    price_guard::{config::PriceGuardConfig, guard::PriceGuard},
+    worker_pool::task_queue::TaskQueueHandle,
+    BlockInfo, Order, OrderQuote, Quote, QuoteOptions, QuoteRequest, QuoteStatus, SolveError,
 };
 
 /// Handle to a solver pool for dispatching orders.
@@ -81,6 +83,11 @@ pub struct WorkerPoolRouter {
     config: WorkerPoolRouterConfig,
     /// Encoder for encoding solutions into on-chain transactions.
     encoder: Encoder,
+    /// Validates solution outputs against external price sources.
+    price_guard: Option<PriceGuard>,
+    /// Server-side default config for the price guard.
+    /// Used when a request does not include per-request overrides.
+    price_guard_config: PriceGuardConfig,
 }
 
 impl WorkerPoolRouter {
@@ -90,7 +97,20 @@ impl WorkerPoolRouter {
         config: WorkerPoolRouterConfig,
         encoder: Encoder,
     ) -> Self {
-        Self { solver_pools, config, encoder }
+        Self {
+            solver_pools,
+            config,
+            encoder,
+            price_guard: None,
+            price_guard_config: PriceGuardConfig::default(),
+        }
+    }
+
+    /// Enables price guard validation with a custom configuration.
+    pub fn with_price_guard(mut self, price_guard: PriceGuard, config: PriceGuardConfig) -> Self {
+        self.price_guard = Some(price_guard);
+        self.price_guard_config = config;
+        self
     }
 
     /// Returns the number of registered solver pools.
@@ -132,6 +152,23 @@ impl WorkerPoolRouter {
             .into_iter()
             .map(|responses| self.select_best(&responses, request.options()))
             .collect();
+
+        // Validate against external prices if enabled.
+        // Per-request config overrides the server default.
+        if let Some(ref guard) = self.price_guard {
+            let config = request
+                .options()
+                .price_guard()
+                .cloned()
+                .unwrap_or(self.price_guard_config.clone());
+            match guard.validate(order_quotes, &config) {
+                Ok(validated) => order_quotes = validated,
+                Err(e) => {
+                    warn!(error = %e, "price guard validation error");
+                    return Err(SolveError::Internal(e.to_string()));
+                }
+            }
+        }
 
         // Encode solutions if encoding_options is set
         if let Some(encoding_options) = request.options().encoding_options() {
@@ -263,6 +300,7 @@ impl WorkerPoolRouter {
                 SolveError::NoRouteFound { .. } => "no_route",
                 SolveError::QueueFull => "queue_full",
                 SolveError::Internal(_) => "internal",
+                SolveError::PriceCheckFailed { .. } => "price_check_failed",
                 _ => "other",
             };
             counter!("worker_router_solver_failures_total", "pool" => pool_name.clone(), "error_type" => error_type).increment(1);

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -86,8 +86,7 @@ pub struct WorkerPoolRouter {
     /// Validates solution outputs against external price sources.
     price_guard: Option<PriceGuard>,
     /// Server-side default config for the price guard.
-    /// Used when a request does not include per-request overrides.
-    price_guard_config: PriceGuardConfig,
+    price_guard_config: Option<PriceGuardConfig>,
 }
 
 impl WorkerPoolRouter {
@@ -97,19 +96,13 @@ impl WorkerPoolRouter {
         config: WorkerPoolRouterConfig,
         encoder: Encoder,
     ) -> Self {
-        Self {
-            solver_pools,
-            config,
-            encoder,
-            price_guard: None,
-            price_guard_config: PriceGuardConfig::default(),
-        }
+        Self { solver_pools, config, encoder, price_guard: None, price_guard_config: None }
     }
 
     /// Enables price guard validation with a custom configuration.
     pub fn with_price_guard(mut self, price_guard: PriceGuard, config: PriceGuardConfig) -> Self {
         self.price_guard = Some(price_guard);
-        self.price_guard_config = config;
+        self.price_guard_config = Some(config);
         self
     }
 
@@ -156,11 +149,16 @@ impl WorkerPoolRouter {
         // Validate against external prices if enabled.
         // Per-request config overrides the server default.
         if let Some(ref guard) = self.price_guard {
-            let config = request
-                .options()
-                .price_guard()
-                .cloned()
-                .unwrap_or(self.price_guard_config.clone());
+            let config = if let Some(request_config) = request.options().price_guard() {
+                debug!("using request price guard config: {:?}", request_config);
+                request_config.clone()
+            } else if let Some(default_config) = &self.price_guard_config {
+                debug!("using default price guard config: {:?}", default_config);
+                default_config.clone()
+            } else {
+                return Err(SolveError::Internal("no price guard config available".to_string()));
+            };
+
             match guard.validate(order_quotes, &config) {
                 Ok(validated) => order_quotes = validated,
                 Err(e) => {

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -149,11 +149,11 @@ impl WorkerPoolRouter {
         // Validate against external prices if enabled.
         // Per-request config (inside encoding_options) overrides the server default.
         if let Some(ref guard) = self.price_guard {
-            let request_config = request
+            let price_guard_config = request
                 .options()
                 .encoding_options()
                 .and_then(|e| e.price_guard());
-            let config = if let Some(request_config) = request_config {
+            let config = if let Some(request_config) = price_guard_config {
                 debug!("using request price guard config: {:?}", request_config);
                 request_config.clone()
             } else if let Some(default_config) = &self.price_guard_config {

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -147,9 +147,13 @@ impl WorkerPoolRouter {
             .collect();
 
         // Validate against external prices if enabled.
-        // Per-request config overrides the server default.
+        // Per-request config (inside encoding_options) overrides the server default.
         if let Some(ref guard) = self.price_guard {
-            let config = if let Some(request_config) = request.options().price_guard() {
+            let request_config = request
+                .options()
+                .encoding_options()
+                .and_then(|e| e.price_guard());
+            let config = if let Some(request_config) = request_config {
                 debug!("using request price guard config: {:?}", request_config);
                 request_config.clone()
             } else if let Some(default_config) = &self.price_guard_config {

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -214,7 +214,6 @@ impl QuoteOptions {
     pub fn encoding_options(&self) -> Option<&EncodingOptions> {
         self.encoding_options.as_ref()
     }
-
 }
 
 /// Per-request overrides for price guard validation.
@@ -231,12 +230,12 @@ pub struct PriceGuardConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(example = 10000))]
     upper_tolerance_bps: Option<u32>,
-    /// Whether to let solutions pass when no provider can return a price.
+    /// Whether to reject solutions when no provider can return a price.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    allow_on_provider_error: Option<bool>,
-    /// Whether to let solutions pass when no provider returns price for token pair.
+    fail_on_provider_error: Option<bool>,
+    /// Whether to reject solutions when no provider returns price for token pair.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    allow_on_token_price_not_found: Option<bool>,
+    fail_on_token_price_not_found: Option<bool>,
     /// Whether price guard validation is enabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
@@ -255,15 +254,15 @@ impl PriceGuardConfig {
         self
     }
 
-    /// Set whether to allow solutions when providers error.
-    pub fn with_allow_on_provider_error(mut self, allow: bool) -> Self {
-        self.allow_on_provider_error = Some(allow);
+    /// Set whether to reject solutions when providers error.
+    pub fn with_fail_on_provider_error(mut self, fail: bool) -> Self {
+        self.fail_on_provider_error = Some(fail);
         self
     }
 
-    /// Set whether to allow solutions when no provider returns price for token pair.
-    pub fn with_allow_on_token_price_not_found(mut self, allow: bool) -> Self {
-        self.allow_on_token_price_not_found = Some(allow);
+    /// Set whether to reject solutions when no provider returns price for token pair.
+    pub fn with_fail_on_token_price_not_found(mut self, fail: bool) -> Self {
+        self.fail_on_token_price_not_found = Some(fail);
         self
     }
 
@@ -283,14 +282,14 @@ impl PriceGuardConfig {
         self.upper_tolerance_bps
     }
 
-    /// Whether to allow on provider error, if set.
-    pub fn allow_on_provider_error(&self) -> Option<bool> {
-        self.allow_on_provider_error
+    /// Whether to fail on provider error, if set.
+    pub fn fail_on_provider_error(&self) -> Option<bool> {
+        self.fail_on_provider_error
     }
 
-    /// Whether to allow on token price not found, if set.
-    pub fn allow_on_token_price_not_found(&self) -> Option<bool> {
-        self.allow_on_token_price_not_found
+    /// Whether to fail on token not found, if set.
+    pub fn fail_on_token_price_not_found(&self) -> Option<bool> {
+        self.fail_on_token_price_not_found
     }
 
     /// Whether price guard is enabled, if set.
@@ -1555,11 +1554,11 @@ mod conversions {
             if let Some(bps) = self.upper_tolerance_bps {
                 config = config.with_upper_tolerance_bps(bps);
             }
-            if let Some(allow) = self.allow_on_provider_error {
-                config = config.with_allow_on_provider_error(allow);
+            if let Some(fail) = self.fail_on_provider_error {
+                config = config.with_fail_on_provider_error(fail);
             }
-            if let Some(allow) = self.allow_on_token_price_not_found {
-                config = config.with_allow_on_token_price_not_found(allow);
+            if let Some(fail) = self.fail_on_token_price_not_found {
+                config = config.with_fail_on_token_price_not_found(fail);
             }
             if let Some(enabled) = self.enabled {
                 config = config.with_enabled(enabled);
@@ -1898,13 +1897,13 @@ mod conversions {
             let dto = PriceGuardConfig::default()
                 .with_lower_tolerance_bps(200)
                 .with_upper_tolerance_bps(5000)
-                .with_allow_on_provider_error(true)
+                .with_fail_on_provider_error(false)
                 .with_enabled(false);
 
             let core: fynd_core::PriceGuardConfig = dto.into();
             assert_eq!(core.lower_tolerance_bps(), 200);
             assert_eq!(core.upper_tolerance_bps(), 5000);
-            assert!(core.allow_on_provider_error());
+            assert!(!core.fail_on_provider_error());
             assert!(!core.enabled());
         }
 
@@ -1916,7 +1915,7 @@ mod conversions {
             assert_eq!(core.lower_tolerance_bps(), 100);
             // Unset fields get core defaults
             assert_eq!(core.upper_tolerance_bps(), 10_000);
-            assert!(!core.allow_on_provider_error());
+            assert!(!core.fail_on_provider_error());
             assert!(!core.enabled());
         }
 

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -168,9 +168,6 @@ pub struct QuoteOptions {
     max_gas: Option<BigUint>,
     /// Options during encoding. If None, quote will be returned without calldata.
     encoding_options: Option<EncodingOptions>,
-    /// Per-request price guard overrides. If `None`, uses server defaults.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    price_guard: Option<PriceGuardConfig>,
 }
 
 impl QuoteOptions {
@@ -218,16 +215,6 @@ impl QuoteOptions {
         self.encoding_options.as_ref()
     }
 
-    /// Set per-request price guard overrides.
-    pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
-        self.price_guard = Some(config);
-        self
-    }
-
-    /// Per-request price guard config, if set.
-    pub fn price_guard(&self) -> Option<&PriceGuardConfig> {
-        self.price_guard.as_ref()
-    }
 }
 
 /// Per-request overrides for price guard validation.
@@ -464,6 +451,9 @@ pub struct EncodingOptions {
     /// Client fee configuration. When absent, no fee is charged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     client_fee_params: Option<ClientFeeParams>,
+    /// Per-request price guard overrides. If `None`, uses server defaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    price_guard: Option<PriceGuardConfig>,
 }
 
 impl EncodingOptions {
@@ -475,6 +465,7 @@ impl EncodingOptions {
             permit: None,
             permit2_signature: None,
             client_fee_params: None,
+            price_guard: None,
         }
     }
 
@@ -520,6 +511,17 @@ impl EncodingOptions {
     /// Client fee params, if set.
     pub fn client_fee_params(&self) -> Option<&ClientFeeParams> {
         self.client_fee_params.as_ref()
+    }
+
+    /// Set per-request price guard overrides.
+    pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
+        self.price_guard = Some(config);
+        self
+    }
+
+    /// Per-request price guard config, if set.
+    pub fn price_guard(&self) -> Option<&PriceGuardConfig> {
+        self.price_guard.as_ref()
     }
 }
 
@@ -1540,9 +1542,6 @@ mod conversions {
             if let Some(enc) = self.encoding_options {
                 opts = opts.with_encoding_options(enc.into());
             }
-            if let Some(pg) = self.price_guard {
-                opts = opts.with_price_guard(pg.into());
-            }
             opts
         }
     }
@@ -1580,6 +1579,9 @@ mod conversions {
             }
             if let Some(fee) = self.client_fee_params {
                 opts = opts.with_client_fee_params(fee.into());
+            }
+            if let Some(pg) = self.price_guard {
+                opts = opts.with_price_guard(pg.into());
             }
             opts
         }
@@ -1812,7 +1814,6 @@ mod conversions {
                     min_responses: None,
                     max_gas: None,
                     encoding_options: None,
-                    price_guard: None,
                 },
             };
 
@@ -1920,7 +1921,9 @@ mod conversions {
         }
 
         #[test]
-        fn test_quote_options_with_price_guard_roundtrip() {
+        fn test_encoding_options_with_price_guard_roundtrip() {
+            let enc = EncodingOptions::new(0.01)
+                .with_price_guard(PriceGuardConfig::default().with_enabled(false));
             let dto = QuoteRequest {
                 orders: vec![Order {
                     id: "pg-test".to_string(),
@@ -1931,13 +1934,14 @@ mod conversions {
                     sender: make_address(0xAA),
                     receiver: None,
                 }],
-                options: QuoteOptions::default()
-                    .with_price_guard(PriceGuardConfig::default().with_enabled(false)),
+                options: QuoteOptions::default().with_encoding_options(enc),
             };
 
             let core: fynd_core::QuoteRequest = dto.into();
             let pg = core
                 .options()
+                .encoding_options()
+                .expect("encoding_options should be set")
                 .price_guard()
                 .expect("price_guard should be set");
             assert!(!pg.enabled());

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -66,6 +66,7 @@ impl ResponseError for ApiError {
                 SolveError::NotReady(_) => "NOT_READY",
                 SolveError::ComputationFailed(_) => "COMPUTATION_FAILED",
                 SolveError::FailedEncoding(_) => "FAILED_ENCODING",
+                SolveError::PriceCheckFailed { .. } => "PRICE_CHECK_FAILED",
                 other => {
                     warn!(?other, "unhandled SolveError variant");
                     "INTERNAL_ERROR"

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -162,6 +162,18 @@ impl FyndRPCBuilder {
         self
     }
 
+    /// Enables the price guard with a custom configuration.
+    ///
+    /// The `enabled` field in the config controls whether validation runs.
+    /// When enabled, default providers are auto-registered if none were added
+    /// manually.
+    pub fn with_price_guard_config(mut self, config: fynd_core::PriceGuardConfig) -> Self {
+        self.fynd_builder = self
+            .fynd_builder
+            .price_guard_config(config);
+        self
+    }
+
     /// Assemble all components and return a running [`FyndRPC`] server handle.
     ///
     /// Starts all worker pools and binds the HTTP listener. Returns an error if any component

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,6 +109,31 @@ pub struct ServeArgs {
     /// Disabled by default.
     #[arg(long)]
     pub gas_price_stale_threshold_secs: Option<u64>,
+
+    /// Enable price guard validation against external price sources.
+    /// Disabled by default.
+    #[arg(long)]
+    pub enable_price_guard: bool,
+
+    /// Maximum allowed deviation below external price, in basis points (1 bps = 0.01%).
+    /// Default: 300 (3%).
+    #[arg(long, default_value_t = 300)]
+    pub price_guard_lower_tolerance_bps: u32,
+
+    /// Maximum allowed deviation above external price, in basis points (1 bps = 0.01%).
+    /// Default: 10000 (100%).
+    #[arg(long, default_value_t = 10_000)]
+    pub price_guard_upper_tolerance_bps: u32,
+
+    /// Allow solutions through when all price providers error (network issues, API down).
+    /// Default: true.
+    #[arg(long, default_value_t = true)]
+    pub price_guard_allow_on_provider_error: bool,
+
+    /// Allow solutions through when no provider has a price for the token pair.
+    /// Default: true.
+    #[arg(long, default_value_t = true)]
+    pub price_guard_allow_on_token_not_found: bool,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,15 +125,15 @@ pub struct ServeArgs {
     #[arg(long, default_value_t = 10_000)]
     pub price_guard_upper_tolerance_bps: u32,
 
-    /// Allow solutions through when all price providers error (network issues, API down).
+    /// Reject solutions when all price providers error (network issues, API down).
     /// Default: false.
     #[arg(long, default_value_t = false)]
-    pub price_guard_allow_on_provider_error: bool,
+    pub price_guard_fail_on_provider_error: bool,
 
-    /// Allow solutions through when no provider has a price for the token pair.
+    /// Reject solutions when no provider has a price for the token pair.
     /// Default: false.
     #[arg(long, default_value_t = false)]
-    pub price_guard_allow_on_token_not_found: bool,
+    pub price_guard_fail_on_token_price_not_found: bool,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,13 +126,13 @@ pub struct ServeArgs {
     pub price_guard_upper_tolerance_bps: u32,
 
     /// Allow solutions through when all price providers error (network issues, API down).
-    /// Default: true.
-    #[arg(long, default_value_t = true)]
+    /// Default: false.
+    #[arg(long, default_value_t = false)]
     pub price_guard_allow_on_provider_error: bool,
 
     /// Allow solutions through when no provider has a price for the token pair.
-    /// Default: true.
-    #[arg(long, default_value_t = true)]
+    /// Default: false.
+    #[arg(long, default_value_t = false)]
     pub price_guard_allow_on_token_not_found: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,8 +297,8 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
             .with_enabled(args.enable_price_guard)
             .with_lower_tolerance_bps(args.price_guard_lower_tolerance_bps)
             .with_upper_tolerance_bps(args.price_guard_upper_tolerance_bps)
-            .with_allow_on_provider_error(args.price_guard_allow_on_provider_error)
-            .with_allow_on_token_price_not_found(args.price_guard_allow_on_token_not_found),
+            .with_fail_on_provider_error(args.price_guard_fail_on_provider_error)
+            .with_fail_on_token_price_not_found(args.price_guard_fail_on_token_price_not_found),
     );
 
     // Build and start solver

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,6 +292,14 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
     };
 
     builder = builder.blocklist(blocklist);
+    builder = builder.with_price_guard_config(
+        fynd_core::PriceGuardConfig::default()
+            .with_enabled(args.enable_price_guard)
+            .with_lower_tolerance_bps(args.price_guard_lower_tolerance_bps)
+            .with_upper_tolerance_bps(args.price_guard_upper_tolerance_bps)
+            .with_allow_on_provider_error(args.price_guard_allow_on_provider_error)
+            .with_allow_on_token_price_not_found(args.price_guard_allow_on_token_not_found),
+    );
 
     // Build and start solver
     let solver = builder

--- a/tools/benchmark/src/compare.rs
+++ b/tools/benchmark/src/compare.rs
@@ -130,6 +130,7 @@ fn status_str(status: QuoteStatus) -> &'static str {
         QuoteStatus::InsufficientLiquidity => "insufficient_liquidity",
         QuoteStatus::Timeout => "timeout",
         QuoteStatus::NotReady => "not_ready",
+        QuoteStatus::PriceCheckFailed => "price_check_failed",
     }
 }
 


### PR DESCRIPTION
sorry for chained PRs :( 

fynd-rpc/fynd-client:
- On our hosted endpoint, PriceGuard is running with default providers, and caching provider prices, though the default config disables the checks by default. If the user wants to submit their order with PriceGuard checks, they need to enable it via the config. 

fynd-core: Users running their own fynd instance:
- Lets you define your own price provider via the FyndBuilder, starts all providers in the FyndBuilder.build method
- Via the CLI, the user can pass the fynd config args. I am assuming that the user will use the FyndBuilder directly if they want to register custom providers. This is not supported in any way via CLI.
- The meat is in the WorkerPoolRouter. So we pass the guard+config from the FyndBuilder into there.

TODO:
- Double-check reasoning above
- Double-check that nothing is missing on the client side (backwards compatibility?)
- Double-check error handling
- Include integration test? 

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>