### PR TITLE
feat: improve swap-cli UX

### DIFF
--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -29,8 +29,9 @@ use alloy::{
 };
 use bytes::Bytes;
 use fynd_client::{
-    ApprovalParams, ClientFeeParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order,
-    OrderSide, QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints,
+    AllowanceCheck, ApprovalParams, ClientFeeParams, EncodingOptions, ExecutionOptions,
+    FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams, SignedApproval, SignedSwap,
+    SigningHints,
 };
 use num_bigint::BigUint;
 
@@ -81,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &ApprovalParams::new(
                 Bytes::copy_from_slice(sell_token.as_slice()),
                 BigUint::from(SELL_AMOUNT),
-                true,
+                AllowanceCheck::AtLeast(BigUint::from(SELL_AMOUNT)),
             ),
             &SigningHints::default(),
         )

--- a/clients/rust/examples/swap_erc20.rs
+++ b/clients/rust/examples/swap_erc20.rs
@@ -26,8 +26,8 @@ use alloy::{
 };
 use bytes::Bytes;
 use fynd_client::{
-    ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
-    QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints,
+    AllowanceCheck, ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order,
+    OrderSide, QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints,
 };
 use num_bigint::BigUint;
 
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &ApprovalParams::new(
                 Bytes::copy_from_slice(sell_token.as_slice()),
                 BigUint::from(SELL_AMOUNT),
-                true,
+                AllowanceCheck::AtLeast(BigUint::from(SELL_AMOUNT)),
             ),
             &SigningHints::default(),
         )

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -27,8 +27,8 @@ use alloy::{
 };
 use bytes::Bytes;
 use fynd_client::{
-    ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order, OrderSide,
-    PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle, QuoteOptions,
+    AllowanceCheck, ApprovalParams, EncodingOptions, ExecutionOptions, FyndClientBuilder, Order,
+    OrderSide, PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle, QuoteOptions,
     QuoteParams, SignedApproval, SignedSwap, SigningHints, UserTransferType,
 };
 use num_bigint::BigUint;
@@ -77,7 +77,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             &ApprovalParams::new(
                 Bytes::copy_from_slice(sell_token.as_slice()),
                 BigUint::from(SELL_AMOUNT),
-                true,
+                AllowanceCheck::AtLeast(BigUint::from(SELL_AMOUNT)),
             )
             .with_transfer_type(UserTransferType::TransferFromPermit2),
             &SigningHints::default(),

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -839,7 +839,7 @@ where
                             compute_settled_amount(&receipt, &token_out_addr, &receiver_addr);
                         let gas_cost = BigUint::from(receipt.gas_used) *
                             BigUint::from(receipt.effective_gas_price);
-                        return Ok(SettledOrder::new(settled_amount, gas_cost));
+                        return Ok(SettledOrder::new(Some(tx_hash), settled_amount, gas_cost));
                     }
                     None => tokio::time::sleep(Duration::from_secs(2)).await,
                 }
@@ -1115,7 +1115,7 @@ where
             None
         };
         let gas_cost = BigUint::from(gas_used) * BigUint::from(tx_eip1559.max_fee_per_gas);
-        let settled = SettledOrder::new(settled_amount, gas_cost);
+        let settled = SettledOrder::new(None, settled_amount, gas_cost);
 
         Ok(ExecutionReceipt::Transaction(Box::pin(async move { Ok(settled) })))
     }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -851,8 +851,8 @@ where
                         }
                         let settled_amount =
                             compute_settled_amount(&receipt, &token_out_addr, &receiver_addr);
-                        let gas_cost = BigUint::from(receipt.gas_used)
-                            * BigUint::from(receipt.effective_gas_price);
+                        let gas_cost = BigUint::from(receipt.gas_used) *
+                            BigUint::from(receipt.effective_gas_price);
                         return Ok(SettledOrder::new(Some(tx_hash), settled_amount, gas_cost));
                     }
                     None => tokio::time::sleep(Duration::from_secs(2)).await,
@@ -888,8 +888,8 @@ where
     /// 1. Calls [`info()`](Self::info) to resolve the spender address from `params.transfer_type`.
     /// 2. If `params.allowance_check` is [`AllowanceCheck::AtLeast`], checks the current ERC-20
     ///    allowance and returns `None` if it meets the threshold (skipping nonce and fee
-    ///    resolution). With [`AllowanceCheck::Skip`] the check is skipped and the approval
-    ///    payload is always built.
+    ///    resolution). With [`AllowanceCheck::Skip`] the check is skipped and the approval payload
+    ///    is always built.
     /// 3. Resolves nonce and EIP-1559 fees via `hints` (same semantics as
     ///    [`swap_payload`](Self::swap_payload)).
     /// 4. Encodes the `approve(spender, amount)` calldata using the ERC-20 ABI.
@@ -1067,8 +1067,8 @@ where
                             };
                             return Err(FyndError::TransactionReverted(reason));
                         }
-                        let gas_cost = BigUint::from(receipt.gas_used)
-                            * BigUint::from(receipt.effective_gas_price);
+                        let gas_cost = BigUint::from(receipt.gas_used) *
+                            BigUint::from(receipt.effective_gas_price);
                         return Ok(MinedTx::new(tx_hash, gas_cost));
                     }
                     None => tokio::time::sleep(Duration::from_secs(2)).await,

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -274,12 +274,25 @@ impl Default for ExecutionOptions {
 // APPROVAL PARAMS
 // ============================================================================
 
+/// Controls whether [`FyndClient::approval`] checks the current on-chain allowance before
+/// building an approval transaction.
+pub enum AllowanceCheck {
+    /// Always build the approval payload — do not read the current allowance.
+    Skip,
+    /// Return `None` (no approval needed) if the current allowance is ≥ the given threshold.
+    ///
+    /// Pass the minimum amount required for the operation. For standard ERC-20 flows this is the
+    /// same as the approve amount; for Permit2 it can be the swap amount while the actual
+    /// approval is for a larger value (e.g. `max_uint160`) to avoid re-approving every swap.
+    AtLeast(BigUint),
+}
+
 /// Parameters for [`FyndClient::approval`].
 pub struct ApprovalParams {
     token: bytes::Bytes,
-    amount: num_bigint::BigUint,
+    amount: BigUint,
+    allowance_check: AllowanceCheck,
     transfer_type: UserTransferType,
-    check_allowance: bool,
 }
 
 impl ApprovalParams {
@@ -288,11 +301,12 @@ impl ApprovalParams {
     /// Defaults to a standard ERC-20 approval against the router contract.
     /// Use [`with_transfer_type`](Self::with_transfer_type) to approve the Permit2 contract
     /// instead.
-    ///
-    /// When `check_allowance` is `true`, [`FyndClient::approval`] checks the on-chain allowance
-    /// first and returns `None` if it is already sufficient.
-    pub fn new(token: bytes::Bytes, amount: num_bigint::BigUint, check_allowance: bool) -> Self {
-        Self { token, amount, transfer_type: UserTransferType::TransferFrom, check_allowance }
+    pub fn new(
+        token: bytes::Bytes,
+        amount: num_bigint::BigUint,
+        allowance_check: AllowanceCheck,
+    ) -> Self {
+        Self { token, amount, allowance_check, transfer_type: UserTransferType::TransferFrom }
     }
 
     /// Override the transfer type (and thus the spender contract).
@@ -837,8 +851,8 @@ where
                         }
                         let settled_amount =
                             compute_settled_amount(&receipt, &token_out_addr, &receiver_addr);
-                        let gas_cost = BigUint::from(receipt.gas_used) *
-                            BigUint::from(receipt.effective_gas_price);
+                        let gas_cost = BigUint::from(receipt.gas_used)
+                            * BigUint::from(receipt.effective_gas_price);
                         return Ok(SettledOrder::new(Some(tx_hash), settled_amount, gas_cost));
                     }
                     None => tokio::time::sleep(Duration::from_secs(2)).await,
@@ -871,9 +885,11 @@ where
     /// Build an unsigned EIP-1559 `approve(spender, amount)` transaction for the given token,
     /// or `None` if the allowance is already sufficient.
     ///
-    /// 1. Calls [`info()`](Self::info) to resolve the spender address from `params.spender`.
-    /// 2. If `params.check_allowance` is `true`, checks the current ERC-20 allowance and returns
-    ///    `None` immediately if it is already sufficient (skipping nonce and fee resolution).
+    /// 1. Calls [`info()`](Self::info) to resolve the spender address from `params.transfer_type`.
+    /// 2. If `params.allowance_check` is [`AllowanceCheck::AtLeast`], checks the current ERC-20
+    ///    allowance and returns `None` if it meets the threshold (skipping nonce and fee
+    ///    resolution). With [`AllowanceCheck::Skip`] the check is skipped and the approval
+    ///    payload is always built.
     /// 3. Resolves nonce and EIP-1559 fees via `hints` (same semantics as
     ///    [`swap_payload`](Self::swap_payload)).
     /// 4. Encodes the `approve(spender, amount)` calldata using the ERC-20 ABI.
@@ -906,7 +922,7 @@ where
         let amount_u256 = mapping::biguint_to_u256(&params.amount);
 
         // Check allowance before any other RPC calls so we can return early.
-        if params.check_allowance {
+        if let AllowanceCheck::AtLeast(min) = &params.allowance_check {
             let call_data =
                 erc20::allowanceCall { owner: sender, spender: spender_addr }.abi_encode();
             let req = alloy::rpc::types::TransactionRequest {
@@ -924,7 +940,7 @@ where
             } else {
                 alloy::primitives::U256::ZERO
             };
-            if current_allowance >= amount_u256 {
+            if current_allowance >= mapping::biguint_to_u256(min) {
                 return Ok(None);
             }
         }
@@ -1051,8 +1067,8 @@ where
                             };
                             return Err(FyndError::TransactionReverted(reason));
                         }
-                        let gas_cost = BigUint::from(receipt.gas_used) *
-                            BigUint::from(receipt.effective_gas_price);
+                        let gas_cost = BigUint::from(receipt.gas_used)
+                            * BigUint::from(receipt.effective_gas_price);
                         return Ok(MinedTx::new(tx_hash, gas_cost));
                     }
                     None => tokio::time::sleep(Duration::from_secs(2)).await,
@@ -1942,14 +1958,14 @@ mod tests {
         let params = ApprovalParams::new(
             bytes::Bytes::copy_from_slice(&[0xdd; 20]),
             num_bigint::BigUint::from(1_000_000u64),
-            false,
+            AllowanceCheck::Skip,
         );
 
         let payload = client
             .approval(&params, &hints)
             .await
             .expect("approval should succeed")
-            .expect("should build payload when check_allowance is false");
+            .expect("should build payload when AllowanceCheck::Skip");
 
         // Verify function selector is approve(address,uint256) = 0x095ea7b3.
         let selector = &payload.tx().input[0..4];
@@ -1996,7 +2012,7 @@ mod tests {
         let params = ApprovalParams::new(
             bytes::Bytes::copy_from_slice(&[0xdd; 20]),
             num_bigint::BigUint::from(500_000u64),
-            true,
+            AllowanceCheck::AtLeast(num_bigint::BigUint::from(500_000u64)),
         );
 
         let result = client
@@ -2046,7 +2062,7 @@ mod tests {
         let params = ApprovalParams::new(
             bytes::Bytes::copy_from_slice(&[0xdd; 20]),
             num_bigint::BigUint::from(500_000u64),
-            true,
+            AllowanceCheck::AtLeast(num_bigint::BigUint::from(500_000u64)),
         );
 
         let result = client

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -73,8 +73,8 @@
 //! ```
 
 pub use client::{
-    ApprovalParams, ExecutionOptions, FyndClient, FyndClientBuilder, RetryConfig, SigningHints,
-    StorageOverrides,
+    AllowanceCheck, ApprovalParams, ExecutionOptions, FyndClient, FyndClientBuilder, RetryConfig,
+    SigningHints, StorageOverrides,
 };
 pub use error::{ErrorCode, FyndError};
 pub use signing::{

--- a/clients/rust/src/signing.rs
+++ b/clients/rust/src/signing.rs
@@ -166,15 +166,25 @@ impl SignedSwap {
 /// The result of a successfully mined or simulated swap transaction.
 ///
 /// Returned by awaiting an [`ExecutionReceipt`]. For dry-run executions
-/// ([`ExecutionOptions::dry_run`](crate::ExecutionOptions)), `tx_receipt` is `None`.
+/// ([`ExecutionOptions::dry_run`](crate::ExecutionOptions)), `tx_hash` and `tx_receipt` are `None`.
 pub struct SettledOrder {
+    tx_hash: Option<B256>,
     settled_amount: Option<BigUint>,
     gas_cost: BigUint,
 }
 
 impl SettledOrder {
-    pub(crate) fn new(settled_amount: Option<BigUint>, gas_cost: BigUint) -> Self {
-        Self { settled_amount, gas_cost }
+    pub(crate) fn new(
+        tx_hash: Option<B256>,
+        settled_amount: Option<BigUint>,
+        gas_cost: BigUint,
+    ) -> Self {
+        Self { tx_hash, settled_amount, gas_cost }
+    }
+
+    /// The transaction hash of the mined swap. `None` for dry-run simulations.
+    pub fn tx_hash(&self) -> Option<B256> {
+        self.tx_hash
     }
 
     /// The total amount of `token_out` actually received by the receiver, summed across all

--- a/docs/guides/server-configuration.md
+++ b/docs/guides/server-configuration.md
@@ -31,7 +31,7 @@ Specify protocols explicitly:
 
 ```bash
 cargo run --release -- serve \
-  --protocols uniswap_v2,uniswap_v3,vm:curve
+  --protocols uniswap_v2,uniswap_v3,ekubo_v3,fluid_v1
 ```
 
 See the full [list of available protocols](https://docs.propellerheads.xyz/tycho/for-solvers/supported-protocols).

--- a/docs/guides/swap-cli.md
+++ b/docs/guides/swap-cli.md
@@ -99,7 +99,7 @@ fynd-swap-cli --execute
 
 ## Execute on-chain (Permit2)
 
-Add `--execute --transfer-type transfer-from-permit2`. The CLI checks the Permit2 allowance and submits an approval transaction first if needed, then reads the current nonce, builds the EIP-712 permit, signs it, and submits the swap.
+Add `--execute --transfer-type transfer-from-permit2`. The CLI checks whether the ERC-20 allowance to the Permit2 contract is sufficient for the swap. If not, it approves the maximum amount so subsequent swaps do not require re-approval. It then reads the current nonce, builds the EIP-712 permit, signs it, and submits the swap.
 
 ```bash
 export RPC_URL=https://your-rpc-provider.com/v1/your_key

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -186,21 +186,23 @@ async fn ensure_approval(
     transfer_type: UserTransferType,
     sender: Address,
 ) -> anyhow::Result<()> {
+    println!("Checking ERC-20 allowance...");
     let params = ApprovalParams::new(sell_token, amount, true).with_transfer_type(transfer_type);
     let hints = SigningHints::default().with_sender(sender);
     let Some(approval_payload) = client.approval(&params, &hints).await? else {
-        return Ok(()); // allowance already sufficient
+        println!("Allowance sufficient, no approval needed.");
+        return Ok(());
     };
-    info!("Submitting approval transaction...");
+    println!("Allowance insufficient — submitting approval transaction...");
     let sig = signer
         .sign_hash(&approval_payload.signing_hash())
         .await?;
     let signed = SignedApproval::assemble(approval_payload, sig);
     let receipt = client.execute_approval(signed).await?;
-    tokio::time::timeout(Duration::from_secs(120), receipt)
+    let mined = tokio::time::timeout(Duration::from_secs(120), receipt)
         .await
         .map_err(|_| anyhow::anyhow!("timed out waiting for approval to be mined"))??;
-    info!("Approval confirmed.");
+    println!("Approved! (tx: {:#x})", mined.tx_hash());
     Ok(())
 }
 
@@ -385,7 +387,7 @@ async fn main() -> anyhow::Result<()> {
     );
     let order = Order::new(
         sell_token_bytes.clone(),
-        buy_token_bytes,
+        buy_token_bytes.clone(),
         amount.clone(),
         OrderSide::Sell,
         sender_bytes,
@@ -399,17 +401,19 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     println!("\n========== Quote ==========");
-    println!("Status:            {:?}", quote.status());
-    println!("Amount in:         {}", quote.amount_in());
-    println!("Amount out:        {}", quote.amount_out());
-    println!("Amount out net gas:{}", quote.amount_out_net_gas());
-    println!("Gas estimate:      {}", quote.gas_estimate());
-    println!("Solve time:        {}ms", quote.solve_time_ms());
+    println!("Status:              {:?}", quote.status());
+    println!("Amount in:           {}", quote.amount_in());
+    println!("Amount out:          {}", quote.amount_out());
+    println!("Amount out net gas:  {}", quote.amount_out_net_gas());
+    println!("Token in:            {}", format!("0x{}", hex::encode(&sell_token_bytes)));
+    println!("Token out:           {}", format!("0x{}", hex::encode(&buy_token_bytes)));
+    println!("Gas estimate:        {}", quote.gas_estimate());
+    println!("Solve time:          {}ms", quote.solve_time_ms());
     if let Some(route) = quote.route() {
         println!("Route ({} hops):", route.swaps().len());
         for (i, swap) in route.swaps().iter().enumerate() {
             println!(
-                "  {}. {} -> {} via {} (pool: {})",
+                "  {}. 0x{} -> 0x{} via {} (pool: {})",
                 i + 1,
                 hex::encode(swap.token_in()),
                 hex::encode(swap.token_out()),
@@ -442,7 +446,7 @@ async fn main() -> anyhow::Result<()> {
 
     // ── Build execution options ───────────────────────────────────────────────
     let exec_options = if cli.execute {
-        info!("Submitting on-chain transaction...");
+        println!("Submitting on-chain transaction...");
         ExecutionOptions::default()
     } else {
         let overrides = if dry_run_spenders.is_empty() {
@@ -473,7 +477,11 @@ async fn main() -> anyhow::Result<()> {
     };
 
     if cli.execute {
-        println!("\nSwap executed on-chain!");
+        if let Some(hash) = settled.tx_hash() {
+            println!("\nSwap executed on-chain! (tx: {hash:#x})");
+        } else {
+            println!("\nSwap executed on-chain!");
+        }
     } else {
         println!("\nSimulation successful!");
     }

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -358,7 +358,7 @@ async fn main() -> anyhow::Result<()> {
                     &client,
                     &signer,
                     sell_token_bytes.clone(),
-                    max_uint160(),
+                    amount.clone(),
                     AllowanceCheck::AtLeast(amount.clone()),
                     UserTransferType::TransferFromPermit2,
                     sender,

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -24,10 +24,10 @@ use anyhow::{bail, Context};
 use bytes::Bytes;
 use clap::Parser;
 use fynd_client::{
-    ApprovalParams, EncodingOptions, ExecutionOptions, FyndClient, FyndClientBuilder, HealthStatus,
-    Order, OrderSide, PermitDetails as FyndPermitDetails, PermitSingle as FyndPermitSingle,
-    QuoteOptions, QuoteParams, SignedApproval, SignedSwap, SigningHints, StorageOverrides,
-    UserTransferType,
+    AllowanceCheck, ApprovalParams, EncodingOptions, ExecutionOptions, FyndClient,
+    FyndClientBuilder, HealthStatus, Order, OrderSide, PermitDetails as FyndPermitDetails,
+    PermitSingle as FyndPermitSingle, QuoteOptions, QuoteParams, SignedApproval, SignedSwap,
+    SigningHints, StorageOverrides, UserTransferType,
 };
 use num_bigint::BigUint;
 use tracing::info;
@@ -174,20 +174,19 @@ async fn wait_for_health(client: &FyndClient, fynd_url: &str) -> anyhow::Result<
     }
 }
 
-/// Check allowance and, if insufficient, submit and mine an ERC-20 approval.
-///
-/// `transfer_type` controls the spender: `TransferFrom` -> router, `TransferFromPermit2` ->
-/// Permit2 contract. Resolves the spender address via `GET /v1/info`.
+/// Submit an ERC-20 approval, optionally skipping or customising the allowance check.
 async fn ensure_approval(
     client: &FyndClient,
     signer: &PrivateKeySigner,
     sell_token: Bytes,
     amount: BigUint,
+    allowance_check: AllowanceCheck,
     transfer_type: UserTransferType,
     sender: Address,
 ) -> anyhow::Result<()> {
     println!("Checking ERC-20 allowance...");
-    let params = ApprovalParams::new(sell_token, amount, true).with_transfer_type(transfer_type);
+    let params =
+        ApprovalParams::new(sell_token, amount, allowance_check).with_transfer_type(transfer_type);
     let hints = SigningHints::default().with_sender(sender);
     let Some(approval_payload) = client.approval(&params, &hints).await? else {
         println!("Allowance sufficient, no approval needed.");
@@ -337,6 +336,7 @@ async fn main() -> anyhow::Result<()> {
                     &signer,
                     sell_token_bytes.clone(),
                     amount.clone(),
+                    AllowanceCheck::AtLeast(amount.clone()),
                     UserTransferType::TransferFrom,
                     sender,
                 )
@@ -352,12 +352,14 @@ async fn main() -> anyhow::Result<()> {
             let router_addr = Address::try_from(info.router_address().as_ref())
                 .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
             if cli.execute {
-                // Approve the full unlimited amount to Permit2 so future swaps don't re-approve.
+                // Check against the swap amount but approve max — subsequent swaps won't
+                // need re-approval even after Permit2 deducts from the ERC-20 allowance.
                 ensure_approval(
                     &client,
                     &signer,
                     sell_token_bytes.clone(),
                     max_uint160(),
+                    AllowanceCheck::AtLeast(amount.clone()),
                     UserTransferType::TransferFromPermit2,
                     sender,
                 )

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -408,8 +408,8 @@ async fn main() -> anyhow::Result<()> {
     println!("Amount in:           {}", quote.amount_in());
     println!("Amount out:          {}", quote.amount_out());
     println!("Amount out net gas:  {}", quote.amount_out_net_gas());
-    println!("Token in:            {}", format!("0x{}", hex::encode(&sell_token_bytes)));
-    println!("Token out:           {}", format!("0x{}", hex::encode(&buy_token_bytes)));
+    println!("Token in:            0x{}", hex::encode(&sell_token_bytes));
+    println!("Token out:           0x{}", hex::encode(&buy_token_bytes));
     println!("Gas estimate:        {}", quote.gas_estimate());
     println!("Solve time:          {}ms", quote.solve_time_ms());
     if let Some(route) = quote.route() {

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -352,11 +352,12 @@ async fn main() -> anyhow::Result<()> {
             let router_addr = Address::try_from(info.router_address().as_ref())
                 .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
             if cli.execute {
+                // Approve the full unlimited amount to Permit2 so future swaps don't re-approve.
                 ensure_approval(
                     &client,
                     &signer,
                     sell_token_bytes.clone(),
-                    amount.clone(),
+                    max_uint160(),
                     UserTransferType::TransferFromPermit2,
                     sender,
                 )


### PR DESCRIPTION
## Summary
  
  - Return transaction hash from execute_swap in the Rust client instead of discarding it
  - Add AllowanceCheck enum to control ERC-20 approval behavior — supports skipping checks or checking against a minimum threshold, so users can approve once (e.g. unlimited for Permit2) and skip redundant approvals on subsequent swaps
  - Approve unlimited amount for Permit2 in the swap CLI to avoid repeated approval transactions
  - Improve swap CLI console output with progress messages for allowance checks, transaction submissions, token addresses, and transaction hashes
  - Update protocol list in docs (replace vm:curve with ekubo and fluid)