### PR TITLE
feat(swap-cli): use client approval API, fetch router from /v1/info

### DIFF
--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -209,6 +209,14 @@ impl StorageOverrides {
             .or_default()
             .insert(slot, value);
     }
+
+    /// Merge all slot overrides from `other` into `self`.
+    pub fn merge(&mut self, other: StorageOverrides) {
+        for (address, slots) in other.slots {
+            let entry = self.slots.entry(address).or_default();
+            entry.extend(slots);
+        }
+    }
 }
 
 fn storage_overrides_to_alloy(so: &StorageOverrides) -> Result<StateOverride, FyndError> {

--- a/docs/guides/swap-cli.md
+++ b/docs/guides/swap-cli.md
@@ -76,7 +76,7 @@ The output prints the quote (amount\_in, amount\_out, gas estimate, route) follo
 
 ## Dry-run a swap (Permit2)
 
-Add `--transfer-type transfer-from-permit2`. The router address is fetched automatically from the Fynd server. The dry-run uses nonce 0 and maximum deadlines, so no chain reads are needed.
+Add `--transfer-type transfer-from-permit2`. The dry-run uses nonce 0 and maximum deadlines, so no chain reads are needed.
 
 ```bash
 fynd-swap-cli --transfer-type transfer-from-permit2
@@ -99,7 +99,7 @@ fynd-swap-cli --execute
 
 ## Execute on-chain (Permit2)
 
-Add `--execute --transfer-type transfer-from-permit2`. The router address is resolved automatically from the Fynd server. The CLI checks the Permit2 allowance and submits an approval transaction first if needed, then reads the current nonce, builds the EIP-712 permit, signs it, and submits the swap.
+Add `--execute --transfer-type transfer-from-permit2`. The CLI checks the Permit2 allowance and submits an approval transaction first if needed, then reads the current nonce, builds the EIP-712 permit, signs it, and submits the swap.
 
 ```bash
 export RPC_URL=https://your-rpc-provider.com/v1/your_key

--- a/docs/guides/swap-cli.md
+++ b/docs/guides/swap-cli.md
@@ -76,22 +76,18 @@ The output prints the quote (amount\_in, amount\_out, gas estimate, route) follo
 
 ## Dry-run a swap (Permit2)
 
-Add `--transfer-type transfer-from-permit2` and supply the TychoRouter address with `--router`. The dry-run uses nonce 0 and maximum deadlines, so you don't need any chain reads for Permit2 state.
+Add `--transfer-type transfer-from-permit2`. The router address is fetched automatically from the Fynd server. The dry-run uses nonce 0 and maximum deadlines, so no chain reads are needed.
 
 ```bash
-fynd-swap-cli \
-  --transfer-type transfer-from-permit2 \
-  --router        <TychoRouter address>
+fynd-swap-cli --transfer-type transfer-from-permit2
 ```
-
-Find the TychoRouter address for your chain in the [Tycho contract addresses](https://docs.propellerheads.xyz/tycho/for-solvers/execution/contract-addresses).
 
 ## Execute on-chain (ERC-20)
 
-Add `--execute` and set `PRIVATE_KEY`. The CLI will verify that the router has sufficient allowance before submitting and will print the required `cast send` approval command if it doesn't.
+Add `--execute` and set `PRIVATE_KEY`. The CLI checks the router allowance automatically and submits an approval transaction first if one is needed.
 
 {% hint style="warning" %}
-This sends a real transaction. Ensure your wallet has the sell token and has approved the TychoRouter to spend it before running with `--execute`.
+This sends real transactions. Ensure your wallet has the sell token before running with `--execute`.
 {% endhint %}
 
 ```bash
@@ -103,18 +99,13 @@ fynd-swap-cli --execute
 
 ## Execute on-chain (Permit2)
 
-Add `--execute --transfer-type transfer-from-permit2 --router <addr>`. The CLI reads the current Permit2 nonce from the contract, builds the EIP-712 permit, signs it with your key, and submits the swap in one step.
-
-Your wallet must have already approved the Permit2 contract (`0x000000000022D473030F116dDEE9F6B43aC78BA3`) to spend the sell token. The CLI prints the required `cast send` command if that approval is missing.
+Add `--execute --transfer-type transfer-from-permit2`. The router address is resolved automatically from the Fynd server. The CLI checks the Permit2 allowance and submits an approval transaction first if needed, then reads the current nonce, builds the EIP-712 permit, signs it, and submits the swap.
 
 ```bash
 export RPC_URL=https://your-rpc-provider.com/v1/your_key
 export PRIVATE_KEY=your_private_key_hex   # no 0x prefix
 
-fynd-swap-cli \
-  --transfer-type transfer-from-permit2 \
-  --router        <TychoRouter address> \
-  --execute
+fynd-swap-cli --transfer-type transfer-from-permit2 --execute
 ```
 
 ## Swap using vault funds
@@ -138,7 +129,6 @@ fynd-swap-cli --transfer-type use-vaults-funds
 | `--fynd-url`      | `FYND_URL` | `http://localhost:3000`                     | Fynd server URL                                                 |
 | `--transfer-type` | —         | `transfer-from`                              | `transfer-from`, `transfer-from-permit2`, or `use-vaults-funds` |
 | `--execute`       | —         | false (dry-run)                              | Submit the swap on-chain. Requires `PRIVATE_KEY`.               |
-| `--router`        | —         | —                                            | TychoRouter address. Required for `transfer-from-permit2`.      |
 | `--permit2`       | —         | `0x000000000022D473030F116dDEE9F6B43aC78BA3` | Permit2 contract address                                        |
 | `--rpc-url`       | `RPC_URL` | `https://reth-ethereum.ithaca.xyz/rpc`       | Ethereum RPC endpoint (must support `eth_call` state overrides) |
 
@@ -147,7 +137,7 @@ fynd-swap-cli --transfer-type use-vaults-funds
 1. **Never expose your private key.** Use the `PRIVATE_KEY` environment variable, never a CLI argument. Run `unset HISTFILE` before setting it to prevent it from being saved to your shell history.
 2. **Dry-run first.** The default mode (no `--execute`) simulates the full swap with storage overrides — no funds needed. Confirm the output looks correct before adding `--execute`.
 3. **Slippage protection.** The default 0.5% slippage may not be sufficient for large trades or volatile markets. Adjust `--slippage-bps` accordingly.
-4. **Mainnet warning.** `--execute` sends a real transaction. Start with small amounts. All routes execute through the [Tycho Router](https://docs.propellerheads.xyz/tycho/for-solvers/execution/contract-addresses) contract.
+4. **Mainnet warning.** `--execute` may send multiple transactions (approval + swap). Start with small amounts. All routes execute through the [Tycho Router](https://docs.propellerheads.xyz/tycho/for-solvers/execution/contract-addresses) contract.
 5. **Verify routes.** The CLI prints the full route before executing. Multi-hop routes through low-liquidity pools can result in worse execution.
 6. **Prices are indicative.** Quotes reflect the best route at query time but are not guaranteed on-chain. Pool states change every block, and the longer you wait to execute, the more the price may drift.
 
@@ -158,5 +148,3 @@ fynd-swap-cli --transfer-type use-vaults-funds
 **"Sell/buy token not found"**: Ensure the token address is correct and [the token exists on Tycho's indexer](https://docs.propellerheads.xyz/tycho/for-solvers/indexer/tycho-rpc#post-v1-tokens).
 
 **"No route found"**: Fynd couldn't find a path between your tokens. Check that both tokens have enough on-chain liquidity.
-
-**"Insufficient allowance"**: The CLI prints the exact `cast send` approval command needed. Run it, then retry.

--- a/tools/fynd-swap-cli/src/erc20.rs
+++ b/tools/fynd-swap-cli/src/erc20.rs
@@ -15,7 +15,6 @@ use alloy::{
     sol_types::SolCall,
 };
 use anyhow::bail;
-use num_bigint::BigUint;
 
 sol! {
     interface IERC20 {
@@ -110,26 +109,6 @@ pub async fn find_allowance_slot(
         "could not detect allowance slot for {token:#x} (tried 0..={MAX_PROBE_SLOT}); \
          the token may use a non-standard storage layout"
     )
-}
-
-pub async fn read_erc20_allowance(
-    provider: &RootProvider<Ethereum>,
-    token: Address,
-    owner: Address,
-    spender: Address,
-) -> anyhow::Result<BigUint> {
-    let calldata = IERC20::allowanceCall { owner, spender }.abi_encode();
-    let result = provider
-        .call(TransactionRequest {
-            to: Some(TxKind::Call(token)),
-            input: AlloyBytes::from(calldata).into(),
-            ..Default::default()
-        })
-        .await?;
-    if result.len() < 32 {
-        bail!("allowance() returned {} bytes, expected 32", result.len());
-    }
-    Ok(BigUint::from_bytes_be(&result[..32]))
 }
 
 #[cfg(test)]

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -101,8 +101,10 @@ fn max_uint160() -> BigUint {
 
 /// Detect ERC-20 storage slots and build `StorageOverrides` for a dry-run.
 ///
-/// Injects `U256::MAX` into both the holder's balance slot and the
-/// `holder → spender` allowance slot so the simulation succeeds without real funds.
+/// Injects a large sentinel into the holder's balance slot and the `holder → spender`
+/// allowance slot so the simulation succeeds without real funds. Uses `U256::MAX >> 1`
+/// rather than `U256::MAX` to avoid triggering tokens that pack metadata into bit 255
+/// (e.g. USDC uses that bit as a blacklist flag).
 async fn build_dry_run_overrides(
     provider: &RootProvider<Ethereum>,
     sell_token: Address,
@@ -118,7 +120,10 @@ async fn build_dry_run_overrides(
     let allowance_pos = allowance_res?;
     info!("Found balance slot {balance_pos} and allowance slot {allowance_pos}");
 
-    let max_val = Bytes::copy_from_slice(&B256::from(U256::MAX).0);
+    // Use MAX >> 1 (clear the top bit) to avoid triggering tokens that pack metadata into
+    // bit 255 of the storage slot — e.g. USDC uses the top bit as a blacklist flag.
+    // 2^255 - 1 is still large enough to cover any realistic balance or allowance.
+    let max_val = Bytes::copy_from_slice(&B256::from(U256::MAX >> 1).0);
     let token_key = Bytes::copy_from_slice(sell_token.as_slice());
     let mut overrides = StorageOverrides::default();
     overrides.insert(

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -436,8 +436,14 @@ async fn main() -> anyhow::Result<()> {
                 Some(overrides)
             }
             TransferType::TransferFromPermit2 => {
-                let overrides =
+                // Inject allowance to both Permit2 (for the permit2.transferFrom path) and
+                // directly to the router (in case the router calls token.transferFrom itself).
+                let mut overrides =
                     build_dry_run_overrides(&provider, sell_token, sender, permit2_addr).await?;
+                let router_overrides =
+                    build_dry_run_overrides(&provider, sell_token, sender, router_from_quote)
+                        .await?;
+                overrides.merge(router_overrides);
                 Some(overrides)
             }
             TransferType::UseVaultsFunds => None,

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -301,14 +301,30 @@ async fn main() -> anyhow::Result<()> {
     let amount = BigUint::from(cli.sell_amount);
     let slippage = cli.slippage_bps as f64 / 10_000.0;
 
-    // ── Permit2 pre-flight ────────────────────────────────────────────────────
-    let encoding_options = match cli.transfer_type {
-        TransferType::TransferFrom => EncodingOptions::new(slippage),
+    // ── Setup: encoding options, approvals, dry-run spenders ─────────────────
+    // dry_run_spenders: token spenders whose allowance slots are injected for dry-run simulation.
+    let (encoding_options, dry_run_spenders): (_, Vec<Address>) = match cli.transfer_type {
+        TransferType::TransferFrom => {
+            if cli.execute {
+                ensure_approval(
+                    &client,
+                    &signer,
+                    sell_token_bytes.clone(),
+                    amount.clone(),
+                    UserTransferType::TransferFrom,
+                    sender,
+                )
+                .await?;
+            }
+            let info = client.info().await?;
+            let router_addr = Address::try_from(info.router_address().as_ref())
+                .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
+            (EncodingOptions::new(slippage), vec![router_addr])
+        }
         TransferType::TransferFromPermit2 => {
             let info = client.info().await?;
             let router_addr = Address::try_from(info.router_address().as_ref())
                 .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
-
             if cli.execute {
                 ensure_approval(
                     &client,
@@ -320,8 +336,7 @@ async fn main() -> anyhow::Result<()> {
                 )
                 .await?;
             }
-
-            create_permit2_encoding(
+            let enc = create_permit2_encoding(
                 &provider,
                 &signer,
                 Permit2Args {
@@ -333,9 +348,10 @@ async fn main() -> anyhow::Result<()> {
                     execute: cli.execute,
                 },
             )
-            .await?
+            .await?;
+            (enc, vec![permit2_addr, router_addr])
         }
-        TransferType::UseVaultsFunds => EncodingOptions::new(slippage).with_vault_funds(),
+        TransferType::UseVaultsFunds => (EncodingOptions::new(slippage).with_vault_funds(), vec![]),
     };
 
     // ── Quote ─────────────────────────────────────────────────────────────────
@@ -379,26 +395,6 @@ async fn main() -> anyhow::Result<()> {
     }
     println!("============================\n");
 
-    let tx = quote.transaction().ok_or_else(|| {
-        anyhow::anyhow!("quote has no calldata; ensure encoding_options were set in the request")
-    })?;
-    let router_from_quote = Address::from_slice(tx.to().as_ref());
-
-    // ── ERC-20 execute: ensure router approval ────────────────────────────────
-    if cli.execute {
-        if let TransferType::TransferFrom = cli.transfer_type {
-            ensure_approval(
-                &client,
-                &signer,
-                sell_token_bytes,
-                amount.clone(),
-                UserTransferType::TransferFrom,
-                sender,
-            )
-            .await?;
-        }
-    }
-
     // ── Sign order payload ────────────────────────────────────────────────────
     let gas_limit: u64 = quote.gas_estimate().try_into().unwrap();
     // For dry-run, set gas price to 0 so eth_call bypasses the ETH balance check.
@@ -424,29 +420,16 @@ async fn main() -> anyhow::Result<()> {
         info!("Submitting on-chain transaction...");
         ExecutionOptions::default()
     } else {
-        // Dry-run: the spender for the allowance slot depends on the flow.
-        // TransferFrom: spender is the Fynd router (from quote).
-        // TransferFromPermit2: spender is the Permit2 contract (router authorised via EIP-712).
-        // UseVaultsFunds: no allowance needed — funds are in the router vault.
-        let overrides = match cli.transfer_type {
-            TransferType::TransferFrom => {
-                let overrides =
-                    build_dry_run_overrides(&provider, sell_token, sender, router_from_quote)
-                        .await?;
-                Some(overrides)
+        let overrides = if dry_run_spenders.is_empty() {
+            None
+        } else {
+            let mut overrides =
+                build_dry_run_overrides(&provider, sell_token, sender, dry_run_spenders[0]).await?;
+            for &spender in &dry_run_spenders[1..] {
+                let extra = build_dry_run_overrides(&provider, sell_token, sender, spender).await?;
+                overrides.merge(extra);
             }
-            TransferType::TransferFromPermit2 => {
-                // Inject allowance to both Permit2 (for the permit2.transferFrom path) and
-                // directly to the router (in case the router calls token.transferFrom itself).
-                let mut overrides =
-                    build_dry_run_overrides(&provider, sell_token, sender, permit2_addr).await?;
-                let router_overrides =
-                    build_dry_run_overrides(&provider, sell_token, sender, router_from_quote)
-                        .await?;
-                overrides.merge(router_overrides);
-                Some(overrides)
-            }
-            TransferType::UseVaultsFunds => None,
+            Some(overrides)
         };
         info!("Submitting dry-run execution...");
         ExecutionOptions { dry_run: true, storage_overrides: overrides, fetch_revert_reason: true }

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -16,7 +16,7 @@ use std::{env, str::FromStr, time::Duration};
 use alloy::{
     hex,
     network::Ethereum,
-    primitives::{address, Address, B256, U256},
+    primitives::{Address, B256, U256},
     providers::{Provider, ProviderBuilder, RootProvider},
     signers::{local::PrivateKeySigner, Signer},
 };
@@ -35,10 +35,6 @@ use tracing_subscriber::EnvFilter;
 
 mod erc20;
 mod permit2;
-
-/// Vitalik's address — used as the dry-run sender so `eth_call` simulations don't fail due
-/// to insufficient ETH for gas. Signatures are not checked in dry-run mode.
-const DRY_RUN_SENDER: Address = address!("d8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 
@@ -274,9 +270,7 @@ async fn main() -> anyhow::Result<()> {
     } else {
         PrivateKeySigner::random()
     };
-    // In dry-run mode use a well-funded address so the eth_call simulation has enough ETH for gas.
-    // The actual signing key is irrelevant since signatures are not validated in dry-run.
-    let sender = if cli.execute { signer.address() } else { DRY_RUN_SENDER };
+    let sender = signer.address();
     info!("Sender: {sender:?}");
 
     let provider: RootProvider<Ethereum> = ProviderBuilder::default().connect_http(
@@ -407,8 +401,18 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Sign order payload ────────────────────────────────────────────────────
     let gas_limit: u64 = quote.gas_estimate().try_into().unwrap();
+    // For dry-run, set gas price to 0 so eth_call bypasses the ETH balance check.
+    // The EVM still executes the full contract code; it just skips gas*price deduction.
+    let signing_hints = if cli.execute {
+        SigningHints::default().with_gas_limit(gas_limit * 10u64)
+    } else {
+        SigningHints::default()
+            .with_gas_limit(gas_limit * 10u64)
+            .with_max_fee_per_gas(0)
+            .with_max_priority_fee_per_gas(0)
+    };
     let payload = client
-        .swap_payload(quote, &SigningHints::default().with_gas_limit(gas_limit * 10u64))
+        .swap_payload(quote, &signing_hints)
         .await?;
     let order_sig = signer
         .sign_hash(&payload.signing_hash())

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -8,7 +8,8 @@
 //!
 //! # On-chain execution (`--execute`)
 //!
-//! Requires `PRIVATE_KEY` env var and a funded wallet with appropriate approvals.
+//! Requires `PRIVATE_KEY` env var and a funded wallet. Any missing approvals are submitted
+//! automatically before the swap.
 
 use std::{env, str::FromStr, time::Duration};
 
@@ -23,9 +24,10 @@ use anyhow::{bail, Context};
 use bytes::Bytes;
 use clap::Parser;
 use fynd_client::{
-    EncodingOptions, ExecutionOptions, FyndClient, FyndClientBuilder, HealthStatus, Order,
-    OrderSide, PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle, QuoteOptions,
-    QuoteParams, SignedSwap, SigningHints, StorageOverrides,
+    ApprovalParams, EncodingOptions, ExecutionOptions, FyndClient, FyndClientBuilder, HealthStatus,
+    Order, OrderSide, PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle,
+    QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints, StorageOverrides,
+    UserTransferType,
 };
 use num_bigint::BigUint;
 use tracing::info;
@@ -84,10 +86,6 @@ struct Cli {
     /// Requires the PRIVATE_KEY environment variable.
     #[arg(long)]
     execute: bool,
-
-    /// Tycho Router address (required for transfer-from-permit2 flow)
-    #[arg(long)]
-    router: Option<String>,
 
     /// Permit2 contract address (defaults to the canonical cross-chain deployment)
     #[arg(long, default_value = "0x000000000022D473030F116dDEE9F6B43aC78BA3")]
@@ -156,53 +154,58 @@ async fn wait_for_health(client: &FyndClient, fynd_url: &str) -> anyhow::Result<
     }
 }
 
-struct Permit2Args<'a> {
+/// Check allowance and, if insufficient, submit and mine an ERC-20 approval.
+///
+/// `transfer_type` controls the spender: `TransferFrom` -> router, `TransferFromPermit2` ->
+/// Permit2 contract. Resolves the spender address via `GET /v1/info`.
+async fn ensure_approval(
+    client: &FyndClient,
+    signer: &PrivateKeySigner,
+    sell_token: Bytes,
+    amount: BigUint,
+    transfer_type: UserTransferType,
+    sender: Address,
+) -> anyhow::Result<()> {
+    let params = ApprovalParams::new(sell_token, amount, true).with_transfer_type(transfer_type);
+    let hints = SigningHints::default().with_sender(sender);
+    let Some(approval_payload) = client.approval(&params, &hints).await? else {
+        return Ok(()); // allowance already sufficient
+    };
+    info!("Submitting approval transaction...");
+    let sig = signer
+        .sign_hash(&approval_payload.signing_hash())
+        .await?;
+    let signed = SignedApproval::assemble(approval_payload, sig);
+    let receipt = client.execute_approval(signed).await?;
+    tokio::time::timeout(Duration::from_secs(120), receipt)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for approval to be mined"))??;
+    info!("Approval confirmed.");
+    Ok(())
+}
+
+struct Permit2Args {
     sell_token: Address,
     sender: Address,
     permit2_addr: Address,
-    router_str: &'a str,
-    amount: &'a BigUint,
+    router_addr: Address,
     slippage: f64,
     execute: bool,
 }
 
-/// Build Permit2 `EncodingOptions`: validate allowance, read nonce, sign EIP-712 hash.
+/// Build Permit2 `EncodingOptions`: read nonce, sign EIP-712 hash.
 async fn create_permit2_encoding(
     provider: &RootProvider<Ethereum>,
     signer: &PrivateKeySigner,
-    args: Permit2Args<'_>,
+    args: Permit2Args,
 ) -> anyhow::Result<EncodingOptions> {
-    let router_addr = Address::from_str(args.router_str)
-        .with_context(|| format!("invalid router address: {}", args.router_str))?;
-
     let (nonce, expiration, sig_deadline) = if args.execute {
-        let allowance =
-            erc20::read_erc20_allowance(provider, args.sell_token, args.sender, args.permit2_addr)
-                .await?;
-        if allowance < *args.amount {
-            eprintln!("\nError: insufficient ERC-20 allowance to the Permit2 contract.");
-            eprintln!("  Token:     {:#x}", args.sell_token);
-            eprintln!("  Permit2:   {:#x}", args.permit2_addr);
-            eprintln!("  Allowance: {allowance}");
-            eprintln!("  Required:  {}", args.amount);
-            eprintln!("\nApprove Permit2 with:");
-            eprintln!(
-                "  cast send {:#x} \"approve(address,uint256)\" \
-                 {:#x} {} \\\n    \
-                 --rpc-url $RPC_URL --private-key $PRIVATE_KEY",
-                args.sell_token,
-                args.permit2_addr,
-                u128::MAX
-            );
-            bail!("insufficient allowance to Permit2");
-        }
-
         let nonce = permit2::read_nonce(
             provider,
             args.permit2_addr,
             args.sender,
             args.sell_token,
-            router_addr,
+            args.router_addr,
         )
         .await?;
         info!("Permit2 nonce for sender: {nonce}");
@@ -225,7 +228,7 @@ async fn create_permit2_encoding(
             BigUint::from(expiration),
             BigUint::from(nonce),
         ),
-        Bytes::copy_from_slice(router_addr.as_slice()),
+        Bytes::copy_from_slice(args.router_addr.as_slice()),
         BigUint::from(sig_deadline),
     );
 
@@ -308,9 +311,22 @@ async fn main() -> anyhow::Result<()> {
     let encoding_options = match cli.transfer_type {
         TransferType::TransferFrom => EncodingOptions::new(slippage),
         TransferType::TransferFromPermit2 => {
-            let router_str = cli.router.as_deref().ok_or_else(|| {
-                anyhow::anyhow!("--router is required for --transfer-type transfer-from-permit2")
-            })?;
+            let info = client.info().await?;
+            let router_addr = Address::try_from(info.router_address().as_ref())
+                .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
+
+            if cli.execute {
+                ensure_approval(
+                    &client,
+                    &signer,
+                    sell_token_bytes.clone(),
+                    amount.clone(),
+                    UserTransferType::TransferFromPermit2,
+                    sender,
+                )
+                .await?;
+            }
+
             create_permit2_encoding(
                 &provider,
                 &signer,
@@ -318,8 +334,7 @@ async fn main() -> anyhow::Result<()> {
                     sell_token,
                     sender,
                     permit2_addr,
-                    router_str,
-                    amount: &amount,
+                    router_addr,
                     slippage,
                     execute: cli.execute,
                 },
@@ -335,7 +350,7 @@ async fn main() -> anyhow::Result<()> {
         cli.sell_amount, cli.sell_token, cli.buy_token
     );
     let order = Order::new(
-        sell_token_bytes,
+        sell_token_bytes.clone(),
         buy_token_bytes,
         amount.clone(),
         OrderSide::Sell,
@@ -375,27 +390,18 @@ async fn main() -> anyhow::Result<()> {
     })?;
     let router_from_quote = Address::from_slice(tx.to().as_ref());
 
-    // ── ERC-20 execute: verify allowance before signing ───────────────────────
+    // ── ERC-20 execute: ensure router approval ────────────────────────────────
     if cli.execute {
         if let TransferType::TransferFrom = cli.transfer_type {
-            let allowance =
-                erc20::read_erc20_allowance(&provider, sell_token, sender, router_from_quote)
-                    .await?;
-            if allowance < amount {
-                eprintln!("\nError: insufficient sell-token allowance for the Fynd router.");
-                eprintln!("  Token:     {sell_token:#x}");
-                eprintln!("  Router:    {router_from_quote:#x}");
-                eprintln!("  Allowance: {allowance}");
-                eprintln!("  Required:  {amount}");
-                eprintln!("\nApprove the router with:");
-                eprintln!(
-                    "  cast send {sell_token:#x} \"approve(address,uint256)\" \
-                     {router_from_quote:#x} {} \\\n    \
-                     --rpc-url $RPC_URL --private-key $PRIVATE_KEY",
-                    cli.sell_amount
-                );
-                bail!("insufficient sell-token allowance");
-            }
+            ensure_approval(
+                &client,
+                &signer,
+                sell_token_bytes,
+                amount.clone(),
+                UserTransferType::TransferFrom,
+                sender,
+            )
+            .await?;
         }
     }
 
@@ -466,7 +472,7 @@ async fn main() -> anyhow::Result<()> {
 mod tests {
     use super::*;
 
-    // ── max_uint160 ───────────────────────────────────────────────────────────
+    // -- max_uint160 -----------------------------------------------------------
 
     #[test]
     fn max_uint160_is_20_bytes_of_ff() {
@@ -481,7 +487,7 @@ mod tests {
         assert_eq!(max_uint160(), expected);
     }
 
-    // ── CLI parsing ───────────────────────────────────────────────────────────
+    // -- CLI parsing -----------------------------------------------------------
 
     #[test]
     fn cli_defaults() {
@@ -495,21 +501,6 @@ mod tests {
         assert_eq!(cli.transfer_type, TransferType::TransferFrom);
         assert_eq!(cli.permit2, "0x000000000022D473030F116dDEE9F6B43aC78BA3");
         assert!(!cli.execute);
-        assert!(cli.router.is_none());
-    }
-
-    #[test]
-    fn cli_permit2_transfer_type_with_router() {
-        let cli = Cli::try_parse_from([
-            "fynd-swap-cli",
-            "--transfer-type",
-            "transfer-from-permit2",
-            "--router",
-            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-        ])
-        .unwrap();
-        assert_eq!(cli.transfer_type, TransferType::TransferFromPermit2);
-        assert_eq!(cli.router.as_deref(), Some("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Remove `--router` flag** — the Tycho Router address is now fetched automatically from `GET /v1/info`. The Permit2 path uses this to construct the EIP-712 permit and storage overrides.

- **Automatic approvals** — both ERC-20 and Permit2 execute paths now call `client.approval()` + `client.execute_approval()` instead of printing a `cast send` command. If the allowance is already sufficient, the approval is skipped. Removes the dead `erc20::read_erc20_allowance` helper.

- **Fix Permit2 dry-run simulation** — three issues fixed:
  - Permit2 validates `ecrecover(sig) == owner`: the dry-run now uses the ephemeral signer's own address as the order sender so this check passes.
  - `eth_call` was rejecting calls from zero-ETH accounts: `maxFeePerGas=0` is set in dry-run signing hints, bypassing the balance pre-check without needing a funded address. `DRY_RUN_SENDER` (Vitalik's address) is removed.
  - `TRANSFER_FROM_FAILED` revert: the TychoRouter may call `token.transferFrom(sender, router, amount)` directly, so the dry-run now injects `allowance[sender][router]` in addition to `allowance[sender][permit2]`.

- **Fix dry-run for tokens with bit-packed storage** — storage overrides now inject `U256::MAX >> 1` instead of `U256::MAX`. USDC packs a blacklist flag into bit 255 of its balance slot, so injecting all-ones caused a "Blacklistable: account is blacklisted" revert. Clearing the top bit avoids this while still providing an effectively unlimited balance/allowance.

- **Refactor**: all per-transfer-type logic (encoding options, approvals, dry-run spender addresses) is consolidated into a single `match cli.transfer_type` block.

- **Docs**: removes `--router` from examples, describes automatic approval handling, drops the stale "Insufficient allowance / cast send" troubleshooting entry.


Tested onchain with a couple of transactions. Example:
https://etherscan.io/tx/0x128238213a9281b7789c013986c99e341bcd863e1f2131adfc274d81bf600df4

🤖 Generated with [Claude Code](https://claude.com/claude-code)