### PR TITLE
feat: keep ranked quote candidates for price guard fallback

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,9 @@
+[advisories]
+# rustls-webpki 0.101.7 is locked by tonic 0.9; fix requires tonic 0.11+ (prost 0.11 -> 0.12).
+# RUSTSEC-2025-0055: tracing-subscriber ^0.2 log poisoning via ANSI escapes
+# Dep chain: tycho-simulation <- revm <- ark-bn254 <- ark-r1cs-std <- ark-relations <- tracing-subscriber ^0.2
+# We need ark to update their dependencies to fix this.
+ignore = [
+    "RUSTSEC-2026-0104",
+    "RUSTSEC-2025-0055",
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -153,4 +153,4 @@ jobs:
         with:
           tool: cargo-audit
       - name: Run security audit
-        run: cargo audit --ignore RUSTSEC-2025-0055 # The dependency relation is tycho-simulation <- revm <- ark-bn254 <- ark-r1cs-std <- ark-relations <- tracing-subscriber ^0.2 (which is the problematic version). We need ark to update their dependencies to fix this.
+        run: cargo audit

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -90,8 +90,7 @@ impl PriceGuard {
         let mut last = None;
         for candidate in candidates {
             if candidate.status() != QuoteStatus::Success {
-                last = Some(candidate);
-                continue;
+                return Ok(candidate);
             }
             let Some((token_in, token_out)) = self.validated_token_pair(&candidate) else {
                 last = Some(candidate);
@@ -104,9 +103,7 @@ impl PriceGuard {
         }
 
         if let Some(mut order_quote) = last {
-            if order_quote.status() == QuoteStatus::Success {
-                order_quote.set_status(QuoteStatus::PriceCheckFailed);
-            }
+            order_quote.set_status(QuoteStatus::PriceCheckFailed);
             Ok(order_quote)
         } else {
             // should never happen since the solver should always return at least one candidate per

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -20,6 +20,9 @@ pub enum PriceGuardError {
     /// Price guard is enabled but no providers are registered.
     #[error("price guard is enabled but no providers are registered")]
     NoProviders,
+    /// Received an empty candidates list.
+    #[error("received empty candidates list")]
+    EmptyQuoteCandidates,
 }
 
 /// Validates solver outputs against external price sources.
@@ -48,43 +51,68 @@ impl PriceGuard {
         Self { registry, worker_handles }
     }
 
-    /// Validates a list of order quotes against external prices.
+    /// Validates ranked quote candidates against external prices.
     ///
-    /// For each successful quote with a route:
-    /// 1. Checks that the quote has a well-formed route
-    /// 2. Queries all registered providers
-    /// 3. Passes if at least one provider validates within BPS tolerance
-    ///
-    /// Failures are always per-quote: the quote's status is set to
-    /// `PriceCheckFailed` and processing continues. Never aborts the batch.
+    /// Each inner `Vec<OrderQuote>` contains ranked candidates for a single order
+    /// (sorted by `amount_out_net_gas` descending). For each order, returns the
+    /// first candidate that passes price validation. If none pass, returns the
+    /// last candidate with status `PriceCheckFailed`.
     pub fn validate(
         &self,
-        mut quotes: Vec<OrderQuote>,
+        ranked_quotes: Vec<Vec<OrderQuote>>,
         config: &PriceGuardConfig,
     ) -> Result<Vec<OrderQuote>, PriceGuardError> {
         if !config.enabled() {
-            return Ok(quotes);
+            return Ok(ranked_quotes
+                .into_iter()
+                .filter_map(|candidates| candidates.into_iter().next())
+                .collect());
         }
 
         if self.registry.is_empty() {
             return Err(PriceGuardError::NoProviders);
         }
 
-        for quote in &mut quotes {
-            if quote.status() != QuoteStatus::Success {
+        let mut results = Vec::with_capacity(ranked_quotes.len());
+        for candidates in ranked_quotes {
+            results.push(self.select_first_valid(candidates, config)?);
+        }
+        Ok(results)
+    }
+
+    /// Returns the first candidate that passes price validation, or the last
+    /// one marked as `PriceCheckFailed`.
+    fn select_first_valid(
+        &self,
+        candidates: Vec<OrderQuote>,
+        config: &PriceGuardConfig,
+    ) -> Result<OrderQuote, PriceGuardError> {
+        let mut last = None;
+        for candidate in candidates {
+            if candidate.status() != QuoteStatus::Success {
+                last = Some(candidate);
                 continue;
             }
-            let Some((token_in, token_out)) = self.validated_token_pair(quote) else {
-                // This should not happen.
-                quote.set_status(QuoteStatus::NoRouteFound);
+            let Some((token_in, token_out)) = self.validated_token_pair(&candidate) else {
+                last = Some(candidate);
                 continue;
             };
-            if !self.check_price(quote, &token_in, &token_out, config) {
-                quote.set_status(QuoteStatus::PriceCheckFailed);
+            if self.check_price(&candidate, &token_in, &token_out, config) {
+                return Ok(candidate);
             }
+            last = Some(candidate);
         }
 
-        Ok(quotes)
+        if let Some(mut order_quote) = last {
+            if order_quote.status() == QuoteStatus::Success {
+                order_quote.set_status(QuoteStatus::PriceCheckFailed);
+            }
+            Ok(order_quote)
+        } else {
+            // should never happen since the solver should always return at least one candidate per
+            // order
+            Err(PriceGuardError::EmptyQuoteCandidates)
+        }
     }
 
     /// Checks that a successful quote has a route with input/output tokens.
@@ -355,7 +383,7 @@ mod tests {
         let guard = price_guard(vec![mock_provider(provider_amount)]);
 
         let result = guard
-            .validate(vec![make_quote(fynd_amount)], &config)
+            .validate(vec![vec![make_quote(fynd_amount)]], &config)
             .unwrap();
 
         let expected_status =
@@ -374,7 +402,7 @@ mod tests {
         let guard = price_guard(vec![Box::new(FailingProvider), Box::new(FailingProvider)]);
 
         let result = guard
-            .validate(vec![make_quote(500)], &config)
+            .validate(vec![vec![make_quote(500)]], &config)
             .unwrap();
 
         let want = if should_pass { QuoteStatus::Success } else { QuoteStatus::PriceCheckFailed };
@@ -390,7 +418,7 @@ mod tests {
         let guard = price_guard(vec![mock_provider(10_000)]);
 
         let result = guard
-            .validate(vec![make_quote(50)], &config)
+            .validate(vec![vec![make_quote(50)]], &config)
             .unwrap();
 
         assert_eq!(result.len(), 1);
@@ -410,7 +438,7 @@ mod tests {
         let guard = price_guard(vec![mock_provider(1000), mock_provider(970)]);
 
         let result = guard
-            .validate(vec![make_quote(960)], &config)
+            .validate(vec![vec![make_quote(960)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::Success);
@@ -424,7 +452,7 @@ mod tests {
         let guard = price_guard(vec![Box::new(FailingProvider), mock_provider(1000)]);
 
         let result = guard
-            .validate(vec![make_quote(980)], &config)
+            .validate(vec![vec![make_quote(980)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::Success);
@@ -440,7 +468,7 @@ mod tests {
         quote.set_status(QuoteStatus::NoRouteFound);
 
         let result = guard
-            .validate(vec![quote], &config)
+            .validate(vec![vec![quote]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::NoRouteFound);
@@ -451,26 +479,58 @@ mod tests {
         let config = PriceGuardConfig::default().with_enabled(true);
         let guard = price_guard(vec![]);
 
-        let result = guard.validate(vec![make_quote(1000)], &config);
+        let result = guard.validate(vec![vec![make_quote(1000)]], &config);
 
         assert!(matches!(result, Err(PriceGuardError::NoProviders)));
     }
 
     #[test]
-    fn test_multiple_quotes() {
-        // Test that multiple quotes get statuses independent of each other.
-        // For example - one passes and one fails.
+    fn test_multiple_orders() {
+        // Test that multiple orders get statuses independent of each other.
         let config = PriceGuardConfig::default()
             .with_enabled(true)
             .with_lower_tolerance_bps(300);
         let guard = price_guard(vec![mock_provider(1000)]);
 
         let result = guard
-            .validate(vec![make_quote(980), make_quote(500)], &config)
+            .validate(vec![vec![make_quote(980)], vec![make_quote(500)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::Success);
         assert_eq!(result[1].status(), QuoteStatus::PriceCheckFailed);
+    }
+
+    #[test]
+    fn test_ranked_fallback() {
+        // Best candidate fails price check, second-best passes.
+        let config = PriceGuardConfig::default()
+            .with_enabled(true)
+            .with_lower_tolerance_bps(300)
+            .with_upper_tolerance_bps(300);
+        let guard = price_guard(vec![mock_provider(1000)]);
+
+        let result = guard
+            .validate(vec![vec![make_quote(1100), make_quote(980)]], &config)
+            .unwrap();
+
+        // Should fall back to the second candidate (980) which passes
+        assert_eq!(result[0].status(), QuoteStatus::Success);
+        assert_eq!(*result[0].amount_out(), BigUint::from(980u64));
+    }
+
+    #[test]
+    fn test_ranked_all_fail() {
+        // All candidates fail price check — last one gets PriceCheckFailed.
+        let config = PriceGuardConfig::default()
+            .with_enabled(true)
+            .with_lower_tolerance_bps(100);
+        let guard = price_guard(vec![mock_provider(1000)]);
+
+        let result = guard
+            .validate(vec![vec![make_quote(600), make_quote(500)]], &config)
+            .unwrap();
+
+        assert_eq!(result[0].status(), QuoteStatus::PriceCheckFailed);
     }
 
     #[rstest]
@@ -485,7 +545,7 @@ mod tests {
             price_guard(vec![Box::new(PriceNotFoundProvider), Box::new(PriceNotFoundProvider)]);
 
         let result = guard
-            .validate(vec![make_quote(500)], &config)
+            .validate(vec![vec![make_quote(500)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), result_status);
@@ -503,7 +563,7 @@ mod tests {
         let guard = price_guard(vec![Box::new(PriceNotFoundProvider), Box::new(FailingProvider)]);
 
         let result = guard
-            .validate(vec![make_quote(500)], &config)
+            .validate(vec![vec![make_quote(500)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::PriceCheckFailed);
@@ -521,7 +581,7 @@ mod tests {
         let guard = price_guard(vec![mock_provider(1000), Box::new(PriceNotFoundProvider)]);
 
         let result = guard
-            .validate(vec![make_quote(980)], &config)
+            .validate(vec![vec![make_quote(980)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::Success);
@@ -539,7 +599,7 @@ mod tests {
         let guard = price_guard(vec![mock_provider(1000), Box::new(PriceNotFoundProvider)]);
 
         let result = guard
-            .validate(vec![make_quote(500)], &config)
+            .validate(vec![vec![make_quote(500)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::PriceCheckFailed);
@@ -556,7 +616,7 @@ mod tests {
             price_guard(vec![Box::new(PriceNotFoundProvider), Box::new(PriceNotFoundProvider)]);
 
         let result = guard
-            .validate(vec![make_quote(500)], &config)
+            .validate(vec![vec![make_quote(500)]], &config)
             .unwrap();
 
         assert_eq!(result[0].status(), QuoteStatus::PriceCheckFailed);

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -80,36 +80,31 @@ impl PriceGuard {
         Ok(results)
     }
 
-    /// Returns the first candidate that passes price validation, or the last
+    /// Returns the first candidate that passes price validation, or the first
     /// one marked as `PriceCheckFailed`.
     fn select_first_valid(
         &self,
         candidates: Vec<OrderQuote>,
         config: &PriceGuardConfig,
     ) -> Result<OrderQuote, PriceGuardError> {
-        let mut last = None;
+        let mut first = None;
         for candidate in candidates {
             if candidate.status() != QuoteStatus::Success {
                 return Ok(candidate);
             }
-            let Some((token_in, token_out)) = self.validated_token_pair(&candidate) else {
-                last = Some(candidate);
-                continue;
-            };
-            if self.check_price(&candidate, &token_in, &token_out, config) {
-                return Ok(candidate);
+            if let Some((token_in, token_out)) = self.validated_token_pair(&candidate) {
+                if self.check_price(&candidate, &token_in, &token_out, config) {
+                    return Ok(candidate);
+                }
             }
-            last = Some(candidate);
+            first.get_or_insert(candidate);
         }
 
-        if let Some(mut order_quote) = last {
-            order_quote.set_status(QuoteStatus::PriceCheckFailed);
-            Ok(order_quote)
-        } else {
-            // should never happen since the solver should always return at least one candidate per
-            // order
-            Err(PriceGuardError::EmptyQuoteCandidates)
-        }
+        // should never happen since the solver should always return at least one candidate per
+        // order
+        let mut order_quote = first.ok_or(PriceGuardError::EmptyQuoteCandidates)?;
+        order_quote.set_status(QuoteStatus::PriceCheckFailed);
+        Ok(order_quote)
     }
 
     /// Checks that a successful quote has a route with input/output tokens.

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -371,7 +371,7 @@ impl WorkerPoolRouter {
 
         // No valid quote found - return a NoRouteFound response
         // Try to get any response to extract block info, or create a placeholder
-        let placeholder = if let Some((_, any_q)) = responses.quotes.first() {
+        let fallback = if let Some((_, any_q)) = responses.quotes.first() {
             counter!("worker_router_orders_total", "status" => "no_route").increment(1);
             OrderQuote::new(
                 responses.order_id.clone(),
@@ -430,7 +430,7 @@ impl WorkerPoolRouter {
                 Bytes::default(),
             )
         };
-        vec![placeholder]
+        vec![fallback]
     }
 
     /// Returns the effective timeout for a request.

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -140,15 +140,15 @@ impl WorkerPoolRouter {
 
         let order_responses = futures::future::join_all(order_futures).await;
 
-        // Select best quote for each order
-        let mut order_quotes: Vec<OrderQuote> = order_responses
+        // Rank quotes for each order (sorted by amount_out_net_gas descending)
+        let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
-            .map(|responses| self.select_best(&responses, request.options()))
+            .map(|responses| self.rank_quotes(&responses, request.options()))
             .collect();
 
         // Validate against external prices if enabled.
         // Per-request config (inside encoding_options) overrides the server default.
-        if let Some(ref guard) = self.price_guard {
+        let mut order_quotes: Vec<OrderQuote> = if let Some(ref guard) = self.price_guard {
             let price_guard_config = request
                 .options()
                 .encoding_options()
@@ -163,14 +163,19 @@ impl WorkerPoolRouter {
                 return Err(SolveError::Internal("no price guard config available".to_string()));
             };
 
-            match guard.validate(order_quotes, &config) {
-                Ok(validated) => order_quotes = validated,
+            match guard.validate(ranked_quotes, &config) {
+                Ok(validated) => validated,
                 Err(e) => {
                     warn!(error = %e, "price guard validation error");
                     return Err(SolveError::Internal(e.to_string()));
                 }
             }
-        }
+        } else {
+            ranked_quotes
+                .into_iter()
+                .filter_map(|candidates| candidates.into_iter().next())
+                .collect()
+        };
 
         // Encode solutions if encoding_options is set
         if let Some(encoding_options) = request.options().encoding_options() {
@@ -325,18 +330,16 @@ impl WorkerPoolRouter {
         OrderResponses { order_id, quotes, failed_solvers }
     }
 
-    /// Selects the best quote from collected responses.
+    /// Returns all valid quotes for an order, ranked by `amount_out_net_gas` descending.
     ///
-    /// Selection criteria:
-    /// 1. Filter by constraints (e.g., max_gas)
-    /// 2. Select by maximum `amount_out_net_gas`
-    fn select_best(&self, responses: &OrderResponses, options: &QuoteOptions) -> OrderQuote {
-        let valid_quotes: Vec<_> = responses
+    /// If no valid quotes exist, returns a single-element vec with a placeholder
+    /// (`NoRouteFound` or `Timeout`) so that downstream always has at least one
+    /// candidate per order.
+    fn rank_quotes(&self, responses: &OrderResponses, options: &QuoteOptions) -> Vec<OrderQuote> {
+        let mut valid_quotes: Vec<_> = responses
             .quotes
             .iter()
-            // Only consider successful quotes
             .filter(|(_, q)| q.status() == QuoteStatus::Success)
-            // Filter by max_gas constraint if specified
             .filter(|(_, q)| {
                 options
                     .max_gas()
@@ -345,27 +348,30 @@ impl WorkerPoolRouter {
             })
             .collect();
 
-        // Select by max amount_out_net_gas
-        if let Some((pool_name, best)) = valid_quotes
-            .into_iter()
-            .max_by_key(|(_, q)| q.amount_out_net_gas())
-        {
-            // Record metrics for successful selection
-            counter!("worker_router_orders_total", "status" => "success").increment(1);
-            counter!("worker_router_best_quote_pool", "pool" => pool_name.clone()).increment(1);
+        // Sort descending by amount_out_net_gas
+        valid_quotes.sort_by(|(_, a), (_, b)| {
+            b.amount_out_net_gas()
+                .cmp(a.amount_out_net_gas())
+        });
 
+        if !valid_quotes.is_empty() {
+            counter!("worker_router_orders_total", "status" => "success").increment(1);
+            let (pool_name, best) = valid_quotes[0];
+            counter!("worker_router_best_quote_pool", "pool" => pool_name.clone()).increment(1);
             debug!(
                 order_id = %best.order_id(),
-                pool = %pool_name,
-                amount_out_net_gas = %best.amount_out_net_gas(),
-                "selected best quote"
+                number_of_candidates = valid_quotes.len(),
+                "ranked quotes"
             );
-            return best.clone();
+            return valid_quotes
+                .into_iter()
+                .map(|(_, q)| q.clone())
+                .collect();
         }
 
         // No valid quote found - return a NoRouteFound response
         // Try to get any response to extract block info, or create a placeholder
-        if let Some((_, any_q)) = responses.quotes.first() {
+        let placeholder = if let Some((_, any_q)) = responses.quotes.first() {
             counter!("worker_router_orders_total", "status" => "no_route").increment(1);
             OrderQuote::new(
                 responses.order_id.clone(),
@@ -423,7 +429,8 @@ impl WorkerPoolRouter {
                 Bytes::default(),
                 Bytes::default(),
             )
-        }
+        };
+        vec![placeholder]
     }
 
     /// Returns the effective timeout for a request.
@@ -722,12 +729,12 @@ mod tests {
 
         let worker_router =
             WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
-        let result = worker_router.select_best(&responses, &options);
+        let result = worker_router.rank_quotes(&responses, &options);
 
         if should_pass {
-            assert_eq!(result.status(), QuoteStatus::Success);
+            assert_eq!(result[0].status(), QuoteStatus::Success);
         } else {
-            assert_eq!(result.status(), QuoteStatus::NoRouteFound);
+            assert_eq!(result[0].status(), QuoteStatus::NoRouteFound);
         }
     }
 
@@ -757,7 +764,7 @@ mod tests {
     }
 
     #[test]
-    fn test_select_best_all_timeouts_returns_timeout_status() {
+    fn test_rank_quotes_all_timeouts_returns_timeout_status() {
         let responses = OrderResponses {
             order_id: "test".to_string(),
             quotes: vec![],
@@ -769,13 +776,14 @@ mod tests {
 
         let worker_router =
             WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
-        let result = worker_router.select_best(&responses, &QuoteOptions::default());
+        let result = worker_router.rank_quotes(&responses, &QuoteOptions::default());
 
-        assert_eq!(result.status(), QuoteStatus::Timeout);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].status(), QuoteStatus::Timeout);
     }
 
     #[test]
-    fn test_select_best_mixed_failures_returns_no_route_found() {
+    fn test_rank_quotes_mixed_failures_returns_no_route_found() {
         let responses = OrderResponses {
             order_id: "test".to_string(),
             quotes: vec![],
@@ -787,22 +795,70 @@ mod tests {
 
         let worker_router =
             WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
-        let result = worker_router.select_best(&responses, &QuoteOptions::default());
+        let result = worker_router.rank_quotes(&responses, &QuoteOptions::default());
 
-        // Mixed failures (not all timeouts) should return NoRouteFound
-        assert_eq!(result.status(), QuoteStatus::NoRouteFound);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].status(), QuoteStatus::NoRouteFound);
     }
 
     #[test]
-    fn test_select_best_no_failures_returns_no_route_found() {
+    fn test_rank_quotes_no_failures_returns_no_route_found() {
         let responses =
             OrderResponses { order_id: "test".to_string(), quotes: vec![], failed_solvers: vec![] };
 
         let worker_router =
             WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
-        let result = worker_router.select_best(&responses, &QuoteOptions::default());
+        let result = worker_router.rank_quotes(&responses, &QuoteOptions::default());
 
-        // No failures but also no quotes means NoRouteFound
-        assert_eq!(result.status(), QuoteStatus::NoRouteFound);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].status(), QuoteStatus::NoRouteFound);
+    }
+
+    #[test]
+    fn test_rank_quotes_returns_sorted_candidates() {
+        let responses = OrderResponses {
+            order_id: "test".to_string(),
+            quotes: vec![
+                (
+                    "pool_a".to_string(),
+                    OrderQuote::new(
+                        "test".to_string(),
+                        QuoteStatus::Success,
+                        BigUint::from(1000u64),
+                        BigUint::from(800u64),
+                        BigUint::from(100_000u64),
+                        BigUint::from(800u64),
+                        BlockInfo::new(1, "0x123".to_string(), 1000),
+                        "test".to_string(),
+                        Bytes::from(make_address(0xAA).as_ref()),
+                        Bytes::from(make_address(0xAA).as_ref()),
+                    ),
+                ),
+                (
+                    "pool_b".to_string(),
+                    OrderQuote::new(
+                        "test".to_string(),
+                        QuoteStatus::Success,
+                        BigUint::from(1000u64),
+                        BigUint::from(950u64),
+                        BigUint::from(100_000u64),
+                        BigUint::from(950u64),
+                        BlockInfo::new(1, "0x123".to_string(), 1000),
+                        "test".to_string(),
+                        Bytes::from(make_address(0xAA).as_ref()),
+                        Bytes::from(make_address(0xAA).as_ref()),
+                    ),
+                ),
+            ],
+            failed_solvers: vec![],
+        };
+
+        let worker_router =
+            WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
+        let result = worker_router.rank_quotes(&responses, &QuoteOptions::default());
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(*result[0].amount_out_net_gas(), BigUint::from(950u64));
+        assert_eq!(*result[1].amount_out_net_gas(), BigUint::from(800u64));
     }
 }


### PR DESCRIPTION
This PR improves quote selection by introducing a fallback mechanism during PriceGuard validation. Instead of validating only the top-ranked quote per order, we keep all quotes, rank them by amount_out_net_gas, and return the first one that passes the PriceGuard check. If PriceGuard is disabled, the top-ranked quote is returned as before.