### PR TITLE
fix: normalize pool depth to ETH for path scoring

### DIFF
--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -47,7 +47,7 @@ pub struct MostLiquidAlgorithm {
 pub struct DepthAndPrice {
     /// Spot price (token_out per token_in) for this edge direction.
     pub spot_price: f64,
-    /// Liquidity depth normalized to gas token (ETH) units.
+    /// Liquidity depth normalized to gas token (native token) units.
     pub depth: f64,
 }
 
@@ -119,28 +119,53 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
             }
         };
 
-        // Normalize depth from raw token_in units to gas token (ETH) units.
+        // Normalize depth from raw token_in units to gas token units.
         // TokenGasPrices stores Price { numerator, denominator } where
         // numerator/denominator = "token units per gas token unit".
-        // To convert token->ETH: depth_eth = raw_depth * denominator / numerator.
+        // To convert to gas token: depth_gas = raw_depth * denominator / numerator.
         let depth = match derived
             .token_prices()
             .and_then(|p| p.get(&token_in.address))
         {
             Some(price) => {
-                let num = price.numerator.to_f64().unwrap_or(0.0);
-                let den = price
-                    .denominator
-                    .to_f64()
-                    .unwrap_or(0.0);
-                if num == 0.0 || den == 0.0 {
-                    trace!(
-                        component_id = %component_id,
-                        token_in = %token_in.address,
-                        "token price has zero numerator or denominator, skipping edge"
-                    );
-                    return None;
-                }
+                let num = match price.numerator.to_f64() {
+                    Some(v) if v > 0.0 => v,
+                    Some(_) => {
+                        trace!(
+                            component_id = %component_id,
+                            token_in = %token_in.address,
+                            "token price numerator is zero, skipping edge"
+                        );
+                        return None;
+                    }
+                    None => {
+                        trace!(
+                            component_id = %component_id,
+                            token_in = %token_in.address,
+                            "token price numerator overflows f64, skipping edge"
+                        );
+                        return None;
+                    }
+                };
+                let den = match price.denominator.to_f64() {
+                    Some(v) if v > 0.0 => v,
+                    Some(_) => {
+                        trace!(
+                            component_id = %component_id,
+                            token_in = %token_in.address,
+                            "token price denominator is zero, skipping edge"
+                        );
+                        return None;
+                    }
+                    None => {
+                        trace!(
+                            component_id = %component_id,
+                            token_in = %token_in.address,
+                            "token price denominator overflows f64, skipping edge"
+                        );
+                        return None;
+                    }
+                };
                 raw_depth * den / num
             }
             None => {
@@ -653,7 +678,7 @@ impl Algorithm for MostLiquidAlgorithm {
     fn computation_requirements(&self) -> ComputationRequirements {
         // MostLiquidAlgorithm uses token prices for two purposes:
         // 1. Converting gas costs from wei to output token terms (net_amount_out)
-        // 2. Normalizing pool depth to ETH units for path scoring (from_sim_and_derived)
+        // 2. Normalizing pool depth to gas token units for path scoring (from_sim_and_derived)
         //
         // Token prices are marked as `allow_stale` since they don't change much
         // block-to-block. Stale prices affect scoring order (not correctness)

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -130,11 +130,11 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
             Some(price) => {
                 let num = price.numerator.to_f64().unwrap_or(0.0);
                 let den = price.denominator.to_f64().unwrap_or(0.0);
-                if num == 0.0 {
+                if num == 0.0 || den == 0.0 {
                     trace!(
                         component_id = %component_id,
                         token_in = %token_in.address,
-                        "token price numerator is zero, skipping edge"
+                        "token price has zero numerator or denominator, skipping edge"
                     );
                     return None;
                 }
@@ -648,12 +648,13 @@ impl Algorithm for MostLiquidAlgorithm {
     }
 
     fn computation_requirements(&self) -> ComputationRequirements {
-        // MostLiquidAlgorithm uses token prices to convert gas costs from wei
-        // to output token terms for accurate amount_out_net_gas calculation.
+        // MostLiquidAlgorithm uses token prices for two purposes:
+        // 1. Converting gas costs from wei to output token terms (net_amount_out)
+        // 2. Normalizing pool depth to ETH units for path scoring (from_sim_and_derived)
         //
         // Token prices are marked as `allow_stale` since they don't change much
-        // block-to-block and having slightly stale prices is acceptable for
-        // gas cost estimation.
+        // block-to-block. Stale prices affect scoring order (not correctness)
+        // and gas cost estimation accuracy.
         ComputationRequirements::none()
             .allow_stale("token_prices")
             .expect("Conflicting Computation Requirements")

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -924,6 +924,36 @@ mod tests {
         assert!(result.is_none());
     }
 
+    #[test]
+    fn test_from_sim_and_derived_missing_token_price_returns_none() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let tok_in = token(0x01, "A");
+        let tok_out = token(0x02, "B");
+
+        let mut derived = DerivedData::new();
+        // Spot price and pool depth both present
+        let mut prices = crate::derived::types::SpotPrices::default();
+        prices.insert(key.clone(), 1.5);
+        derived.set_spot_prices(prices, vec![], 10, true);
+
+        let mut depths = crate::derived::types::PoolDepths::default();
+        depths.insert(key.clone(), BigUint::from(1000u64));
+        derived.set_pool_depths(depths, vec![], 10, true);
+
+        // No token prices set — normalization should return None
+
+        let sim = make_mock_sim();
+        let result =
+            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
+                &sim, &key.0, &tok_in, &tok_out, &derived,
+            );
+
+        assert!(
+            result.is_none(),
+            "should return None when token price is missing for depth normalization"
+        );
+    }
+
     // ==================== find_paths Tests ====================
 
     fn all_ids(paths: Vec<Path<'_, DepthAndPrice>>) -> HashSet<Vec<&str>> {

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -954,6 +954,96 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_from_sim_and_derived_normalizes_depth_to_eth() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let tok_in = token(0x01, "A");
+        let tok_out = token(0x02, "B");
+
+        let mut derived = DerivedData::new();
+
+        // Spot price
+        let mut spot = crate::derived::types::SpotPrices::default();
+        spot.insert(key.clone(), 2.0);
+        derived.set_spot_prices(spot, vec![], 10, true);
+
+        // Raw depth: 2_000_000 token_in units
+        let mut depths = crate::derived::types::PoolDepths::default();
+        depths.insert(key.clone(), BigUint::from(2_000_000u64));
+        derived.set_pool_depths(depths, vec![], 10, true);
+
+        // Token price: 2000 token_in per 1 ETH (numerator=2000, denominator=1)
+        // So 2_000_000 raw units / 2000 = 1000 ETH
+        let mut token_prices = TokenGasPrices::new();
+        token_prices.insert(
+            tok_in.address.clone(),
+            Price {
+                numerator: BigUint::from(2000u64),
+                denominator: BigUint::from(1u64),
+            },
+        );
+        derived.set_token_prices(token_prices, vec![], 10, true);
+
+        let sim = make_mock_sim();
+        let result =
+            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
+                &sim, &key.0, &tok_in, &tok_out, &derived,
+            );
+
+        let data = result.expect("should return Some when all data present");
+        assert!((data.spot_price - 2.0).abs() < f64::EPSILON, "spot price should be 2.0");
+        // depth_in_eth = 2_000_000 * 1 / 2000 = 1000.0
+        assert!(
+            (data.depth - 1000.0).abs() < f64::EPSILON,
+            "depth should be 1000.0 ETH, got {}",
+            data.depth
+        );
+    }
+
+    #[test]
+    fn test_from_sim_and_derived_normalizes_depth_fractional_price() {
+        let key = pair_key("pool1", 0x01, 0x02);
+        let tok_in = token(0x01, "A");
+        let tok_out = token(0x02, "B");
+
+        let mut derived = DerivedData::new();
+
+        let mut spot = crate::derived::types::SpotPrices::default();
+        spot.insert(key.clone(), 0.5);
+        derived.set_spot_prices(spot, vec![], 10, true);
+
+        // Raw depth: 500 token_in units
+        let mut depths = crate::derived::types::PoolDepths::default();
+        depths.insert(key.clone(), BigUint::from(500u64));
+        derived.set_pool_depths(depths, vec![], 10, true);
+
+        // Token price: numerator=3, denominator=2 -> 1.5 tokens per ETH
+        // depth_in_eth = 500 * 2 / 3 = 333.333...
+        let mut token_prices = TokenGasPrices::new();
+        token_prices.insert(
+            tok_in.address.clone(),
+            Price {
+                numerator: BigUint::from(3u64),
+                denominator: BigUint::from(2u64),
+            },
+        );
+        derived.set_token_prices(token_prices, vec![], 10, true);
+
+        let sim = make_mock_sim();
+        let result =
+            <DepthAndPrice as crate::graph::EdgeWeightFromSimAndDerived>::from_sim_and_derived(
+                &sim, &key.0, &tok_in, &tok_out, &derived,
+            );
+
+        let data = result.expect("should return Some when all data present");
+        let expected_depth = 500.0 * 2.0 / 3.0;
+        assert!(
+            (data.depth - expected_depth).abs() < 1e-10,
+            "depth should be {expected_depth}, got {}",
+            data.depth
+        );
+    }
+
     // ==================== find_paths Tests ====================
 
     fn all_ids(paths: Vec<Path<'_, DepthAndPrice>>) -> HashSet<Vec<&str>> {

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -796,6 +796,18 @@ mod tests {
         format!("{comp}/{}/{}", addr(b_in), addr(b_out))
     }
 
+    fn make_token_prices(addresses: &[Address]) -> TokenGasPrices {
+        let mut prices = TokenGasPrices::new();
+        for addr in addresses {
+            // 1:1 price (1 token unit = 1 gas token unit)
+            prices.insert(
+                addr.clone(),
+                Price { numerator: BigUint::from(1u64), denominator: BigUint::from(1u64) },
+            );
+        }
+        prices
+    }
+
     #[test]
     fn test_from_sim_and_derived_failed_spot_price_returns_none() {
         let key = pair_key("pool1", 0x01, 0x02);
@@ -815,6 +827,12 @@ mod tests {
             true,
         );
         derived.set_pool_depths(Default::default(), vec![], 10, true);
+        derived.set_token_prices(
+            make_token_prices(&[tok_in.address.clone(), tok_out.address.clone()]),
+            vec![],
+            10,
+            true,
+        );
 
         let sim = make_mock_sim();
         let result =
@@ -844,6 +862,12 @@ mod tests {
                 key: key_str,
                 error: FailedItemError::SimulationFailed("depth error".into()),
             }],
+            10,
+            true,
+        );
+        derived.set_token_prices(
+            make_token_prices(&[tok_in.address.clone(), tok_out.address.clone()]),
+            vec![],
             10,
             true,
         );
@@ -880,6 +904,12 @@ mod tests {
                 key: key_str,
                 error: FailedItemError::SimulationFailed("depth error".into()),
             }],
+            10,
+            true,
+        );
+        derived.set_token_prices(
+            make_token_prices(&[tok_in.address.clone(), tok_out.address.clone()]),
+            vec![],
             10,
             true,
         );

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -129,7 +129,10 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
         {
             Some(price) => {
                 let num = price.numerator.to_f64().unwrap_or(0.0);
-                let den = price.denominator.to_f64().unwrap_or(0.0);
+                let den = price
+                    .denominator
+                    .to_f64()
+                    .unwrap_or(0.0);
                 if num == 0.0 || den == 0.0 {
                     trace!(
                         component_id = %component_id,
@@ -977,10 +980,7 @@ mod tests {
         let mut token_prices = TokenGasPrices::new();
         token_prices.insert(
             tok_in.address.clone(),
-            Price {
-                numerator: BigUint::from(2000u64),
-                denominator: BigUint::from(1u64),
-            },
+            Price { numerator: BigUint::from(2000u64), denominator: BigUint::from(1u64) },
         );
         derived.set_token_prices(token_prices, vec![], 10, true);
 
@@ -1022,10 +1022,7 @@ mod tests {
         let mut token_prices = TokenGasPrices::new();
         token_prices.insert(
             tok_in.address.clone(),
-            Price {
-                numerator: BigUint::from(3u64),
-                denominator: BigUint::from(2u64),
-            },
+            Price { numerator: BigUint::from(3u64), denominator: BigUint::from(2u64) },
         );
         derived.set_token_prices(token_prices, vec![], 10, true);
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -47,7 +47,7 @@ pub struct MostLiquidAlgorithm {
 pub struct DepthAndPrice {
     /// Spot price (token_out per token_in) for this edge direction.
     pub spot_price: f64,
-    /// Liquidity depth in raw units of the sell token.
+    /// Liquidity depth normalized to gas token (ETH) units.
     pub depth: f64,
 }
 
@@ -108,13 +108,44 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
         };
 
         // Look up pre-computed depth; skip edge if unavailable.
-        let depth = match derived
+        let raw_depth = match derived
             .pool_depths()
             .and_then(|d| d.get(&key))
         {
             Some(d) => d.to_f64().unwrap_or(0.0),
             None => {
                 trace!(component_id = %component_id, "pool depth not found, skipping edge");
+                return None;
+            }
+        };
+
+        // Normalize depth from raw token_in units to gas token (ETH) units.
+        // TokenGasPrices stores Price { numerator, denominator } where
+        // numerator/denominator = "token units per gas token unit".
+        // To convert token->ETH: depth_eth = raw_depth * denominator / numerator.
+        let depth = match derived
+            .token_prices()
+            .and_then(|p| p.get(&token_in.address))
+        {
+            Some(price) => {
+                let num = price.numerator.to_f64().unwrap_or(0.0);
+                let den = price.denominator.to_f64().unwrap_or(0.0);
+                if num == 0.0 {
+                    trace!(
+                        component_id = %component_id,
+                        token_in = %token_in.address,
+                        "token price numerator is zero, skipping edge"
+                    );
+                    return None;
+                }
+                raw_depth * den / num
+            }
+            None => {
+                trace!(
+                    component_id = %component_id,
+                    token_in = %token_in.address,
+                    "token price not found, skipping edge"
+                );
                 return None;
             }
         };


### PR DESCRIPTION
## Summary

- Normalize pool depth from raw `token_in` units to ETH-equivalent in `DepthAndPrice::from_sim_and_derived`, using `TokenGasPrices` already available in `DerivedData`
- Fix `min(depths)` comparison across hops — previously meaningless when comparing different token denominations (e.g., WETH 18 decimals vs USDC 6 decimals)
- Guard against zero numerator/denominator in token price

## Problem

`MostLiquidAlgorithm::try_score_path` computes `score = product(spot_prices) × min(depths)` to prioritize which paths to simulate. Depth was stored in raw `token_in` units, so a WETH edge depth of `1e18` (1 WETH) appeared 10^12x larger than a USDC depth of `1e9` (1000 USDC). This caused misordered simulation priority, and with `max_routes` truncation or timeout, genuinely good paths could be permanently excluded.

## Changes

Single file change: `fynd-core/src/algorithm/most_liquid.rs`

**Production code:**
- `from_sim_and_derived`: after reading raw `BigUint` depth, converts to ETH using `depth_eth = raw_depth * denominator / numerator` from `TokenGasPrices`
- Returns `None` (skips edge) if token price is missing or has zero numerator/denominator
- Updated `depth` field doc comment and `computation_requirements()` comment

**Tests (6 new/updated):**
- 3 existing tests updated to provide token prices in `DerivedData`
- `test_from_sim_and_derived_missing_token_price_returns_none`
- `test_from_sim_and_derived_normalizes_depth_to_eth` (integer price ratio)
- `test_from_sim_and_derived_normalizes_depth_fractional_price` (fractional price ratio)

## Benchmark Results (500 requests, `fynd-benchmark compare`)

```
Coverage:
  Both found route:          371
  Only main found route:       0
  Only normalized-depth:       0
  Neither found route:       129

Head-to-head (amount out before gas):
  normalized-depth wins:  65  (13.0%)
  main wins:              29  ( 5.8%)
  Ties:                  406  (81.2%)
  Avg diff:           +0.50 bps

Head-to-head (net of gas, server-side):
  normalized-depth wins:  96  (19.2%)
  main wins:              26  ( 5.2%)
  Ties:                  378  (75.6%)
  Avg diff:           +0.67 bps

Solve Time:
  main:             avg=34ms  p50=35  p95=87   p99=103
  normalized-depth: avg=34ms  p50=34  p95=88   p99=102

Route Depth:
  main avg swaps: 1.6  (max 3)
  normalized-depth avg swaps: 1.7  (max 3)
  Identical routes: 415/500
```

**Key takeaways:**
- Zero coverage regression — no routes lost from skipping edges without token prices
- 2:1 win ratio pre-gas (65 vs 29), improving to ~4:1 net-of-gas (96 vs 26)
- Top outliers show +18-20 bps on multi-hop routes (WETH → small tokens) where the fix matters most
- Solve time unchanged — normalization adds negligible overhead
- Worst single trade: -11.9 bps; best: +19.9 bps; average consistently positive

## Test plan

- [x] All 324 fynd-core tests pass
- [x] Clippy clean (`-D warnings`)
- [x] Formatting clean
- [x] Benchmark comparison against main (500 requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)