### PR TITLE
feat: gate Prometheus metrics behind a Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ edition = "2021"
 description = "High-performance DeFi route-finding engine — embeddable library and CLI"
 license = "MIT"
 
+[features]
+default = ["metrics"]
+# Enables the Prometheus metrics exporter on a separate HTTP server.
+# Disable with `--no-default-features` to omit Actix-Web and the Prometheus
+# recorder from the binary (e.g. for embedded/minimal builds).
+metrics = ["dep:actix-web", "dep:metrics-exporter-prometheus"]
+
 [dependencies]
 fynd-rpc = { workspace = true }
 fynd-core = { workspace = true }
@@ -22,8 +29,8 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 
-# HTTP (for metrics server)
-actix-web = { workspace = true }
+# HTTP (for metrics server, gated behind the `metrics` feature)
+actix-web = { workspace = true, optional = true }
 
 # Observability
 tracing = { workspace = true }
@@ -32,7 +39,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-metrics-exporter-prometheus = { workspace = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
 
 # Serialization (for OpenAPI spec output)
 serde_json = { workspace = true }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ cargo run --release serve --chain base
 
 See the [full quickstart](https://docs.fynd.xyz/get-started/quickstart) for Docker, build-from-source, and client SDK examples (Rust & TypeScript).
 
+## Build features
+
+The `fynd` binary exposes the following Cargo features:
+
+| Feature   | Default | What it enables                                                                            |
+| --------- | ------- | ------------------------------------------------------------------------------------------ |
+| `metrics` | on      | Prometheus `/metrics` endpoint on a separate HTTP server (port 9898). Pulls in Actix-Web.  |
+
+```bash
+# Default build (metrics on)
+cargo install fynd
+cargo build --release
+
+# Build without the metrics exporter (smaller binary, no /metrics endpoint)
+cargo install fynd --no-default-features
+cargo build --release --no-default-features
+```
+
 ## Documentation
 
 For API reference, configuration options, encoding, client fees, custom algorithms, architecture, and more, visit the full documentation at **[docs.fynd.xyz](https://docs.fynd.xyz/)**.

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@
 
 use std::time::Duration;
 
+#[cfg(feature = "metrics")]
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 use anyhow::anyhow;
 use clap::Parser;
@@ -40,6 +41,7 @@ use fynd_rpc::{
 };
 mod cli;
 use cli::{Cli, Commands};
+#[cfg(feature = "metrics")]
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::WithExportConfig;
@@ -144,6 +146,8 @@ fn create_tracing_subscriber() -> Option<TracerProvider> {
 /// Creates and runs the Prometheus metrics exporter using Actix Web.
 ///
 /// This exposes the metrics on the '/metrics' endpoint on a separate HTTP server on port 9898.
+/// Compiled only when the `metrics` feature is enabled.
+#[cfg(feature = "metrics")]
 fn create_metrics_exporter() -> tokio::task::JoinHandle<()> {
     let exporter_builder = PrometheusBuilder::new();
     let handle = exporter_builder
@@ -307,6 +311,7 @@ async fn run_solver(args: cli::ServeArgs) -> Result<(), SolverError> {
     let provider = create_tracing_subscriber();
     info!("Starting Fynd");
 
+    #[cfg(feature = "metrics")]
     let _metrics_task = create_metrics_exporter();
 
     // Setup solver, but allow SIGINT to cancel it for fast exit during startup


### PR DESCRIPTION
The Actix-Web `/metrics` server and the `metrics-exporter-prometheus` recorder are now gated behind a `metrics` Cargo feature. The feature is on by default, so default builds (`cargo install fynd`, `cargo build --release`) keep the existing `/metrics` endpoint on port 9898. Embedders or operators wanting a smaller binary can opt out with `--no-default-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)