### PR TITLE
feat: add docker-compose for frontend + quickstart docs

### DIFF
--- a/docker-compose.frontend.yml
+++ b/docker-compose.frontend.yml
@@ -1,0 +1,43 @@
+# Starts Fynd router + swap frontend.
+#
+# Usage:
+#   export TYCHO_API_KEY=your-api-key
+#   docker compose -f docker-compose.frontend.yml up
+#   Open http://localhost:3005
+#
+# Required env vars (set in .env or export before running):
+#   TYCHO_API_KEY  — Tycho API key (https://t.me/fynd_portal_bot)
+#
+# Optional env vars:
+#   CHAIN      — chain name (default: Ethereum)
+#   PROTOCOLS  — comma-separated protocol list (default: mainnet preset)
+#   TYCHO_URL  — Tycho WebSocket endpoint (default: tycho-fynd-ethereum.propellerheads.xyz)
+#   RUST_LOG   — tracing filter (default: fynd=info)
+
+services:
+  fynd-serve:
+    image: ghcr.io/propeller-heads/fynd:latest
+    entrypoint: ["/usr/local/bin/fynd"]
+    command:
+      - serve
+      - "--chain"
+      - "${CHAIN:-Ethereum}"
+      - "--protocols"
+      - "${PROTOCOLS:-uniswap_v2,uniswap_v3,ekubo_v2,pancakeswap_v3,sushiswap_v2,fluid_v1,pancakeswap_v2}"
+    ports:
+      - "3000:3000"
+    environment:
+      - TYCHO_API_KEY=${TYCHO_API_KEY}
+      - TYCHO_URL=${TYCHO_URL:-tycho-fynd-ethereum.propellerheads.xyz}
+      - RUST_LOG=${RUST_LOG:-fynd=info}
+
+  fynd-frontend:
+    image: ghcr.io/propeller-heads/fynd-frontend:latest
+    ports:
+      - "3005:3005"
+    environment:
+      - PATHFINDER_BASE_URL=http://fynd-serve:3000
+      - TYCHO_AUTH_TOKEN=${TYCHO_API_KEY}
+      - TYCHO_BASE_URL=${TYCHO_BASE_URL:-https://tycho-beta.propellerheads.xyz}
+    depends_on:
+      - fynd-serve

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 
 * [Overview](README.md)
 * [Quickstart](get-started/quickstart/README.md)
+* [Quickstart (Frontend)](get-started/quickstart-frontend/README.md)
 
 ## Guides
 

--- a/docs/get-started/quickstart-frontend/README.md
+++ b/docs/get-started/quickstart-frontend/README.md
@@ -1,0 +1,71 @@
+---
+description: Swap via Fynd using the web frontend — no CLI, no private keys.
+icon: browser
+layout:
+  width: default
+  title:
+    visible: true
+  description:
+    visible: true
+  tableOfContents:
+    visible: true
+  outline:
+    visible: true
+  pagination:
+    visible: true
+  metadata:
+    visible: true
+  tags:
+    visible: true
+---
+
+# Quickstart (Frontend)
+
+Run the Fynd swap frontend locally with Docker Compose. Connect your browser wallet (MetaMask, Ledger, etc.) and swap — no private key export required.
+
+## Prerequisites
+
+* **Docker** ([install Docker](https://docs.docker.com/get-started/get-docker/))
+* **Tycho API key** (set as `TYCHO_API_KEY`, [get one here](https://t.me/fynd_portal_bot))
+
+## Step 0 — Start Fynd + Frontend
+
+```bash
+export TYCHO_API_KEY=your-api-key
+docker compose -f docker-compose.frontend.yml up
+```
+
+This pulls two images and starts them:
+- **Fynd router** on port 3000 — finds optimal swap routes
+- **Swap frontend** on port 3005 — the web UI you interact with
+
+## Step 1 — Connect your wallet
+
+Open [http://localhost:3005](http://localhost:3005) in your browser.
+
+Click **Connect Wallet** in the top-right corner and connect your wallet (MetaMask, WalletConnect, Coinbase Wallet, or any injected wallet).
+
+{% hint style="info" %}
+The router needs ~30 seconds to load market data after starting. The UI will show a loading state until the router is ready — this is normal on first launch.
+{% endhint %}
+
+## Step 2 — Swap
+
+1. Select the token you want to sell (top input)
+2. Select the token you want to buy (bottom input)
+3. Enter the amount to sell
+4. Click **Get Route** to fetch the best route
+5. Review the route details (price impact, gas estimate, route visualization)
+6. Click **Swap** to execute — your wallet will prompt you to sign the transaction
+
+## Stopping
+
+```bash
+docker compose -f docker-compose.frontend.yml down
+```
+
+## Next steps
+
+* [Server configuration](../../guides/server-configuration.md) — customize the router (protocols, timeouts, worker pools)
+* [Quickstart (CLI/SDK)](../quickstart/) — integrate Fynd programmatically with TypeScript or Rust
+* [API reference](../../reference/api.md) — full endpoint documentation


### PR DESCRIPTION
## Summary

- Add `docker-compose.frontend.yml` to run Fynd router + swap frontend with a single command
- Add quickstart-frontend docs page for zero-friction onboarding (Docker only, no Rust/CLI needed)
- Users set one env var (`TYCHO_API_KEY`), run `docker compose up`, and open `localhost:3005`

**Depends on:** propeller-heads/fynd-frontend PR (publishes `ghcr.io/propeller-heads/fynd-frontend` image)

## Test Plan

- [ ] `docker compose -f docker-compose.frontend.yml config` validates successfully
- [ ] Both services start with `docker compose -f docker-compose.frontend.yml up`
- [ ] Frontend reaches router via internal Docker DNS (`http://fynd-serve:3000`)
- [ ] Quickstart docs render correctly in GitBook
- [ ] SUMMARY.md links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)