### PR TITLE
refactor: change server config to be binary-oriented

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ COPY --from=builder /app/target/release/fynd-swap-cli /usr/local/bin/fynd-swap-c
 
 EXPOSE 3000 9898
 
-ENTRYPOINT ["/usr/local/bin/fynd", "serve"]
+ENTRYPOINT ["/usr/local/bin/fynd"]

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -53,7 +53,7 @@ docker run \
   -e TYCHO_API_KEY=your-api-key \
   -e RUST_LOG=fynd=info \
   -p 3000:3000 -p 9898:9898 \
-  ghcr.io/propeller-heads/fynd
+  ghcr.io/propeller-heads/fynd serve
 ```
 {% endtab %}
 

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -61,9 +61,10 @@ docker run \
 ```bash
 git clone https://github.com/propeller-heads/fynd.git
 cd fynd
+cargo install --locked --path .
 export TYCHO_API_KEY=your-api-key
 export RUST_LOG=fynd=info
-cargo run --release -- serve
+fynd serve
 ```
 {% endtab %}
 {% endtabs %}

--- a/docs/guides/server-configuration.md
+++ b/docs/guides/server-configuration.md
@@ -11,26 +11,26 @@ Reference for all Fynd server flags, worker pool tuning, blocklist configuration
 All on-chain protocols available on your configured Tycho endpoint are fetched by default, so `--protocols` is optional. The `--tycho-url` also defaults to the Fynd endpoint for the selected chain.
 
 ```bash
-cargo run --release -- serve
+fynd serve
 ```
 
 To run on a different chain:
 
 ```bash
-cargo run --release -- serve --chain base
+fynd serve --chain base
 ```
 
 `--rpc-url` defaults to the public endpoint `https://eth.llamarpc.com`. For production, use a dedicated endpoint:
 
 ```bash
-cargo run --release -- serve \
+fynd serve \
   --rpc-url https://your-rpc-provider.com/v1/your_key
 ```
 
 Specify protocols explicitly:
 
 ```bash
-cargo run --release -- serve \
+fynd serve \
   --protocols uniswap_v2,uniswap_v3,ekubo_v3,fluid_v1
 ```
 
@@ -41,14 +41,14 @@ See the full [list of available protocols](https://docs.propellerheads.xyz/tycho
 Include RFQ (Request-for-Quote) protocols alongside on-chain protocols. Use the `all_onchain` keyword to combine auto-fetched on-chain protocols with specific RFQ protocols:
 
 ```bash
-cargo run --release -- serve \
+fynd serve \
   --protocols all_onchain,rfq:bebop
 ```
 
 Or specify both on-chain and RFQ protocols explicitly:
 
 ```bash
-cargo run --release -- serve \
+fynd serve \
   --protocols uniswap_v2,uniswap_v3,rfq:bebop
 ```
 
@@ -63,7 +63,7 @@ cargo run --release -- serve \
 
 ## Flag reference
 
-Run `cargo run --release -- serve --help` for the full list.
+Run `fynd serve --help` for the full list.
 
 ### Required
 
@@ -125,7 +125,7 @@ All pools solve every incoming order in parallel. Fynd picks the best result acr
 To use a custom config file:
 
 ```bash
-cargo run --release -- serve -w my_worker_pools.toml
+fynd serve -w my_worker_pools.toml
 ```
 
 ## Blocklist config
@@ -133,7 +133,7 @@ cargo run --release -- serve -w my_worker_pools.toml
 By default, Fynd loads `blocklist.toml` from tycho-simulation. The default excludes components with known simulation issues (e.g., [rebasing tokens on UniswapV3 pools](https://docs.uniswap.org/concepts/protocol/integration-issues)). Override with `--blocklist-config`:
 
 ```bash
-cargo run --release -- serve --blocklist-config my_blocklist.toml
+fynd serve --blocklist-config my_blocklist.toml
 ```
 
 The config file uses a `[blocklist]` section listing component IDs to exclude:
@@ -153,16 +153,16 @@ Control log verbosity with `RUST_LOG`:
 
 ```bash
 # Minimal output
-RUST_LOG=warn cargo run --release -- serve ...
+RUST_LOG=warn fynd serve ...
 
 # Default (recommended)
-RUST_LOG=fynd=info cargo run --release -- serve ...
+RUST_LOG=fynd=info fynd serve ...
 
 # Debug solver internals
-RUST_LOG=info,fynd_core=debug cargo run --release -- serve ...
+RUST_LOG=info,fynd_core=debug fynd serve ...
 
 # Trace-level (very verbose, not recommended)
-RUST_LOG=info,fynd_core=trace cargo run --release -- serve ...
+RUST_LOG=info,fynd_core=trace fynd serve ...
 ```
 
 ### Prometheus metrics


### PR DESCRIPTION
- Updated README and server configuration documentation to reflect the new command usage without 'cargo run --release --'.
- Changed the ENTRYPOINT in Dockerfile to make it more flexible (like the binary).