### PR TITLE
feat: Simplify Price Guard Config

### DIFF
--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.49.1"
+    "version": "0.52.0"
   },
   "paths": {
     "/v1/health": {
@@ -244,7 +244,7 @@
               },
               {
                 "$ref": "#/components/schemas/PriceGuardConfig",
-                "description": "Per-request price guard overrides. If `None`, uses server defaults."
+                "description": "Per-request price guard configuration. If `None`, struct defaults are used."
               }
             ]
           },
@@ -590,7 +590,7 @@
       },
       "PriceGuardConfig": {
         "type": "object",
-        "description": "Per-request overrides for price guard validation.\n\nAll fields are optional. When `None`, the server's configured defaults are used.",
+        "description": "Per-request price guard configuration.\n\nAll fields are optional. When `None`, struct defaults are used.",
         "properties": {
           "enabled": {
             "type": [

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -325,9 +325,9 @@ impl EncodingOptions {
         self
     }
 
-    /// Override server-side price guard defaults for this request.
+    /// Configure price guard tolerance and fallback behavior for this request.
     ///
-    /// Fields left as `None` in [`PriceGuardConfig`] inherit the server defaults.
+    /// Fields left as `None` in [`PriceGuardConfig`] use struct defaults.
     pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
         self.price_guard = Some(config);
         self
@@ -449,9 +449,9 @@ impl Order {
     }
 }
 
-/// Per-request overrides for price guard validation.
+/// Per-request price guard configuration.
 ///
-/// All fields are optional. When `None`, the server's configured defaults are used.
+/// All fields are optional. When `None`, struct defaults are used.
 /// Re-exported from `fynd-rpc-types` for wire compatibility.
 pub use fynd_rpc_types::PriceGuardConfig;
 

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -373,9 +373,9 @@ export interface components {
             spender: string;
         };
         /**
-         * @description Per-request overrides for price guard validation.
+         * @description Per-request price guard configuration.
          *
-         *     All fields are optional. When `None`, the server's configured defaults are used.
+         *     All fields are optional. When `None`, struct defaults are used.
          */
         PriceGuardConfig: {
             /** @description Whether price guard validation is enabled. */

--- a/docs/guides/price-guard.md
+++ b/docs/guides/price-guard.md
@@ -91,6 +91,19 @@ When responses mix `price_not_found` with infrastructure errors, the token might
 of the unreachable providers, so the guard applies `fail_on_provider_error` rather than
 `fail_on_token_price_not_found`.
 
+## Symbol collisions and long-tail tokens
+
+Price providers (Binance, Hyperliquid) identify tokens by their trading symbol — e.g. "ETH",
+"LINK", "PEPE". On-chain, symbols are not unique: any token can declare itself "PEPE", and
+multiple unrelated tokens on the same chain may share a symbol. The guard resolves tokens by
+matching the on-chain symbol from `SharedMarketData` to a provider's symbol, so a long-tail token
+whose symbol collides with a well-known token will be priced as if it were that token.
+
+In practice this means the guard works reliably for major tokens listed on CEXs, but may produce
+false rejections (or false passes) for obscure tokens that happen to share a symbol with a listed
+asset. Clients trading long-tail tokens should consider leaving `enabled: false` for those
+requests.
+
 ## Custom providers
 
 The `PriceProvider` trait, `ExternalPrice`, and `PriceProviderError` are public. Implement the

--- a/docs/guides/price-guard.md
+++ b/docs/guides/price-guard.md
@@ -15,31 +15,46 @@ to `price_check_failed`; other orders in the same batch are unaffected.
 
 ## Configuration
 
+The server controls only whether the guard is on or off. All other parameters — tolerance
+thresholds and fallback behavior — are set per-request by the client. Omitted fields fall back to
+struct defaults.
+
+### Server-side
+
+The guard is disabled by default. Enable it with `--enable-price-guard`:
+
+```bash
+fynd --enable-price-guard
+```
+
+When enabled, price providers (Hyperliquid, Binance) are started in the background so their
+caches stay warm. Validation only runs for requests where the client sets `enabled: true` in
+`encoding_options.price_guard`. When disabled, no providers are started and requests that set
+`enabled: true` return an error.
+
+### Per-request
+
+Clients configure tolerance and fallback behavior through `encoding_options.price_guard`
+(see [encoding options](encoding-options.md)). Omitted fields use the defaults shown below.
+
 | Field                            | Type      | Default | Description                                                                                                                   |
 |----------------------------------|-----------|---------|-------------------------------------------------------------------------------------------------------------------------------|
-| `enabled`                        | `boolean` | `false` | Turns the guard on or off. When off, all other fields are ignored and every quote passes through unchecked.                   |
+| `enabled`                        | `boolean` | `false` | Set to `true` to run price guard validation for this request. Requires the server to have `--enable-price-guard`.             |
 | `lower_tolerance_bps`            | `integer` | `300`   | Max allowed deviation in basis points when the quote's `amount_out` is below the provider's expected amount out.              |
 | `upper_tolerance_bps`            | `integer` | `10000` | Max allowed deviation in basis points when the quote's `amount_out` is above the provider's expected amount out.              |
 | `fail_on_provider_error`         | `boolean` | `false` | See [fallback behavior](#fallback-behavior).                                                                                  |
 | `fail_on_token_price_not_found`  | `boolean` | `false` | See [fallback behavior](#fallback-behavior).                                                                                  |
 
-These fields can be set in two places: server-side (as defaults for all requests) or per-request
-(as client overrides).
+```bash
+fynd --enable-price-guard
+```
 
-### Server-side
+**Development** — leave the guard disabled on the server. No providers are started and no resources
+are used.
 
-The guard is disabled by default. Enable it with `--enable-price-guard`; tolerances and fallback
-behavior can be tuned via the matching `--price-guard-*` flags, which use the same names as the
-fields above with a `--price-guard-` prefix (e.g. `lower_tolerance_bps` →
-`--price-guard-lower-tolerance-bps`). See [server configuration](server-configuration.md) for the
-full list.
-
-### Per-request
-
-Clients can override the configuration per request through `encoding_options.price_guard`
-(see [encoding options](encoding-options.md)). When present, the request config **replaces** the
-server config entirely — any field omitted from the request falls back to the default in the table
-above, not to the server's configured value.
+```bash
+fynd  # no --enable-price-guard
+```
 
 ## Tolerance
 
@@ -85,9 +100,7 @@ trait to add your own price provider and register it via
 ```rust
 let solver = FyndBuilder::new(chain, tycho_url, rpc_url, protocols, min_tvl)
     .register_price_provider(Box::new(MyCustomProvider::new()))
-    .price_guard_config(
-        PriceGuardConfig::default().with_enabled(true),
-    )
+    .price_guard_enabled(true)
     .build()
     .await?;
 ```
@@ -106,16 +119,15 @@ To keep the defaults **and** add a custom provider, call `add_default_price_prov
 let solver = FyndBuilder::new(chain, tycho_url, rpc_url, protocols, min_tvl)
     .add_default_price_providers()
     .register_price_provider(Box::new(MyCustomProvider::new()))
-    .price_guard_config(
-        PriceGuardConfig::default().with_enabled(true),
-    )
+    .price_guard_enabled(true)
     .build()
     .await?;
 ```
 
 ## Example Quote with Price Guard protection
 
-Enable the price guard with a tight lower bound and fail-closed on unknown tokens:
+Enable the price guard server-side, then tighten the lower bound and fail-closed on unknown tokens
+for a specific request:
 
 ```json
 {
@@ -151,3 +163,4 @@ To disable the price guard on a server that has it enabled, send `enabled: false
   "price_guard": { "enabled": false }
 }
 ```
+

--- a/fynd-core/src/price_guard/config.rs
+++ b/fynd-core/src/price_guard/config.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// Controls tolerance thresholds, fail-open behavior, and whether validation
 /// is enabled at all. All fields have sensible defaults via [`Default`].
+///
+/// On the wire (JSON), every field is optional — omitted fields fall back to
+/// these defaults. See `fynd-rpc-types` for the wire representation.
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PriceGuardConfig {

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -34,8 +34,7 @@ use crate::{
     },
     graph::EdgeWeightUpdaterWithDerived,
     price_guard::{
-        config::PriceGuardConfig, guard::PriceGuard, provider::PriceProvider,
-        provider_registry::PriceProviderRegistry,
+        guard::PriceGuard, provider::PriceProvider, provider_registry::PriceProviderRegistry,
     },
     types::constants::native_token,
     worker_pool::{
@@ -298,7 +297,7 @@ pub struct FyndBuilder {
     router_min_responses: usize,
     encoder: Option<Encoder>,
     pools: Vec<PoolEntry>,
-    price_guard_config: PriceGuardConfig,
+    price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
 }
 
@@ -329,7 +328,7 @@ impl FyndBuilder {
             router_min_responses: defaults::ROUTER_MIN_RESPONSES,
             encoder: None,
             pools: Vec::new(),
-            price_guard_config: PriceGuardConfig::default(),
+            price_guard_enabled: false,
             price_providers: Vec::new(),
         }
     }
@@ -478,12 +477,14 @@ impl FyndBuilder {
         self
     }
 
-    /// Sets the server-side default [`PriceGuardConfig`].
+    /// Enables or disables the price guard.
     ///
-    /// This config is used when a quote request does not include per-request
-    /// price guard overrides. Defaults to [`PriceGuardConfig::default`].
-    pub fn price_guard_config(mut self, config: PriceGuardConfig) -> Self {
-        self.price_guard_config = config;
+    /// When enabled, providers are started and caches stay warm. Validation
+    /// only runs for requests where the client sets `enabled: true` in
+    /// `PriceGuardConfig`. When disabled, no providers are started and
+    /// per-request attempts to use the guard return an error.
+    pub fn price_guard_enabled(mut self, enabled: bool) -> Self {
+        self.price_guard_enabled = enabled;
         self
     }
 
@@ -637,23 +638,23 @@ impl FyndBuilder {
         let chain = self.chain;
         let router_address = encoder.router_address().clone();
 
-        // Start price providers and construct the guard.
-        // Providers are started even when `enabled: false` so caches stay warm
-        // for per-request opt-in. The `enabled` flag only controls whether
-        // validation runs at request time.
+        // Only start price providers when the guard is enabled.
+        // When disabled, per-request attempts to enable the guard return an error.
         let router_config = WorkerPoolRouterConfig::default()
             .with_timeout(self.router_timeout)
             .with_min_responses(self.router_min_responses);
         let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
 
-        let mut registry = PriceProviderRegistry::new();
-        let mut worker_handles = Vec::new();
-        for mut provider in self.price_providers {
-            worker_handles.push(provider.start(Arc::clone(&market_data)));
-            registry = registry.register(provider);
+        if self.price_guard_enabled {
+            let mut registry = PriceProviderRegistry::new();
+            let mut worker_handles = Vec::new();
+            for mut provider in self.price_providers {
+                worker_handles.push(provider.start(Arc::clone(&market_data)));
+                registry = registry.register(provider);
+            }
+            let price_guard = PriceGuard::new(registry, worker_handles);
+            router = router.with_price_guard(price_guard);
         }
-        let price_guard = PriceGuard::new(registry, worker_handles);
-        router = router.with_price_guard(price_guard, self.price_guard_config);
 
         let feed_handle = tokio::spawn(async move {
             if let Err(e) = tycho_feed.run().await {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -265,9 +265,9 @@ pub struct EncodingOptions {
     /// Client fee configuration. When absent, no client fee is charged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     client_fee_params: Option<ClientFeeParams>,
-    /// Per-request price guard overrides. If `None`, uses server defaults.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    price_guard: Option<PriceGuardConfig>,
+    /// Per-request price guard configuration. Defaults to disabled.
+    #[serde(default)]
+    price_guard: PriceGuardConfig,
 }
 
 impl EncodingOptions {
@@ -279,7 +279,7 @@ impl EncodingOptions {
             permit: None,
             permit2_signature: None,
             client_fee_params: None,
-            price_guard: None,
+            price_guard: PriceGuardConfig::default(),
         }
     }
 
@@ -332,15 +332,15 @@ impl EncodingOptions {
         self.client_fee_params.as_ref()
     }
 
-    /// Sets per-request price guard config.
+    /// Sets per-request price guard configuration.
     pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
-        self.price_guard = Some(config);
+        self.price_guard = config;
         self
     }
 
-    /// Returns the per-request price guard config.
-    pub fn price_guard(&self) -> Option<&PriceGuardConfig> {
-        self.price_guard.as_ref()
+    /// Returns the per-request price guard configuration.
+    pub fn price_guard(&self) -> &PriceGuardConfig {
+        &self.price_guard
     }
 }
 

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -153,13 +153,6 @@ impl WorkerPoolRouter {
             .map(|e| e.price_guard())
             .filter(|c| c.enabled());
 
-        if price_guard_config.is_some() && self.price_guard.is_none() {
-            return Err(SolveError::Internal(
-                "price guard config provided but price guard is not enabled on this server"
-                    .to_string(),
-            ));
-        }
-
         let mut order_quotes: Vec<OrderQuote> = match (&self.price_guard, price_guard_config) {
             (Some(guard), Some(config)) => guard
                 .validate(ranked_quotes, config)
@@ -167,6 +160,12 @@ impl WorkerPoolRouter {
                     warn!(error = %e, "price guard validation error");
                     SolveError::Internal(e.to_string())
                 })?,
+            (None, Some(_)) => {
+                return Err(SolveError::Internal(
+                    "price guard config provided but price guard is not enabled on this server"
+                        .to_string(),
+                ));
+            }
             _ => ranked_quotes
                 .into_iter()
                 .filter_map(|candidates| candidates.into_iter().next())

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -31,10 +31,9 @@ use tracing::{debug, warn};
 use tycho_simulation::tycho_common::Bytes;
 
 use crate::{
-    encoding::encoder::Encoder,
-    price_guard::{config::PriceGuardConfig, guard::PriceGuard},
-    worker_pool::task_queue::TaskQueueHandle,
-    BlockInfo, Order, OrderQuote, Quote, QuoteOptions, QuoteRequest, QuoteStatus, SolveError,
+    encoding::encoder::Encoder, price_guard::guard::PriceGuard,
+    worker_pool::task_queue::TaskQueueHandle, BlockInfo, Order, OrderQuote, Quote, QuoteOptions,
+    QuoteRequest, QuoteStatus, SolveError,
 };
 
 /// Handle to a solver pool for dispatching orders.
@@ -84,9 +83,8 @@ pub struct WorkerPoolRouter {
     /// Encoder for encoding solutions into on-chain transactions.
     encoder: Encoder,
     /// Validates solution outputs against external price sources.
+    /// Present when the server has price guard enabled; `None` when disabled.
     price_guard: Option<PriceGuard>,
-    /// Server-side default config for the price guard.
-    price_guard_config: Option<PriceGuardConfig>,
 }
 
 impl WorkerPoolRouter {
@@ -96,13 +94,15 @@ impl WorkerPoolRouter {
         config: WorkerPoolRouterConfig,
         encoder: Encoder,
     ) -> Self {
-        Self { solver_pools, config, encoder, price_guard: None, price_guard_config: None }
+        Self { solver_pools, config, encoder, price_guard: None }
     }
 
-    /// Enables price guard validation with a custom configuration.
-    pub fn with_price_guard(mut self, price_guard: PriceGuard, config: PriceGuardConfig) -> Self {
+    /// Makes price guard validation available for this router.
+    ///
+    /// Providers are started and caches stay warm. Validation only runs for
+    /// requests where the client sets `enabled: true` in `PriceGuardConfig`.
+    pub fn with_price_guard(mut self, price_guard: PriceGuard) -> Self {
         self.price_guard = Some(price_guard);
-        self.price_guard_config = Some(config);
         self
     }
 
@@ -146,35 +146,31 @@ impl WorkerPoolRouter {
             .map(|responses| self.rank_quotes(&responses, request.options()))
             .collect();
 
-        // Validate against external prices if enabled.
-        // Per-request config (inside encoding_options) overrides the server default.
-        let mut order_quotes: Vec<OrderQuote> = if let Some(ref guard) = self.price_guard {
-            let price_guard_config = request
-                .options()
-                .encoding_options()
-                .and_then(|e| e.price_guard());
-            let config = if let Some(request_config) = price_guard_config {
-                debug!("using request price guard config: {:?}", request_config);
-                request_config.clone()
-            } else if let Some(default_config) = &self.price_guard_config {
-                debug!("using default price guard config: {:?}", default_config);
-                default_config.clone()
-            } else {
-                return Err(SolveError::Internal("no price guard config available".to_string()));
-            };
+        // Validate against external prices when the client explicitly enables it.
+        let price_guard_config = request
+            .options()
+            .encoding_options()
+            .map(|e| e.price_guard())
+            .filter(|c| c.enabled());
 
-            match guard.validate(ranked_quotes, &config) {
-                Ok(validated) => validated,
-                Err(e) => {
+        if price_guard_config.is_some() && self.price_guard.is_none() {
+            return Err(SolveError::Internal(
+                "price guard config provided but price guard is not enabled on this server"
+                    .to_string(),
+            ));
+        }
+
+        let mut order_quotes: Vec<OrderQuote> = match (&self.price_guard, price_guard_config) {
+            (Some(guard), Some(config)) => guard
+                .validate(ranked_quotes, config)
+                .map_err(|e| {
                     warn!(error = %e, "price guard validation error");
-                    return Err(SolveError::Internal(e.to_string()));
-                }
-            }
-        } else {
-            ranked_quotes
+                    SolveError::Internal(e.to_string())
+                })?,
+            _ => ranked_quotes
                 .into_iter()
                 .filter_map(|candidates| candidates.into_iter().next())
-                .collect()
+                .collect(),
         };
 
         // Encode solutions if encoding_options is set

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -216,9 +216,9 @@ impl QuoteOptions {
     }
 }
 
-/// Per-request overrides for price guard validation.
+/// Per-request price guard configuration.
 ///
-/// All fields are optional. When `None`, the server's configured defaults are used.
+/// All fields are optional. When `None`, struct defaults are used.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct PriceGuardConfig {
@@ -450,7 +450,7 @@ pub struct EncodingOptions {
     /// Client fee configuration. When absent, no fee is charged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     client_fee_params: Option<ClientFeeParams>,
-    /// Per-request price guard overrides. If `None`, uses server defaults.
+    /// Per-request price guard configuration. If `None`, struct defaults are used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     price_guard: Option<PriceGuardConfig>,
 }
@@ -512,7 +512,7 @@ impl EncodingOptions {
         self.client_fee_params.as_ref()
     }
 
-    /// Set per-request price guard overrides.
+    /// Set per-request price guard configuration.
     pub fn with_price_guard(mut self, config: PriceGuardConfig) -> Self {
         self.price_guard = Some(config);
         self
@@ -1900,23 +1900,11 @@ mod conversions {
                 .with_fail_on_provider_error(false)
                 .with_enabled(false);
 
-            let core: fynd_core::PriceGuardConfig = dto.into();
-            assert_eq!(core.lower_tolerance_bps(), 200);
-            assert_eq!(core.upper_tolerance_bps(), 5000);
-            assert!(!core.fail_on_provider_error());
-            assert!(!core.enabled());
-        }
-
-        #[test]
-        fn test_price_guard_config_defaults_preserved() {
-            let dto = PriceGuardConfig::default().with_lower_tolerance_bps(100);
-            let core: fynd_core::PriceGuardConfig = dto.into();
-
-            assert_eq!(core.lower_tolerance_bps(), 100);
-            // Unset fields get core defaults
-            assert_eq!(core.upper_tolerance_bps(), 10_000);
-            assert!(!core.fail_on_provider_error());
-            assert!(!core.enabled());
+            let config: fynd_core::PriceGuardConfig = dto.into();
+            assert_eq!(config.lower_tolerance_bps(), 200);
+            assert_eq!(config.upper_tolerance_bps(), 5000);
+            assert!(!config.fail_on_provider_error());
+            assert!(!config.enabled());
         }
 
         #[test]
@@ -1937,13 +1925,12 @@ mod conversions {
             };
 
             let core: fynd_core::QuoteRequest = dto.into();
-            let pg = core
+            let config = core
                 .options()
                 .encoding_options()
                 .expect("encoding_options should be set")
-                .price_guard()
-                .expect("price_guard should be set");
-            assert!(!pg.enabled());
+                .price_guard();
+            assert!(!config.enabled());
         }
 
         #[test]

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -162,15 +162,14 @@ impl FyndRPCBuilder {
         self
     }
 
-    /// Enables the price guard with a custom configuration.
+    /// Enables or disables the price guard.
     ///
-    /// The `enabled` field in the config controls whether validation runs.
     /// When enabled, default providers are auto-registered if none were added
-    /// manually.
-    pub fn with_price_guard_config(mut self, config: fynd_core::PriceGuardConfig) -> Self {
+    /// manually. When disabled, per-request attempts to enable the guard return an error.
+    pub fn price_guard_enabled(mut self, enabled: bool) -> Self {
         self.fynd_builder = self
             .fynd_builder
-            .price_guard_config(config);
+            .price_guard_enabled(enabled);
         self
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -114,26 +114,6 @@ pub struct ServeArgs {
     /// Disabled by default.
     #[arg(long)]
     pub enable_price_guard: bool,
-
-    /// Maximum allowed deviation below external price, in basis points (1 bps = 0.01%).
-    /// Default: 300 (3%).
-    #[arg(long, default_value_t = 300)]
-    pub price_guard_lower_tolerance_bps: u32,
-
-    /// Maximum allowed deviation above external price, in basis points (1 bps = 0.01%).
-    /// Default: 10000 (100%).
-    #[arg(long, default_value_t = 10_000)]
-    pub price_guard_upper_tolerance_bps: u32,
-
-    /// Reject solutions when all price providers error (network issues, API down).
-    /// Default: false.
-    #[arg(long, default_value_t = false)]
-    pub price_guard_fail_on_provider_error: bool,
-
-    /// Reject solutions when no provider has a price for the token pair.
-    /// Default: false.
-    #[arg(long, default_value_t = false)]
-    pub price_guard_fail_on_token_price_not_found: bool,
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,14 +292,7 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
     };
 
     builder = builder.blocklist(blocklist);
-    builder = builder.with_price_guard_config(
-        fynd_core::PriceGuardConfig::default()
-            .with_enabled(args.enable_price_guard)
-            .with_lower_tolerance_bps(args.price_guard_lower_tolerance_bps)
-            .with_upper_tolerance_bps(args.price_guard_upper_tolerance_bps)
-            .with_fail_on_provider_error(args.price_guard_fail_on_provider_error)
-            .with_fail_on_token_price_not_found(args.price_guard_fail_on_token_price_not_found),
-    );
+    builder = builder.price_guard_enabled(args.enable_price_guard);
 
     // Build and start solver
     let solver = builder


### PR DESCRIPTION
Server controls on/off, clients set all params per-request. Request cannot enable if guard is disabled on the server side (gives more power to server-runner to completely disable reliance on external providers).

This was done because the previous behaviour (configurable on both the client and the request side) was becoming quite confusing. Server-side set parameters wre obscure and hidden from the request-maker, and defaults became meaningless.
