### PR TITLE
docs: sync claude docs and fix CI TypeScript package filter

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -1,4 +1,4 @@
-<!-- docs-synced-at: 55b446762d25462cf184f9ea653050ae0a0b8dbd -->
+<!-- docs-synced-at: 353a6a831f91313b1b8d5b66985f91b0385da4dc -->
 # Fynd Codebase Guide
 
 High-performance DeFi route-finding engine built on Tycho. Finds optimal swap routes across
@@ -75,7 +75,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 2. `WorkerPoolRouter` fans out each order to all worker pools in parallel
 3. Each pool's `TaskQueue` dispatches to a `SolverWorker` on a dedicated OS thread
 4. Worker calls `Algorithm::find_best_route` with its local graph + shared market/derived data
-5. `WorkerPoolRouter` collects results, selects best by `amount_out_net_gas`
+5. `WorkerPoolRouter` collects results, ranks candidates by `amount_out_net_gas` descending; if price guard is enabled it validates in rank order
 6. If `EncodingOptions` provided, `Encoder` produces ABI-encoded calldata
 7. Returns `Quote` response
 
@@ -104,7 +104,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 
 | Command | Purpose |
 |---|---|
-| `serve` | Run the solver: Tycho feed + HTTP RPC server |
+| `serve` | Run the solver: Tycho feed + HTTP RPC server. Notable flags: `--enable-price-guard` (default `false`) |
 | `openapi` | Print the OpenAPI spec JSON to stdout |
 
 ### Config Files
@@ -112,7 +112,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 | File | Purpose |
 |---|---|
 | `worker_pools.toml` | Worker pool definitions: algorithm, num_workers, hop limits, timeout. Optional — binary falls back to embedded defaults if not found |
-| `blocklist.toml` | Pool IDs to exclude from routing. Optional — falls back to tycho-simulation defaults if not found |
+| `blocklist.toml` | Component IDs to exclude from the Tycho stream. Optional — falls back to tycho-simulation defaults if not found |
 
 ## Testing
 

--- a/.claude/skills/run-ci/SKILL.md
+++ b/.claude/skills/run-ci/SKILL.md
@@ -86,7 +86,7 @@ Report pass/fail. If drift is detected, tell the user to run `./scripts/update-o
 #### TypeScript checks (if TypeScript files changed)
 
 ```bash
-pnpm --dir clients/typescript install --frozen-lockfile && pnpm --dir clients/typescript --filter @fynd/autogen run build && pnpm --dir clients/typescript --filter @fynd/client run typecheck && pnpm --dir clients/typescript --filter @fynd/client run lint && pnpm --dir clients/typescript --filter @fynd/client run test
+pnpm --dir clients/typescript install --frozen-lockfile && pnpm --dir clients/typescript --filter @fynd/autogen run build && pnpm --dir clients/typescript --filter @kayibal/fynd-client run typecheck && pnpm --dir clients/typescript --filter @kayibal/fynd-client run lint && pnpm --dir clients/typescript --filter @kayibal/fynd-client run test
 ```
 
 Report pass/fail. If pnpm is not available, skip and note it.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,9 +138,9 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: clients/typescript/pnpm-lock.yaml
       - run: pnpm --dir clients/typescript install --frozen-lockfile
-      - run: pnpm --dir clients/typescript --filter @fynd/client run typecheck
-      - run: pnpm --dir clients/typescript --filter @fynd/client run lint
-      - run: pnpm --dir clients/typescript --filter @fynd/client run test
+      - run: pnpm --dir clients/typescript --filter @kayibal/fynd-client run typecheck
+      - run: pnpm --dir clients/typescript --filter @kayibal/fynd-client run lint
+      - run: pnpm --dir clients/typescript --filter @kayibal/fynd-client run test
 
   security_audit:
     name: Security Audit

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -45,6 +45,7 @@ FyndClientBuilder::new(fynd_url, rpc_url)
 
 **`FyndClient`**
 - `quote(params: QuoteParams) -> Result<Quote, FyndError>` — request a swap quote
+- `batch_quote(params: BatchQuoteParams) -> Result<Vec<Quote>, FyndError>` — request multiple quotes in one call
 - `health() -> Result<HealthStatus, FyndError>` — check solver health
 - `info() -> Result<InstanceInfo, FyndError>` — fetch static instance metadata (cached)
 - `swap_payload(quote, signer, hints) -> Result<SwapPayload, FyndError>` — EIP-712 sign a quote
@@ -56,6 +57,13 @@ FyndClientBuilder::new(fynd_url, rpc_url)
 
 **`StorageOverrides`** — Dry-run execution with simulated ERC-20 balances/approvals (storage slot
 overrides for `eth_call`).
+
+**`ApprovalParams`** — `new(token, allowance_check: AllowanceCheck)` where `AllowanceCheck` is
+`Skip` (always build approval) or `AtLeast(BigUint)` (check current allowance first; skip if
+sufficient).
+
+**`BatchQuoteParams`**, **`PriceGuardConfig`** — exported from the crate root alongside other
+client types (`Quote`, `Order`, `QuoteParams`, etc.).
 
 ### Backend Detection
 
@@ -79,7 +87,7 @@ pnpm workspace at `clients/typescript/` with two packages:
 ```bash
 pnpm --dir clients/typescript install --frozen-lockfile
 pnpm --dir clients/typescript --filter @fynd/autogen run build
-pnpm --dir clients/typescript --filter @fynd/client run typecheck
-pnpm --dir clients/typescript --filter @fynd/client run lint
-pnpm --dir clients/typescript --filter @fynd/client run test
+pnpm --dir clients/typescript --filter @kayibal/fynd-client run typecheck
+pnpm --dir clients/typescript --filter @kayibal/fynd-client run lint
+pnpm --dir clients/typescript --filter @kayibal/fynd-client run test
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,7 +39,7 @@ This modular architecture allows users to:
 │                         Async I/O - Non-blocking                            │
 │  ┌──────────────────────────────────────────────────────────────────────┐   │
 │  │                           RouterApi                                  │   │
-│  │  POST /v1/quote    GET /v1/health    GET /v1/info    GET /metrics    │   │
+│  │        POST /v1/quote      GET /v1/health      GET /v1/info          │   │
 │  └───────────────────────────────┬──────────────────────────────────────┘   │
 └──────────────────────────────────┼──────────────────────────────────────────┘
                                    │

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -10,10 +10,10 @@ applications.
 | `algorithm/`          | `Algorithm` trait + built-in `MostLiquidAlgorithm`, `BellmanFordAlgorithm`. Pluggable via associated graph types. `AlgorithmConfig` shared by both                                 |
 | `solver.rs`           | `FyndBuilder` assembles the full pipeline (feed + gas + computations + pools + encoder + router). `Solver` runs it                                                                 |
 | `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based |
-| `worker_pool_router/` | `WorkerPoolRouter` fans out orders to all pools, selects best by `amount_out_net_gas`, optionally encodes                                                                          |
+| `worker_pool_router/` | `WorkerPoolRouter` fans out orders to all pools, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes          |
 | `feed/`               | `TychoFeed` (WebSocket → SharedMarketData), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`                                                                      |
 | `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `PoolDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
-| `graph/`              | `pub(crate)` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `EdgeWeightUpdaterWithDerived`, `Path` type                                 |
+| `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
 | `price_guard/`        | Price guard: external price validation for quotes. Sub-modules: `guard` (validation logic), `binance_ws` (Binance WebSocket price provider), `hyperliquid` (Hyperliquid oracle provider), `provider_registry`, `config`, `utils` |
 | `encoding/`           | `Encoder` wraps `tycho-execution` to produce ABI-encoded calldata (singleSwap, sequentialSwap, Permit2 variants). Computes `FeeBreakdown` mirroring on-chain `FeeCalculator` logic |
 | `types/`              | Core types: `Order`, `Route`, `Swap`, `Quote`, `QuoteRequest`, `BlockInfo`, `EncodingOptions`, `FeeBreakdown`, error types                                                         |
@@ -55,6 +55,9 @@ pub trait EdgeWeightUpdaterWithDerived {
 **`FyndBuilder`** (`solver.rs`): Assembles feed + gas + computations + pools + encoder + router.
 Returns a `Solver` that can `quote()` directly. For standalone (non-HTTP) use.
 
+Price guard methods: `price_guard_enabled(bool)`, `register_price_provider(Box<dyn PriceProvider>)`,
+`add_default_price_providers()` (registers Binance WS + Hyperliquid providers).
+
 ## Adding a Custom Algorithm
 
 1. Implement `Algorithm` with your `GraphType` and `GraphManager`
@@ -62,7 +65,7 @@ Returns a `Solver` that can `quote()` directly. For standalone (non-HTTP) use.
    `WorkerPoolBuilder::with_algorithm("name", factory)`
 3. No changes to fynd-core required
 
-See `examples/custom_algorithm.rs` for a walkthrough.
+See `fynd-core/examples/custom_algorithm.rs` for a walkthrough.
 
 ## Data Flow
 

--- a/fynd-rpc-types/CLAUDE.md
+++ b/fynd-rpc-types/CLAUDE.md
@@ -18,8 +18,8 @@ Single file: `src/lib.rs`. All types derive `Serialize + Deserialize`.
 
 - `QuoteRequest` — orders + options
 - `Order` — token_in, token_out, amount, side (Sell only), sender, optional receiver
-- `QuoteOptions` — timeout_ms, min_responses, max_gas, encoding_options, price_guard (optional `PriceGuardConfig`)
-- `EncodingOptions` — slippage, transfer_type, permit, permit2_signature, client_fee_params
+- `QuoteOptions` — timeout_ms, min_responses, max_gas, encoding_options
+- `EncodingOptions` — slippage, transfer_type, permit, permit2_signature, client_fee_params, price_guard (optional `PriceGuardConfig`)
 - `UserTransferType` — TransferFrom (default) / TransferFromPermit2 / UseVaultsFunds
 - `ClientFeeParams` — bps, receiver, max_subsidy, signature (client fee on swap output)
 - `PriceGuardConfig` — external price validation config (provider registry, deviation thresholds)
@@ -30,7 +30,7 @@ Single file: `src/lib.rs`. All types derive `Serialize + Deserialize`.
 - `Quote` — orders (Vec<OrderQuote>), total_gas_estimate, solve_time_ms
 - `OrderQuote` — order_id, status, route, amount_in/out, gas_estimate, price_impact_bps, amount_out_net_gas, block, gas_price, transaction, fee_breakdown
 - `FeeBreakdown` — router_fee, client_fee, max_slippage, min_amount_received (all absolute token-out amounts, populated when encoding_options is set)
-- `QuoteStatus` — Success, NoRouteFound, InsufficientLiquidity, Timeout, NotReady
+- `QuoteStatus` — Success, NoRouteFound, InsufficientLiquidity, Timeout, NotReady, PriceCheckFailed
 - `Route` — Vec<Swap>
 - `Swap` — component_id, protocol, token_in/out, amount_in/out, gas_estimate, split
 - `BlockInfo` — number, hash, timestamp

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -42,6 +42,7 @@ infrastructure.
 `FyndRPCBuilder` delegates all solver configuration to `FyndBuilder` and adds:
 - `http_host` / `http_port` (defaults: `0.0.0.0:3000`)
 - `gas_price_stale_threshold` (health returns 503 when exceeded)
+- `price_guard_enabled(bool)` (delegates to `FyndBuilder`; default `false`)
 
 The builder calls `FyndBuilder::build()` → `Solver::into_parts()` → wraps the router in
 `AppState` → starts an Actix `HttpServer`.


### PR DESCRIPTION
Update all CLAUDE.md and .claude/ docs to reflect changes since the last sync (price guard integration, batch_quote, AllowanceCheck API, QuoteStatus variants, graph visibility, blocklist semantics, worker pool ranking).

Fix @fynd/client → @kayibal/fynd-client in ci.yaml and run-ci skill — the wrong filter caused TypeScript checks to silently no-op.