### PR TITLE
feat: Cap tycho-execution version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,7 +3312,6 @@ dependencies = [
  "bytes",
  "clap",
  "dialoguer 0.11.0",
- "dotenv",
  "fynd-client",
  "fynd-core",
  "fynd-rpc",
@@ -6138,9 +6137,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ metrics-exporter-prometheus = "0.16"
 
 # Tycho
 tycho-simulation = ">=0.254.0"
-tycho-execution = ">=0.171.2"
+tycho-execution = "<=0.175.0"
 typetag = "0.2"
 
 # Graph algorithms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ alloy = { workspace = true, features = [
 ] }
 alloy-chains = "0.2"
 dialoguer = "0.11"
-dotenv = "0.15"
 serde = { workspace = true }
 serde_json = { workspace = true }
 num-bigint = { workspace = true }


### PR DESCRIPTION
The latest versions of tycho-execution are not compatible with the currently deployed router. This cap will be removed once we redeploy the router at the end of the audit