### PR TITLE
feat(fynd-core): labeled simulation-state overlays

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -55,8 +55,8 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 2. **WorkerPoolRouter** (`fynd-core/src/worker_pool_router/`) — Fans out orders to all pools, selects best by `amount_out_net_gas`
 3. **WorkerPool** (`fynd-core/src/worker_pool/`) — N `SolverWorker` instances on dedicated OS threads per pool
 4. **Algorithm trait** (`fynd-core/src/algorithm/`) — Pluggable route-finding; built-in: `MostLiquidAlgorithm`, `BellmanFordAlgorithm`
-5. **SharedMarketData** (`fynd-core/src/feed/market_data.rs`) — `Arc<RwLock<>>` of all pool/token/gas state
-6. **TychoFeed** (`fynd-core/src/feed/tycho_feed.rs`) — Background task: Tycho WebSocket → SharedMarketData → broadcast events
+5. **MarketState** (`fynd-core/src/feed/market_data.rs`) — `Arc<RwLock<>>` of all pool/token/gas state; accessed via `MarketData` handle
+6. **TychoFeed** (`fynd-core/src/feed/tycho_feed.rs`) — Background task: Tycho WebSocket → MarketState → broadcast events
 7. **Derived Data** (`fynd-core/src/derived/`) — Pre-computed spot prices, pool depths, token gas prices
 8. **Encoding** (`fynd-core/src/encoding/`) — Encodes solved routes into on-chain transactions via `TychoEncoder`
 9. **Graph** (`fynd-core/src/graph/`) — `GraphManager` trait + `PetgraphStableDiGraphManager` implementation
@@ -65,9 +65,9 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 
 **Market update path** (continuous, every block):
 1. `TychoFeed` receives state updates from Tycho WebSocket
-2. Writes new component/token/state data into `SharedMarketData` (write lock)
+2. Writes new component/token/state data into `MarketState` (write lock)
 3. Broadcasts `MarketEvent` → each `SolverWorker` updates its local graph via `GraphManager`
-4. Signals `GasPriceFetcher` → fetches gas price from RPC node → writes to `SharedMarketData`
+4. Signals `GasPriceFetcher` → fetches gas price from RPC node → writes to `MarketState`
 5. Triggers `ComputationManager` → runs spot prices → pool depths → token gas prices (in dependency order) → broadcasts `DerivedDataEvent` → workers update edge weights
 
 **Quote request path** (`POST /v1/quote`):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,7 @@ This modular architecture allows users to:
 ## Design Decisions
 
 * **Concurrency Model**: Hybrid async/threaded -- I/O on tokio, route finding on dedicated OS threads
-* **Data Sharing**: `Arc<RwLock<>>` with write-preferring lock for SharedMarketData (single writer, many readers)
+* **Data Sharing**: `Arc<RwLock<>>` with write-preferring lock for MarketState (single writer, many readers)
 * **Path-Finding**: Pluggable `Algorithm` trait with associated graph types, allowing each algorithm to use its preferred graph representation
 * **Graph Management**: `GraphManager` trait with incremental updates from market events; built-in implementation uses `petgraph::StableDiGraph`
 * **Multi-Solver Competition**: Multiple worker pools with different configurations compete per request; WorkerPoolRouter selects the best result
@@ -77,7 +77,7 @@ This modular architecture allows users to:
                                    │ Reads shared data
                                    ▼
 ┌────────────────────────────────────────────────────────────────────────────────────┐
-│                         SharedMarketData (Arc<RwLock<>>)                           │
+│                         MarketState (Arc<RwLock<>>, via MarketData handle)          │
 │  ┌────────────────────────────────────────────────────────────────────────────┐    │
 │  │  components: HashMap<ComponentId, ProtocolComponent>                       │    │
 │  │  simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>>             │    │
@@ -93,7 +93,7 @@ This modular architecture allows users to:
 │                              TychoFeed                                      │
 │                     Background task (single instance)                       │
 │  ┌────────────────────────────────────────────────────────────────────┐     │
-│  │  Tycho Stream ──► Update SharedMarketData ──► Broadcast Event      │     │
+│  │  Tycho Stream ──► Update MarketState ──► Broadcast Event            │     │
 │  └────────────────────────────────────────────────────────────────────┘     │
 │                                   │                                         │
 │                                   ▼ broadcast::Sender<MarketEvent>          │
@@ -226,13 +226,13 @@ Graph management infrastructure:
 
 ***
 
-### 8. SharedMarketData
+### 8. MarketState / MarketData
 
 **Crate:** `fynd-core` **Location:** `fynd-core/src/feed/market_data.rs`
 
-Single source of truth for all market state. Contains components, simulation states, tokens, gas prices, sync status, and block info. Protected by `Arc<RwLock<>>` (write-preferring).
+`MarketState` is the single source of truth for all market state. Contains components, simulation states, tokens, gas prices, sync status, and block info. Protected by `Arc<RwLock<>>` (write-preferring). `MarketData` is the cheap-to-clone shared handle used to access it — call `read()` for a base view or `read_labeled(label)` for an overlay-aware view.
 
-Provides `extract_subset()` for creating filtered snapshots that algorithms can use without holding the main lock.
+Provides `extract_subset_with_overlay()` for creating filtered snapshots that algorithms can use without holding the main lock.
 
 ***
 
@@ -240,7 +240,7 @@ Provides `extract_subset()` for creating filtered snapshots that algorithms can 
 
 **Crate:** `fynd-core` **Location:** `fynd-core/src/feed/tycho_feed.rs`
 
-Background task that connects to Tycho's WebSocket API, processes component/state updates, updates SharedMarketData, and broadcasts `MarketEvent`s. Applies TVL filtering with hysteresis (components are added at `min_tvl` and removed at `min_tvl / tvl_buffer_ratio`), token recency filtering (`traded_n_days_ago`), blocklisting, and token quality filtering.
+Background task that connects to Tycho's WebSocket API, processes component/state updates, updates `MarketState` (via `MarketData`), and broadcasts `MarketEvent`s. Applies TVL filtering with hysteresis (components are added at `min_tvl` and removed at `min_tvl / tvl_buffer_ratio`), token recency filtering (`traded_n_days_ago`), blocklisting, and token quality filtering.
 
 ***
 
@@ -316,7 +316,7 @@ Tycho WebSocket Stream
     │
     ▼
 TychoFeed
-    ├──► Write SharedMarketData (RwLock write)
+    ├──► Write MarketState (RwLock write)
     ├──► Broadcast MarketEvent
     │       ├──► Worker 1 GraphManager (update graph)
     │       ├──► Worker 2 GraphManager (update graph)
@@ -359,4 +359,4 @@ Worker Pool B (dedicated OS threads)
 * Workers -> WorkerPoolRouter: `oneshot` channel (single response)
 * TychoFeed -> Workers: `broadcast` channel (MarketEvent)
 * ComputationManager -> Workers: `broadcast` channel (DerivedDataEvent)
-* All -> SharedMarketData: `Arc<RwLock<>>` (read-heavy)
+* All -> MarketState (via MarketData): `Arc<RwLock<>>` (read-heavy)

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Fynd puts you in control:
 
 ### Key Design Principles
 
-* **Single source of truth**: All market data lives in one `SharedMarketData` structure. A single feed writes to it; all workers read from it. No duplication.
+* **Single source of truth**: All market data lives in one `MarketState` structure. A single feed writes to it; all workers read from it. No duplication.
 * **Algorithm-agnostic**: Built around a pluggable `Algorithm` trait. Different algorithms use different graph representations and strategies. Multiple algorithms compete in parallel; the best result wins.
 * **Performance-first**: CPU-bound route finding runs on dedicated OS threads (not the async runtime). Each worker pool has its own task queue for independent backpressure and scaling.
 * **Observability built-in**: Prometheus metrics, structured logging via `tracing`, and health endpoints are first-class citizens.
@@ -79,7 +79,7 @@ Fynd works with any protocol Tycho supports. See the [list of supported protocol
 <figure><picture><source srcset=".gitbook/assets/how-it-works-darkmode.png" media="(prefers-color-scheme: dark)"><img src=".gitbook/assets/how-it-works-lightmode.png" alt="How It Works"></picture><figcaption></figcaption></figure>
 
 1. **TychoFeed** connects to **Tycho Streams** ([on-chain protocols](https://docs.propellerheads.xyz/tycho/for-solvers/simulation#streaming-protocol-states) and [RFQs](https://docs.propellerheads.xyz/tycho/for-solvers/request-for-quote-protocols#stream-real-time-price-updates)) and processes market updates (added/removed components and state changes) every block.
-2. **SharedMarketData** stores all component states, tokens, and gas prices in a single shared structure.
+2. **MarketState** stores all component states, tokens, and gas prices in a single shared structure.
 3. When a **quote request** arrives via HTTP, the **WorkerPoolRouter** fans it out to all worker pools in parallel.
 4. Each **Worker Pool** runs a specific algorithm. Workers compete to pick up the task, find routes through their local graph, simulate swaps against shared market state, and return ranked results.
 5. The **WorkerPoolRouter** collects results from all pools, picks the best solution by `amount_out_net_gas`, optionally encodes it for execution against the `TychoRouter`, and returns it.

--- a/docs/guides/custom-algorithm.md
+++ b/docs/guides/custom-algorithm.md
@@ -56,7 +56,10 @@ impl Algorithm for DirectPoolAlgorithm {
         _derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
-        let market = market.read(label.as_ref()).await;
+        let market = market
+            .read_opt(label.as_ref())
+            .await
+            .map_err(|e| AlgorithmError::Other(e.to_string()))?;
 
         let gas_price = market
             .gas_price()

--- a/docs/guides/custom-algorithm.md
+++ b/docs/guides/custom-algorithm.md
@@ -51,11 +51,12 @@ impl Algorithm for DirectPoolAlgorithm {
     async fn find_best_route(
         &self,
         graph: &Self::GraphType,
-        market: SharedMarketDataRef,
+        market: MarketData,
+        label: Option<StateLabel>,
         _derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
-        let market = market.read().await;
+        let market = market.read(label.as_ref()).await;
 
         let gas_price = market
             .gas_price()

--- a/docs/guides/custom-algorithm.md
+++ b/docs/guides/custom-algorithm.md
@@ -56,10 +56,13 @@ impl Algorithm for DirectPoolAlgorithm {
         _derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
-        let market = market
-            .read_opt(label.as_ref())
-            .await
-            .map_err(|e| AlgorithmError::Other(e.to_string()))?;
+        let market = match label.as_ref() {
+            Some(l) => market
+                .read_labeled(l)
+                .await
+                .map_err(|e| AlgorithmError::Other(e.to_string()))?,
+            None => market.read().await,
+        };
 
         let gas_price = market
             .gas_price()

--- a/docs/guides/price-guard.md
+++ b/docs/guides/price-guard.md
@@ -96,7 +96,7 @@ of the unreachable providers, so the guard applies `fail_on_provider_error` rath
 Price providers (Binance, Hyperliquid) identify tokens by their trading symbol — e.g. "ETH",
 "LINK", "PEPE". On-chain, symbols are not unique: any token can declare itself "PEPE", and
 multiple unrelated tokens on the same chain may share a symbol. The guard resolves tokens by
-matching the on-chain symbol from `SharedMarketData` to a provider's symbol, so a long-tail token
+matching the on-chain symbol from `MarketState` to a provider's symbol, so a long-tail token
 whose symbol collides with a well-known token will be priced as if it were that token.
 
 In practice this means the guard works reliably for major tokens listed on CEXs, but may produce

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -11,7 +11,7 @@ applications.
 | `solver.rs`           | `FyndBuilder` assembles the full pipeline (feed + gas + computations + pools + encoder + router). `Solver` runs it                                                                 |
 | `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based |
 | `worker_pool_router/` | `WorkerPoolRouter` fans out orders to all pools, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes          |
-| `feed/`               | `TychoFeed` (WebSocket → SharedMarketData), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`                                                                      |
+| `feed/`               | `TychoFeed` (WebSocket → MarketState), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`                                                                           |
 | `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `PoolDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
 | `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
 | `price_guard/`        | Price guard: external price validation for quotes. Sub-modules: `guard` (validation logic), `binance_ws` (Binance WebSocket price provider), `hyperliquid` (Hyperliquid oracle provider), `provider_registry`, `config`, `utils` |
@@ -27,7 +27,7 @@ pub trait Algorithm: Send + Sync {
     type GraphType: Send + Sync;
     type GraphManager: GraphManager<Self::GraphType> + Default;
     fn name(&self) -> &str;
-    async fn find_best_route(&self, graph: &Self::GraphType, market: SharedMarketDataRef, derived: Option<SharedDerivedDataRef>, order: &Order) -> Result<RouteResult, AlgorithmError>;
+    async fn find_best_route(&self, graph: &Self::GraphType, market: MarketData, label: Option<StateLabel>, derived: Option<SharedDerivedDataRef>, order: &Order) -> Result<RouteResult, AlgorithmError>;
     fn computation_requirements(&self) -> ComputationRequirements;
     fn timeout(&self) -> Duration;
 }
@@ -46,7 +46,7 @@ pub trait GraphManager<G>: Send + Sync {
 
 ```rust
 pub trait EdgeWeightUpdaterWithDerived {
-    fn update_edge_weights_with_derived(&mut self, market: &SharedMarketData, derived: &DerivedData) -> usize;
+    fn update_edge_weights_with_derived(&mut self, market: MarketDataView<'_>, derived: &DerivedData) -> usize;
 }
 ```
 
@@ -71,7 +71,7 @@ See `fynd-core/examples/custom_algorithm.rs` for a walkthrough.
 
 **Market updates** (every block):
 
-1. `TychoFeed` writes new state into `SharedMarketData` (`Arc<RwLock<>>`)
+1. `TychoFeed` writes new state into `MarketState` (via `MarketData`, `Arc<RwLock<>>`)
 2. Broadcasts `MarketEvent` → workers update local graph via `GraphManager`
 3. Signals `GasPriceFetcher`
 4. Triggers `ComputationManager` → `DerivedData` → workers update edge weights

--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -21,7 +21,7 @@ use std::{env, str::FromStr, time::Duration};
 
 use fynd_core::{
     derived::SharedDerivedDataRef,
-    feed::market_data::SharedMarketDataRef,
+    feed::market_data::MarketData,
     graph::{PetgraphStableDiGraphManager, StableDiGraph},
     types::RouteResult,
     Algorithm, AlgorithmError, ComputationRequirements, EncodingOptions, FyndBuilder, Order,
@@ -65,7 +65,7 @@ impl Algorithm for DirectPoolAlgorithm {
     async fn find_best_route(
         &self,
         graph: &Self::GraphType,
-        market: SharedMarketDataRef,
+        market: MarketData,
         _derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {

--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -70,10 +70,13 @@ impl Algorithm for DirectPoolAlgorithm {
         _derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
-        let market = market
-            .read_opt(label.as_ref())
-            .await
-            .map_err(|e| AlgorithmError::Other(e.to_string()))?;
+        let market = match label.as_ref() {
+            Some(l) => market
+                .read_labeled(l)
+                .await
+                .map_err(|e| AlgorithmError::Other(e.to_string()))?,
+            None => market.read().await,
+        };
 
         let gas_price = market
             .gas_price()

--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -21,7 +21,7 @@ use std::{env, str::FromStr, time::Duration};
 
 use fynd_core::{
     derived::SharedDerivedDataRef,
-    feed::market_data::MarketData,
+    feed::market_data::{MarketData, StateLabel},
     graph::{PetgraphStableDiGraphManager, StableDiGraph},
     types::RouteResult,
     Algorithm, AlgorithmError, ComputationRequirements, EncodingOptions, FyndBuilder, Order,
@@ -66,10 +66,11 @@ impl Algorithm for DirectPoolAlgorithm {
         &self,
         graph: &Self::GraphType,
         market: MarketData,
+        label: Option<StateLabel>,
         _derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
-        let market = market.read().await;
+        let market = market.read(label.as_ref()).await;
 
         let gas_price = market
             .gas_price()

--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -70,7 +70,10 @@ impl Algorithm for DirectPoolAlgorithm {
         _derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
-        let market = market.read(label.as_ref()).await;
+        let market = market
+            .read_opt(label.as_ref())
+            .await
+            .map_err(|e| AlgorithmError::Other(e.to_string()))?;
 
         let gas_price = market
             .gas_price()

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -379,7 +379,10 @@ impl Algorithm for BellmanFordAlgorithm {
 
         // Acquire read lock only for market data extraction, then release.
         let (token_map, market_subset) = {
-            let market = market.read(label.as_ref()).await;
+            let market = market
+                .read_opt(label.as_ref())
+                .await
+                .map_err(|e| AlgorithmError::Other(e.to_string()))?;
 
             let token_map: HashMap<NodeIndex, Token> = token_nodes
                 .iter()

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -44,7 +44,7 @@ use crate::{
         types::{SpotPrices, TokenGasPrices},
         SharedDerivedDataRef,
     },
-    feed::market_data::SharedMarketDataRef,
+    feed::market_data::MarketData,
     graph::{petgraph::StableDiGraph, PetgraphStableDiGraphManager},
     types::{ComponentId, Order, Route, RouteResult, Swap},
 };
@@ -338,7 +338,7 @@ impl Algorithm for BellmanFordAlgorithm {
     async fn find_best_route(
         &self,
         graph: &Self::GraphType,
-        market: SharedMarketDataRef,
+        market: MarketData,
         derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
@@ -666,7 +666,10 @@ impl Algorithm for BellmanFordAlgorithm {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use num_bigint::BigInt;
+    use tokio::sync::RwLock;
     use tycho_simulation::{
         tycho_common::{models::Address, simulation::protocol_sim::ProtocolSim},
         tycho_ethereum::gas::{BlockGasPrice, GasPrice},
@@ -676,7 +679,7 @@ mod tests {
     use crate::{
         algorithm::test_utils::{component, order, token, MockProtocolSim},
         derived::{types::TokenGasPrices, DerivedData},
-        feed::market_data::{SharedMarketData, SharedMarketDataRef},
+        feed::market_data::{MarketData, MarketState},
         graph::GraphManager,
         types::quote::OrderSide,
     };
@@ -686,8 +689,8 @@ mod tests {
     /// Sets up market and graph with `()` edge weights for BellmanFord tests.
     fn setup_market_bf(
         pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
-    ) -> (SharedMarketDataRef, PetgraphStableDiGraphManager<()>) {
-        let mut market = SharedMarketData::new();
+    ) -> (MarketData, PetgraphStableDiGraphManager<()>) {
+        let mut market = MarketState::new();
 
         market.update_gas_price(BlockGasPrice {
             block_number: 1,
@@ -708,10 +711,7 @@ mod tests {
         let mut graph_manager = PetgraphStableDiGraphManager::default();
         graph_manager.initialize_graph(&market.component_topology());
 
-        (
-            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market))),
-            graph_manager,
-        )
+        (MarketData::new(Arc::new(RwLock::new(market))), graph_manager)
     }
 
     fn setup_derived_with_token_prices(
@@ -729,7 +729,7 @@ mod tests {
 
         let mut derived_data = DerivedData::new();
         derived_data.set_token_prices(token_prices, vec![], 1, true);
-        std::sync::Arc::new(tokio::sync::RwLock::new(derived_data))
+        Arc::new(RwLock::new(derived_data))
     }
 
     fn bf_algorithm(max_hops: usize, timeout_ms: u64) -> BellmanFordAlgorithm {

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -379,10 +379,13 @@ impl Algorithm for BellmanFordAlgorithm {
 
         // Acquire read lock only for market data extraction, then release.
         let (token_map, market_subset) = {
-            let market = market
-                .read_opt(label.as_ref())
-                .await
-                .map_err(|e| AlgorithmError::Other(e.to_string()))?;
+            let market = match label.as_ref() {
+                Some(l) => market
+                    .read_labeled(l)
+                    .await
+                    .map_err(|e| AlgorithmError::Other(e.to_string()))?,
+                None => market.read().await,
+            };
 
             let token_map: HashMap<NodeIndex, Token> = token_nodes
                 .iter()
@@ -394,7 +397,7 @@ impl Algorithm for BellmanFordAlgorithm {
                 })
                 .collect();
 
-            let market_subset = market.extract_subset(&component_ids);
+            let market_subset = market.extract_subset_with_overlay(&component_ids);
 
             (token_map, market_subset)
         };

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -666,10 +666,7 @@ impl Algorithm for BellmanFordAlgorithm {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use num_bigint::BigInt;
-    use tokio::sync::RwLock;
     use tycho_simulation::{
         tycho_common::{models::Address, simulation::protocol_sim::ProtocolSim},
         tycho_ethereum::gas::{BlockGasPrice, GasPrice},
@@ -679,7 +676,7 @@ mod tests {
     use crate::{
         algorithm::test_utils::{component, order, token, MockProtocolSim},
         derived::{types::TokenGasPrices, DerivedData},
-        feed::market_data::SharedMarketData,
+        feed::market_data::{SharedMarketData, SharedMarketDataRef},
         graph::GraphManager,
         types::quote::OrderSide,
     };
@@ -689,7 +686,7 @@ mod tests {
     /// Sets up market and graph with `()` edge weights for BellmanFord tests.
     fn setup_market_bf(
         pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
-    ) -> (Arc<RwLock<SharedMarketData>>, PetgraphStableDiGraphManager<()>) {
+    ) -> (SharedMarketDataRef, PetgraphStableDiGraphManager<()>) {
         let mut market = SharedMarketData::new();
 
         market.update_gas_price(BlockGasPrice {
@@ -711,7 +708,10 @@ mod tests {
         let mut graph_manager = PetgraphStableDiGraphManager::default();
         graph_manager.initialize_graph(&market.component_topology());
 
-        (Arc::new(RwLock::new(market)), graph_manager)
+        (
+            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market))),
+            graph_manager,
+        )
     }
 
     fn setup_derived_with_token_prices(
@@ -729,7 +729,7 @@ mod tests {
 
         let mut derived_data = DerivedData::new();
         derived_data.set_token_prices(token_prices, vec![], 1, true);
-        Arc::new(RwLock::new(derived_data))
+        std::sync::Arc::new(tokio::sync::RwLock::new(derived_data))
     }
 
     fn bf_algorithm(max_hops: usize, timeout_ms: u64) -> BellmanFordAlgorithm {

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -44,7 +44,7 @@ use crate::{
         types::{SpotPrices, TokenGasPrices},
         SharedDerivedDataRef,
     },
-    feed::market_data::MarketData,
+    feed::market_data::{MarketData, StateLabel},
     graph::{petgraph::StableDiGraph, PetgraphStableDiGraphManager},
     types::{ComponentId, Order, Route, RouteResult, Swap},
 };
@@ -339,6 +339,7 @@ impl Algorithm for BellmanFordAlgorithm {
         &self,
         graph: &Self::GraphType,
         market: MarketData,
+        label: Option<StateLabel>,
         derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
@@ -378,7 +379,7 @@ impl Algorithm for BellmanFordAlgorithm {
 
         // Acquire read lock only for market data extraction, then release.
         let (token_map, market_subset) = {
-            let market = market.read().await;
+            let market = market.read(label.as_ref()).await;
 
             let token_map: HashMap<NodeIndex, Token> = token_nodes
                 .iter()
@@ -758,7 +759,7 @@ mod tests {
         let ord = order(&token_a, &token_d, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -788,7 +789,7 @@ mod tests {
         let ord = order(&token_a, &token_d, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -814,7 +815,7 @@ mod tests {
         let ord = order(&token_a, &token_b, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -843,7 +844,7 @@ mod tests {
         let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
         assert!(matches!(result, Err(AlgorithmError::NoPath { .. })));
     }
@@ -861,7 +862,7 @@ mod tests {
         let ord = order(&token_x, &token_b, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
         assert!(matches!(
             result,
@@ -882,7 +883,7 @@ mod tests {
         let ord = order(&token_a, &token_x, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
         assert!(matches!(
             result,
@@ -908,7 +909,7 @@ mod tests {
         let ord = order(&token_a, &token_d, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
         assert!(
             matches!(result, Err(AlgorithmError::NoPath { .. })),
@@ -933,7 +934,7 @@ mod tests {
         let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -964,7 +965,7 @@ mod tests {
         let ord = order(&token_a, &token_d, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -992,7 +993,7 @@ mod tests {
         let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -1019,7 +1020,7 @@ mod tests {
         let derived = setup_derived_with_token_prices(std::slice::from_ref(&token_b.address));
 
         let result = algo
-            .find_best_route(manager.graph(), market, Some(derived), &ord)
+            .find_best_route(manager.graph(), market, None, Some(derived), &ord)
             .await
             .unwrap();
 
@@ -1046,7 +1047,7 @@ mod tests {
         let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
 
         // With 0ms timeout, we expect either:
@@ -1083,7 +1084,7 @@ mod tests {
         let ord = order(&token_a, &token_b, 1000, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -1109,7 +1110,7 @@ mod tests {
 
         // Should fail due to insufficient liquidity
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
         assert!(
             matches!(result, Err(AlgorithmError::NoPath { .. })),
@@ -1134,7 +1135,7 @@ mod tests {
         let ord = order(&token_a, &token_e, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
         assert!(
             matches!(result, Err(AlgorithmError::NoPath { .. })),
@@ -1161,7 +1162,7 @@ mod tests {
         let ord = order(&token_a, &token_b, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await;
 
         // Should find A->C->B despite A->B failing
@@ -1196,7 +1197,7 @@ mod tests {
         let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -1267,7 +1268,7 @@ mod tests {
         ]);
 
         let result = algo
-            .find_best_route(manager.graph(), market, Some(derived), &ord)
+            .find_best_route(manager.graph(), market, None, Some(derived), &ord)
             .await
             .unwrap();
 
@@ -1301,7 +1302,7 @@ mod tests {
 
         // No derived data: should fall back to gross comparison
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -1352,7 +1353,7 @@ mod tests {
         let ord = order(&token_a, &token_d, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -1376,7 +1377,7 @@ mod tests {
         let ord = order(&token_a, &token_b, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 
@@ -1403,7 +1404,7 @@ mod tests {
         let ord = order(&token_a, &token_d, 100, OrderSide::Sell);
 
         let result = algo
-            .find_best_route(manager.graph(), market, None, &ord)
+            .find_best_route(manager.graph(), market, None, None, &ord)
             .await
             .unwrap();
 

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -32,7 +32,7 @@ use tycho_simulation::tycho_core::models::Address;
 
 use crate::{
     derived::{computation::ComputationRequirements, SharedDerivedDataRef},
-    feed::market_data::MarketData,
+    feed::market_data::{MarketData, StateLabel},
     graph::GraphManager,
     types::{quote::Order, RouteResult},
 };
@@ -183,6 +183,8 @@ pub trait Algorithm: Send + Sync {
     /// * `graph` - The algorithm's preferred graph type (e.g., petgraph::Graph)
     /// * `market` - Shared reference to market data for state lookups (algorithms acquire their own
     ///   locks)
+    /// * `label` - Optional overlay label; when `Some`, the algorithm reads market state through
+    ///   the named overlay so per-request pool overrides are applied during solving
     /// * `derived` - Optional shared reference to derived data (token prices, etc.)
     /// * `order` - The order to solve
     ///
@@ -194,6 +196,7 @@ pub trait Algorithm: Send + Sync {
         &self,
         graph: &Self::GraphType,
         market: MarketData,
+        label: Option<StateLabel>,
         derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError>;

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -32,7 +32,7 @@ use tycho_simulation::tycho_core::models::Address;
 
 use crate::{
     derived::{computation::ComputationRequirements, SharedDerivedDataRef},
-    feed::market_data::SharedMarketDataRef,
+    feed::market_data::MarketData,
     graph::GraphManager,
     types::{quote::Order, RouteResult},
 };
@@ -193,7 +193,7 @@ pub trait Algorithm: Send + Sync {
     async fn find_best_route(
         &self,
         graph: &Self::GraphType,
-        market: SharedMarketDataRef,
+        market: MarketData,
         derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError>;
@@ -201,7 +201,7 @@ pub trait Algorithm: Send + Sync {
     /// Returns the derived data computation requirements for this algorithm.
     ///
     /// Algorithms declare freshness requirements for derived data:
-    /// - `require_fresh`: Data must be from the current block (same as SharedMarketData)
+    /// - `require_fresh`: Data must be from the current block (same as MarketState)
     /// - `allow_stale`: Data can be from any past block, as long as it exists
     ///
     /// Workers use this to determine when they can safely solve.

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -564,7 +564,10 @@ impl Algorithm for MostLiquidAlgorithm {
 
         // Step 4: Brief lock — check gas price + extract market subset for simulation
         let market = {
-            let market = market.read(label.as_ref()).await;
+            let market = market
+                .read_opt(label.as_ref())
+                .await
+                .map_err(|e| AlgorithmError::Other(e.to_string()))?;
             if market.gas_price().is_none() {
                 return Err(AlgorithmError::DataNotFound { kind: "gas price", id: None });
             }

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -25,7 +25,7 @@ use tycho_simulation::{
 use super::{Algorithm, AlgorithmConfig, NoPathReason};
 use crate::{
     derived::{computation::ComputationRequirements, types::TokenGasPrices, SharedDerivedDataRef},
-    feed::market_data::{SharedMarketData, SharedMarketDataRef},
+    feed::market_data::{MarketData, MarketState},
     graph::{petgraph::StableDiGraph, Path, PetgraphStableDiGraphManager},
     types::{ComponentId, Order, Route, RouteResult, Swap},
     AlgorithmError,
@@ -349,7 +349,7 @@ impl MostLiquidAlgorithm {
     #[instrument(level = "trace", skip(path, market, token_prices), fields(hop_count = path.len()))]
     pub(crate) fn simulate_path<D>(
         path: &Path<D>,
-        market: &SharedMarketData,
+        market: &MarketState,
         token_prices: Option<&TokenGasPrices>,
         amount_in: BigUint,
     ) -> Result<RouteResult, AlgorithmError> {
@@ -477,7 +477,7 @@ impl Algorithm for MostLiquidAlgorithm {
     async fn find_best_route(
         &self,
         graph: &Self::GraphType,
-        market: SharedMarketDataRef,
+        market: MarketData,
         derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
@@ -739,8 +739,8 @@ mod tests {
         types::OrderSide,
     };
 
-    fn wrap_market(market: SharedMarketData) -> SharedMarketDataRef {
-        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
+    fn wrap_market(market: MarketState) -> MarketData {
+        MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     /// Creates a SharedDerivedDataRef with token prices set for testing.
@@ -1302,7 +1302,7 @@ mod tests {
 
         let result = MostLiquidAlgorithm::simulate_path(
             &path,
-            &market_read(&market),
+            market_read(&market).base_market_state(),
             None,
             BigUint::from(100u64),
         )
@@ -1338,7 +1338,7 @@ mod tests {
 
         let result = MostLiquidAlgorithm::simulate_path(
             &path,
-            &market_read(&market),
+            market_read(&market).base_market_state(),
             None,
             BigUint::from(10u64),
         )
@@ -1380,7 +1380,7 @@ mod tests {
 
         let result = MostLiquidAlgorithm::simulate_path(
             &path,
-            &market_read(&market),
+            market_read(&market).base_market_state(),
             None,
             BigUint::from(10u64),
         )
@@ -1416,8 +1416,12 @@ mod tests {
                 .unwrap();
         let path = paths.into_iter().next().unwrap();
 
-        let result =
-            MostLiquidAlgorithm::simulate_path(&path, &market, None, BigUint::from(100u64));
+        let result = MostLiquidAlgorithm::simulate_path(
+            &path,
+            market.base_market_state(),
+            None,
+            BigUint::from(100u64),
+        );
         assert!(matches!(result, Err(AlgorithmError::DataNotFound { kind: "token", .. })));
     }
 
@@ -1441,7 +1445,7 @@ mod tests {
 
         let result = MostLiquidAlgorithm::simulate_path(
             &path,
-            &market_read(&market),
+            market_read(&market).base_market_state(),
             None,
             BigUint::from(100u64),
         );
@@ -1618,7 +1622,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         // Set up market with both pools using new API
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         let pool1_state = MockProtocolSim::new(2.0);
         let pool2_state = MockProtocolSim::new(3.0); // Higher multiplier but no edge weight
 
@@ -1685,7 +1689,7 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         let pool_state = MockProtocolSim::new(2.0);
         let pool_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
 
@@ -1795,7 +1799,7 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         let pool_state = MockProtocolSim::new(2.0);
         let pool_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -564,14 +564,17 @@ impl Algorithm for MostLiquidAlgorithm {
 
         // Step 4: Brief lock — check gas price + extract market subset for simulation
         let market = {
-            let market = market
-                .read_opt(label.as_ref())
-                .await
-                .map_err(|e| AlgorithmError::Other(e.to_string()))?;
+            let market = match label.as_ref() {
+                Some(l) => market
+                    .read_labeled(l)
+                    .await
+                    .map_err(|e| AlgorithmError::Other(e.to_string()))?,
+                None => market.read().await,
+            };
             if market.gas_price().is_none() {
                 return Err(AlgorithmError::DataNotFound { kind: "gas price", id: None });
             }
-            let market_subset = market.extract_subset(&component_ids);
+            let market_subset = market.extract_subset_with_overlay(&component_ids);
             drop(market);
             market_subset
         };

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -25,7 +25,7 @@ use tycho_simulation::{
 use super::{Algorithm, AlgorithmConfig, NoPathReason};
 use crate::{
     derived::{computation::ComputationRequirements, types::TokenGasPrices, SharedDerivedDataRef},
-    feed::market_data::{MarketData, MarketState},
+    feed::market_data::{MarketData, MarketState, StateLabel},
     graph::{petgraph::StableDiGraph, Path, PetgraphStableDiGraphManager},
     types::{ComponentId, Order, Route, RouteResult, Swap},
     AlgorithmError,
@@ -478,6 +478,7 @@ impl Algorithm for MostLiquidAlgorithm {
         &self,
         graph: &Self::GraphType,
         market: MarketData,
+        label: Option<StateLabel>,
         derived: Option<SharedDerivedDataRef>,
         order: &Order,
     ) -> Result<RouteResult, AlgorithmError> {
@@ -563,7 +564,7 @@ impl Algorithm for MostLiquidAlgorithm {
 
         // Step 4: Brief lock — check gas price + extract market subset for simulation
         let market = {
-            let market = market.read().await;
+            let market = market.read(label.as_ref()).await;
             if market.gas_price().is_none() {
                 return Err(AlgorithmError::DataNotFound { kind: "gas price", id: None });
             }
@@ -1516,7 +1517,7 @@ mod tests {
         .unwrap();
         let order = order(&token_a, &token_b, ONE_ETH, OrderSide::Sell);
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await
             .unwrap();
 
@@ -1556,7 +1557,7 @@ mod tests {
         let derived = setup_derived_with_token_prices(std::slice::from_ref(&token_b.address));
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, Some(derived), &order)
+            .find_best_route(manager.graph(), market, None, Some(derived), &order)
             .await
             .unwrap();
 
@@ -1580,7 +1581,7 @@ mod tests {
         let order = order(&token_a, &token_c, ONE_ETH, OrderSide::Sell);
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await;
         assert!(matches!(result, Err(AlgorithmError::NoPath { .. })));
     }
@@ -1603,7 +1604,7 @@ mod tests {
         let order = order(&token_a, &token_c, ONE_ETH, OrderSide::Sell);
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await
             .unwrap();
 
@@ -1673,7 +1674,7 @@ mod tests {
         let order = order(&token_a, &token_b, ONE_ETH, OrderSide::Sell);
         let market = wrap_market(market);
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await
             .unwrap();
 
@@ -1720,7 +1721,7 @@ mod tests {
         let market = wrap_market(market);
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await;
         assert!(matches!(
             result,
@@ -1758,7 +1759,7 @@ mod tests {
 
         // Route should still be returned, but with negative net_amount_out
         let result = algorithm
-            .find_best_route(manager.graph(), market, Some(derived), &order)
+            .find_best_route(manager.graph(), market, None, Some(derived), &order)
             .await
             .expect("should return route even with negative net_amount_out");
 
@@ -1788,7 +1789,7 @@ mod tests {
         let order = order(&token_a, &token_b, ONE_ETH, OrderSide::Sell); // More than 1000 wei liquidity
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await;
         assert!(matches!(result, Err(AlgorithmError::InsufficientLiquidity)));
     }
@@ -1830,7 +1831,7 @@ mod tests {
         let market = wrap_market(market);
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await;
 
         // Should get DataNotFound for gas price, not InsufficientLiquidity
@@ -1857,7 +1858,7 @@ mod tests {
         let order = order(&token_a, &token_a, 100, OrderSide::Sell);
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await
             .unwrap();
 
@@ -1905,7 +1906,7 @@ mod tests {
         let derived = setup_derived_with_token_prices(std::slice::from_ref(&token_b.address));
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, Some(derived), &order)
+            .find_best_route(manager.graph(), market, None, Some(derived), &order)
             .await
             .unwrap();
 
@@ -1936,7 +1937,7 @@ mod tests {
         let order = order(&token_a, &token_c, 100, OrderSide::Sell);
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await;
         assert!(
             matches!(result, Err(AlgorithmError::NoPath { .. })),
@@ -1969,7 +1970,7 @@ mod tests {
         let order = order(&token_a, &token_b, 100, OrderSide::Sell);
 
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await;
 
         // With 0ms timeout, we either get:
@@ -2058,7 +2059,7 @@ mod tests {
         .unwrap();
         let order = order(&token_a, &token_b, 1000, OrderSide::Sell);
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await
             .unwrap();
 
@@ -2089,7 +2090,7 @@ mod tests {
         .unwrap();
         let order = order(&token_a, &token_b, 1000, OrderSide::Sell);
         let result = algorithm
-            .find_best_route(manager.graph(), market, None, &order)
+            .find_best_route(manager.graph(), market, None, None, &order)
             .await
             .unwrap();
 

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -715,10 +715,9 @@ impl Algorithm for MostLiquidAlgorithm {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashSet, sync::Arc};
+    use std::collections::HashSet;
 
     use rstest::rstest;
-    use tokio::sync::RwLock;
     use tycho_simulation::{
         tycho_core::simulation::protocol_sim::Price,
         tycho_ethereum::gas::{BlockGasPrice, GasPrice},
@@ -741,7 +740,7 @@ mod tests {
     };
 
     fn wrap_market(market: SharedMarketData) -> SharedMarketDataRef {
-        Arc::new(RwLock::new(market))
+        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     /// Creates a SharedDerivedDataRef with token prices set for testing.
@@ -760,7 +759,7 @@ mod tests {
 
         let mut derived_data = DerivedData::new();
         derived_data.set_token_prices(token_prices, vec![], 1, true);
-        Arc::new(RwLock::new(derived_data))
+        std::sync::Arc::new(tokio::sync::RwLock::new(derived_data))
     }
     // ==================== try_score_path Tests ====================
 

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -22,7 +22,7 @@ use tycho_simulation::{
 
 use crate::{
     algorithm::most_liquid::DepthAndPrice,
-    feed::market_data::{SharedMarketData, SharedMarketDataRef},
+    feed::market_data::{MarketData, MarketState},
     graph::{petgraph::PetgraphStableDiGraphManager, GraphManager},
     types::{quote::OrderSide, BlockInfo, Order},
 };
@@ -312,11 +312,11 @@ pub fn order(token_in: &Token, token_out: &Token, amount: u128, side: OrderSide)
 
 /// Sets up market with components and a graph. Returns (market_ref, graph_manager).
 ///
-/// Use `market_read(&market_ref)` to get a `SharedMarketData` reference for other tests.
+/// Use `market_read(&market_ref)` to get a `MarketState` reference for other tests.
 pub fn setup_market(
     pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
-) -> (SharedMarketDataRef, PetgraphStableDiGraphManager<DepthAndPrice>) {
-    let mut market = SharedMarketData::new();
+) -> (MarketData, PetgraphStableDiGraphManager<DepthAndPrice>) {
+    let mut market = MarketState::new();
     let mut component_weights = HashMap::new();
 
     // Set gas_price = 1 wei/gas for simple calculations
@@ -366,14 +366,11 @@ pub fn setup_market(
             .unwrap();
     }
 
-    (SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market))), graph_manager)
+    (MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market))), graph_manager)
 }
 
-/// Helper to get a read guard for `simulate_path` tests that need `&SharedMarketData`.
-/// Returns the guard which derefs to `&SharedMarketData` via `Deref`.
-pub fn market_read(
-    market: &SharedMarketDataRef,
-) -> crate::feed::market_data::MarketDataReadGuard<'_> {
+/// Returns a `MarketDataView` for tests that need to access market data synchronously.
+pub fn market_read(market: &MarketData) -> crate::feed::market_data::MarketDataView<'_> {
     market
         .try_read_blocking()
         .expect("lock should not be contested in test")

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -1,10 +1,9 @@
 //! Shared test utilities for algorithm tests.
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use chrono::NaiveDateTime;
 use num_bigint::BigUint;
-use tokio::sync::RwLock;
 use tycho_simulation::{
     tycho_core::{
         dto::ProtocolStateDelta,
@@ -23,7 +22,7 @@ use tycho_simulation::{
 
 use crate::{
     algorithm::most_liquid::DepthAndPrice,
-    feed::market_data::SharedMarketData,
+    feed::market_data::{SharedMarketData, SharedMarketDataRef},
     graph::{petgraph::PetgraphStableDiGraphManager, GraphManager},
     types::{quote::OrderSide, BlockInfo, Order},
 };
@@ -311,13 +310,12 @@ pub fn order(token_in: &Token, token_out: &Token, amount: u128, side: OrderSide)
     .with_id("test-order".to_string())
 }
 
-/// Sets up market with components and a graph. Returns (market_lock, graph_manager).
+/// Sets up market with components and a graph. Returns (market_ref, graph_manager).
 ///
-/// The market is wrapped in `Arc<RwLock<...>>` for use with `find_best_route`.
-/// Use `market_read(&market_lock)` to get a `SharedMarketData` for other tests.
+/// Use `market_read(&market_ref)` to get a `SharedMarketData` reference for other tests.
 pub fn setup_market(
     pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
-) -> (Arc<RwLock<SharedMarketData>>, PetgraphStableDiGraphManager<DepthAndPrice>) {
+) -> (SharedMarketDataRef, PetgraphStableDiGraphManager<DepthAndPrice>) {
     let mut market = SharedMarketData::new();
     let mut component_weights = HashMap::new();
 
@@ -368,15 +366,16 @@ pub fn setup_market(
             .unwrap();
     }
 
-    (Arc::new(RwLock::new(market)), graph_manager)
+    (SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market))), graph_manager)
 }
 
 /// Helper to get a read guard for `simulate_path` tests that need `&SharedMarketData`.
-/// Returns the guard which derefs to `&SharedMarketData`.
+/// Returns the guard which derefs to `&SharedMarketData` via `Deref`.
 pub fn market_read(
-    lock: &Arc<RwLock<SharedMarketData>>,
-) -> tokio::sync::RwLockReadGuard<'_, SharedMarketData> {
-    lock.try_read()
+    market: &SharedMarketDataRef,
+) -> crate::feed::market_data::MarketDataReadGuard<'_> {
+    market
+        .try_read_blocking()
         .expect("lock should not be contested in test")
 }
 

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -8,7 +8,7 @@ use super::{
     error::ComputationError,
     manager::{ChangedComponents, SharedDerivedDataRef},
 };
-use crate::feed::market_data::SharedMarketDataRef;
+use crate::feed::market_data::MarketData;
 
 /// Unique identifier for a computation type.
 ///
@@ -34,8 +34,8 @@ impl RequirementConflict {
 ///
 /// Each algorithm declares which computations it needs and their freshness requirements:
 ///
-/// - `require_fresh`: Data must be from the current block (same block as SharedMarketData). Workers
-///   wait for these computations to complete for the current block before solving.
+/// - `require_fresh`: Data must be from the current block (same block as MarketState). Workers wait
+///   for these computations to complete for the current block before solving.
 ///
 /// - `allow_stale`: Data can be from any past block, as long as it has been computed at least once.
 ///   Workers only check that the data exists, not that it's from the current block.
@@ -215,7 +215,7 @@ impl<T> ComputationOutput<T> {
 ///
 ///     async fn compute(
 ///         &self,
-///         market: &SharedMarketDataRef,
+///         market: &MarketData,
 ///         store: &SharedDerivedDataRef,
 ///         changed: &ChangedComponents,
 ///     ) -> Result<Self::Output, ComputationError> {
@@ -265,7 +265,7 @@ pub trait DerivedComputation: Send + Sync + 'static {
     /// as possible to minimize contention. Use `.read().await` for async lock acquisition.
     async fn compute(
         &self,
-        market: &SharedMarketDataRef,
+        market: &MarketData,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<ComputationOutput<Self::Output>, ComputationError>;

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -112,7 +112,7 @@ impl DerivedComputation for PoolDepthComputation {
 
         // Snapshot market data under brief lock.
         let (snapshot, components_to_compute) = {
-            let market_guard = market.read(None).await;
+            let market_guard = market.read().await;
             let topology = market_guard.component_topology();
 
             // Determine which components need (re)computation.

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -34,7 +34,7 @@ use crate::{
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::PoolDepths,
     },
-    feed::market_data::{SharedMarketData, SharedMarketDataRef},
+    feed::market_data::{MarketData, MarketState},
     types::ComponentId,
 };
 
@@ -81,7 +81,7 @@ impl DerivedComputation for PoolDepthComputation {
     #[instrument(level = "debug", skip(market, store, changed), fields(computation_id = Self::ID, updated_pool_depths))]
     async fn compute(
         &self,
-        market: &SharedMarketDataRef,
+        market: &MarketData,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<ComputationOutput<Self::Output>, ComputationError> {
@@ -131,7 +131,7 @@ impl DerivedComputation for PoolDepthComputation {
                 .iter()
                 .cloned()
                 .collect();
-            let snapshot: SharedMarketData = market_guard.extract_subset(&component_ids);
+            let snapshot: MarketState = market_guard.extract_subset(&component_ids);
 
             (snapshot, components_to_compute)
         };
@@ -352,7 +352,7 @@ mod tests {
             store::DerivedData,
             types::{PoolDepthKey, SpotPrices},
         },
-        feed::market_data::SharedMarketDataRef,
+        feed::market_data::MarketData,
     };
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_handles_empty_market() {
-        let market = SharedMarketDataRef::new_shared();
+        let market = MarketData::new_shared();
         let derived = DerivedData::new_shared();
         derived
             .try_write()
@@ -790,7 +790,7 @@ mod tests {
         let usdc = token(0x02, "USDC");
 
         // Empty market — no simulation state
-        let market = SharedMarketDataRef::new_shared();
+        let market = MarketData::new_shared();
         let derived = DerivedData::new_shared();
         derived
             .try_write()

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -112,7 +112,7 @@ impl DerivedComputation for PoolDepthComputation {
 
         // Snapshot market data under brief lock.
         let (snapshot, components_to_compute) = {
-            let market_guard = market.read().await;
+            let market_guard = market.read(None).await;
             let topology = market_guard.component_topology();
 
             // Determine which components need (re)computation.

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -352,7 +352,7 @@ mod tests {
             store::DerivedData,
             types::{PoolDepthKey, SpotPrices},
         },
-        feed::market_data::SharedMarketData,
+        feed::market_data::SharedMarketDataRef,
     };
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_handles_empty_market() {
-        let market = SharedMarketData::new_shared();
+        let market = SharedMarketDataRef::new_shared();
         let derived = DerivedData::new_shared();
         derived
             .try_write()
@@ -790,7 +790,7 @@ mod tests {
         let usdc = token(0x02, "USDC");
 
         // Empty market — no simulation state
-        let market = SharedMarketData::new_shared();
+        let market = SharedMarketDataRef::new_shared();
         let derived = DerivedData::new_shared();
         derived
             .try_write()

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -192,7 +192,7 @@ mod tests {
     use crate::{
         algorithm::test_utils::{component, setup_market, token, MockProtocolSim},
         derived::store::DerivedData,
-        feed::market_data::SharedMarketData,
+        feed::market_data::SharedMarketDataRef,
     };
 
     #[test]
@@ -202,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn handles_empty_market() {
-        let market_ref = SharedMarketData::new_shared();
+        let market_ref = SharedMarketDataRef::new_shared();
         let derived_ref = DerivedData::new_shared();
         let changed = ChangedComponents::default();
 

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -70,7 +70,7 @@ impl DerivedComputation for SpotPriceComputation {
             existing_prices
         };
 
-        let market_guard = market.read().await;
+        let market_guard = market.read(None).await;
         let topology = market_guard.component_topology();
         let tokens = market_guard.token_registry_ref();
 

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -70,7 +70,7 @@ impl DerivedComputation for SpotPriceComputation {
             existing_prices
         };
 
-        let market_guard = market.read(None).await;
+        let market_guard = market.read().await;
         let topology = market_guard.component_topology();
         let tokens = market_guard.token_registry_ref();
 

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -21,7 +21,7 @@ use crate::{
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::SpotPrices,
     },
-    feed::market_data::SharedMarketDataRef,
+    feed::market_data::MarketData,
 };
 
 /// Computes spot prices for all pools.
@@ -49,7 +49,7 @@ impl DerivedComputation for SpotPriceComputation {
     #[instrument(level = "debug", skip(market, store, changed), fields(computation_id = Self::ID, updated_spot_prices))]
     async fn compute(
         &self,
-        market: &SharedMarketDataRef,
+        market: &MarketData,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<ComputationOutput<Self::Output>, ComputationError> {
@@ -192,7 +192,7 @@ mod tests {
     use crate::{
         algorithm::test_utils::{component, setup_market, token, MockProtocolSim},
         derived::store::DerivedData,
-        feed::market_data::SharedMarketDataRef,
+        feed::market_data::MarketData,
     };
 
     #[test]
@@ -202,7 +202,7 @@ mod tests {
 
     #[tokio::test]
     async fn handles_empty_market() {
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
         let derived_ref = DerivedData::new_shared();
         let changed = ChangedComponents::default();
 

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -330,7 +330,7 @@ impl TokenGasPriceComputation {
     > {
         // Brief lock 1: topology + gas_price + block (all cheap clones)
         let (topology, gas_price, block) = {
-            let guard = market.read(None).await;
+            let guard = market.read().await;
             let topology = guard.component_topology();
             let block = guard
                 .last_updated()
@@ -366,7 +366,7 @@ impl TokenGasPriceComputation {
         // Brief lock 2: extract only the simulation states we need
         let subset = {
             market
-                .read(None)
+                .read()
                 .await
                 .extract_subset(&needed_component_ids)
         };

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -1258,12 +1258,14 @@ mod tests {
         let usdc = token(1, "USDC");
 
         // Create market without gas price set
-        let mut market = SharedMarketData::new();
+        let mut market_inner = SharedMarketData::new();
         let comp = component("pool", &[eth.clone(), usdc.clone()]);
-        market.upsert_components(std::iter::once(comp));
-        market.update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
-        market.upsert_tokens([eth.clone(), usdc.clone()]);
-        let market = SharedMarketData::new_shared();
+        market_inner.upsert_components(std::iter::once(comp));
+        market_inner
+            .update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
+        market_inner.upsert_tokens([eth.clone(), usdc.clone()]);
+        let market =
+            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market_inner)));
 
         // Compute spot prices
         let derived = DerivedData::new_shared();

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -50,7 +50,7 @@ use crate::{
         manager::{ChangedComponents, SharedDerivedDataRef},
         types::{SpotPriceKey, SpotPrices, TokenGasPrices, TokenPriceEntry, TokenPricesWithDeps},
     },
-    feed::market_data::{SharedMarketData, SharedMarketDataRef},
+    feed::market_data::{MarketData, MarketState},
     graph::{GraphManager, Path, PetgraphStableDiGraphManager},
     types::ComponentId,
     MostLiquidAlgorithm,
@@ -205,7 +205,7 @@ impl TokenGasPriceComputation {
     fn compute_spread_and_mid_price(
         &self,
         path: Path<()>,
-        market: &SharedMarketData,
+        market: &MarketState,
         gas_price: &BigUint,
     ) -> Result<(f64, Price, HashSet<ComponentId>), ComputationError> {
         // Extract component IDs from path edges for dependency tracking
@@ -321,7 +321,7 @@ impl TokenGasPriceComputation {
     #[allow(clippy::type_complexity)]
     async fn simulate_token_prices(
         &self,
-        market: &SharedMarketDataRef,
+        market: &MarketData,
         spot_prices: &SpotPrices,
         filter_tokens: Option<&HashSet<Address>>,
     ) -> Result<
@@ -467,7 +467,7 @@ impl TokenGasPriceComputation {
     /// or `Err` if computation failed.
     async fn try_incremental_compute(
         &self,
-        market: &SharedMarketDataRef,
+        market: &MarketData,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<Option<ComputationOutput<TokenGasPrices>>, ComputationError> {
@@ -558,7 +558,7 @@ impl DerivedComputation for TokenGasPriceComputation {
     #[instrument(level = "debug", skip(market, store, changed), fields(computation_id = Self::ID, updated_token_prices))]
     async fn compute(
         &self,
-        market: &SharedMarketDataRef,
+        market: &MarketData,
         store: &SharedDerivedDataRef,
         changed: &ChangedComponents,
     ) -> Result<ComputationOutput<Self::Output>, ComputationError> {
@@ -644,7 +644,7 @@ mod tests {
     /// Returns (market_guard, store) ready for computation.
     async fn setup_test_env(
         pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
-    ) -> (SharedMarketDataRef, SharedDerivedDataRef) {
+    ) -> (MarketData, SharedDerivedDataRef) {
         let (wrapped_market, _) = setup_market(pools.clone());
 
         let wrapped_store = DerivedData::new_shared();
@@ -890,7 +890,7 @@ mod tests {
         let gas_price = BigUint::from(GAS_PRICE);
         let computation = computation_for(&eth.address);
         let (spread, mid_price, _path_components) = computation
-            .compute_spread_and_mid_price(path, &market, &gas_price)
+            .compute_spread_and_mid_price(path, market.base_market_state(), &gas_price)
             .unwrap();
 
         // Expected values from exact fractions
@@ -1258,14 +1258,13 @@ mod tests {
         let usdc = token(1, "USDC");
 
         // Create market without gas price set
-        let mut market_inner = SharedMarketData::new();
+        let mut market_inner = MarketState::new();
         let comp = component("pool", &[eth.clone(), usdc.clone()]);
         market_inner.upsert_components(std::iter::once(comp));
         market_inner
             .update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market_inner.upsert_tokens([eth.clone(), usdc.clone()]);
-        let market =
-            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market_inner)));
+        let market = MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market_inner)));
 
         // Compute spot prices
         let derived = DerivedData::new_shared();

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -330,7 +330,7 @@ impl TokenGasPriceComputation {
     > {
         // Brief lock 1: topology + gas_price + block (all cheap clones)
         let (topology, gas_price, block) = {
-            let guard = market.read().await;
+            let guard = market.read(None).await;
             let topology = guard.component_topology();
             let block = guard
                 .last_updated()
@@ -366,7 +366,7 @@ impl TokenGasPriceComputation {
         // Brief lock 2: extract only the simulation states we need
         let subset = {
             market
-                .read()
+                .read(None)
                 .await
                 .extract_subset(&needed_component_ids)
         };

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -229,7 +229,7 @@ impl ComputationManager {
                                 "computation manager lagged, skipped {} events. Recomputing from current state.",
                                 skipped
                             );
-                            let market = self.market_data.read().await;
+                            let market = self.market_data.read(None).await;
                             let changed = ChangedComponents::all(market.base_market_state());
                             drop(market);
                             self.compute_all(&changed).await;
@@ -255,7 +255,7 @@ impl ComputationManager {
         // Get block info for tracking
         let Some(block) = self
             .market_data
-            .read()
+            .read(None)
             .await
             .last_updated()
             .map(|b| b.number())

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -17,7 +17,7 @@ use tokio::sync::{broadcast, RwLock};
 use tracing::{debug, info, trace, warn};
 use tycho_simulation::tycho_common::models::Address;
 
-use crate::{feed::market_data::MarketState, types::ComponentId};
+use crate::types::ComponentId;
 
 /// Information about which components changed in a market update.
 ///
@@ -39,7 +39,7 @@ impl ChangedComponents {
     /// Creates a marker for full recompute where all components are considered changed.
     ///
     /// Used for startup and lag recovery scenarios.
-    pub fn all(market: &MarketState) -> Self {
+    pub fn all(market: MarketDataView) -> Self {
         Self {
             added: market.component_topology().clone(),
             removed: vec![],
@@ -72,7 +72,7 @@ use super::{
 };
 use crate::feed::{
     events::{EventError, MarketEvent, MarketEventHandler},
-    market_data::MarketData,
+    market_data::{MarketData, MarketDataView},
 };
 
 /// Thread-safe handle to shared derived data store.
@@ -230,8 +230,7 @@ impl ComputationManager {
                                 skipped
                             );
                             let market = self.market_data.read(None).await;
-                            let changed = ChangedComponents::all(market.base_market_state());
-                            drop(market);
+                            let changed = ChangedComponents::all(market);
                             self.compute_all(&changed).await;
                         }
                     }

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -229,7 +229,7 @@ impl ComputationManager {
                                 "computation manager lagged, skipped {} events. Recomputing from current state.",
                                 skipped
                             );
-                            let market = self.market_data.read(None).await;
+                            let market = self.market_data.read().await;
                             let changed = ChangedComponents::all(market);
                             self.compute_all(&changed).await;
                         }
@@ -254,7 +254,7 @@ impl ComputationManager {
         // Get block info for tracking
         let Some(block) = self
             .market_data
-            .read(None)
+            .read()
             .await
             .last_updated()
             .map(|b| b.number())

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -17,7 +17,7 @@ use tokio::sync::{broadcast, RwLock};
 use tracing::{debug, info, trace, warn};
 use tycho_simulation::tycho_common::models::Address;
 
-use crate::{feed::market_data::SharedMarketData, types::ComponentId};
+use crate::{feed::market_data::MarketState, types::ComponentId};
 
 /// Information about which components changed in a market update.
 ///
@@ -39,7 +39,7 @@ impl ChangedComponents {
     /// Creates a marker for full recompute where all components are considered changed.
     ///
     /// Used for startup and lag recovery scenarios.
-    pub fn all(market: &SharedMarketData) -> Self {
+    pub fn all(market: &MarketState) -> Self {
         Self {
             added: market.component_topology().clone(),
             removed: vec![],
@@ -72,7 +72,7 @@ use super::{
 };
 use crate::feed::{
     events::{EventError, MarketEvent, MarketEventHandler},
-    market_data::SharedMarketDataRef,
+    market_data::MarketData,
 };
 
 /// Thread-safe handle to shared derived data store.
@@ -142,7 +142,7 @@ impl Default for ComputationManagerConfig {
 /// Manages derived data computations triggered by market events.
 pub struct ComputationManager {
     /// Reference to shared market data (read access).
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     /// Shared derived data store (write access).
     store: SharedDerivedDataRef,
     /// Token gas price computation.
@@ -163,7 +163,7 @@ impl ComputationManager {
     /// computation readiness.
     pub fn new(
         config: ComputationManagerConfig,
-        market_data: SharedMarketDataRef,
+        market_data: MarketData,
     ) -> Result<(Self, broadcast::Receiver<DerivedDataEvent>), ComputationError> {
         let pool_depth_computation = PoolDepthComputation::new(config.depth_slippage_threshold)?;
         let (event_tx, event_rx) = broadcast::channel(64);
@@ -230,7 +230,7 @@ impl ComputationManager {
                                 skipped
                             );
                             let market = self.market_data.read().await;
-                            let changed = ChangedComponents::all(&market);
+                            let changed = ChangedComponents::all(market.base_market_state());
                             drop(market);
                             self.compute_all(&changed).await;
                         }
@@ -490,7 +490,7 @@ mod tests {
     use super::*;
     use crate::{
         algorithm::test_utils::{component, setup_market, token, MockProtocolSim},
-        feed::market_data::{SharedMarketData, SharedMarketDataRef},
+        feed::market_data::{MarketData, MarketState},
         types::BlockInfo,
     };
 
@@ -595,22 +595,22 @@ mod tests {
     ///
     /// Used to trigger `TotalFailure` in spot_price computation (full recompute with
     /// all components missing sim_state → succeeded == 0 → failure).
-    fn market_with_component_no_sim_state() -> SharedMarketDataRef {
+    fn market_with_component_no_sim_state() -> MarketData {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let pool = component("pool", &[eth.clone(), usdc.clone()]);
 
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
         market.upsert_components(std::iter::once(pool));
         // Note: no update_states() — simulation state is intentionally absent
         market.upsert_tokens([eth, usdc]);
-        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
+        MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     /// Creates a market with two pools: one with sim state (pool succeeds) and one without (pool
     /// fails). Used to trigger partial spot price failure.
-    fn market_with_mixed_sim_states() -> SharedMarketDataRef {
+    fn market_with_mixed_sim_states() -> MarketData {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let dai = token(3, "DAI");
@@ -618,32 +618,32 @@ mod tests {
         let pool1 = component("eth_usdc", &[eth.clone(), usdc.clone()]);
         let pool2 = component("eth_dai", &[eth.clone(), dai.clone()]);
 
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
         market.upsert_components([pool1, pool2]);
         // Only pool1 has simulation state; pool2 intentionally has none
         market
             .update_states([("eth_usdc".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market.upsert_tokens([eth, usdc, dai]);
-        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
+        MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     /// Creates a market WITH sim_state but WITHOUT gas_price.
     ///
     /// Spot price computation succeeds (MockProtocolSim works), but token_price
     /// computation fails with `MissingDependency("gas_price")`.
-    fn market_with_sim_state_no_gas_price() -> SharedMarketDataRef {
+    fn market_with_sim_state_no_gas_price() -> MarketData {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let pool = component("pool", &[eth.clone(), usdc.clone()]);
 
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         // Note: no update_gas_price() — gas price is intentionally absent
         market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
         market.upsert_components(std::iter::once(pool));
         market.update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market.upsert_tokens([eth, usdc]);
-        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
+        MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     #[tokio::test]

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -483,14 +483,14 @@ impl MarketEventHandler for ComputationManager {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::collections::HashMap;
 
-    use tokio::sync::{broadcast, RwLock};
+    use tokio::sync::broadcast;
 
     use super::*;
     use crate::{
         algorithm::test_utils::{component, setup_market, token, MockProtocolSim},
-        feed::market_data::SharedMarketData,
+        feed::market_data::{SharedMarketData, SharedMarketDataRef},
         types::BlockInfo,
     };
 
@@ -595,7 +595,7 @@ mod tests {
     ///
     /// Used to trigger `TotalFailure` in spot_price computation (full recompute with
     /// all components missing sim_state → succeeded == 0 → failure).
-    fn market_with_component_no_sim_state() -> Arc<RwLock<SharedMarketData>> {
+    fn market_with_component_no_sim_state() -> SharedMarketDataRef {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let pool = component("pool", &[eth.clone(), usdc.clone()]);
@@ -605,12 +605,12 @@ mod tests {
         market.upsert_components(std::iter::once(pool));
         // Note: no update_states() — simulation state is intentionally absent
         market.upsert_tokens([eth, usdc]);
-        Arc::new(RwLock::new(market))
+        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     /// Creates a market with two pools: one with sim state (pool succeeds) and one without (pool
     /// fails). Used to trigger partial spot price failure.
-    fn market_with_mixed_sim_states() -> Arc<RwLock<SharedMarketData>> {
+    fn market_with_mixed_sim_states() -> SharedMarketDataRef {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let dai = token(3, "DAI");
@@ -625,14 +625,14 @@ mod tests {
         market
             .update_states([("eth_usdc".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market.upsert_tokens([eth, usdc, dai]);
-        Arc::new(RwLock::new(market))
+        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     /// Creates a market WITH sim_state but WITHOUT gas_price.
     ///
     /// Spot price computation succeeds (MockProtocolSim works), but token_price
     /// computation fails with `MissingDependency("gas_price")`.
-    fn market_with_sim_state_no_gas_price() -> Arc<RwLock<SharedMarketData>> {
+    fn market_with_sim_state_no_gas_price() -> SharedMarketDataRef {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let pool = component("pool", &[eth.clone(), usdc.clone()]);
@@ -643,7 +643,7 @@ mod tests {
         market.upsert_components(std::iter::once(pool));
         market.update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market.upsert_tokens([eth, usdc]);
-        Arc::new(RwLock::new(market))
+        SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
     #[tokio::test]

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -442,6 +442,7 @@ mod tests {
             "test".to_string(),
             Bytes::from(make_address(0xAA).as_ref()),
             Bytes::from(make_address(0xAA).as_ref()),
+            "1".to_string(),
         )
     }
 
@@ -503,6 +504,7 @@ mod tests {
             "test".to_string(),
             Bytes::from(make_address(0xAA).as_ref()),
             Bytes::from(make_address(0xAA).as_ref()),
+            "1".to_string(),
         );
 
         let result = Solution::try_from(&quote);
@@ -555,6 +557,7 @@ mod tests {
             "test".to_string(),
             Bytes::from(make_address(0xAA).as_ref()),
             Bytes::from(make_address(0xAA).as_ref()),
+            "1".to_string(),
         );
 
         let encoding_options = EncodingOptions::new(0.01);

--- a/fynd-core/src/feed/events.rs
+++ b/fynd-core/src/feed/events.rs
@@ -17,9 +17,11 @@ use crate::{graph::GraphError, types::ComponentId};
 pub enum MarketEvent {
     /// Market was updated.
     MarketUpdated {
+        /// Components added in this update, keyed by component ID.
         added_components: HashMap<ComponentId, Vec<Address>>,
+        /// Component IDs that were removed.
         removed_components: Vec<ComponentId>,
-
+        /// Component IDs whose state changed.
         updated_components: Vec<ComponentId>,
     },
 }

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -145,7 +145,7 @@ mod tests {
         // Gas price should still be None (error path skips update)
         assert!(
             market_data
-                .read(None)
+                .read()
                 .await
                 .gas_price()
                 .is_none(),
@@ -159,7 +159,7 @@ mod tests {
 
         assert!(
             market_data
-                .read(None)
+                .read()
                 .await
                 .gas_price()
                 .is_some(),
@@ -191,7 +191,7 @@ mod tests {
 
             assert!(
                 market_data
-                    .read(None)
+                    .read()
                     .await
                     .gas_price()
                     .is_none(),
@@ -205,7 +205,7 @@ mod tests {
             .expect("ack should succeed after recovery");
 
         let gas = market_data
-            .read(None)
+            .read()
             .await
             .gas_price()
             .cloned();

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -145,7 +145,7 @@ mod tests {
         // Gas price should still be None (error path skips update)
         assert!(
             market_data
-                .read()
+                .read(None)
                 .await
                 .gas_price()
                 .is_none(),
@@ -159,7 +159,7 @@ mod tests {
 
         assert!(
             market_data
-                .read()
+                .read(None)
                 .await
                 .gas_price()
                 .is_some(),
@@ -191,7 +191,7 @@ mod tests {
 
             assert!(
                 market_data
-                    .read()
+                    .read(None)
                     .await
                     .gas_price()
                     .is_none(),
@@ -205,7 +205,7 @@ mod tests {
             .expect("ack should succeed after recovery");
 
         let gas = market_data
-            .read()
+            .read(None)
             .await
             .gas_price()
             .cloned();

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -4,19 +4,19 @@ use tokio::sync::{mpsc, oneshot};
 use tracing::warn;
 use tycho_simulation::{tycho_core::traits::FeePriceGetter, tycho_ethereum::gas::BlockGasPrice};
 
-use crate::feed::{market_data::SharedMarketDataRef, DataFeedError};
+use crate::feed::{market_data::MarketData, DataFeedError};
 
 // TODO: Refactor gas price fetching into a `DerivedComputation`.
 pub(crate) struct GasPriceFetcher<C: FeePriceGetter<FeePrice = BlockGasPrice>> {
     client: C,
     signal_rx: mpsc::Receiver<oneshot::Sender<()>>,
-    shared_market_data: SharedMarketDataRef,
+    shared_market_data: MarketData,
 }
 
 impl<C: FeePriceGetter<FeePrice = BlockGasPrice>> GasPriceFetcher<C> {
     pub(crate) fn new(
         client: C,
-        shared_market_data: SharedMarketDataRef,
+        shared_market_data: MarketData,
     ) -> (Self, mpsc::Sender<oneshot::Sender<()>>) {
         let (signal_tx, signal_rx) = mpsc::channel(5);
         (Self { client, signal_rx, shared_market_data }, signal_tx)
@@ -131,7 +131,7 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_error_does_not_crash_and_acks_oneshot() {
-        let market_data = SharedMarketDataRef::new_shared();
+        let market_data = MarketData::new_shared();
         let (mut fetcher, signal_tx) =
             GasPriceFetcher::new(MockFeePriceGetter::new(1), market_data.clone());
 
@@ -176,7 +176,7 @@ mod tests {
 
     #[tokio::test]
     async fn persistent_failure_keeps_loop_alive() {
-        let market_data = SharedMarketDataRef::new_shared();
+        let market_data = MarketData::new_shared();
         // Fail 3 times, then succeed
         let (mut fetcher, signal_tx) =
             GasPriceFetcher::new(MockFeePriceGetter::new(3), market_data.clone());

--- a/fynd-core/src/feed/gas.rs
+++ b/fynd-core/src/feed/gas.rs
@@ -71,18 +71,14 @@ impl<C: FeePriceGetter<FeePrice = BlockGasPrice>> GasPriceFetcher<C> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    };
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use async_trait::async_trait;
     use num_bigint::BigUint;
-    use tokio::sync::{oneshot, RwLock};
+    use tokio::sync::oneshot;
     use tycho_simulation::tycho_ethereum::gas::{BlockGasPrice, GasPrice};
 
     use super::*;
-    use crate::feed::market_data::SharedMarketData;
 
     /// Mock client that returns errors for the first `fail_count` calls,
     /// then succeeds with a fixed gas price.
@@ -118,10 +114,6 @@ mod tests {
         }
     }
 
-    fn shared_market_data() -> SharedMarketDataRef {
-        Arc::new(RwLock::new(SharedMarketData::new()))
-    }
-
     /// Helper: send one signal and wait for the ack (with timeout).
     async fn trigger_and_await_ack(
         signal_tx: &mpsc::Sender<oneshot::Sender<()>>,
@@ -139,9 +131,9 @@ mod tests {
 
     #[tokio::test]
     async fn fetch_error_does_not_crash_and_acks_oneshot() {
-        let market_data = shared_market_data();
+        let market_data = SharedMarketDataRef::new_shared();
         let (mut fetcher, signal_tx) =
-            GasPriceFetcher::new(MockFeePriceGetter::new(1), Arc::clone(&market_data));
+            GasPriceFetcher::new(MockFeePriceGetter::new(1), market_data.clone());
 
         let handle = tokio::spawn(async move { fetcher.run().await });
 
@@ -184,10 +176,10 @@ mod tests {
 
     #[tokio::test]
     async fn persistent_failure_keeps_loop_alive() {
-        let market_data = shared_market_data();
+        let market_data = SharedMarketDataRef::new_shared();
         // Fail 3 times, then succeed
         let (mut fetcher, signal_tx) =
-            GasPriceFetcher::new(MockFeePriceGetter::new(3), Arc::clone(&market_data));
+            GasPriceFetcher::new(MockFeePriceGetter::new(3), market_data.clone());
 
         let handle = tokio::spawn(async move { fetcher.run().await });
 

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -6,9 +6,17 @@
 //! - Solvers: READ access to query states during solving
 //!
 //! We use tokio RwLock (which is write-preferring) to avoid writer starvation.
+//!
+//! # Overlay design
+//!
+//! Labeled overlay states (used by solver pools to inject per-request pool states) are stored in a
+//! separate `Arc<RwLock<...>>` on `SharedMarketDataRef` rather than inside the main
+//! `SharedMarketData` lock. This decouples overlay writes from base-state reads: a TychoFeed block
+//! update no longer stalls overlay registrations and vice versa.
 
 use std::{
     collections::{HashMap, HashSet},
+    ops::Deref,
     sync::Arc,
 };
 
@@ -24,8 +32,192 @@ use tycho_simulation::{
 
 use crate::types::{BlockInfo, ComponentId};
 
-/// Thread-safe handle to shared market data.
-pub type SharedMarketDataRef = Arc<RwLock<SharedMarketData>>;
+/// A label identifying an overlay state layer.
+///
+/// Each labeled overlay is an independent snapshot of pool states that can be layered
+/// on top of the base market state for a specific worker pool or request context.
+pub type StateLabel = String;
+
+/// An immutable snapshot of per-component simulation states for one overlay layer.
+pub type OverlayStates = Arc<HashMap<ComponentId, Box<dyn ProtocolSim>>>;
+
+/// The shared overlay registry: maps each label to its snapshot.
+type OverlayRegistry = Arc<RwLock<HashMap<StateLabel, OverlayStates>>>;
+
+/// Thread-safe handle to shared market data with optional overlay support.
+///
+/// Cloning this handle is cheap: all clones share the same underlying data and overlays.
+/// Use `with_label` to obtain a handle scoped to a specific overlay layer.
+#[derive(Clone)]
+pub struct SharedMarketDataRef {
+    data: Arc<RwLock<SharedMarketData>>,
+    /// Per-label overlay states. Stored separately from the base data lock so that
+    /// overlay writes do not block base-state reads.
+    overlays: OverlayRegistry,
+    label: Option<StateLabel>,
+}
+
+impl SharedMarketDataRef {
+    /// Creates a new handle wrapping the given data store with no active overlay label.
+    pub fn new(data: Arc<RwLock<SharedMarketData>>) -> Self {
+        Self { data, overlays: Arc::new(RwLock::new(HashMap::new())), label: None }
+    }
+
+    /// Creates a new empty market data store wrapped in a `SharedMarketDataRef`.
+    pub fn new_shared() -> Self {
+        Self::new(Arc::new(RwLock::new(SharedMarketData::new())))
+    }
+
+    /// Returns a clone of this handle scoped to the given overlay label.
+    ///
+    /// All clones share the same overlay registry, so a state registered via any handle
+    /// is visible to all handles with the same label.
+    pub fn with_label(&self, label: StateLabel) -> Self {
+        Self {
+            data: Arc::clone(&self.data),
+            overlays: Arc::clone(&self.overlays),
+            label: Some(label),
+        }
+    }
+
+    /// Acquires a read guard that exposes both the base data and the active overlay (if any).
+    ///
+    /// The overlay lock is held only briefly to clone the overlay `Arc` pointer; it is released
+    /// before the guard is returned, so solving never holds two locks simultaneously.
+    pub async fn read(&self) -> MarketDataReadGuard<'_> {
+        let guard = self.data.read().await;
+        let overlay = if let Some(ref label) = self.label {
+            self.overlays
+                .read()
+                .await
+                .get(label)
+                .cloned()
+        } else {
+            None
+        };
+        MarketDataReadGuard { guard, overlay }
+    }
+
+    /// Acquires an exclusive write guard on the base data store.
+    pub async fn write(&self) -> tokio::sync::RwLockWriteGuard<'_, SharedMarketData> {
+        self.data.write().await
+    }
+
+    /// Attempts a non-blocking read of the base data store.
+    ///
+    /// Returns `None` if the lock is currently held for writing.
+    pub fn try_read(&self) -> Option<tokio::sync::RwLockReadGuard<'_, SharedMarketData>> {
+        self.data.try_read().ok()
+    }
+
+    /// Attempts a non-blocking write lock on the base data store.
+    ///
+    /// Returns `None` if the lock is currently held for reading or writing.
+    pub fn try_write(&self) -> Option<tokio::sync::RwLockWriteGuard<'_, SharedMarketData>> {
+        self.data.try_write().ok()
+    }
+
+    /// Attempts a non-blocking read and wraps the result in a `MarketDataReadGuard`.
+    ///
+    /// The overlay is not applied because this is a synchronous helper intended for tests where
+    /// no overlay is active.  Returns `None` if the lock is currently held for writing.
+    pub fn try_read_blocking(&self) -> Option<MarketDataReadGuard<'_>> {
+        self.data
+            .try_read()
+            .ok()
+            .map(|guard| MarketDataReadGuard { guard, overlay: None })
+    }
+
+    // ==================== Overlay CRUD ====================
+
+    /// Registers or replaces an overlay for the given label.
+    pub async fn register_labeled_state(
+        &self,
+        label: StateLabel,
+        states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
+    ) {
+        self.overlays
+            .write()
+            .await
+            .insert(label, Arc::new(states));
+    }
+
+    /// Removes the overlay for the given label, if it exists.
+    pub async fn remove_labeled_state(&self, label: &StateLabel) {
+        self.overlays
+            .write()
+            .await
+            .remove(label);
+    }
+
+    /// Clears all overlays.
+    pub async fn clear_labeled_states(&self) {
+        self.overlays.write().await.clear();
+    }
+
+    /// Returns the labels of all registered overlays.
+    pub async fn labeled_state_ids(&self) -> Vec<StateLabel> {
+        self.overlays
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect()
+    }
+}
+
+/// A read guard that exposes the base market data and an optional overlay snapshot.
+///
+/// Derefs to `SharedMarketData` for access to base fields. Use `get_simulation_state`
+/// to perform an overlay-aware lookup.
+pub struct MarketDataReadGuard<'a> {
+    guard: tokio::sync::RwLockReadGuard<'a, SharedMarketData>,
+    overlay: Option<OverlayStates>,
+}
+
+impl Deref for MarketDataReadGuard<'_> {
+    type Target = SharedMarketData;
+
+    fn deref(&self) -> &SharedMarketData {
+        &self.guard
+    }
+}
+
+impl<'a> MarketDataReadGuard<'a> {
+    /// Returns the simulation state for the given component, checking the overlay first.
+    pub fn get_simulation_state(&self, id: &str) -> Option<&dyn ProtocolSim> {
+        if let Some(ref ov) = self.overlay {
+            if let Some(s) = ov.get(id) {
+                return Some(s.as_ref());
+            }
+        }
+        self.guard.get_simulation_state(id)
+    }
+
+    /// Extracts a base-data subset for the given component IDs, then layers the active overlay
+    /// on top by replacing any simulation states found in both the subset and the overlay.
+    ///
+    /// If no overlay is active, this is equivalent to `self.extract_subset(component_ids)`.
+    pub fn extract_subset_with_overlay(
+        &self,
+        component_ids: &HashSet<ComponentId>,
+    ) -> SharedMarketData {
+        let mut subset = self.guard.extract_subset(component_ids);
+        if let Some(ref ov) = self.overlay {
+            for (id, state) in ov.iter() {
+                if subset
+                    .simulation_states
+                    .contains_key(id)
+                {
+                    subset
+                        .simulation_states
+                        .insert(id.clone(), state.clone_box());
+                }
+            }
+        }
+        subset
+    }
+}
 
 /// Shared market data containing all component states and market information.
 ///
@@ -36,7 +228,7 @@ pub struct SharedMarketData {
     /// All components indexed by their ID.
     components: HashMap<ComponentId, ProtocolComponent>,
     /// All states indexed by their component ID.
-    simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
+    pub(crate) simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
     /// All tokens indexed by their address.
     tokens: HashMap<Address, Token>,
     /// Current gas price. None if not fetched yet.
@@ -59,12 +251,6 @@ impl SharedMarketData {
             protocol_sync_status: HashMap::new(),
             last_updated: None,
         }
-    }
-
-    /// Creates a new shared market data store for async computation tests that is wrapped in an
-    /// `Arc<RwLock<>>`.
-    pub fn new_shared() -> SharedMarketDataRef {
-        Arc::new(RwLock::new(Self::new()))
     }
 
     /// Returns the block info for the last update.
@@ -295,5 +481,170 @@ mod tests {
         assert!(empty_subset
             .simulation_states
             .is_empty());
+    }
+
+    // ==================== SharedMarketDataRef overlay tests ====================
+
+    #[tokio::test]
+    async fn register_and_retrieve_overlay_via_labeled_read() {
+        let market_ref = SharedMarketDataRef::new_shared();
+
+        let label = "test_label".to_string();
+        let mut states: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
+        states.insert(
+            "pool_ab".to_string(),
+            Box::new(MockProtocolSim::new(99.0)) as Box<dyn ProtocolSim>,
+        );
+
+        market_ref
+            .register_labeled_state(label.clone(), states)
+            .await;
+
+        let labeled_ref = market_ref.with_label(label);
+        let guard = labeled_ref.read().await;
+        // Base data is empty — overlay provides the state
+        let sim = guard.get_simulation_state("pool_ab");
+        assert!(sim.is_some());
+    }
+
+    #[tokio::test]
+    async fn read_without_label_returns_no_overlay() {
+        let market_ref = SharedMarketDataRef::new_shared();
+
+        market_ref
+            .register_labeled_state(
+                "my_label".to_string(),
+                HashMap::from([(
+                    "pool1".to_string(),
+                    Box::new(MockProtocolSim::new(5.0)) as Box<dyn ProtocolSim>,
+                )]),
+            )
+            .await;
+
+        // A handle with no label must not see the overlay
+        let guard = market_ref.read().await;
+        assert!(guard
+            .get_simulation_state("pool1")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_labeled_state_clears_overlay() {
+        let market_ref = SharedMarketDataRef::new_shared();
+        let label = "lbl".to_string();
+
+        market_ref
+            .register_labeled_state(
+                label.clone(),
+                HashMap::from([(
+                    "pool".to_string(),
+                    Box::new(MockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
+                )]),
+            )
+            .await;
+
+        market_ref
+            .remove_labeled_state(&label)
+            .await;
+
+        let ids = market_ref.labeled_state_ids().await;
+        assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn clear_labeled_states_removes_all() {
+        let market_ref = SharedMarketDataRef::new_shared();
+
+        for i in 0..3u8 {
+            market_ref
+                .register_labeled_state(
+                    format!("label_{i}"),
+                    HashMap::from([(
+                        format!("pool_{i}"),
+                        Box::new(MockProtocolSim::new(f64::from(i))) as Box<dyn ProtocolSim>,
+                    )]),
+                )
+                .await;
+        }
+
+        market_ref.clear_labeled_states().await;
+        assert!(market_ref
+            .labeled_state_ids()
+            .await
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn with_label_shares_overlay_registry() {
+        // Registering via one handle must be visible to another handle pointing at the same
+        // overlay registry.
+        let base = SharedMarketDataRef::new_shared();
+        let handle_a = base.with_label("shared".to_string());
+        let handle_b = base.with_label("shared".to_string());
+
+        base.register_labeled_state(
+            "shared".to_string(),
+            HashMap::from([(
+                "pool_x".to_string(),
+                Box::new(MockProtocolSim::new(7.0)) as Box<dyn ProtocolSim>,
+            )]),
+        )
+        .await;
+
+        let guard_a = handle_a.read().await;
+        let guard_b = handle_b.read().await;
+        assert!(guard_a
+            .get_simulation_state("pool_x")
+            .is_some());
+        assert!(guard_b
+            .get_simulation_state("pool_x")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn extract_subset_with_overlay_replaces_matching_states() {
+        use crate::algorithm::test_utils::{component as mk_component, token as mk_token};
+
+        let market_ref = SharedMarketDataRef::new_shared();
+
+        let tok_a = mk_token(0x01, "A");
+        let tok_b = mk_token(0x02, "B");
+
+        {
+            let mut data = market_ref.write().await;
+            data.upsert_components([mk_component("pool_ab", &[tok_a.clone(), tok_b.clone()])]);
+            data.upsert_tokens([tok_a.clone(), tok_b.clone()]);
+            data.update_states([(
+                "pool_ab".to_string(),
+                Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+            )]);
+        }
+
+        let label = "overlay".to_string();
+        market_ref
+            .register_labeled_state(
+                label.clone(),
+                HashMap::from([(
+                    "pool_ab".to_string(),
+                    Box::new(MockProtocolSim::new(99.0)) as Box<dyn ProtocolSim>,
+                )]),
+            )
+            .await;
+
+        let labeled = market_ref.with_label(label);
+        let guard = labeled.read().await;
+        let ids: HashSet<ComponentId> = ["pool_ab".to_string()]
+            .into_iter()
+            .collect();
+        let subset = guard.extract_subset_with_overlay(&ids);
+
+        let sim = subset
+            .get_simulation_state("pool_ab")
+            .unwrap();
+        let mock = sim
+            .as_any()
+            .downcast_ref::<MockProtocolSim>()
+            .unwrap();
+        assert_eq!(mock.spot_price, 99.0, "overlay state should replace base state");
     }
 }

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -290,7 +290,7 @@ pub struct MarketState {
     /// All components indexed by their ID.
     components: HashMap<ComponentId, ProtocolComponent>,
     /// All states indexed by their component ID.
-    pub(crate) simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
+    simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
     /// All tokens indexed by their address.
     tokens: HashMap<Address, Token>,
     /// Current gas price. None if not fetched yet.

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -10,13 +10,12 @@
 //! # Overlay design
 //!
 //! Labeled overlay states (used by solver pools to inject per-request pool states) are stored in a
-//! separate `Arc<RwLock<...>>` on `SharedMarketDataRef` rather than inside the main
-//! `SharedMarketData` lock. This decouples overlay writes from base-state reads: a TychoFeed block
+//! separate `Arc<RwLock<...>>` on `MarketData` rather than inside the main
+//! `MarketState` lock. This decouples overlay writes from base-state reads: a TychoFeed block
 //! update no longer stalls overlay registrations and vice versa.
 
 use std::{
     collections::{HashMap, HashSet},
-    ops::Deref,
     sync::Arc,
 };
 
@@ -58,23 +57,23 @@ type OverlayRegistry = Arc<RwLock<HashMap<StateLabel, OverlayEntry>>>;
 /// Cloning this handle is cheap: all clones share the same underlying data and overlays.
 /// Use `with_label` to obtain a handle scoped to a specific overlay layer.
 #[derive(Clone)]
-pub struct SharedMarketDataRef {
-    data: Arc<RwLock<SharedMarketData>>,
+pub struct MarketData {
+    data: Arc<RwLock<MarketState>>,
     /// Per-label overlay states. Stored separately from the base data lock so that
     /// overlay writes do not block base-state reads.
     overlays: OverlayRegistry,
     label: Option<StateLabel>,
 }
 
-impl SharedMarketDataRef {
+impl MarketData {
     /// Creates a new handle wrapping the given data store with no active overlay label.
-    pub fn new(data: Arc<RwLock<SharedMarketData>>) -> Self {
+    pub fn new(data: Arc<RwLock<MarketState>>) -> Self {
         Self { data, overlays: Arc::new(RwLock::new(HashMap::new())), label: None }
     }
 
-    /// Creates a new empty market data store wrapped in a `SharedMarketDataRef`.
+    /// Creates a new empty market data store wrapped in a `MarketData`.
     pub fn new_shared() -> Self {
-        Self::new(Arc::new(RwLock::new(SharedMarketData::new())))
+        Self::new(Arc::new(RwLock::new(MarketState::new())))
     }
 
     /// Returns a clone of this handle scoped to the given overlay label.
@@ -89,11 +88,11 @@ impl SharedMarketDataRef {
         }
     }
 
-    /// Acquires a read guard that exposes both the base data and the active overlay (if any).
+    /// Acquires a view that exposes both the base data and the active overlay (if any).
     ///
     /// The overlay lock is held only briefly to clone the overlay `Arc` pointer; it is released
-    /// before the guard is returned, so solving never holds two locks simultaneously.
-    pub async fn read(&self) -> MarketDataReadGuard<'_> {
+    /// before the view is returned, so solving never holds two locks simultaneously.
+    pub async fn read(&self) -> MarketDataView<'_> {
         let guard = self.data.read().await;
         let overlay = if let Some(ref label) = self.label {
             self.overlays
@@ -104,37 +103,37 @@ impl SharedMarketDataRef {
         } else {
             None
         };
-        MarketDataReadGuard { guard, overlay }
+        MarketDataView { guard, overlay }
     }
 
     /// Acquires an exclusive write guard on the base data store.
-    pub async fn write(&self) -> tokio::sync::RwLockWriteGuard<'_, SharedMarketData> {
+    pub async fn write(&self) -> tokio::sync::RwLockWriteGuard<'_, MarketState> {
         self.data.write().await
     }
 
     /// Attempts a non-blocking read of the base data store.
     ///
     /// Returns `None` if the lock is currently held for writing.
-    pub fn try_read(&self) -> Option<tokio::sync::RwLockReadGuard<'_, SharedMarketData>> {
+    pub fn try_read(&self) -> Option<tokio::sync::RwLockReadGuard<'_, MarketState>> {
         self.data.try_read().ok()
     }
 
     /// Attempts a non-blocking write lock on the base data store.
     ///
     /// Returns `None` if the lock is currently held for reading or writing.
-    pub fn try_write(&self) -> Option<tokio::sync::RwLockWriteGuard<'_, SharedMarketData>> {
+    pub fn try_write(&self) -> Option<tokio::sync::RwLockWriteGuard<'_, MarketState>> {
         self.data.try_write().ok()
     }
 
-    /// Attempts a non-blocking read and wraps the result in a `MarketDataReadGuard`.
+    /// Attempts a non-blocking read and wraps the result in a `MarketDataView`.
     ///
     /// The overlay is not applied because this is a synchronous helper intended for tests where
     /// no overlay is active.  Returns `None` if the lock is currently held for writing.
-    pub fn try_read_blocking(&self) -> Option<MarketDataReadGuard<'_>> {
+    pub fn try_read_blocking(&self) -> Option<MarketDataView<'_>> {
         self.data
             .try_read()
             .ok()
-            .map(|guard| MarketDataReadGuard { guard, overlay: None })
+            .map(|guard| MarketDataView { guard, overlay: None })
     }
 
     // ==================== Overlay CRUD ====================
@@ -174,7 +173,7 @@ impl SharedMarketDataRef {
     pub async fn apply_block_update(
         &self,
         new_block_number: u64,
-        update: impl FnOnce(&mut SharedMarketData),
+        update: impl FnOnce(&mut MarketState),
     ) {
         self.overlays
             .write()
@@ -194,24 +193,17 @@ impl SharedMarketDataRef {
     }
 }
 
-/// A read guard that exposes the base market data and an optional overlay snapshot.
+/// An overlay-aware view of the market data, held for the duration of a read lock.
 ///
-/// Derefs to `SharedMarketData` for access to base fields. Use `get_simulation_state`
-/// to perform an overlay-aware lookup.
-pub struct MarketDataReadGuard<'a> {
-    guard: tokio::sync::RwLockReadGuard<'a, SharedMarketData>,
+/// Holds a read lock on the base `MarketState` and an optional overlay snapshot.
+/// Use `get_simulation_state` for overlay-aware pool lookups. All other accessors
+/// delegate to the base data.
+pub struct MarketDataView<'a> {
+    guard: tokio::sync::RwLockReadGuard<'a, MarketState>,
     overlay: Option<OverlayStates>,
 }
 
-impl Deref for MarketDataReadGuard<'_> {
-    type Target = SharedMarketData;
-
-    fn deref(&self) -> &SharedMarketData {
-        &self.guard
-    }
-}
-
-impl<'a> MarketDataReadGuard<'a> {
+impl<'a> MarketDataView<'a> {
     /// Returns the simulation state for the given component, checking the overlay first.
     pub fn get_simulation_state(&self, id: &str) -> Option<&dyn ProtocolSim> {
         if let Some(ref ov) = self.overlay {
@@ -226,10 +218,7 @@ impl<'a> MarketDataReadGuard<'a> {
     /// on top by replacing any simulation states found in both the subset and the overlay.
     ///
     /// If no overlay is active, this is equivalent to `self.extract_subset(component_ids)`.
-    pub fn extract_subset_with_overlay(
-        &self,
-        component_ids: &HashSet<ComponentId>,
-    ) -> SharedMarketData {
+    pub fn extract_subset_with_overlay(&self, component_ids: &HashSet<ComponentId>) -> MarketState {
         let mut subset = self.guard.extract_subset(component_ids);
         if let Some(ref ov) = self.overlay {
             for (id, state) in ov.iter() {
@@ -245,6 +234,46 @@ impl<'a> MarketDataReadGuard<'a> {
         }
         subset
     }
+
+    /// Returns the component topology from the base data.
+    pub fn component_topology(&self) -> HashMap<ComponentId, Vec<Address>> {
+        self.guard.component_topology()
+    }
+
+    /// Extracts a base-data subset for the given component IDs (no overlay applied).
+    pub fn extract_subset(&self, component_ids: &HashSet<ComponentId>) -> MarketState {
+        self.guard.extract_subset(component_ids)
+    }
+
+    /// Returns a reference to the token registry from the base data.
+    pub fn token_registry_ref(&self) -> &HashMap<Address, Token> {
+        self.guard.token_registry_ref()
+    }
+
+    /// Returns the current gas price from the base data.
+    pub fn gas_price(&self) -> Option<&BlockGasPrice> {
+        self.guard.gas_price()
+    }
+
+    /// Returns the block info for the last base-state update.
+    pub fn last_updated(&self) -> Option<&BlockInfo> {
+        self.guard.last_updated()
+    }
+
+    /// Returns a token by address from the base data.
+    pub fn get_token(&self, address: &Address) -> Option<&Token> {
+        self.guard.get_token(address)
+    }
+
+    /// Returns a component by ID from the base data.
+    pub fn get_component(&self, id: &str) -> Option<&ProtocolComponent> {
+        self.guard.get_component(id)
+    }
+
+    /// Returns a reference to the underlying base market state, bypassing any overlay.
+    pub fn base_market_state(&self) -> &MarketState {
+        &self.guard
+    }
 }
 
 /// Shared market data containing all component states and market information.
@@ -252,7 +281,7 @@ impl<'a> MarketDataReadGuard<'a> {
 /// This struct is the single source of truth for market data.
 /// The indexer updates it, and solvers read from it.
 #[derive(Debug, Default)]
-pub struct SharedMarketData {
+pub struct MarketState {
     /// All components indexed by their ID.
     components: HashMap<ComponentId, ProtocolComponent>,
     /// All states indexed by their component ID.
@@ -268,8 +297,8 @@ pub struct SharedMarketData {
     last_updated: Option<BlockInfo>,
 }
 
-impl SharedMarketData {
-    /// Creates a new empty SharedMarketData.
+impl MarketState {
+    /// Creates a new empty MarketState.
     pub fn new() -> Self {
         Self {
             components: HashMap::new(),
@@ -392,7 +421,7 @@ impl SharedMarketData {
     /// - Simulation states for those components (cloned via `clone_box`)
     /// - Tokens referenced by those components
     /// - Gas price and block info
-    pub fn extract_subset(&self, component_ids: &HashSet<ComponentId>) -> SharedMarketData {
+    pub fn extract_subset(&self, component_ids: &HashSet<ComponentId>) -> MarketState {
         // Filter components
         let components: HashMap<ComponentId, ProtocolComponent> = self
             .components
@@ -423,7 +452,7 @@ impl SharedMarketData {
             .map(|(id, state)| (id.clone(), state.clone_box()))
             .collect();
 
-        SharedMarketData {
+        MarketState {
             components,
             simulation_states,
             tokens,
@@ -445,7 +474,7 @@ mod tests {
     #[test]
     fn extract_subset_filters_by_component_ids() {
         // Setup: market with 2 pools (A-B, B-C) and 3 tokens
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
 
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
@@ -511,11 +540,11 @@ mod tests {
             .is_empty());
     }
 
-    // ==================== SharedMarketDataRef overlay tests ====================
+    // ==================== MarketData overlay tests ====================
 
     #[tokio::test]
     async fn register_and_retrieve_overlay_via_labeled_read() {
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
 
         let label = "test_label".to_string();
         let mut states: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
@@ -537,7 +566,7 @@ mod tests {
 
     #[tokio::test]
     async fn read_without_label_returns_no_overlay() {
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
 
         market_ref
             .register_labeled_state(
@@ -559,7 +588,7 @@ mod tests {
 
     #[tokio::test]
     async fn remove_labeled_state_clears_overlay() {
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
         let label = "lbl".to_string();
 
         market_ref
@@ -583,7 +612,7 @@ mod tests {
 
     #[tokio::test]
     async fn clear_labeled_states_removes_all() {
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
 
         for i in 0..3u8 {
             market_ref
@@ -609,7 +638,7 @@ mod tests {
     async fn with_label_shares_overlay_registry() {
         // Registering via one handle must be visible to another handle pointing at the same
         // overlay registry.
-        let base = SharedMarketDataRef::new_shared();
+        let base = MarketData::new_shared();
         let handle_a = base.with_label("shared".to_string());
         let handle_b = base.with_label("shared".to_string());
 
@@ -637,7 +666,7 @@ mod tests {
     async fn extract_subset_with_overlay_replaces_matching_states() {
         use crate::algorithm::test_utils::{component as mk_component, token as mk_token};
 
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
 
         let tok_a = mk_token(0x01, "A");
         let tok_b = mk_token(0x02, "B");
@@ -683,7 +712,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_block_update_evicts_stale_overlays() {
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
 
         // Register two overlays: one valid until block 10, one valid until block 20.
         market_ref
@@ -719,7 +748,7 @@ mod tests {
 
     #[tokio::test]
     async fn apply_block_update_applies_mutation() {
-        let market_ref = SharedMarketDataRef::new_shared();
+        let market_ref = MarketData::new_shared();
 
         market_ref
             .apply_block_update(1, |data| {

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -52,6 +52,12 @@ pub struct OverlayEntry {
 /// The shared overlay registry: maps each label to its snapshot.
 type OverlayRegistry = Arc<RwLock<HashMap<StateLabel, OverlayEntry>>>;
 
+/// Error returned by [`MarketData::read_labeled`] when the requested label is not registered as
+/// an overlay and does not match the current base-state label.
+#[derive(Debug, thiserror::Error)]
+#[error("label not found: {0}")]
+pub struct LabelNotFound(pub StateLabel);
+
 /// The main entry point for accessing market data.
 ///
 /// Cloning is cheap — all clones share the same underlying data and overlay registry.
@@ -75,24 +81,44 @@ impl MarketData {
         Self::new(Arc::new(RwLock::new(MarketState::new())))
     }
 
-    /// Acquires an overlay-aware view of the market data.
+    /// Acquires a base view of the market data with no overlay applied.
+    pub async fn read(&self) -> MarketDataView<'_> {
+        MarketDataView { guard: self.data.read().await, overlay: None }
+    }
+
+    /// Acquires an overlay-aware view scoped to `label`.
     ///
-    /// If `label` is `Some`, the view will expose overlay states registered under that label,
-    /// falling back to base state for pools not present in the overlay.
+    /// Succeeds when `label` is registered as an overlay **or** matches the current base-state
+    /// label (the block-number string set by `apply_block_update`). Returns
+    /// [`LabelNotFound`] otherwise so callers cannot silently fall back to stale data.
+    ///
     /// The overlay lock is held only briefly to clone the snapshot pointer; it is released
     /// before the view is returned, so solving never holds two locks simultaneously.
-    pub async fn read(&self, label: Option<&StateLabel>) -> MarketDataView<'_> {
+    pub async fn read_labeled(
+        &self,
+        label: &StateLabel,
+    ) -> Result<MarketDataView<'_>, LabelNotFound> {
         let guard = self.data.read().await;
-        let overlay = if let Some(label) = label {
-            self.overlays
-                .read()
-                .await
-                .get(label)
-                .map(|e| (label.clone(), Arc::clone(&e.states)))
-        } else {
-            None
-        };
-        MarketDataView { guard, overlay }
+        if let Some(e) = self.overlays.read().await.get(label) {
+            let states = Arc::clone(&e.states);
+            return Ok(MarketDataView { guard, overlay: Some((label.clone(), states)) });
+        }
+        if &guard.label == label {
+            return Ok(MarketDataView { guard, overlay: None });
+        }
+        Err(LabelNotFound(label.clone()))
+    }
+
+    /// Convenience wrapper: calls [`read_labeled`](Self::read_labeled) when `label` is `Some`,
+    /// otherwise delegates to the infallible [`read`](Self::read).
+    pub async fn read_opt(
+        &self,
+        label: Option<&StateLabel>,
+    ) -> Result<MarketDataView<'_>, LabelNotFound> {
+        match label {
+            Some(l) => self.read_labeled(l).await,
+            None => Ok(self.read().await),
+        }
     }
 
     /// Acquires an exclusive write guard on the base data store.
@@ -569,7 +595,10 @@ mod tests {
             .register_labeled_state(label.clone(), states, u64::MAX)
             .await;
 
-        let guard = market_ref.read(Some(&label)).await;
+        let guard = market_ref
+            .read_labeled(&label)
+            .await
+            .expect("label was just registered");
         // Base data is empty — overlay provides the state
         let sim = guard.get_simulation_state("pool_ab");
         assert!(sim.is_some());
@@ -591,7 +620,7 @@ mod tests {
             .await;
 
         // A handle with no label must not see the overlay
-        let guard = market_ref.read(None).await;
+        let guard = market_ref.read().await;
         assert!(guard
             .get_simulation_state("pool1")
             .is_none());
@@ -664,13 +693,19 @@ mod tests {
         .await;
 
         let label = "shared".to_string();
-        let guard_a = clone_a.read(Some(&label)).await;
+        let guard_a = clone_a
+            .read_labeled(&label)
+            .await
+            .expect("label was just registered");
         assert!(guard_a
             .get_simulation_state("pool_x")
             .is_some());
         drop(guard_a);
 
-        let guard_b = clone_b.read(Some(&label)).await;
+        let guard_b = clone_b
+            .read_labeled(&label)
+            .await
+            .expect("label was just registered");
         assert!(guard_b
             .get_simulation_state("pool_x")
             .is_some());
@@ -707,7 +742,10 @@ mod tests {
             )
             .await;
 
-        let guard = market_ref.read(Some(&label)).await;
+        let guard = market_ref
+            .read_labeled(&label)
+            .await
+            .expect("label was just registered");
         let ids: HashSet<ComponentId> = ["pool_ab".to_string()]
             .into_iter()
             .collect();
@@ -769,7 +807,7 @@ mod tests {
             })
             .await;
 
-        let guard = market_ref.read(None).await;
+        let guard = market_ref.read().await;
         assert_eq!(
             guard
                 .last_updated()

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -52,23 +52,22 @@ pub struct OverlayEntry {
 /// The shared overlay registry: maps each label to its snapshot.
 type OverlayRegistry = Arc<RwLock<HashMap<StateLabel, OverlayEntry>>>;
 
-/// Thread-safe handle to shared market data with optional overlay support.
+/// The main entry point for accessing market data.
 ///
-/// Cloning this handle is cheap: all clones share the same underlying data and overlays.
-/// Use `with_label` to obtain a handle scoped to a specific overlay layer.
+/// Cloning is cheap — all clones share the same underlying data and overlay registry.
+/// Pass an optional label to `read` to scope the view to a specific overlay.
 #[derive(Clone)]
 pub struct MarketData {
     data: Arc<RwLock<MarketState>>,
     /// Per-label overlay states. Stored separately from the base data lock so that
     /// overlay writes do not block base-state reads.
     overlays: OverlayRegistry,
-    label: Option<StateLabel>,
 }
 
 impl MarketData {
-    /// Creates a new handle wrapping the given data store with no active overlay label.
+    /// Creates a new handle wrapping the given data store.
     pub fn new(data: Arc<RwLock<MarketState>>) -> Self {
-        Self { data, overlays: Arc::new(RwLock::new(HashMap::new())), label: None }
+        Self { data, overlays: Arc::new(RwLock::new(HashMap::new())) }
     }
 
     /// Creates a new empty market data store wrapped in a `MarketData`.
@@ -76,30 +75,20 @@ impl MarketData {
         Self::new(Arc::new(RwLock::new(MarketState::new())))
     }
 
-    /// Returns a clone of this handle scoped to the given overlay label.
+    /// Acquires an overlay-aware view of the market data.
     ///
-    /// All clones share the same overlay registry, so a state registered via any handle
-    /// is visible to all handles with the same label.
-    pub fn with_label(&self, label: StateLabel) -> Self {
-        Self {
-            data: Arc::clone(&self.data),
-            overlays: Arc::clone(&self.overlays),
-            label: Some(label),
-        }
-    }
-
-    /// Acquires a view that exposes both the base data and the active overlay (if any).
-    ///
-    /// The overlay lock is held only briefly to clone the overlay `Arc` pointer; it is released
+    /// If `label` is `Some`, the view will expose overlay states registered under that label,
+    /// falling back to base state for pools not present in the overlay.
+    /// The overlay lock is held only briefly to clone the snapshot pointer; it is released
     /// before the view is returned, so solving never holds two locks simultaneously.
-    pub async fn read(&self) -> MarketDataView<'_> {
+    pub async fn read(&self, label: Option<&StateLabel>) -> MarketDataView<'_> {
         let guard = self.data.read().await;
-        let overlay = if let Some(ref label) = self.label {
+        let overlay = if let Some(label) = label {
             self.overlays
                 .read()
                 .await
                 .get(label)
-                .map(|e| Arc::clone(&e.states))
+                .map(|e| (label.clone(), Arc::clone(&e.states)))
         } else {
             None
         };
@@ -200,14 +189,21 @@ impl MarketData {
 /// delegate to the base data.
 pub struct MarketDataView<'a> {
     guard: tokio::sync::RwLockReadGuard<'a, MarketState>,
-    overlay: Option<OverlayStates>,
+    overlay: Option<(StateLabel, OverlayStates)>,
 }
 
 impl<'a> MarketDataView<'a> {
+    /// Returns the label identifying the active overlay, or `None` if no overlay is in effect.
+    pub fn state_label(&self) -> Option<&StateLabel> {
+        self.overlay
+            .as_ref()
+            .map(|(label, _)| label)
+    }
+
     /// Returns the simulation state for the given component, checking the overlay first.
     pub fn get_simulation_state(&self, id: &str) -> Option<&dyn ProtocolSim> {
-        if let Some(ref ov) = self.overlay {
-            if let Some(s) = ov.get(id) {
+        if let Some((_, ref states)) = self.overlay {
+            if let Some(s) = states.get(id) {
                 return Some(s.as_ref());
             }
         }
@@ -220,8 +216,8 @@ impl<'a> MarketDataView<'a> {
     /// If no overlay is active, this is equivalent to `self.extract_subset(component_ids)`.
     pub fn extract_subset_with_overlay(&self, component_ids: &HashSet<ComponentId>) -> MarketState {
         let mut subset = self.guard.extract_subset(component_ids);
-        if let Some(ref ov) = self.overlay {
-            for (id, state) in ov.iter() {
+        if let Some((_, ref states)) = self.overlay {
+            for (id, state) in states.iter() {
                 if subset
                     .simulation_states
                     .contains_key(id)
@@ -557,8 +553,7 @@ mod tests {
             .register_labeled_state(label.clone(), states, u64::MAX)
             .await;
 
-        let labeled_ref = market_ref.with_label(label);
-        let guard = labeled_ref.read().await;
+        let guard = market_ref.read(Some(&label)).await;
         // Base data is empty — overlay provides the state
         let sim = guard.get_simulation_state("pool_ab");
         assert!(sim.is_some());
@@ -580,7 +575,7 @@ mod tests {
             .await;
 
         // A handle with no label must not see the overlay
-        let guard = market_ref.read().await;
+        let guard = market_ref.read(None).await;
         assert!(guard
             .get_simulation_state("pool1")
             .is_none());
@@ -635,12 +630,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn with_label_shares_overlay_registry() {
-        // Registering via one handle must be visible to another handle pointing at the same
-        // overlay registry.
+    async fn clone_shares_overlay_registry() {
+        // Registering via one clone must be visible when reading via any other clone pointing at
+        // the same overlay registry.
         let base = MarketData::new_shared();
-        let handle_a = base.with_label("shared".to_string());
-        let handle_b = base.with_label("shared".to_string());
+        let clone_a = base.clone();
+        let clone_b = base.clone();
 
         base.register_labeled_state(
             "shared".to_string(),
@@ -652,11 +647,14 @@ mod tests {
         )
         .await;
 
-        let guard_a = handle_a.read().await;
-        let guard_b = handle_b.read().await;
+        let label = "shared".to_string();
+        let guard_a = clone_a.read(Some(&label)).await;
         assert!(guard_a
             .get_simulation_state("pool_x")
             .is_some());
+        drop(guard_a);
+
+        let guard_b = clone_b.read(Some(&label)).await;
         assert!(guard_b
             .get_simulation_state("pool_x")
             .is_some());
@@ -693,8 +691,7 @@ mod tests {
             )
             .await;
 
-        let labeled = market_ref.with_label(label);
-        let guard = labeled.read().await;
+        let guard = market_ref.read(Some(&label)).await;
         let ids: HashSet<ComponentId> = ["pool_ab".to_string()]
             .into_iter()
             .collect();
@@ -756,7 +753,7 @@ mod tests {
             })
             .await;
 
-        let guard = market_ref.read().await;
+        let guard = market_ref.read(None).await;
         assert_eq!(
             guard
                 .last_updated()

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -41,8 +41,17 @@ pub type StateLabel = String;
 /// An immutable snapshot of per-component simulation states for one overlay layer.
 pub type OverlayStates = Arc<HashMap<ComponentId, Box<dyn ProtocolSim>>>;
 
+/// A named simulation-state overlay with a block-number expiry.
+pub struct OverlayEntry {
+    /// The overlay pool states (only pools that differ from base state).
+    pub states: OverlayStates,
+    /// Last block number for which this overlay is valid.
+    /// The overlay is automatically evicted before block `valid_until + 1` is applied.
+    pub valid_until: u64,
+}
+
 /// The shared overlay registry: maps each label to its snapshot.
-type OverlayRegistry = Arc<RwLock<HashMap<StateLabel, OverlayStates>>>;
+type OverlayRegistry = Arc<RwLock<HashMap<StateLabel, OverlayEntry>>>;
 
 /// Thread-safe handle to shared market data with optional overlay support.
 ///
@@ -91,7 +100,7 @@ impl SharedMarketDataRef {
                 .read()
                 .await
                 .get(label)
-                .cloned()
+                .map(|e| Arc::clone(&e.states))
         } else {
             None
         };
@@ -135,11 +144,12 @@ impl SharedMarketDataRef {
         &self,
         label: StateLabel,
         states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
+        valid_until: u64,
     ) {
         self.overlays
             .write()
             .await
-            .insert(label, Arc::new(states));
+            .insert(label, OverlayEntry { states: Arc::new(states), valid_until });
     }
 
     /// Removes the overlay for the given label, if it exists.
@@ -153,6 +163,24 @@ impl SharedMarketDataRef {
     /// Clears all overlays.
     pub async fn clear_labeled_states(&self) {
         self.overlays.write().await.clear();
+    }
+
+    /// Atomically evicts stale overlays then applies a block update to base state.
+    ///
+    /// Overlays with `valid_until < new_block_number` are removed under the overlay
+    /// lock before the base write lock is acquired. This guarantees no solver can
+    /// observe new base state alongside an overlay that was built against the previous
+    /// block.
+    pub async fn apply_block_update(
+        &self,
+        new_block_number: u64,
+        update: impl FnOnce(&mut SharedMarketData),
+    ) {
+        self.overlays
+            .write()
+            .await
+            .retain(|_, entry| entry.valid_until >= new_block_number);
+        update(&mut *self.data.write().await);
     }
 
     /// Returns the labels of all registered overlays.
@@ -497,7 +525,7 @@ mod tests {
         );
 
         market_ref
-            .register_labeled_state(label.clone(), states)
+            .register_labeled_state(label.clone(), states, u64::MAX)
             .await;
 
         let labeled_ref = market_ref.with_label(label);
@@ -518,6 +546,7 @@ mod tests {
                     "pool1".to_string(),
                     Box::new(MockProtocolSim::new(5.0)) as Box<dyn ProtocolSim>,
                 )]),
+                u64::MAX,
             )
             .await;
 
@@ -540,6 +569,7 @@ mod tests {
                     "pool".to_string(),
                     Box::new(MockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
                 )]),
+                u64::MAX,
             )
             .await;
 
@@ -563,6 +593,7 @@ mod tests {
                         format!("pool_{i}"),
                         Box::new(MockProtocolSim::new(f64::from(i))) as Box<dyn ProtocolSim>,
                     )]),
+                    u64::MAX,
                 )
                 .await;
         }
@@ -588,6 +619,7 @@ mod tests {
                 "pool_x".to_string(),
                 Box::new(MockProtocolSim::new(7.0)) as Box<dyn ProtocolSim>,
             )]),
+            u64::MAX,
         )
         .await;
 
@@ -628,6 +660,7 @@ mod tests {
                     "pool_ab".to_string(),
                     Box::new(MockProtocolSim::new(99.0)) as Box<dyn ProtocolSim>,
                 )]),
+                u64::MAX,
             )
             .await;
 
@@ -646,5 +679,61 @@ mod tests {
             .downcast_ref::<MockProtocolSim>()
             .unwrap();
         assert_eq!(mock.spot_price, 99.0, "overlay state should replace base state");
+    }
+
+    #[tokio::test]
+    async fn apply_block_update_evicts_stale_overlays() {
+        let market_ref = SharedMarketDataRef::new_shared();
+
+        // Register two overlays: one valid until block 10, one valid until block 20.
+        market_ref
+            .register_labeled_state(
+                "stale".to_string(),
+                HashMap::from([(
+                    "pool_stale".to_string(),
+                    Box::new(MockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
+                )]),
+                10,
+            )
+            .await;
+        market_ref
+            .register_labeled_state(
+                "fresh".to_string(),
+                HashMap::from([(
+                    "pool_fresh".to_string(),
+                    Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+                )]),
+                20,
+            )
+            .await;
+
+        // Apply block 11: the "stale" overlay (valid_until=10) must be evicted.
+        market_ref
+            .apply_block_update(11, |_data| {})
+            .await;
+
+        let ids = market_ref.labeled_state_ids().await;
+        assert!(!ids.contains(&"stale".to_string()), "stale overlay must be evicted");
+        assert!(ids.contains(&"fresh".to_string()), "fresh overlay must survive");
+    }
+
+    #[tokio::test]
+    async fn apply_block_update_applies_mutation() {
+        let market_ref = SharedMarketDataRef::new_shared();
+
+        market_ref
+            .apply_block_update(1, |data| {
+                data.update_last_updated(BlockInfo::new(1, "0xabc".to_string(), 0));
+            })
+            .await;
+
+        let guard = market_ref.read().await;
+        assert_eq!(
+            guard
+                .last_updated()
+                .expect("last_updated must be set")
+                .number(),
+            1
+        );
     }
 }

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -168,7 +168,9 @@ impl MarketData {
             .write()
             .await
             .retain(|_, entry| entry.valid_until >= new_block_number);
-        update(&mut *self.data.write().await);
+        let mut data = self.data.write().await;
+        data.label = new_block_number.to_string();
+        update(&mut data);
     }
 
     /// Returns the labels of all registered overlays.
@@ -216,7 +218,7 @@ impl<'a> MarketDataView<'a> {
     /// If no overlay is active, this is equivalent to `self.extract_subset(component_ids)`.
     pub fn extract_subset_with_overlay(&self, component_ids: &HashSet<ComponentId>) -> MarketState {
         let mut subset = self.guard.extract_subset(component_ids);
-        if let Some((_, ref states)) = self.overlay {
+        if let Some((ref label, ref states)) = self.overlay {
             for (id, state) in states.iter() {
                 if subset
                     .simulation_states
@@ -227,6 +229,7 @@ impl<'a> MarketDataView<'a> {
                         .insert(id.clone(), state.clone_box());
                 }
             }
+            subset.label = label.clone();
         }
         subset
     }
@@ -278,6 +281,12 @@ impl<'a> MarketDataView<'a> {
 /// The indexer updates it, and solvers read from it.
 #[derive(Debug, Default)]
 pub struct MarketState {
+    /// Identifies the block or overlay this state was produced from.
+    ///
+    /// Set to the block number string by `apply_block_update`; copied from the overlay label by
+    /// `extract_subset_with_overlay` when an overlay is active. Empty string until the first block
+    /// is applied.
+    label: StateLabel,
     /// All components indexed by their ID.
     components: HashMap<ComponentId, ProtocolComponent>,
     /// All states indexed by their component ID.
@@ -297,6 +306,7 @@ impl MarketState {
     /// Creates a new empty MarketState.
     pub fn new() -> Self {
         Self {
+            label: String::new(),
             components: HashMap::new(),
             simulation_states: HashMap::new(),
             tokens: HashMap::new(),
@@ -304,6 +314,11 @@ impl MarketState {
             protocol_sync_status: HashMap::new(),
             last_updated: None,
         }
+    }
+
+    /// Returns the label identifying the block or overlay this state was produced from.
+    pub fn label(&self) -> &StateLabel {
+        &self.label
     }
 
     /// Returns the block info for the last update.
@@ -449,6 +464,7 @@ impl MarketState {
             .collect();
 
         MarketState {
+            label: self.label.clone(),
             components,
             simulation_states,
             tokens,

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -52,11 +52,13 @@ pub struct OverlayEntry {
 /// The shared overlay registry: maps each label to its snapshot.
 type OverlayRegistry = Arc<RwLock<HashMap<StateLabel, OverlayEntry>>>;
 
-/// Error returned by [`MarketData::read_labeled`] when the requested label is not registered as
-/// an overlay and does not match the current base-state label.
+/// Error returned by [`MarketData::read_labeled`] when the requested label cannot be resolved.
 #[derive(Debug, thiserror::Error)]
-#[error("label not found: {0}")]
-pub struct LabelNotFound(pub StateLabel);
+pub enum ReadLabeledError {
+    /// The label is not registered as an overlay and does not match the current base-state label.
+    #[error("label not found: {0}")]
+    NotFound(StateLabel),
+}
 
 /// The main entry point for accessing market data.
 ///
@@ -90,14 +92,14 @@ impl MarketData {
     ///
     /// Succeeds when `label` is registered as an overlay **or** matches the current base-state
     /// label (the block-number string set by `apply_block_update`). Returns
-    /// [`LabelNotFound`] otherwise so callers cannot silently fall back to stale data.
+    /// [`ReadLabeledError::NotFound`] otherwise so callers cannot silently fall back to stale data.
     ///
     /// The overlay lock is held only briefly to clone the snapshot pointer; it is released
     /// before the view is returned, so solving never holds two locks simultaneously.
     pub async fn read_labeled(
         &self,
         label: &StateLabel,
-    ) -> Result<MarketDataView<'_>, LabelNotFound> {
+    ) -> Result<MarketDataView<'_>, ReadLabeledError> {
         let guard = self.data.read().await;
         if let Some(e) = self.overlays.read().await.get(label) {
             let states = Arc::clone(&e.states);
@@ -106,19 +108,7 @@ impl MarketData {
         if &guard.label == label {
             return Ok(MarketDataView { guard, overlay: None });
         }
-        Err(LabelNotFound(label.clone()))
-    }
-
-    /// Convenience wrapper: calls [`read_labeled`](Self::read_labeled) when `label` is `Some`,
-    /// otherwise delegates to the infallible [`read`](Self::read).
-    pub async fn read_opt(
-        &self,
-        label: Option<&StateLabel>,
-    ) -> Result<MarketDataView<'_>, LabelNotFound> {
-        match label {
-            Some(l) => self.read_labeled(l).await,
-            None => Ok(self.read().await),
-        }
+        Err(ReadLabeledError::NotFound(label.clone()))
     }
 
     /// Acquires an exclusive write guard on the base data store.

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -4,11 +4,11 @@ use tycho_simulation::tycho_common::models::Chain;
 
 pub(crate) mod events;
 pub(crate) mod gas;
-/// Shared market data store (`SharedMarketData`, `SharedMarketDataRef`).
+/// Shared market data store (`MarketState`, `MarketData`).
 pub mod market_data;
 /// Protocol system registry: maps protocol names to their Tycho identifiers.
 pub mod protocol_registry;
-/// Tycho WebSocket feed: connects to the Tycho data stream and populates `SharedMarketData`.
+/// Tycho WebSocket feed: connects to the Tycho data stream and populates `MarketState`.
 pub mod tycho_feed;
 
 /// Configuration for the TychoFeed.

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -297,49 +297,47 @@ impl TychoFeed {
             updated_or_new_states.len()
         );
         trace!("Updating market data");
-        // Update market data. We should only hold the write lock inside this code block.
-        {
-            let mut market_data = self
-                .market_data
-                .write()
-                .instrument(span!(Level::DEBUG, "data_feed_write_lock"))
-                .await;
+        let new_block_number = msg.block_number_or_timestamp;
+        self.market_data
+            .apply_block_update(new_block_number, |market_data| {
+                market_data.upsert_components(
+                    added_components
+                        .clone()
+                        .into_values()
+                        .map(|component| {
+                            // We can't use From<ProtocolComponent> because it removes "0x" prefix
+                            // from the id
+                            tycho_simulation::tycho_common::models::protocol::ProtocolComponent {
+                                id: component.id.to_string(),
+                                protocol_system: component.protocol_system,
+                                protocol_type_name: component.protocol_type_name,
+                                chain: component.chain,
+                                tokens: component
+                                    .tokens
+                                    .into_iter()
+                                    .map(|t| t.address)
+                                    .collect(),
+                                static_attributes: component.static_attributes,
+                                change: Default::default(),
+                                creation_tx: component.creation_tx,
+                                created_at: component.created_at,
+                                contract_addresses: component.contract_ids,
+                            }
+                        }),
+                );
+                market_data.remove_components(removed_components.keys());
+                market_data.upsert_tokens(maybe_new_tokens);
+                market_data.update_states(updated_or_new_states);
+                market_data.update_protocol_sync_status(sync_states);
 
-            market_data.upsert_components(
-                added_components
-                    .clone()
-                    .into_values()
-                    .map(|component| {
-                        // We can't use From<ProtocolComponent> because it removes "0x" prefix from
-                        // the id
-                        tycho_simulation::tycho_common::models::protocol::ProtocolComponent {
-                            id: component.id.to_string(),
-                            protocol_system: component.protocol_system,
-                            protocol_type_name: component.protocol_type_name,
-                            chain: component.chain,
-                            tokens: component
-                                .tokens
-                                .into_iter()
-                                .map(|t| t.address)
-                                .collect(),
-                            static_attributes: component.static_attributes,
-                            change: Default::default(),
-                            creation_tx: component.creation_tx,
-                            created_at: component.created_at,
-                            contract_addresses: component.contract_ids,
-                        }
-                    }),
-            );
-            market_data.remove_components(removed_components.keys());
-            market_data.upsert_tokens(maybe_new_tokens);
-            market_data.update_states(updated_or_new_states);
-            market_data.update_protocol_sync_status(sync_states);
-
-            // Update the last updated block info if one of the protocols reported "Ready" status.
-            if let Some(block_info) = latest_block_info {
-                market_data.update_last_updated(block_info);
-            }
-        }
+                // Update the last updated block info if one of the protocols reported "Ready"
+                // status.
+                if let Some(block_info) = latest_block_info {
+                    market_data.update_last_updated(block_info);
+                }
+            })
+            .instrument(span!(Level::DEBUG, "data_feed_write_lock"))
+            .await;
         trace!("Market data updated");
 
         // Only broadcast event if there are actual changes

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -597,7 +597,7 @@ mod tests {
             .expect("Failed to handle message");
 
         // Verify component was added to market data
-        let data = market_data.read().await;
+        let data = market_data.read(None).await;
 
         let component = data
             .get_component(component_id)
@@ -663,7 +663,7 @@ mod tests {
 
         // Verify it was added
         {
-            let data = market_data.read().await;
+            let data = market_data.read(None).await;
             assert!(
                 data.get_component(component_id)
                     .is_some(),
@@ -685,7 +685,7 @@ mod tests {
             .expect("Failed to handle removal");
 
         // Verify component was removed
-        let data = market_data.read().await;
+        let data = market_data.read(None).await;
         assert!(
             data.get_component(component_id)
                 .is_none(),
@@ -752,7 +752,7 @@ mod tests {
 
         // Verify state was updated
         {
-            let data = market_data.read().await;
+            let data = market_data.read(None).await;
             assert_eq!(
                 data.get_component(component_id)
                     .expect("Component should be in market data")
@@ -797,7 +797,7 @@ mod tests {
 
         // Verify state was updated
         {
-            let data = market_data.read().await;
+            let data = market_data.read(None).await;
             assert_eq!(
                 data.get_simulation_state(component_id)
                     .expect("Component should be in market data")
@@ -863,7 +863,7 @@ mod tests {
 
         // Verify the old component was added
         {
-            let data = market_data.read().await;
+            let data = market_data.read(None).await;
             assert!(
                 data.get_component(old_component_id)
                     .is_some(),
@@ -892,7 +892,7 @@ mod tests {
 
         // Verify both operations succeeded
         {
-            let data = market_data.read().await;
+            let data = market_data.read(None).await;
             assert!(
                 data.get_component(new_component_id)
                     .is_some(),

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -2,7 +2,7 @@
 //!
 //! The TychoFeed connects to Tycho's WebSocket API and:
 //! - Receives component/state updates
-//! - Updates SharedMarketData (exclusive write access)
+//! - Updates MarketState (exclusive write access)
 //! - Broadcasts MarketEvents to Solvers
 
 use std::collections::HashSet;
@@ -25,7 +25,7 @@ use tycho_simulation::{
 use crate::{
     feed::{
         events::MarketEvent,
-        market_data::SharedMarketDataRef,
+        market_data::MarketData,
         protocol_registry::{register_exchanges, register_rfq},
         DataFeedError, TychoFeedConfig,
     },
@@ -38,14 +38,14 @@ use crate::{
 ///
 /// - Connect to Tycho WebSocket and maintain connection
 /// - Process incoming component/state updates
-/// - Update SharedMarketData (holds exclusive write access)
+/// - Update MarketState (holds exclusive write access)
 /// - Broadcast MarketEvents to all subscribed Solvers
 /// - Periodically refresh gas prices from RPC
 pub(crate) struct TychoFeed {
     /// Configuration.
     config: TychoFeedConfig,
     /// Shared market data (we have write access).
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     /// Event broadcaster.
     event_tx: broadcast::Sender<MarketEvent>,
     /// Signal channel to notify the gas price worker to refresh gas price.
@@ -59,7 +59,7 @@ impl TychoFeed {
     ///
     /// * `config` - Indexer configuration
     /// * `market_data` - Shared market data reference
-    pub(crate) fn new(config: TychoFeedConfig, market_data: SharedMarketDataRef) -> Self {
+    pub(crate) fn new(config: TychoFeedConfig, market_data: MarketData) -> Self {
         let (event_tx, _event_rx) = broadcast::channel(1024);
 
         Self { config, market_data, event_tx, gas_price_worker_signal_tx: None }
@@ -417,11 +417,11 @@ mod tests {
     };
 
     use super::*;
-    use crate::feed::{market_data::SharedMarketDataRef, TychoFeedConfig};
+    use crate::feed::{market_data::MarketData, TychoFeedConfig};
 
     /// Creates a new shared market data instance.
-    fn new_shared_market_data() -> SharedMarketDataRef {
-        SharedMarketDataRef::new_shared()
+    fn new_shared_market_data() -> MarketData {
+        MarketData::new_shared()
     }
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -597,7 +597,7 @@ mod tests {
             .expect("Failed to handle message");
 
         // Verify component was added to market data
-        let data = market_data.read(None).await;
+        let data = market_data.read().await;
 
         let component = data
             .get_component(component_id)
@@ -663,7 +663,7 @@ mod tests {
 
         // Verify it was added
         {
-            let data = market_data.read(None).await;
+            let data = market_data.read().await;
             assert!(
                 data.get_component(component_id)
                     .is_some(),
@@ -685,7 +685,7 @@ mod tests {
             .expect("Failed to handle removal");
 
         // Verify component was removed
-        let data = market_data.read(None).await;
+        let data = market_data.read().await;
         assert!(
             data.get_component(component_id)
                 .is_none(),
@@ -752,7 +752,7 @@ mod tests {
 
         // Verify state was updated
         {
-            let data = market_data.read(None).await;
+            let data = market_data.read().await;
             assert_eq!(
                 data.get_component(component_id)
                     .expect("Component should be in market data")
@@ -797,7 +797,7 @@ mod tests {
 
         // Verify state was updated
         {
-            let data = market_data.read(None).await;
+            let data = market_data.read().await;
             assert_eq!(
                 data.get_simulation_state(component_id)
                     .expect("Component should be in market data")
@@ -863,7 +863,7 @@ mod tests {
 
         // Verify the old component was added
         {
-            let data = market_data.read(None).await;
+            let data = market_data.read().await;
             assert!(
                 data.get_component(old_component_id)
                     .is_some(),
@@ -892,7 +892,7 @@ mod tests {
 
         // Verify both operations succeeded
         {
-            let data = market_data.read(None).await;
+            let data = market_data.read().await;
             assert!(
                 data.get_component(new_component_id)
                     .is_some(),

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -5,10 +5,10 @@
 //! - Updates SharedMarketData (exclusive write access)
 //! - Broadcasts MarketEvents to Solvers
 
-use std::{collections::HashSet, sync::Arc};
+use std::collections::HashSet;
 
 use tokio::{
-    sync::{broadcast, mpsc, oneshot, RwLock},
+    sync::{broadcast, mpsc, oneshot},
     task::JoinHandle,
 };
 use tokio_stream::StreamExt;
@@ -25,7 +25,7 @@ use tycho_simulation::{
 use crate::{
     feed::{
         events::MarketEvent,
-        market_data::{SharedMarketData, SharedMarketDataRef},
+        market_data::SharedMarketDataRef,
         protocol_registry::{register_exchanges, register_rfq},
         DataFeedError, TychoFeedConfig,
     },
@@ -45,7 +45,7 @@ pub(crate) struct TychoFeed {
     /// Configuration.
     config: TychoFeedConfig,
     /// Shared market data (we have write access).
-    market_data: Arc<RwLock<SharedMarketData>>,
+    market_data: SharedMarketDataRef,
     /// Event broadcaster.
     event_tx: broadcast::Sender<MarketEvent>,
     /// Signal channel to notify the gas price worker to refresh gas price.
@@ -403,10 +403,9 @@ impl TychoFeed {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, env, sync::Arc};
+    use std::{collections::HashMap, env};
 
     use num_bigint::BigUint;
-    use tokio::sync::RwLock;
     use tycho_simulation::{
         protocol::models::{ProtocolComponent, Update},
         tycho_common::{
@@ -420,14 +419,11 @@ mod tests {
     };
 
     use super::*;
-    use crate::feed::{
-        market_data::{SharedMarketData, SharedMarketDataRef},
-        TychoFeedConfig,
-    };
+    use crate::feed::{market_data::SharedMarketDataRef, TychoFeedConfig};
 
-    /// Creates a new shared market data instance wrapped in Arc<RwLock<>>.
+    /// Creates a new shared market data instance.
     fn new_shared_market_data() -> SharedMarketDataRef {
-        Arc::new(RwLock::new(SharedMarketData::new()))
+        SharedMarketDataRef::new_shared()
     }
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/fynd-core/src/graph/mod.rs
+++ b/fynd-core/src/graph/mod.rs
@@ -120,7 +120,7 @@ where
     fn graph(&self) -> &G;
 }
 
-use crate::{derived::DerivedData, feed::market_data::MarketState};
+use crate::{derived::DerivedData, feed::market_data::MarketDataView};
 
 /// Trait for edge weight types that can be computed from a ProtocolSim and DerivedData.
 ///
@@ -169,7 +169,7 @@ pub trait EdgeWeightUpdaterWithDerived {
     /// Returns the number of edges successfully updated.
     fn update_edge_weights_with_derived(
         &mut self,
-        market: &MarketState,
+        market: MarketDataView<'_>,
         derived: &DerivedData,
     ) -> usize;
 }

--- a/fynd-core/src/graph/mod.rs
+++ b/fynd-core/src/graph/mod.rs
@@ -120,7 +120,7 @@ where
     fn graph(&self) -> &G;
 }
 
-use crate::{derived::DerivedData, feed::market_data::SharedMarketData};
+use crate::{derived::DerivedData, feed::market_data::MarketState};
 
 /// Trait for edge weight types that can be computed from a ProtocolSim and DerivedData.
 ///
@@ -169,7 +169,7 @@ pub trait EdgeWeightUpdaterWithDerived {
     /// Returns the number of edges successfully updated.
     fn update_edge_weights_with_derived(
         &mut self,
-        market: &SharedMarketData,
+        market: &MarketState,
         derived: &DerivedData,
     ) -> usize;
 }

--- a/fynd-core/src/graph/petgraph.rs
+++ b/fynd-core/src/graph/petgraph.rs
@@ -20,7 +20,7 @@ use super::GraphManager;
 use crate::{
     feed::{
         events::{EventError, MarketEvent, MarketEventHandler},
-        market_data::MarketState,
+        market_data::MarketDataView,
     },
     graph::GraphError,
     types::ComponentId,
@@ -327,7 +327,7 @@ impl<D: Clone + super::EdgeWeightFromSimAndDerived> PetgraphStableDiGraphManager
     /// The number of edges successfully updated.
     pub fn update_edge_weights_with_derived(
         &mut self,
-        market: &MarketState,
+        market: MarketDataView<'_>,
         derived: &crate::derived::DerivedData,
     ) -> usize {
         let tokens = market.token_registry_ref();
@@ -372,7 +372,7 @@ impl<D: Clone + super::EdgeWeightFromSimAndDerived> super::EdgeWeightUpdaterWith
 {
     fn update_edge_weights_with_derived(
         &mut self,
-        market: &MarketState,
+        market: MarketDataView<'_>,
         derived: &crate::derived::DerivedData,
     ) -> usize {
         self.update_edge_weights_with_derived(market, derived)

--- a/fynd-core/src/graph/petgraph.rs
+++ b/fynd-core/src/graph/petgraph.rs
@@ -20,7 +20,7 @@ use super::GraphManager;
 use crate::{
     feed::{
         events::{EventError, MarketEvent, MarketEventHandler},
-        market_data::SharedMarketData,
+        market_data::MarketState,
     },
     graph::GraphError,
     types::ComponentId,
@@ -327,7 +327,7 @@ impl<D: Clone + super::EdgeWeightFromSimAndDerived> PetgraphStableDiGraphManager
     /// The number of edges successfully updated.
     pub fn update_edge_weights_with_derived(
         &mut self,
-        market: &SharedMarketData,
+        market: &MarketState,
         derived: &crate::derived::DerivedData,
     ) -> usize {
         let tokens = market.token_registry_ref();
@@ -372,7 +372,7 @@ impl<D: Clone + super::EdgeWeightFromSimAndDerived> super::EdgeWeightUpdaterWith
 {
     fn update_edge_weights_with_derived(
         &mut self,
-        market: &SharedMarketData,
+        market: &MarketState,
         derived: &crate::derived::DerivedData,
     ) -> usize {
         self.update_edge_weights_with_derived(market, derived)

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -49,6 +49,7 @@ pub mod worker_pool_router;
 pub use algorithm::{Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgorithm};
 // Required for implementing the Algorithm trait externally
 pub use derived::computation::ComputationRequirements;
+pub use feed::{events::MarketEvent, market_data::StateLabel};
 pub use price_guard::{
     config::PriceGuardConfig,
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
@@ -58,7 +59,7 @@ pub use types::{
     BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, FeeBreakdown, Order, OrderQuote,
     OrderSide, OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions,
     QuoteRequest, QuoteStatus, Route, RouteValidationError, SingleOrderQuote, SolveError,
-    SolveResult, Swap, TaskId, Transaction, UserTransferType,
+    SolveParams, SolveResult, Swap, TaskId, Transaction, UserTransferType,
 };
 pub use worker_pool::{
     pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig},

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -455,7 +455,7 @@ impl BinanceWsWorker {
             .unwrap_or(0);
 
         let new_cache: HashMap<Address, Token> = {
-            let data = self.market_data.read().await;
+            let data = self.market_data.read(None).await;
             let registry = data.token_registry_ref();
             if registry.len() == current_len {
                 return;

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -455,7 +455,7 @@ impl BinanceWsWorker {
             .unwrap_or(0);
 
         let new_cache: HashMap<Address, Token> = {
-            let data = self.market_data.read(None).await;
+            let data = self.market_data.read().await;
             let registry = data.token_registry_ref();
             if registry.len() == current_len {
                 return;

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -1,7 +1,7 @@
 //! Binance WebSocket price provider.
 //!
 //! Connects to the Binance `bookTicker` WebSocket stream, dynamically discovers trading pairs
-//! from [`SharedMarketData`](crate::feed::market_data::SharedMarketData)(crate::feed::market_data::SharedMarketData), and caches real-time
+//! from [`MarketState`](crate::feed::market_data::MarketState)(crate::feed::market_data::MarketState), and caches real-time
 //! bid/ask prices. Price resolution supports direct pairs, reverse pairs, and intermediate
 //! routing through common quote assets (USDT, USDC, ETH, BTC).
 
@@ -23,7 +23,7 @@ use super::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
     utils::{check_staleness, expected_out_from_price},
 };
-use crate::feed::market_data::SharedMarketDataRef;
+use crate::feed::market_data::MarketData;
 
 const DEFAULT_WS_URL: &str = "wss://stream.binance.com:9443/ws";
 const DEFAULT_EXCHANGE_INFO_URL: &str = "https://api.binance.com/api/v3/exchangeInfo";
@@ -96,7 +96,7 @@ type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
 ///
 /// Subscribes to `bookTicker` streams for pairs discovered by cross-referencing
 /// Binance exchange info with tokens in
-/// [`SharedMarketData`](crate::feed::market_data::SharedMarketData). Prices are resolved via direct
+/// [`MarketState`](crate::feed::market_data::MarketState). Prices are resolved via direct
 /// pair (bid), reverse pair (1/ask), or intermediate routing through USDT/USDC/ETH/BTC.
 pub struct BinanceWsProvider {
     price_cache: PriceCache,
@@ -239,7 +239,7 @@ impl Default for BinanceWsProvider {
 }
 
 impl PriceProvider for BinanceWsProvider {
-    fn start(&mut self, market_data: SharedMarketDataRef) -> JoinHandle<()> {
+    fn start(&mut self, market_data: MarketData) -> JoinHandle<()> {
         let worker = BinanceWsWorker {
             price_cache: Arc::clone(&self.price_cache),
             token_cache: Arc::clone(&self.token_cache),
@@ -283,7 +283,7 @@ impl PriceProvider for BinanceWsProvider {
 struct BinanceWsWorker {
     price_cache: PriceCache,
     token_cache: TokenCache,
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     client: Client,
     ws_url: String,
     exchange_info_url: String,
@@ -444,7 +444,7 @@ impl BinanceWsWorker {
             .collect()
     }
 
-    /// Snapshots the token registry from SharedMarketData into the local token cache.
+    /// Snapshots the token registry from MarketState into the local token cache.
     /// Skips the clone when the registry size hasn't changed, since tokens are only
     /// ever added — never removed or replaced.
     async fn refresh_token_cache(&self) {
@@ -477,7 +477,7 @@ impl BinanceWsWorker {
         *cache = new_cache;
     }
 
-    /// Re-reads tokens from SharedMarketData and subscribes to any new Binance
+    /// Re-reads tokens from MarketState and subscribes to any new Binance
     /// pairs that appeared since the last sync.
     async fn discover_new_pairs<S>(&mut self, write: &mut S)
     where
@@ -656,7 +656,7 @@ mod tests {
     use tycho_simulation::evm::tycho_models::Chain;
 
     use super::*;
-    use crate::feed::market_data::SharedMarketData;
+    use crate::feed::market_data::MarketState;
 
     fn make_token(address: Address, symbol: &str, decimals: u32) -> Token {
         Token {
@@ -757,7 +757,7 @@ mod tests {
 
     /// Creates a `BinanceWsWorker` that writes to the given ticker cache.
     fn make_worker(price_cache: &PriceCache) -> BinanceWsWorker {
-        let market_data = crate::feed::market_data::SharedMarketDataRef::new_shared();
+        let market_data = MarketData::new_shared();
         BinanceWsWorker {
             price_cache: Arc::clone(price_cache),
             token_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
@@ -1207,9 +1207,9 @@ mod tests {
         let weth = make_token(weth_address(), "WETH", 18);
         let usdc = make_token(usdc_address(), "USDC", 6);
 
-        let mut market_inner = SharedMarketData::new();
+        let mut market_inner = MarketState::new();
         market_inner.upsert_tokens([weth, usdc]);
-        let market_data = crate::feed::market_data::SharedMarketDataRef::new(std::sync::Arc::new(
+        let market_data = crate::feed::market_data::MarketData::new(std::sync::Arc::new(
             tokio::sync::RwLock::new(market_inner),
         ));
 

--- a/fynd-core/src/price_guard/binance_ws.rs
+++ b/fynd-core/src/price_guard/binance_ws.rs
@@ -653,7 +653,6 @@ struct SymbolInfo {
 mod tests {
     use std::str::FromStr;
 
-    use tokio::sync::RwLock;
     use tycho_simulation::evm::tycho_models::Chain;
 
     use super::*;
@@ -758,7 +757,7 @@ mod tests {
 
     /// Creates a `BinanceWsWorker` that writes to the given ticker cache.
     fn make_worker(price_cache: &PriceCache) -> BinanceWsWorker {
-        let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
+        let market_data = crate::feed::market_data::SharedMarketDataRef::new_shared();
         BinanceWsWorker {
             price_cache: Arc::clone(price_cache),
             token_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
@@ -1208,9 +1207,11 @@ mod tests {
         let weth = make_token(weth_address(), "WETH", 18);
         let usdc = make_token(usdc_address(), "USDC", 6);
 
-        let mut market_data = SharedMarketData::new();
-        market_data.upsert_tokens([weth, usdc]);
-        let market_data = Arc::new(RwLock::new(market_data));
+        let mut market_inner = SharedMarketData::new();
+        market_inner.upsert_tokens([weth, usdc]);
+        let market_data = crate::feed::market_data::SharedMarketDataRef::new(std::sync::Arc::new(
+            tokio::sync::RwLock::new(market_inner),
+        ));
 
         let mut provider = BinanceWsProvider::default();
         let _handle = provider.start(market_data);

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -331,6 +331,7 @@ mod tests {
             "test".to_string(),
             Bytes::from([0xAA; 20].as_slice()),
             Bytes::from([0xBB; 20].as_slice()),
+            "1".to_string(),
         )
         .with_route(Route::new(vec![weth_usdc_swap()]))
     }

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -223,7 +223,7 @@ mod tests {
     use super::{PriceGuard, PriceGuardError};
     use crate::{
         algorithm::test_utils::{component, MockProtocolSim},
-        feed::market_data::SharedMarketDataRef,
+        feed::market_data::MarketData,
         price_guard::{
             config::PriceGuardConfig,
             provider::{ExternalPrice, PriceProvider, PriceProviderError},
@@ -238,7 +238,7 @@ mod tests {
     }
 
     impl PriceProvider for MockProvider {
-        fn start(&mut self, _market_data: SharedMarketDataRef) -> JoinHandle<()> {
+        fn start(&mut self, _market_data: MarketData) -> JoinHandle<()> {
             tokio::spawn(std::future::ready(()))
         }
 
@@ -255,7 +255,7 @@ mod tests {
     struct FailingProvider;
 
     impl PriceProvider for FailingProvider {
-        fn start(&mut self, _market_data: SharedMarketDataRef) -> JoinHandle<()> {
+        fn start(&mut self, _market_data: MarketData) -> JoinHandle<()> {
             tokio::spawn(std::future::ready(()))
         }
 
@@ -272,7 +272,7 @@ mod tests {
     struct PriceNotFoundProvider;
 
     impl PriceProvider for PriceNotFoundProvider {
-        fn start(&mut self, _market_data: SharedMarketDataRef) -> JoinHandle<()> {
+        fn start(&mut self, _market_data: MarketData) -> JoinHandle<()> {
             tokio::spawn(std::future::ready(()))
         }
 

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -211,7 +211,7 @@ impl HyperliquidWorker {
             .unwrap_or(0);
 
         let new_cache: HashMap<Address, Token> = {
-            let data = self.market_data.read().await;
+            let data = self.market_data.read(None).await;
             let registry = data.token_registry_ref();
             if registry.len() == current_len {
                 return;

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -211,7 +211,7 @@ impl HyperliquidWorker {
             .unwrap_or(0);
 
         let new_cache: HashMap<Address, Token> = {
-            let data = self.market_data.read(None).await;
+            let data = self.market_data.read().await;
             let registry = data.token_registry_ref();
             if registry.len() == current_len {
                 return;

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -21,7 +21,7 @@ use super::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
     utils::{check_staleness, expected_out_from_price},
 };
-use crate::feed::market_data::SharedMarketDataRef;
+use crate::feed::market_data::MarketData;
 
 const API_URL: &str = "https://api.hyperliquid.xyz/info";
 const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(3);
@@ -79,7 +79,7 @@ type TokenCache = Arc<RwLock<HashMap<Address, Token>>>;
 ///
 /// All oracle prices are in USD, so pricing any Fynd pair is `oracle_price_in / oracle_price_out`.
 /// The background worker populates both the price cache (from the API) and a token
-/// cache (snapshotted from `SharedMarketData`) so that `get_expected_out` never
+/// cache (snapshotted from `MarketState`) so that `get_expected_out` never
 /// touches the tokio `RwLock`.
 pub struct HyperliquidProvider {
     price_cache: PriceCache,
@@ -122,7 +122,7 @@ impl Default for HyperliquidProvider {
 }
 
 impl PriceProvider for HyperliquidProvider {
-    fn start(&mut self, market_data: SharedMarketDataRef) -> JoinHandle<()> {
+    fn start(&mut self, market_data: MarketData) -> JoinHandle<()> {
         let worker = HyperliquidWorker {
             price_cache: Arc::clone(&self.price_cache),
             token_cache: Arc::clone(&self.token_cache),
@@ -180,7 +180,7 @@ impl PriceProvider for HyperliquidProvider {
 struct HyperliquidWorker {
     price_cache: PriceCache,
     token_cache: TokenCache,
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     client: Client,
     poll_interval: Duration,
     api_url: String,
@@ -200,7 +200,7 @@ impl HyperliquidWorker {
         }
     }
 
-    /// Snapshots the token registry from SharedMarketData into the local token cache.
+    /// Snapshots the token registry from MarketState into the local token cache.
     /// Skips the clone when the registry size hasn't changed, since tokens are only
     /// ever added — never removed or replaced.
     async fn refresh_token_cache(&self) {
@@ -313,7 +313,7 @@ mod tests {
     use tycho_simulation::{evm::tycho_models::Chain, tycho_common::models::token::Token};
 
     use super::*;
-    use crate::feed::market_data::{SharedMarketData, SharedMarketDataRef};
+    use crate::feed::market_data::{MarketData, MarketState};
 
     fn make_token(address: Address, symbol: &str, decimals: u32) -> Token {
         Token {
@@ -499,10 +499,9 @@ mod tests {
         let pepe = make_token(pepe_addr.clone(), "PEPE", 18);
         let usdc = make_token(usdc_address(), "USDC", 6);
 
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         market.upsert_tokens([pepe, usdc]);
-        let market_data =
-            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)));
+        let market_data = MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)));
 
         let mut provider = HyperliquidProvider::default();
         let _handle = provider.start(market_data);
@@ -531,10 +530,9 @@ mod tests {
         let weth = make_token(weth_address(), "WETH", 18);
         let usdc = make_token(usdc_address(), "USDC", 6);
 
-        let mut market = SharedMarketData::new();
+        let mut market = MarketState::new();
         market.upsert_tokens([weth, usdc]);
-        let market_data =
-            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)));
+        let market_data = MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)));
 
         let mut provider = HyperliquidProvider::default();
         let _handle = provider.start(market_data);

--- a/fynd-core/src/price_guard/hyperliquid.rs
+++ b/fynd-core/src/price_guard/hyperliquid.rs
@@ -310,11 +310,10 @@ struct AssetCtx {
 
 #[cfg(test)]
 mod tests {
-    use tokio::sync::RwLock;
     use tycho_simulation::{evm::tycho_models::Chain, tycho_common::models::token::Token};
 
     use super::*;
-    use crate::feed::market_data::SharedMarketData;
+    use crate::feed::market_data::{SharedMarketData, SharedMarketDataRef};
 
     fn make_token(address: Address, symbol: &str, decimals: u32) -> Token {
         Token {
@@ -500,9 +499,10 @@ mod tests {
         let pepe = make_token(pepe_addr.clone(), "PEPE", 18);
         let usdc = make_token(usdc_address(), "USDC", 6);
 
-        let mut market_data = SharedMarketData::new();
-        market_data.upsert_tokens([pepe, usdc]);
-        let market_data = Arc::new(RwLock::new(market_data));
+        let mut market = SharedMarketData::new();
+        market.upsert_tokens([pepe, usdc]);
+        let market_data =
+            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)));
 
         let mut provider = HyperliquidProvider::default();
         let _handle = provider.start(market_data);
@@ -531,9 +531,10 @@ mod tests {
         let weth = make_token(weth_address(), "WETH", 18);
         let usdc = make_token(usdc_address(), "USDC", 6);
 
-        let mut market_data = SharedMarketData::new();
-        market_data.upsert_tokens([weth, usdc]);
-        let market_data = Arc::new(RwLock::new(market_data));
+        let mut market = SharedMarketData::new();
+        market.upsert_tokens([weth, usdc]);
+        let market_data =
+            SharedMarketDataRef::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)));
 
         let mut provider = HyperliquidProvider::default();
         let _handle = provider.start(market_data);

--- a/fynd-core/src/price_guard/provider.rs
+++ b/fynd-core/src/price_guard/provider.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use tokio::task::JoinHandle;
 use tycho_simulation::tycho_common::models::Address;
 
-use crate::feed::market_data::SharedMarketDataRef;
+use crate::feed::market_data::MarketData;
 
 /// Errors that can occur when fetching external prices.
 #[non_exhaustive]
@@ -87,7 +87,7 @@ impl ExternalPrice {
 pub trait PriceProvider: Send + Sync + 'static {
     /// Called once at startup. Spawns a background worker that populates an internal cache and
     /// returns its task handle.
-    fn start(&mut self, market_data: SharedMarketDataRef) -> JoinHandle<()>;
+    fn start(&mut self, market_data: MarketData) -> JoinHandle<()>;
 
     /// Returns the expected output amount for a given input by reading from the internal cache.
     /// Must not block or make network calls.

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -27,11 +27,8 @@ use crate::{
     derived::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef},
     encoding::encoder::Encoder,
     feed::{
-        events::MarketEventHandler,
-        gas::GasPriceFetcher,
-        market_data::{SharedMarketData, SharedMarketDataRef},
-        tycho_feed::TychoFeed,
-        TychoFeedConfig,
+        events::MarketEventHandler, gas::GasPriceFetcher, market_data::SharedMarketDataRef,
+        tycho_feed::TychoFeed, TychoFeedConfig,
     },
     graph::EdgeWeightUpdaterWithDerived,
     price_guard::{
@@ -565,7 +562,7 @@ impl FyndBuilder {
             self = self.add_default_price_providers();
         }
 
-        let market_data = Arc::new(tokio::sync::RwLock::new(SharedMarketData::new()));
+        let market_data = SharedMarketDataRef::new_shared();
 
         let tycho_feed_config = TychoFeedConfig::new(
             self.tycho_url,
@@ -586,9 +583,9 @@ impl FyndBuilder {
             .map_err(|e| SolverBuildError::RpcClient(e.to_string()))?;
 
         let (mut gas_price_fetcher, gas_price_worker_signal_tx) =
-            GasPriceFetcher::new(ethereum_client, Arc::clone(&market_data));
+            GasPriceFetcher::new(ethereum_client, market_data.clone());
 
-        let mut tycho_feed = TychoFeed::new(tycho_feed_config, Arc::clone(&market_data));
+        let mut tycho_feed = TychoFeed::new(tycho_feed_config, market_data.clone());
         tycho_feed = tycho_feed.with_gas_price_worker_signal_tx(gas_price_worker_signal_tx);
 
         let gas_token = native_token(&self.chain).map_err(|_| SolverBuildError::GasToken)?;
@@ -598,7 +595,7 @@ impl FyndBuilder {
         // ComputationManager::new returns a broadcast receiver that we don't need here —
         // workers subscribe via computation_manager.event_sender() below.
         let (computation_manager, _) =
-            ComputationManager::new(computation_config, Arc::clone(&market_data))
+            ComputationManager::new(computation_config, market_data.clone())
                 .map_err(|e| SolverBuildError::ComputationManager(e.to_string()))?;
 
         let derived_data: SharedDerivedDataRef = computation_manager.store();
@@ -643,7 +640,7 @@ impl FyndBuilder {
                         .num_workers(num_workers)
                         .task_queue_capacity(task_queue_capacity)
                         .build(
-                            Arc::clone(&market_data),
+                            market_data.clone(),
                             Arc::clone(&derived_data),
                             pool_event_rx,
                             derived_rx,
@@ -663,7 +660,7 @@ impl FyndBuilder {
                         .task_queue_capacity(custom.task_queue_capacity);
                     let builder = (custom.configure)(builder);
                     builder.build(
-                        Arc::clone(&market_data),
+                        market_data.clone(),
                         Arc::clone(&derived_data),
                         pool_event_rx,
                         derived_rx,
@@ -700,7 +697,7 @@ impl FyndBuilder {
             let mut registry = PriceProviderRegistry::new();
             let mut worker_handles = Vec::new();
             for mut provider in self.price_providers {
-                worker_handles.push(provider.start(Arc::clone(&market_data)));
+                worker_handles.push(provider.start(market_data.clone()));
                 registry = registry.register(provider);
             }
             let price_guard = PriceGuard::new(registry, worker_handles);
@@ -757,7 +754,7 @@ pub struct Solver {
 impl Solver {
     /// Returns a clone of the shared market data reference.
     pub fn market_data(&self) -> SharedMarketDataRef {
-        Arc::clone(&self.market_data)
+        self.market_data.clone()
     }
 
     /// Returns a clone of the shared derived data reference.

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -27,7 +27,7 @@ use crate::{
     derived::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef},
     encoding::encoder::Encoder,
     feed::{
-        events::MarketEventHandler, gas::GasPriceFetcher, market_data::SharedMarketDataRef,
+        events::MarketEventHandler, gas::GasPriceFetcher, market_data::MarketData,
         tycho_feed::TychoFeed, TychoFeedConfig,
     },
     graph::EdgeWeightUpdaterWithDerived,
@@ -562,7 +562,7 @@ impl FyndBuilder {
             self = self.add_default_price_providers();
         }
 
-        let market_data = SharedMarketDataRef::new_shared();
+        let market_data = MarketData::new_shared();
 
         let tycho_feed_config = TychoFeedConfig::new(
             self.tycho_url,
@@ -741,7 +741,7 @@ impl FyndBuilder {
 pub struct Solver {
     router: WorkerPoolRouter,
     worker_pools: Vec<WorkerPool>,
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     derived_data: SharedDerivedDataRef,
     feed_handle: JoinHandle<()>,
     gas_price_handle: JoinHandle<()>,
@@ -753,7 +753,7 @@ pub struct Solver {
 
 impl Solver {
     /// Returns a clone of the shared market data reference.
-    pub fn market_data(&self) -> SharedMarketDataRef {
+    pub fn market_data(&self) -> MarketData {
         self.market_data.clone()
     }
 
@@ -852,7 +852,7 @@ pub struct SolverParts {
     /// One [`WorkerPool`] per configured algorithm pool.
     worker_pools: Vec<WorkerPool>,
     /// Live market snapshot shared across all components.
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     /// Derived on-chain data (spot prices, depths, gas costs) shared across all components.
     derived_data: SharedDerivedDataRef,
     /// Background task running the Tycho market-data feed.
@@ -886,7 +886,7 @@ impl SolverParts {
     }
 
     /// Returns a reference to the shared market data.
-    pub fn market_data(&self) -> &SharedMarketDataRef {
+    pub fn market_data(&self) -> &MarketData {
         &self.market_data
     }
 
@@ -907,7 +907,7 @@ impl SolverParts {
     ) -> (
         WorkerPoolRouter,
         Vec<WorkerPool>,
-        SharedMarketDataRef,
+        MarketData,
         SharedDerivedDataRef,
         JoinHandle<()>,
         JoinHandle<()>,

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -794,7 +794,7 @@ impl Solver {
         loop {
             let market_ready = self
                 .market_data
-                .read()
+                .read(None)
                 .await
                 .last_updated()
                 .is_some();

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -794,7 +794,7 @@ impl Solver {
         loop {
             let market_ready = self
                 .market_data
-                .read(None)
+                .read()
                 .await
                 .last_updated()
                 .is_some();

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -6,7 +6,7 @@ use num_bigint::BigUint;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
-use super::{Order, SingleOrderQuote};
+use super::{quote::SolveParams, Order, SingleOrderQuote};
 
 /// Unique identifier for a solve task.
 pub type TaskId = Uuid;
@@ -20,6 +20,8 @@ pub struct SolveTask {
     id: TaskId,
     /// The order request to process.
     order: Order,
+    /// Solve parameters (overlay label, etc.). Defaults to base state.
+    params: SolveParams,
     /// Channel to send the result back.
     response_tx: oneshot::Sender<SolveResult>,
     /// When this task was created.
@@ -27,9 +29,15 @@ pub struct SolveTask {
 }
 
 impl SolveTask {
-    /// Creates a new solve task.
+    /// Creates a new solve task with default parameters (base Tycho state).
     pub fn new(id: TaskId, order: Order, response_tx: oneshot::Sender<SolveResult>) -> Self {
-        Self { id, order, response_tx, created_at: Instant::now() }
+        Self { id, order, params: SolveParams::default(), response_tx, created_at: Instant::now() }
+    }
+
+    /// Attaches solve parameters to this task.
+    pub fn with_params(mut self, params: SolveParams) -> Self {
+        self.params = params;
+        self
     }
 
     /// Returns the task ID.
@@ -40,6 +48,11 @@ impl SolveTask {
     /// Returns the order to process.
     pub fn order(&self) -> &Order {
         &self.order
+    }
+
+    /// Returns the solve parameters for this task.
+    pub fn params(&self) -> &SolveParams {
+        &self.params
     }
 
     /// Returns how long this task has been waiting.

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -25,6 +25,6 @@ pub use primitives::*;
 pub use quote::{
     BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown, Order, OrderQuote, OrderSide,
     OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteRequest,
-    QuoteStatus, Route, RouteResult, RouteValidationError, SingleOrderQuote, Swap, Transaction,
-    UserTransferType,
+    QuoteStatus, Route, RouteResult, RouteValidationError, SingleOrderQuote, SolveParams, Swap,
+    Transaction, UserTransferType,
 };

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -32,7 +32,7 @@ use tycho_simulation::{
 use uuid::Uuid;
 
 use super::primitives::ComponentId;
-use crate::{price_guard::config::PriceGuardConfig, AlgorithmError};
+use crate::{feed::market_data::StateLabel, price_guard::config::PriceGuardConfig, AlgorithmError};
 
 // ============================================================================
 // REQUEST TYPES
@@ -86,6 +86,10 @@ pub struct QuoteOptions {
     /// Options for encoding the solution into an on-chain transaction.
     /// If `None`, the solution is returned without an encoded transaction.
     encoding_options: Option<EncodingOptions>,
+    /// Solve against this named state overlay. `None` solves against the base Tycho state.
+    /// Skipped during JSON serialization — only meaningful when calling Fynd as a Rust library.
+    #[serde(skip)]
+    state_label: Option<StateLabel>,
 }
 
 impl QuoteOptions {
@@ -113,6 +117,12 @@ impl QuoteOptions {
         self
     }
 
+    /// Targets a named state overlay for this request.
+    pub fn with_state_label(mut self, label: StateLabel) -> Self {
+        self.state_label = Some(label);
+        self
+    }
+
     /// Returns the timeout in milliseconds.
     pub fn timeout_ms(&self) -> Option<u64> {
         self.timeout_ms
@@ -131,6 +141,36 @@ impl QuoteOptions {
     /// Returns the encoding options.
     pub fn encoding_options(&self) -> Option<&EncodingOptions> {
         self.encoding_options.as_ref()
+    }
+
+    /// Returns the overlay label, if one was set.
+    pub fn state_label(&self) -> Option<&StateLabel> {
+        self.state_label.as_ref()
+    }
+}
+
+/// Parameters for a single solve operation.
+///
+/// Constructed from [`QuoteOptions`] and passed through the task pipeline down to the worker.
+/// Kept separate from [`QuoteOptions`] so solve-specific parameters can evolve independently
+/// of the HTTP request surface.
+#[must_use]
+#[derive(Debug, Clone, Default)]
+pub struct SolveParams {
+    /// Solve against this labeled state overlay. `None` uses the base Tycho state.
+    state_label: Option<StateLabel>,
+}
+
+impl SolveParams {
+    /// Targets a named state overlay.
+    pub fn with_state_label(mut self, label: StateLabel) -> Self {
+        self.state_label = Some(label);
+        self
+    }
+
+    /// Returns the overlay label, if one was set.
+    pub fn state_label(&self) -> Option<&StateLabel> {
+        self.state_label.as_ref()
     }
 }
 
@@ -696,6 +736,9 @@ pub struct OrderQuote {
     sender: Bytes,
     /// Address of the receiver.
     receiver: Bytes,
+    /// The state overlay this quote was computed against.
+    /// When no overlay was requested this is the block number of the base state at solve time.
+    solved_against: StateLabel,
 }
 
 impl OrderQuote {
@@ -711,6 +754,7 @@ impl OrderQuote {
         algorithm: String,
         sender: Bytes,
         receiver: Bytes,
+        solved_against: StateLabel,
     ) -> Self {
         Self {
             order_id,
@@ -728,6 +772,7 @@ impl OrderQuote {
             fee_breakdown: None,
             sender,
             receiver,
+            solved_against,
         }
     }
 
@@ -843,6 +888,11 @@ impl OrderQuote {
     /// Returns the receiver address.
     pub fn receiver(&self) -> &Bytes {
         &self.receiver
+    }
+
+    /// Returns the state overlay this quote was computed against.
+    pub fn solved_against(&self) -> &StateLabel {
+        &self.solved_against
     }
 }
 

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -18,7 +18,7 @@ use crate::{
     derived::{events::DerivedDataEvent, SharedDerivedDataRef},
     feed::{
         events::{MarketEvent, MarketEventHandler},
-        market_data::SharedMarketDataRef,
+        market_data::MarketData,
     },
     graph::EdgeWeightUpdaterWithDerived,
     types::internal::SolveTask,
@@ -99,7 +99,7 @@ impl WorkerPool {
     pub fn spawn(
         config: WorkerPoolConfig,
         task_rx: async_channel::Receiver<SolveTask>,
-        market_data: SharedMarketDataRef,
+        market_data: MarketData,
         derived_data: SharedDerivedDataRef,
         event_rx: broadcast::Receiver<MarketEvent>,
         derived_event_rx: broadcast::Receiver<DerivedDataEvent>,
@@ -262,7 +262,7 @@ impl WorkerPoolBuilder {
     /// Returns an error if the algorithm name is not registered.
     pub fn build(
         self,
-        market_data: SharedMarketDataRef,
+        market_data: MarketData,
         derived_data: SharedDerivedDataRef,
         event_rx: broadcast::Receiver<MarketEvent>,
         derived_event_rx: broadcast::Receiver<DerivedDataEvent>,

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -147,7 +147,7 @@ where
 
     for worker_id in 0..params.num_workers {
         let task_rx = params.task_rx.clone();
-        let market_data = Arc::clone(&params.market_data);
+        let market_data = params.market_data.clone();
         let derived_data = Arc::clone(&params.derived_data);
         let event_rx = params.event_rx.resubscribe();
         let derived_event_rx = params.derived_event_rx.resubscribe();
@@ -212,15 +212,13 @@ fn spawn_bellman_ford_workers(params: SpawnWorkersParams) -> Vec<JoinHandle<()>>
 mod tests {
     use std::time::Duration;
 
-    use tokio::sync::RwLock;
-
     use super::*;
-    use crate::{derived::DerivedData, feed::market_data::SharedMarketData};
+    use crate::{derived::DerivedData, feed::market_data::SharedMarketDataRef};
 
     fn make_params(algorithm: &str, num_workers: usize) -> SpawnWorkersParams {
         let (_task_tx, task_rx) = async_channel::bounded(10);
-        let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
-        let derived_data = Arc::new(RwLock::new(DerivedData::new()));
+        let market_data = SharedMarketDataRef::new_shared();
+        let derived_data = Arc::new(tokio::sync::RwLock::new(DerivedData::new()));
         let (_event_tx, event_rx) = broadcast::channel(10);
         let (_derived_event_tx, derived_event_rx) = broadcast::channel(10);
         let (shutdown_tx, _) = broadcast::channel(1);
@@ -256,8 +254,8 @@ mod tests {
     fn test_registry_spawns_correct_number_of_workers() {
         let (shutdown_tx, _) = broadcast::channel(1);
         let (_task_tx, task_rx) = async_channel::bounded(10);
-        let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
-        let derived_data = Arc::new(RwLock::new(DerivedData::new()));
+        let market_data = SharedMarketDataRef::new_shared();
+        let derived_data = Arc::new(tokio::sync::RwLock::new(DerivedData::new()));
         let (event_tx, event_rx) = broadcast::channel(10);
         let (_derived_event_tx, derived_event_rx) = broadcast::channel(10);
 
@@ -295,8 +293,8 @@ mod tests {
         // The Custom spawner bypasses the registry and uses the factory directly.
         let (shutdown_tx, _) = broadcast::channel(1);
         let (_task_tx, task_rx) = async_channel::bounded(10);
-        let market_data = Arc::new(RwLock::new(SharedMarketData::new()));
-        let derived_data = Arc::new(RwLock::new(DerivedData::new()));
+        let market_data = SharedMarketDataRef::new_shared();
+        let derived_data = Arc::new(tokio::sync::RwLock::new(DerivedData::new()));
         let (event_tx, _) = broadcast::channel::<MarketEvent>(10);
         let (derived_event_tx, _) = broadcast::channel(10);
 
@@ -306,7 +304,7 @@ mod tests {
                 num_workers: 1,
                 algorithm_config: AlgorithmConfig::default(),
                 task_rx: task_rx.clone(),
-                market_data: Arc::clone(&market_data),
+                market_data: market_data.clone(),
                 derived_data: Arc::clone(&derived_data),
                 event_rx: event_tx.subscribe(),
                 derived_event_rx: derived_event_tx.subscribe(),

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -22,7 +22,7 @@ use tracing::info;
 use crate::{
     algorithm::{AlgorithmConfig, BellmanFordAlgorithm, MostLiquidAlgorithm},
     derived::{events::DerivedDataEvent, SharedDerivedDataRef},
-    feed::{events::MarketEvent, market_data::SharedMarketDataRef},
+    feed::{events::MarketEvent, market_data::MarketData},
     types::internal::SolveTask,
     worker_pool::worker::SolverWorker,
 };
@@ -44,7 +44,7 @@ pub(crate) struct SpawnWorkersParams {
     /// Receiver for solve tasks.
     pub task_rx: async_channel::Receiver<SolveTask>,
     /// Shared market data reference.
-    pub market_data: SharedMarketDataRef,
+    pub market_data: MarketData,
     /// Shared derived data reference (pool depths, token prices).
     pub derived_data: SharedDerivedDataRef,
     /// Broadcast receiver for market events.
@@ -213,11 +213,11 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::{derived::DerivedData, feed::market_data::SharedMarketDataRef};
+    use crate::{derived::DerivedData, feed::market_data::MarketData};
 
     fn make_params(algorithm: &str, num_workers: usize) -> SpawnWorkersParams {
         let (_task_tx, task_rx) = async_channel::bounded(10);
-        let market_data = SharedMarketDataRef::new_shared();
+        let market_data = MarketData::new_shared();
         let derived_data = Arc::new(tokio::sync::RwLock::new(DerivedData::new()));
         let (_event_tx, event_rx) = broadcast::channel(10);
         let (_derived_event_tx, derived_event_rx) = broadcast::channel(10);
@@ -254,7 +254,7 @@ mod tests {
     fn test_registry_spawns_correct_number_of_workers() {
         let (shutdown_tx, _) = broadcast::channel(1);
         let (_task_tx, task_rx) = async_channel::bounded(10);
-        let market_data = SharedMarketDataRef::new_shared();
+        let market_data = MarketData::new_shared();
         let derived_data = Arc::new(tokio::sync::RwLock::new(DerivedData::new()));
         let (event_tx, event_rx) = broadcast::channel(10);
         let (_derived_event_tx, derived_event_rx) = broadcast::channel(10);
@@ -293,7 +293,7 @@ mod tests {
         // The Custom spawner bypasses the registry and uses the factory directly.
         let (shutdown_tx, _) = broadcast::channel(1);
         let (_task_tx, task_rx) = async_channel::bounded(10);
-        let market_data = SharedMarketDataRef::new_shared();
+        let market_data = MarketData::new_shared();
         let derived_data = Arc::new(tokio::sync::RwLock::new(DerivedData::new()));
         let (event_tx, _) = broadcast::channel::<MarketEvent>(10);
         let (derived_event_tx, _) = broadcast::channel(10);

--- a/fynd-core/src/worker_pool/task_queue.rs
+++ b/fynd-core/src/worker_pool/task_queue.rs
@@ -7,7 +7,7 @@
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
-use crate::{types::internal::SolveTask, Order, SingleOrderQuote, SolveError};
+use crate::{types::internal::SolveTask, Order, SingleOrderQuote, SolveError, SolveParams};
 
 /// Configuration for the task queue.
 #[derive(Debug, Clone)]
@@ -34,7 +34,11 @@ impl TaskQueueHandle {
     /// Enqueues a solve request and returns a future that resolves to the result.
     ///
     /// Returns an error if the queue is full.
-    pub async fn enqueue(&self, order: Order) -> Result<SingleOrderQuote, SolveError> {
+    pub async fn enqueue(
+        &self,
+        order: Order,
+        params: SolveParams,
+    ) -> Result<SingleOrderQuote, SolveError> {
         // Create response channel
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -42,7 +46,7 @@ impl TaskQueueHandle {
         let task_id = Uuid::new_v4();
 
         // Create task
-        let task = SolveTask::new(task_id, order, response_tx);
+        let task = SolveTask::new(task_id, order, response_tx).with_params(params);
 
         // Try to send
         self.sender
@@ -122,7 +126,9 @@ mod tests {
     use tycho_simulation::tycho_core::{models::Address, Bytes};
 
     use super::*;
-    use crate::{BlockInfo, Order, OrderQuote, OrderSide, QuoteStatus, SingleOrderQuote};
+    use crate::{
+        BlockInfo, Order, OrderQuote, OrderSide, QuoteStatus, SingleOrderQuote, SolveParams,
+    };
 
     // -------------------------------------------------------------------------
     // Test Helpers
@@ -156,6 +162,7 @@ mod tests {
                 "test".to_string(),
                 Bytes::from(make_address(0xAA).as_ref()),
                 Bytes::from(make_address(0xAA).as_ref()),
+                "1".to_string(),
             ),
             5,
         )
@@ -246,7 +253,9 @@ mod tests {
         });
 
         // Enqueue an order
-        let result = handle.enqueue(make_order()).await;
+        let result = handle
+            .enqueue(make_order(), SolveParams::default())
+            .await;
 
         worker
             .await
@@ -269,7 +278,9 @@ mod tests {
             task.respond(Err(SolveError::NoRouteFound { order_id: "test".to_string() }));
         });
 
-        let result = handle.enqueue(make_order()).await;
+        let result = handle
+            .enqueue(make_order(), SolveParams::default())
+            .await;
 
         worker
             .await
@@ -292,7 +303,9 @@ mod tests {
             drop(task); // Drop without responding
         });
 
-        let result = handle.enqueue(make_order()).await;
+        let result = handle
+            .enqueue(make_order(), SolveParams::default())
+            .await;
 
         worker
             .await
@@ -309,7 +322,9 @@ mod tests {
         // Drop receiver to close channel
         drop(receiver);
 
-        let result = handle.enqueue(make_order()).await;
+        let result = handle
+            .enqueue(make_order(), SolveParams::default())
+            .await;
         assert!(matches!(result, Err(SolveError::QueueFull)));
     }
 
@@ -425,8 +440,10 @@ mod tests {
         });
 
         // Enqueue from both handles concurrently
-        let (result1, result2) =
-            tokio::join!(handle1.enqueue(make_order()), handle2.enqueue(make_order()),);
+        let (result1, result2) = tokio::join!(
+            handle1.enqueue(make_order(), SolveParams::default()),
+            handle2.enqueue(make_order(), SolveParams::default()),
+        );
 
         worker
             .await
@@ -456,8 +473,12 @@ mod tests {
         });
 
         // Enqueue two orders
-        let _ = handle.enqueue(make_order()).await;
-        let _ = handle.enqueue(make_order()).await;
+        let _ = handle
+            .enqueue(make_order(), SolveParams::default())
+            .await;
+        let _ = handle
+            .enqueue(make_order(), SolveParams::default())
+            .await;
 
         let (id1, id2): (Uuid, Uuid) = collector
             .await

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -101,7 +101,7 @@ where
     pub async fn initialize_graph(&mut self) {
         let topology = {
             // read lock on market data
-            let market = self.market_data.read().await;
+            let market = self.market_data.read(None).await;
             market.component_topology().clone() // clone to avoid holding the lock
         };
 
@@ -168,9 +168,14 @@ where
         // Get block info and resolve the effective state label.
         // TODO: maybe the algorithm should return the block info with the route? The block might
         // update while solving and the route returned might be for the newer block.
-        let (block_info, market_ref, solved_against) = {
-            let market = self.market_data.read().await;
-            let last_block = market
+        let (block_info, solved_against) = {
+            // Read briefly to capture block info; drop the lock before solving so it is not held
+            // across the algorithm's own read call.
+            let view = self
+                .market_data
+                .read(params.state_label())
+                .await;
+            let last_block = view
                 .last_updated()
                 .ok_or(SolveError::NotReady("No block info".to_string()))?;
             let block_info = BlockInfo::new(
@@ -178,23 +183,24 @@ where
                 last_block.hash().to_string(),
                 last_block.timestamp(),
             );
-            // When no label was requested, record the current block number so callers
-            // always know which state the quote was computed against.
-            let label = params
+            // When no overlay was requested, record the block number so callers always know which
+            // state the quote was computed against.
+            let solved_against = view
                 .state_label()
                 .cloned()
                 .unwrap_or_else(|| last_block.number().to_string());
-            drop(market);
-            let market_ref = match params.state_label().cloned() {
-                Some(overlay) => self.market_data.with_label(overlay),
-                None => self.market_data.clone(),
-            };
-            (block_info, market_ref, label)
+            (block_info, solved_against)
         };
 
         let result = self
             .algorithm
-            .find_best_route(graph, market_ref, Some(self.derived_data.clone()), order)
+            .find_best_route(
+                graph,
+                self.market_data.clone(),
+                params.state_label().cloned(),
+                Some(self.derived_data.clone()),
+                order,
+            )
             .await;
 
         let order_quote = match result {
@@ -429,7 +435,7 @@ where
                             // Update edge weights when a relevant computation completes.
                             if let DerivedDataEvent::ComputationComplete { computation_id, block, .. } = &event {
                                 if self.requirements.is_required(computation_id) {
-                                    let market = self.market_data.read().await;
+                                    let market = self.market_data.read(None).await;
                                     let derived = self.derived_data.read().await;
                                     let updated = self.graph_manager.update_edge_weights_with_derived(market.base_market_state(), &derived);
                                     debug!(
@@ -454,7 +460,7 @@ where
                                 skipped
                             );
                             // Recover by updating with whatever derived data is available.
-                            let market = self.market_data.read().await;
+                            let market = self.market_data.read(None).await;
                             let derived = self.derived_data.read().await;
                             let updated = self.graph_manager.update_edge_weights_with_derived(market.base_market_state(), &derived);
                             debug!(
@@ -562,6 +568,7 @@ mod tests {
             &self,
             _graph: &Self::GraphType,
             _market: MarketData,
+            _label: Option<crate::feed::market_data::StateLabel>,
             _derived: Option<SharedDerivedDataRef>,
             _order: &Order,
         ) -> Result<crate::types::RouteResult, crate::AlgorithmError> {

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     feed::{
         events::{MarketEvent, MarketEventHandler},
-        market_data::SharedMarketDataRef,
+        market_data::MarketData,
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
     types::internal::SolveTask,
@@ -43,7 +43,7 @@ where
     /// Graph manager that maintains the graph.
     graph_manager: A::GraphManager,
     /// Reference to shared market data.
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     /// Reference to shared derived data (pool depths, token prices).
     derived_data: SharedDerivedDataRef,
     /// Algorithm's computation requirements (which derived data to react to).
@@ -75,7 +75,7 @@ where
     /// * `algorithm` - The algorithm to use for route finding
     /// * `worker_id` - Identifier for this worker (for logging)
     pub fn new(
-        market_data: SharedMarketDataRef,
+        market_data: MarketData,
         derived_data: SharedDerivedDataRef,
         algorithm: A,
         worker_id: usize,
@@ -94,10 +94,10 @@ where
         }
     }
 
-    /// Initializes the graph from SharedMarketData.
+    /// Initializes the graph from MarketState.
     ///
     /// Call this on startup or to recreate the graph from the latest market topology.
-    /// Gets the market topology from SharedMarketData and uses it to build the graph.
+    /// Gets the market topology from MarketState and uses it to build the graph.
     pub async fn initialize_graph(&mut self) {
         let topology = {
             // read lock on market data
@@ -431,7 +431,7 @@ where
                                 if self.requirements.is_required(computation_id) {
                                     let market = self.market_data.read().await;
                                     let derived = self.derived_data.read().await;
-                                    let updated = self.graph_manager.update_edge_weights_with_derived(&market, &derived);
+                                    let updated = self.graph_manager.update_edge_weights_with_derived(market.base_market_state(), &derived);
                                     debug!(
                                         self.worker_id,
                                         computation_id,
@@ -456,7 +456,7 @@ where
                             // Recover by updating with whatever derived data is available.
                             let market = self.market_data.read().await;
                             let derived = self.derived_data.read().await;
-                            let updated = self.graph_manager.update_edge_weights_with_derived(&market, &derived);
+                            let updated = self.graph_manager.update_edge_weights_with_derived(market.base_market_state(), &derived);
                             debug!(
                                 self.worker_id,
                                 updated,
@@ -561,7 +561,7 @@ mod tests {
         async fn find_best_route(
             &self,
             _graph: &Self::GraphType,
-            _market: SharedMarketDataRef,
+            _market: MarketData,
             _derived: Option<SharedDerivedDataRef>,
             _order: &Order,
         ) -> Result<crate::types::RouteResult, crate::AlgorithmError> {

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -101,7 +101,7 @@ where
     pub async fn initialize_graph(&mut self) {
         let topology = {
             // read lock on market data
-            let market = self.market_data.read(None).await;
+            let market = self.market_data.read().await;
             market.component_topology().clone() // clone to avoid holding the lock
         };
 
@@ -173,8 +173,9 @@ where
             // across the algorithm's own read call.
             let view = self
                 .market_data
-                .read(params.state_label())
-                .await;
+                .read_opt(params.state_label())
+                .await
+                .map_err(|e| SolveError::NotReady(e.to_string()))?;
             let last_block = view
                 .last_updated()
                 .ok_or(SolveError::NotReady("No block info".to_string()))?;
@@ -435,7 +436,7 @@ where
                             // Update edge weights when a relevant computation completes.
                             if let DerivedDataEvent::ComputationComplete { computation_id, block, .. } = &event {
                                 if self.requirements.is_required(computation_id) {
-                                    let market = self.market_data.read(None).await;
+                                    let market = self.market_data.read().await;
                                     let derived = self.derived_data.read().await;
                                     let updated = self.graph_manager.update_edge_weights_with_derived(market, &derived);
                                     debug!(
@@ -460,7 +461,7 @@ where
                                 skipped
                             );
                             // Recover by updating with whatever derived data is available.
-                            let market = self.market_data.read(None).await;
+                            let market = self.market_data.read().await;
                             let derived = self.derived_data.read().await;
                             let updated = self.graph_manager.update_edge_weights_with_derived(market, &derived);
                             debug!(

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -29,7 +29,7 @@ use crate::{
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
     types::internal::SolveTask,
-    BlockInfo, Order, OrderQuote, QuoteStatus, SingleOrderQuote, SolveError,
+    BlockInfo, Order, OrderQuote, QuoteStatus, SingleOrderQuote, SolveError, SolveParams,
 };
 
 /// A solver worker instance that maintains a market graph and processes solve requests.
@@ -127,8 +127,12 @@ where
         }
     }
 
-    /// Returns a quote for an order.
-    pub async fn quote(&mut self, order: &Order) -> Result<SingleOrderQuote, SolveError> {
+    /// Returns a quote for an order, optionally solved against a named state overlay.
+    pub async fn quote(
+        &mut self,
+        order: &Order,
+        params: SolveParams,
+    ) -> Result<SingleOrderQuote, SolveError> {
         let start_time = Instant::now();
 
         // Log order details once at entry
@@ -161,29 +165,36 @@ where
         // Get the graph from the graph manager
         let graph = self.graph_manager.graph();
 
-        // Get block info
+        // Get block info and resolve the effective state label.
         // TODO: maybe the algorithm should return the block info with the route? The block might
         // update while solving and the route returned might be for the newer block.
-        let block_info = {
+        let (block_info, market_ref, solved_against) = {
             let market = self.market_data.read().await;
             let last_block = market
                 .last_updated()
                 .ok_or(SolveError::NotReady("No block info".to_string()))?;
-            BlockInfo::new(
+            let block_info = BlockInfo::new(
                 last_block.number(),
                 last_block.hash().to_string(),
                 last_block.timestamp(),
-            )
+            );
+            // When no label was requested, record the current block number so callers
+            // always know which state the quote was computed against.
+            let label = params
+                .state_label()
+                .cloned()
+                .unwrap_or_else(|| last_block.number().to_string());
+            drop(market);
+            let market_ref = match params.state_label().cloned() {
+                Some(overlay) => self.market_data.with_label(overlay),
+                None => self.market_data.clone(),
+            };
+            (block_info, market_ref, label)
         };
 
         let result = self
             .algorithm
-            .find_best_route(
-                graph,
-                self.market_data.clone(),
-                Some(self.derived_data.clone()),
-                order,
-            )
+            .find_best_route(graph, market_ref, Some(self.derived_data.clone()), order)
             .await;
 
         let order_quote = match result {
@@ -239,6 +250,7 @@ where
                     self.algorithm.name().to_string(),
                     Bytes::from(order.sender().as_ref()),
                     Bytes::from(order.effective_receiver().as_ref()),
+                    solved_against,
                 )
                 .with_route(route)
                 .with_gas_price(gas_price)
@@ -476,8 +488,9 @@ where
 
                             // Process the task
                             let result = {
+                                let params = task.params().clone();
                                 let order = task.order();
-                                self.quote(order).await
+                                self.quote(order, params).await
                             };
 
                             if let Err(ref e) = result {

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -171,11 +171,14 @@ where
         let (block_info, solved_against) = {
             // Read briefly to capture block info; drop the lock before solving so it is not held
             // across the algorithm's own read call.
-            let view = self
-                .market_data
-                .read_opt(params.state_label())
-                .await
-                .map_err(|e| SolveError::NotReady(e.to_string()))?;
+            let view = match params.state_label() {
+                Some(l) => self
+                    .market_data
+                    .read_labeled(l)
+                    .await
+                    .map_err(|e| SolveError::NotReady(e.to_string()))?,
+                None => self.market_data.read().await,
+            };
             let last_block = view
                 .last_updated()
                 .ok_or(SolveError::NotReady("No block info".to_string()))?;

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -437,7 +437,7 @@ where
                                 if self.requirements.is_required(computation_id) {
                                     let market = self.market_data.read(None).await;
                                     let derived = self.derived_data.read().await;
-                                    let updated = self.graph_manager.update_edge_weights_with_derived(market.base_market_state(), &derived);
+                                    let updated = self.graph_manager.update_edge_weights_with_derived(market, &derived);
                                     debug!(
                                         self.worker_id,
                                         computation_id,
@@ -462,7 +462,7 @@ where
                             // Recover by updating with whatever derived data is available.
                             let market = self.market_data.read(None).await;
                             let derived = self.derived_data.read().await;
-                            let updated = self.graph_manager.update_edge_weights_with_derived(market.base_market_state(), &derived);
+                            let updated = self.graph_manager.update_edge_weights_with_derived(market, &derived);
                             debug!(
                                 self.worker_id,
                                 updated,

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -33,7 +33,7 @@ use tycho_simulation::tycho_common::Bytes;
 use crate::{
     encoding::encoder::Encoder, price_guard::guard::PriceGuard,
     worker_pool::task_queue::TaskQueueHandle, BlockInfo, Order, OrderQuote, Quote, QuoteOptions,
-    QuoteRequest, QuoteStatus, SolveError,
+    QuoteRequest, QuoteStatus, SolveError, SolveParams,
 };
 
 /// Handle to a solver pool for dispatching orders.
@@ -131,11 +131,16 @@ impl WorkerPoolRouter {
             return Err(SolveError::Internal("no solver pools configured".to_string()));
         }
 
+        let params = match request.options().state_label().cloned() {
+            Some(label) => SolveParams::default().with_state_label(label),
+            None => SolveParams::default(),
+        };
+
         // Process each order independently in parallel
         let order_futures: Vec<_> = request
             .orders()
             .iter()
-            .map(|order| self.solve_order(order.clone(), deadline, min_responses))
+            .map(|order| self.solve_order(order.clone(), params.clone(), deadline, min_responses))
             .collect();
 
         let order_responses = futures::future::join_all(order_futures).await;
@@ -195,6 +200,7 @@ impl WorkerPoolRouter {
     async fn solve_order(
         &self,
         order: Order,
+        params: SolveParams,
         deadline: Instant,
         min_responses: usize,
     ) -> OrderResponses {
@@ -211,9 +217,12 @@ impl WorkerPoolRouter {
                 let order_clone = order.clone();
                 let pool_name = pool.name().to_string();
                 let queue = pool.queue().clone();
+                let task_params = params.clone();
 
                 async move {
-                    let result = queue.enqueue(order_clone).await;
+                    let result = queue
+                        .enqueue(order_clone, task_params)
+                        .await;
                     (pool_name, result)
                 }
             })
@@ -379,6 +388,7 @@ impl WorkerPoolRouter {
                 String::new(),
                 any_q.sender().clone(),
                 any_q.receiver().clone(),
+                any_q.solved_against().clone(),
             )
         } else {
             // No responses at all - determine status from failure types
@@ -412,6 +422,12 @@ impl WorkerPoolRouter {
             };
             counter!("worker_router_orders_total", "status" => status_label).increment(1);
 
+            // No worker responded — use the requested label if set, otherwise "0"
+            // (we have no block context here since no worker completed).
+            let label = options
+                .state_label()
+                .cloned()
+                .unwrap_or_else(|| "0".to_string());
             OrderQuote::new(
                 responses.order_id.clone(),
                 status,
@@ -423,6 +439,7 @@ impl WorkerPoolRouter {
                 String::new(),
                 Bytes::default(),
                 Bytes::default(),
+                label,
             )
         };
         vec![fallback]
@@ -515,6 +532,7 @@ mod tests {
             "test".to_string(),
             Bytes::from(make_address(0xAA).as_ref()),
             Bytes::from(make_address(0xAA).as_ref()),
+            "1".to_string(),
         )
         .with_route(Route::new(vec![swap]));
         SingleOrderQuote::new(quote, 5)
@@ -712,6 +730,7 @@ mod tests {
                     "test".to_string(),
                     Bytes::from(make_address(0xAA).as_ref()),
                     Bytes::from(make_address(0xAA).as_ref()),
+                    "1".to_string(),
                 ),
             )],
             failed_solvers: vec![],
@@ -827,6 +846,7 @@ mod tests {
                         "test".to_string(),
                         Bytes::from(make_address(0xAA).as_ref()),
                         Bytes::from(make_address(0xAA).as_ref()),
+                        "1".to_string(),
                     ),
                 ),
                 (
@@ -842,6 +862,7 @@ mod tests {
                         "test".to_string(),
                         Bytes::from(make_address(0xAA).as_ref()),
                         Bytes::from(make_address(0xAA).as_ref()),
+                        "1".to_string(),
                     ),
                 ),
             ],

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -305,7 +305,7 @@ mod tests {
     use fynd_core::{
         derived::SharedDerivedDataRef,
         encoding::encoder::Encoder,
-        feed::market_data::{SharedMarketData, SharedMarketDataRef},
+        feed::market_data::SharedMarketDataRef,
         worker_pool_router::{config::WorkerPoolRouterConfig, WorkerPoolRouter},
     };
     use serde_json::Value;
@@ -341,8 +341,7 @@ mod tests {
     }
 
     fn make_test_state() -> AppState {
-        let market_data: SharedMarketDataRef =
-            Arc::new(tokio::sync::RwLock::new(SharedMarketData::new()));
+        let market_data: SharedMarketDataRef = SharedMarketDataRef::new_shared();
         let derived_data: SharedDerivedDataRef =
             Arc::new(tokio::sync::RwLock::new(Default::default()));
 
@@ -352,8 +351,7 @@ mod tests {
         let encoder = Encoder::new(Chain::Ethereum, registry).expect("encoder should build");
 
         let router = WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), encoder);
-        let health_tracker =
-            HealthTracker::new(Arc::clone(&market_data), Arc::clone(&derived_data));
+        let health_tracker = HealthTracker::new(market_data.clone(), Arc::clone(&derived_data));
 
         let router_address =
             Bytes::from(hex::decode("fD0b31d2E955fA55e3fa641Fe90e08b677188d35").unwrap());

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -305,7 +305,7 @@ mod tests {
     use fynd_core::{
         derived::SharedDerivedDataRef,
         encoding::encoder::Encoder,
-        feed::market_data::SharedMarketDataRef,
+        feed::market_data::MarketData,
         worker_pool_router::{config::WorkerPoolRouterConfig, WorkerPoolRouter},
     };
     use serde_json::Value;
@@ -341,7 +341,7 @@ mod tests {
     }
 
     fn make_test_state() -> AppState {
-        let market_data: SharedMarketDataRef = SharedMarketDataRef::new_shared();
+        let market_data: MarketData = MarketData::new_shared();
         let derived_data: SharedDerivedDataRef =
             Arc::new(tokio::sync::RwLock::new(Default::default()));
 

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -19,7 +19,7 @@ use actix_web::{web, HttpResponse, ResponseError};
 pub use dto::HealthStatus;
 pub use error::ApiError;
 use fynd_core::{
-    derived::SharedDerivedDataRef, feed::market_data::SharedMarketDataRef,
+    derived::SharedDerivedDataRef, feed::market_data::MarketData,
     worker_pool_router::WorkerPoolRouter,
 };
 use handlers::configure_routes;
@@ -70,11 +70,11 @@ pub struct ExperimentalApiDoc;
 
 /// Simple tracker for service health metrics.
 ///
-/// Reads the last update timestamp from SharedMarketData to determine how fresh the market data is,
+/// Reads the last update timestamp from MarketState to determine how fresh the market data is,
 /// and checks derived data overall readiness.
 #[derive(Clone)]
 pub(crate) struct HealthTracker {
-    market_data: SharedMarketDataRef,
+    market_data: MarketData,
     derived_data: SharedDerivedDataRef,
     gas_price_stale_threshold: Option<Duration>,
     created_at: Instant,
@@ -82,10 +82,7 @@ pub(crate) struct HealthTracker {
 
 impl HealthTracker {
     /// Creates a new health tracker.
-    pub(crate) fn new(
-        market_data: SharedMarketDataRef,
-        derived_data: SharedDerivedDataRef,
-    ) -> Self {
+    pub(crate) fn new(market_data: MarketData, derived_data: SharedDerivedDataRef) -> Self {
         Self {
             market_data,
             derived_data,

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -99,7 +99,7 @@ impl HealthTracker {
 
     /// Returns milliseconds since the last market data update.
     pub(crate) async fn age_ms(&self) -> u64 {
-        let data = self.market_data.read(None).await;
+        let data = self.market_data.read().await;
         match data.last_updated() {
             Some(block_info) => {
                 let now = SystemTime::now()
@@ -116,7 +116,7 @@ impl HealthTracker {
 
     /// Returns milliseconds since the last gas price update, if available.
     pub(crate) async fn gas_price_age_ms(&self) -> Option<u64> {
-        let data = self.market_data.read(None).await;
+        let data = self.market_data.read().await;
         let gas_price = data.gas_price()?;
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -99,7 +99,7 @@ impl HealthTracker {
 
     /// Returns milliseconds since the last market data update.
     pub(crate) async fn age_ms(&self) -> u64 {
-        let data = self.market_data.read().await;
+        let data = self.market_data.read(None).await;
         match data.last_updated() {
             Some(block_info) => {
                 let now = SystemTime::now()
@@ -116,7 +116,7 @@ impl HealthTracker {
 
     /// Returns milliseconds since the last gas price update, if available.
     pub(crate) async fn gas_price_age_ms(&self) -> Option<u64> {
-        let data = self.market_data.read().await;
+        let data = self.market_data.read(None).await;
         let gas_price = data.gas_price()?;
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -220,7 +220,7 @@ impl FyndRPCBuilder {
         };
 
         let health_tracker =
-            HealthTracker::new(Arc::clone(parts.market_data()), Arc::clone(parts.derived_data()))
+            HealthTracker::new(parts.market_data().clone(), Arc::clone(parts.derived_data()))
                 .with_gas_price_stale_threshold(self.gas_price_stale_threshold);
 
         #[cfg(feature = "experimental")]

--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -103,7 +103,7 @@ pub async fn run(args: DeriveConnectorTokensArgs) -> Result<()> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(args.wait_secs);
     loop {
         if market_data
-            .read()
+            .read(None)
             .await
             .last_updated()
             .is_some()
@@ -146,7 +146,7 @@ struct TokenScore {
 }
 
 async fn score_tokens(market_data: &MarketData) -> HashMap<Address, TokenScore> {
-    let guard = market_data.read().await;
+    let guard = market_data.read(None).await;
     let topology = guard.component_topology();
 
     // Count pool appearances per token.

--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -103,7 +103,7 @@ pub async fn run(args: DeriveConnectorTokensArgs) -> Result<()> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(args.wait_secs);
     loop {
         if market_data
-            .read(None)
+            .read()
             .await
             .last_updated()
             .is_some()
@@ -146,7 +146,7 @@ struct TokenScore {
 }
 
 async fn score_tokens(market_data: &MarketData) -> HashMap<Address, TokenScore> {
-    let guard = market_data.read(None).await;
+    let guard = market_data.read().await;
     let topology = guard.component_topology();
 
     // Count pool appearances per token.

--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, time::Duration};
 use anyhow::{Context, Result};
 use clap::Args;
 use fynd_core::{
-    feed::market_data::SharedMarketDataRef,
+    feed::market_data::MarketData,
     solver::{FyndBuilder, SolverBuildError},
 };
 use fynd_rpc::builder::parse_chain;
@@ -145,7 +145,7 @@ struct TokenScore {
     pool_count: usize,
 }
 
-async fn score_tokens(market_data: &SharedMarketDataRef) -> HashMap<Address, TokenScore> {
+async fn score_tokens(market_data: &MarketData) -> HashMap<Address, TokenScore> {
     let guard = market_data.read().await;
     let topology = guard.component_topology();
 


### PR DESCRIPTION
## Summary

- Solve requests can now target a named state overlay via `QuoteOptions::with_state_label`. Pools absent from the overlay fall through to the base Tycho state — two O(1) lookups, no allocation.
- Overlays are stored on `SharedMarketDataRef` under a dedicated `overlays` lock, separate from the base-state `data` lock. Overlay inserts and solver reads are fully concurrent.
- `MarketDataReadGuard` pre-fetches the overlay snapshot under a brief overlay read lock, releases it, then `get_simulation_state` checks overlay first — algorithm call sites are unchanged.
- Overlays carry `valid_until: u64`. `apply_block_update` atomically evicts stale overlays then applies the block, making the correct ordering structural.
- `Solver::subscribe_market_events` lets external state managers (mempool, flashblock feeds) react to block transitions without any logic living in `fynd-core`.
- `SolveParams` flows through the full task pipeline (`QuoteOptions` → router → `TaskQueueHandle::enqueue` → `SolveTask` → `SolverWorker::quote`), keeping the public request surface and internal solve parameters distinct. `OrderQuote::solved_against` records the state actually used, not the label requested.

Replaces #199. The initial design (also in #199) stored overlays inside `SharedMarketData` under the same `RwLock` as pool state, so every overlay insert competed with solver reads of the base state. After reviewing that design we separated the two locks: base state and overlay registry are independent `Arc<RwLock<_>>` fields on `SharedMarketDataRef`, so inserts never block solvers.