### PR TITLE
fix: make graph construction and SPFA relaxation deterministic

### DIFF
--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -531,6 +531,8 @@ impl Algorithm for BellmanFordAlgorithm {
             }
 
             active_nodes = next_active.into_iter().collect();
+            // Deterministic order: HashSet iteration is random per process.
+            active_nodes.sort_unstable();
         }
 
         // Check if destination was reached

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -12,6 +12,16 @@
 //! - **SPFA (Shortest Path Faster Algorithm) queuing**: Only re-relaxes edges from nodes whose
 //!   amount improved
 //! - **Forbid revisits**: Skips edges that would revisit a token or pool already in the path
+//!
+//! # Known limitation: SPFA order-dependence
+//!
+//! SPFA reads and writes the same `amount[]` array within a round (unlike
+//! textbook Bellman-Ford which snapshots between rounds). Processing node B
+//! before node C can update intermediate amounts that C then builds on,
+//! producing different routes depending on iteration order. Active nodes are
+//! sorted by `NodeIndex` for determinism, but the chosen ordering is not
+//! guaranteed to find the globally optimal route. A proper fix would be to
+//! snapshot amounts between rounds or use a priority-based processing order.
 
 use std::{
     collections::{HashMap, HashSet, VecDeque},
@@ -532,6 +542,9 @@ impl Algorithm for BellmanFordAlgorithm {
 
             active_nodes = next_active.into_iter().collect();
             // Deterministic order: HashSet iteration is random per process.
+            // This pins SPFA to a fixed propagation order. The chosen order
+            // may not yield the optimal route (see module docs), but the
+            // previous random order was statistically no better.
             active_nodes.sort_unstable();
         }
 

--- a/fynd-core/src/graph/petgraph.rs
+++ b/fynd-core/src/graph/petgraph.rs
@@ -166,7 +166,11 @@ impl<D: Clone> PetgraphStableDiGraphManager<D> {
         let mut invalid_components = Vec::new();
         let mut skipped_duplicates = 0usize;
 
-        for (comp_id, tokens) in components {
+        // Sort components for deterministic node/edge insertion order.
+        let mut sorted_components: Vec<_> = components.iter().collect();
+        sorted_components.sort_by_key(|(id, _)| *id);
+
+        for (comp_id, tokens) in sorted_components {
             if self.edge_map.contains_key(comp_id) {
                 trace!(component_id = %comp_id, "skipping already-tracked component");
                 skipped_duplicates += 1;
@@ -177,12 +181,12 @@ impl<D: Clone> PetgraphStableDiGraphManager<D> {
                 invalid_components.push(comp_id.clone());
                 continue;
             }
-            // Ensure all tokens are added as nodes (or get existing ones) and collect their indices
-            let node_indices: Vec<NodeIndex> = tokens
+            let mut sorted_tokens: Vec<&Address> = tokens.iter().collect();
+            sorted_tokens.sort();
+            let node_indices: Vec<NodeIndex> = sorted_tokens
                 .iter()
                 .map(|token| self.get_or_create_node(token))
                 .collect();
-            // Add edges for all token pairs in this component
             self.add_component_edges(comp_id, &node_indices);
         }
 
@@ -388,23 +392,33 @@ impl<D: Clone + Send + Sync> GraphManager<StableDiGraph<D>> for PetgraphStableDi
         self.edge_map.clear();
         self.node_map.clear();
 
-        let unique_tokens: HashSet<Address> = component_topology
+        // Sort tokens for deterministic NodeIndex assignment across processes.
+        // HashMap/HashSet iteration order varies per process (random SipHash
+        // seeds), which would otherwise give different graph structure each run.
+        let mut unique_tokens: Vec<Address> = component_topology
             .values()
             .flat_map(|v| v.iter())
             .cloned()
+            .collect::<HashSet<_>>()
+            .into_iter()
             .collect();
+        unique_tokens.sort();
 
-        // Add all nodes (tokens) to the graph
         for token in unique_tokens {
             let node_idx = self.graph.add_node(token.clone());
             self.node_map.insert(token, node_idx);
         }
 
-        // Add edges between all tokens in each component
-        for (comp_id, tokens) in component_topology {
-            let node_indices: Vec<NodeIndex> = tokens
+        // Sort components for deterministic edge insertion order.
+        let mut sorted_components: Vec<_> = component_topology.iter().collect();
+        sorted_components.sort_by_key(|(id, _)| *id);
+
+        for (comp_id, tokens) in sorted_components {
+            let mut sorted_tokens: Vec<&Address> = tokens.iter().collect();
+            sorted_tokens.sort();
+            let node_indices: Vec<NodeIndex> = sorted_tokens
                 .iter()
-                .map(|token| self.node_map[token])
+                .map(|token| self.node_map[*token])
                 .collect();
             self.add_component_edges(comp_id, &node_indices);
         }

--- a/fynd-core/src/graph/petgraph.rs
+++ b/fynd-core/src/graph/petgraph.rs
@@ -392,9 +392,10 @@ impl<D: Clone + Send + Sync> GraphManager<StableDiGraph<D>> for PetgraphStableDi
         self.edge_map.clear();
         self.node_map.clear();
 
-        // Sort tokens for deterministic NodeIndex assignment across processes.
-        // HashMap/HashSet iteration order varies per process (random SipHash
-        // seeds), which would otherwise give different graph structure each run.
+        // Sort tokens for deterministic NodeIndex assignment across processes
+        // given the same input. HashMap/HashSet iteration order varies per
+        // process (random SipHash seeds), which would otherwise give different
+        // graph structure each run.
         let mut unique_tokens: Vec<Address> = component_topology
             .values()
             .flat_map(|v| v.iter())


### PR DESCRIPTION
## Summary

- Sort tokens and components before graph construction in `initialize_graph` and `add_components`, giving deterministic `NodeIndex` assignment and edge insertion order across process runs
- Sort the SPFA `active_nodes` set after collecting from `HashSet`, ensuring deterministic relaxation order between rounds
- Sort token lists within each component before generating edge pairs (defense-in-depth)

## Problem

The solver produced different routing results across process runs. Rust's `HashMap`/`HashSet` use random SipHash seeds per process, and graph construction iterated these collections to assign node indices and insert edges. Since petgraph's `graph.edges(node)` returns edges in insertion order, different seeds produced different BFS traversal and SPFA relaxation orders.

In the Bellman-Ford SPFA loop, within-round amount propagation means the order active nodes are processed affects which intermediate amounts get used — producing different final routes depending on iteration order.

## Test plan

- [ ] Existing unit tests pass (363 tests, 0 failures)
- [ ] Verify determinism: run integration quality test multiple times — same result each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)