### PR TITLE
feat(fynd-client): make constructor functions public for test fixture support

### DIFF
--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -640,8 +640,9 @@ impl Swap {
         &self.gas_estimate
     }
 
+    /// Create a new [`Swap`].
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub fn new(
         component_id: String,
         protocol: String,
         token_in: Bytes,
@@ -678,7 +679,8 @@ impl Route {
         &self.swaps
     }
 
-    pub(crate) fn new(swaps: Vec<Swap>) -> Self {
+    /// Create a new [`Route`] from a list of swaps.
+    pub fn new(swaps: Vec<Swap>) -> Self {
         Self { swaps }
     }
 }

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -584,7 +584,8 @@ impl BlockInfo {
         self.timestamp
     }
 
-    pub(crate) fn new(number: u64, hash: String, timestamp: u64) -> Self {
+    /// Create a new [`BlockInfo`].
+    pub fn new(number: u64, hash: String, timestamp: u64) -> Self {
         Self { number, hash, timestamp }
     }
 }
@@ -850,8 +851,9 @@ impl Quote {
         self.solve_time_ms
     }
 
+    /// Create a new [`Quote`].
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn new(
+    pub fn new(
         order_id: String,
         status: QuoteStatus,
         backend: BackendKind,

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -335,7 +335,12 @@ pub struct Transaction {
 }
 
 impl Transaction {
-    pub(crate) fn new(to: Bytes, value: BigUint, data: Vec<u8>) -> Self {
+    /// Create a new transaction from the given parameters.
+    /// 
+    /// - `to`: 20-byte contract address to call.
+    /// - `value`: native token value to send with the transaction.
+    /// - `data`: ABI-encoded calldata.
+    pub fn new(to: Bytes, value: BigUint, data: Vec<u8>) -> Self {
         Self { to, value, data }
     }
 

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -336,7 +336,7 @@ pub struct Transaction {
 
 impl Transaction {
     /// Create a new transaction from the given parameters.
-    /// 
+    ///
     /// - `to`: 20-byte contract address to call.
     /// - `value`: native token value to send with the transaction.
     /// - `data`: ABI-encoded calldata.


### PR DESCRIPTION
## Summary

- `Quote::new`, `BlockInfo::new`, `Route::new`, and `Swap::new` in `fynd-client` were `pub(crate)`, preventing external crates from constructing test fixtures
- Changed visibility to `pub` and added doc comments to satisfy `#![deny(missing_docs)]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)