### PR TITLE
feat: add --metrics-port flag to serve command

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -99,6 +99,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 | `WORKER_POOLS_CONFIG` | Worker pools config file (default: `worker_pools.toml`) |
 | `BLOCKLIST_CONFIG` | Blocklist config file |
 | `RUST_LOG` | Tracing filter (e.g. `info,fynd=debug`) |
+| `METRICS_PORT` | Prometheus metrics server port (default: `9898`, requires `metrics` feature) |
 
 ### CLI Commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,7 +143,7 @@ Actix Web HTTP handlers. Validates requests, delegates to WorkerPoolRouter, retu
 * `POST /v1/quote` -- Submit quote requests
 * `GET /v1/health` -- Health check (data freshness, derived data readiness, pool count)
 * `GET /v1/info` -- Instance info (chain ID, router address, Permit2 address)
-* `GET /metrics` -- Prometheus metrics (separate server, port 9898)
+* `GET /metrics` -- Prometheus metrics (separate server, port 9898 by default)
 
 ***
 

--- a/docs/guides/server-configuration.md
+++ b/docs/guides/server-configuration.md
@@ -98,6 +98,7 @@ Run `fynd serve --help` for the full list.
 | `--price-guard-upper-tolerance-bps`          | —        | `10000`      | Max allowed deviation (bps) when the quote's output is above the provider's expected amount.                                                                           |
 | `--price-guard-fail-on-provider-error`       | —        | `false`      | Reject quotes when all price providers fail with infrastructure errors.                                                                                                |
 | `--price-guard-fail-on-token-price-not-found`| —        | `false`      | Reject quotes when no provider lists the token.                                                                                                                        |
+| `--metrics-port`                             | `METRICS_PORT` | `9898`  | Port for the Prometheus metrics HTTP server. Requires the `metrics` feature (enabled by default).                                                                      |
 
 ## Worker pools (`worker_pools.toml`)
 
@@ -172,7 +173,19 @@ RUST_LOG=info,fynd_core=trace fynd serve ...
 
 ### Prometheus metrics
 
-***
+Fynd exposes Prometheus metrics on a dedicated HTTP server (enabled by default via the `metrics` feature). Scrape the `/metrics` endpoint with Prometheus or any compatible tool:
+
+```
+http://localhost:9898/metrics
+```
+
+The port defaults to `9898` and can be changed with `--metrics-port` or the `METRICS_PORT` environment variable:
+
+```bash
+fynd serve --metrics-port 9090
+```
+
+Available metrics include solve duration, response counts, failure types, and pool performance.
 
 ## Tuning tips
 
@@ -187,5 +200,3 @@ RUST_LOG=info,fynd_core=trace fynd serve ...
 ### Request routing
 
 * **Lower `--worker-router-min-responses`** = faster response with multiple pools — set to `1` to return as soon as the first pool finishes, at the cost of potentially missing a better result from a slower pool.
-
-Metrics are exposed at `http://localhost:9898/metrics` (always on). Scrape this endpoint with Prometheus or any compatible tool. Available metrics: solve duration, response counts, failure types, and pool performance.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,9 @@ use std::path::PathBuf;
 use clap::Parser;
 use fynd_rpc::config::defaults;
 
+#[cfg(feature = "metrics")]
+pub(crate) const METRICS_PORT: u16 = 9898;
+
 /// Fynd - High-performance DEX solver built on Tycho
 ///
 /// Finds optimal swap routes across multiple protocols using real-time market data.
@@ -114,6 +117,11 @@ pub struct ServeArgs {
     /// Disabled by default.
     #[arg(long)]
     pub enable_price_guard: bool,
+
+    /// Port for the Prometheus metrics HTTP server (requires `metrics` feature).
+    #[cfg(feature = "metrics")]
+    #[arg(long, default_value_t = METRICS_PORT, env)]
+    pub metrics_port: u16,
 }
 
 #[cfg(test)]
@@ -188,6 +196,8 @@ mod cli_tests {
         assert_eq!(args.worker_router_timeout_ms, 100);
         assert_eq!(args.worker_router_min_responses, 0);
         assert_eq!(args.blocklist_config, None);
+        #[cfg(feature = "metrics")]
+        assert_eq!(args.metrics_port, METRICS_PORT);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,10 +145,10 @@ fn create_tracing_subscriber() -> Option<TracerProvider> {
 
 /// Creates and runs the Prometheus metrics exporter using Actix Web.
 ///
-/// This exposes the metrics on the '/metrics' endpoint on a separate HTTP server on port 9898.
+/// Exposes `/metrics` on a dedicated HTTP server bound to `port`.
 /// Compiled only when the `metrics` feature is enabled.
 #[cfg(feature = "metrics")]
-fn create_metrics_exporter() -> tokio::task::JoinHandle<()> {
+fn create_metrics_exporter(port: u16) -> tokio::task::JoinHandle<()> {
     let exporter_builder = PrometheusBuilder::new();
     let handle = exporter_builder
         .install_recorder()
@@ -171,7 +171,7 @@ fn create_metrics_exporter() -> tokio::task::JoinHandle<()> {
                 }),
             )
         })
-        .bind(("0.0.0.0", 9898))
+        .bind(("0.0.0.0", port))
         .expect("Failed to bind metrics server")
         .run()
         .await
@@ -312,7 +312,7 @@ async fn run_solver(args: cli::ServeArgs) -> Result<(), SolverError> {
     info!("Starting Fynd");
 
     #[cfg(feature = "metrics")]
-    let _metrics_task = create_metrics_exporter();
+    let _metrics_task = create_metrics_exporter(args.metrics_port);
 
     // Setup solver, but allow SIGINT to cancel it for fast exit during startup
     let solver = tokio::select! {


### PR DESCRIPTION
I'd like to be able to customize the metrics port. This can be very useful to run 2 fynd servers on different chains without opening them with a container. 