### PR TITLE
fix: set min token quality filter on tycho stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 
 # Tycho
-tycho-simulation = ">=0.251.1"
+tycho-simulation = ">=0.254.0"
 tycho-execution = ">=0.171.2"
 typetag = "0.2"
 

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -140,6 +140,7 @@ impl TychoFeed {
                 )?
                 .auth_key(self.config.tycho_api_key.clone())
                 .skip_state_decode_failures(true)
+                .min_token_quality(self.config.min_token_quality as u32)
                 .set_tokens(all_tokens.clone())
                 .await
                 .build()


### PR DESCRIPTION
Previously it was only used at start-up to filter the initial tokens retrieved.