### PR TITLE
feat(gas-estimation): Use estimate_gas_usage to refine gas estimations

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,9 +155,10 @@ Orchestrates quote requests across multiple worker pools:
 
 1. Fans out each order to all pools in parallel
 2. Manages per-request timeouts with optional early return
-3. Selects the best solution by `amount_out_net_gas`
-4. Optionally encodes winning solutions into on-chain transactions (when `EncodingOptions` are provided)
-5. Reports failures with error types and metrics
+3. Refines gas estimates using `estimate_gas_usage` (tycho-execution) before cross-pool ranking — algorithms use a fast naive estimate internally; this step applies a more accurate one that accounts for token transfers and protocol overhead
+4. Selects the best solution by refined `amount_out_net_gas`
+5. Optionally encodes winning solutions into on-chain transactions (when `EncodingOptions` are provided)
+6. Reports failures with error types and metrics
 
 ***
 
@@ -200,8 +201,8 @@ Pluggable interface for route-finding algorithms:
 
 **Built-in algorithms:**
 
-* `MostLiquidAlgorithm` -- BFS path enumeration, depth-weighted scoring, ProtocolSim simulation, gas-adjusted ranking.
-* `BellmanFordAlgorithm` -- Bellman-Ford relaxation with gas-aware edge weights, configurable via `AlgorithmConfig.gas_aware`.
+* `MostLiquidAlgorithm` -- BFS path enumeration, depth-weighted scoring, ProtocolSim simulation, gas-adjusted ranking (naive `route.total_gas()` within the algorithm; more accurate estimate applied by the router before cross-pool ranking).
+* `BellmanFordAlgorithm` -- Bellman-Ford relaxation with gas-aware edge weights, configurable via `AlgorithmConfig.gas_aware` (same two-phase gas estimation as above).
 
 ***
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,8 +201,8 @@ Pluggable interface for route-finding algorithms:
 
 **Built-in algorithms:**
 
-* `MostLiquidAlgorithm` -- BFS path enumeration, depth-weighted scoring, ProtocolSim simulation, gas-adjusted ranking (naive `route.total_gas()` within the algorithm; more accurate estimate applied by the router before cross-pool ranking).
-* `BellmanFordAlgorithm` -- Bellman-Ford relaxation with gas-aware edge weights, configurable via `AlgorithmConfig.gas_aware` (same two-phase gas estimation as above).
+* `MostLiquidAlgorithm` -- BFS path enumeration, depth-weighted scoring, ProtocolSim simulation, gas-adjusted ranking.
+* `BellmanFordAlgorithm` -- Bellman-Ford relaxation with gas-aware edge weights, configurable via `AlgorithmConfig.gas_aware`.
 
 ***
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,4 +81,4 @@ Fynd works with any protocol Tycho supports. See the [list of supported protocol
 
 ## Try it out
 
-Head to the [quickstart](get-started/quickstart/ "mention") to get Fynd running.
+Head to the [quickstart](get-started/quickstart/README.md) to get Fynd running.

--- a/docs/algorithms/bellman-ford.md
+++ b/docs/algorithms/bellman-ford.md
@@ -200,9 +200,11 @@ Run the reconstructed path forward, calling `get_amount_out()` at each hop with 
 
 ### Step 8: Gas adjustment
 
-Compute the total gas cost of the route (sum of each swap's gas estimate), multiply by the current gas price, convert to the output token using price ratios, and subtract from the gross output. The result is `net_amount_out`: the output after accounting for execution cost.
+Compute the total gas cost of the route (sum of each swap's gas estimate `route.total_gas()`), multiply by the current gas price, convert to the output token using price ratios, and subtract from the gross output. The result is `net_amount_out`: the output after accounting for execution cost.
 
 Return the route and net amount.
+
+> **Note:** `route.total_gas()` is a fast, approximate estimate used for ranking paths *within* this algorithm. When multiple worker pools compete, the `WorkerPoolRouter` applies a more accurate gas estimate (`estimate_gas_usage` from tycho-execution, which accounts for token transfers and router overhead) before the final cross-pool ranking.
 
 ***
 

--- a/docs/algorithms/most-liquid.md
+++ b/docs/algorithms/most-liquid.md
@@ -65,6 +65,8 @@ Where `total_gas` is the sum of gas estimates for each swap in the route, `gas_p
 
 The path with the highest `net_output` wins.
 
+> **Note:** `route.total_gas()` is a fast, approximate estimate used for ranking paths *within* this algorithm. When multiple worker pools compete, the `WorkerPoolRouter` applies a more accurate gas estimate (`estimate_gas_usage` from tycho-execution, which accounts for token transfers and router overhead) before the final cross-pool ranking.
+
 ## When it works well
 
 * **Common pairs** (WETH/USDC, WETH/WBTC): a few high-liquidity pools dominate, and the heuristic reliably ranks them correctly.

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -762,6 +762,10 @@ impl OrderQuote {
         self.gas_estimate = gas_estimate;
     }
 
+    pub(crate) fn set_amount_out_net_gas(&mut self, value: BigUint) {
+        self.amount_out_net_gas = value;
+    }
+
     /// Returns the order ID.
     pub fn order_id(&self) -> &str {
         &self.order_id

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -474,6 +474,7 @@ fn refine_gas_estimates(
                     BigUint::ZERO
                 };
                 quote.set_amount_out_net_gas(new_net);
+                quote.set_gas_estimate(refined_gas);
             }
         }
     }
@@ -482,16 +483,13 @@ fn refine_gas_estimates(
 
 fn derive_strategy(quote: &OrderQuote) -> Strategy {
     let Some(route) = quote.route() else { return Strategy::Single };
-    match route.swaps().len() {
-        1 => Strategy::Single,
-        _ if route
-            .swaps()
-            .iter()
-            .any(|s| *s.split() > 0.0) =>
-        {
-            Strategy::Split
-        }
-        _ => Strategy::Sequential,
+    let swaps = route.swaps();
+    if swaps.len() == 1 {
+        Strategy::Single
+    } else if swaps.iter().any(|s| *s.split() > 0.0) {
+        Strategy::Split
+    } else {
+        Strategy::Sequential
     }
 }
 

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -11,8 +11,13 @@
 //!    customized, but initially it's set to relay to all solvers.
 //! 2. **Timeout**: Cancel if solver response takes too long
 //! 3. **Collection**: Wait for N responses OR timeout per order
-//! 4. **Selection**: Choose best quote (max `amount_out_net_gas`)
-//! 5. **Encoding**: If [`EncodingOptions`](crate::EncodingOptions) are provided in the request,
+//! 4. **Gas refinement**: Before cross-pool ranking, replace each candidate's naive
+//!    `route.total_gas()` estimate (used internally by algorithms for intra-pool ranking) with the
+//!    more accurate `estimate_gas_usage` from tycho-execution, which accounts for token transfer
+//!    costs and router overhead. The `amount_out_net_gas` values are rescaled proportionally so the
+//!    final ranking reflects realistic execution cost.
+//! 5. **Selection**: Choose best quote (max refined `amount_out_net_gas`)
+//! 6. **Encoding**: If [`EncodingOptions`](crate::EncodingOptions) are provided in the request,
 //!    encode winning solutions into executable on-chain transactions via the
 //!    [`encoding::encoder::Encoder`](crate::encoding::encoder::Encoder)
 
@@ -28,12 +33,16 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, histogram};
 use num_bigint::BigUint;
 use tracing::{debug, warn};
+use tycho_execution::encoding::{
+    evm::gas_estimator::estimate_gas_usage,
+    models::{Solution, Strategy},
+};
 use tycho_simulation::tycho_common::Bytes;
 
 use crate::{
     encoding::encoder::Encoder, price_guard::guard::PriceGuard,
-    worker_pool::task_queue::TaskQueueHandle, BlockInfo, Order, OrderQuote, Quote, QuoteOptions,
-    QuoteRequest, QuoteStatus, SolveError,
+    worker_pool::task_queue::TaskQueueHandle, BlockInfo, EncodingOptions, Order, OrderQuote, Quote,
+    QuoteOptions, QuoteRequest, QuoteStatus, SolveError,
 };
 
 /// Handle to a solver pool for dispatching orders.
@@ -138,9 +147,15 @@ impl WorkerPoolRouter {
             .map(|order| self.solve_order(order.clone(), deadline, min_responses))
             .collect();
 
-        let order_responses = futures::future::join_all(order_futures).await;
+        let mut order_responses = futures::future::join_all(order_futures).await;
 
-        // Rank quotes for each order (sorted by amount_out_net_gas descending)
+        // Refine gas estimates for all candidates using estimate_gas_usage before ranking,
+        // so ranking uses accurate gas costs rather than naive route.total_gas().
+        if let Some(encoding_options) = request.options().encoding_options() {
+            refine_gas_estimates(&mut order_responses, encoding_options)?;
+        }
+
+        // Rank quotes for each order (sorted by refined amount_out_net_gas descending)
         let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
             .map(|responses| self.rank_quotes(&responses, request.options()))
@@ -437,6 +452,49 @@ impl WorkerPoolRouter {
     }
 }
 
+fn refine_gas_estimates(
+    order_responses: &mut Vec<OrderResponses>,
+    encoding_options: &EncodingOptions,
+) -> Result<(), SolveError> {
+    for responses in order_responses {
+        for (_, quote) in &mut responses.quotes {
+            if quote.status() != QuoteStatus::Success {
+                continue;
+            }
+            let solution = Solution::try_from(&*quote)?
+                .with_user_transfer_type(encoding_options.transfer_type().clone());
+            let refined_gas = estimate_gas_usage(&solution, derive_strategy(quote));
+            let naive_gas = quote.gas_estimate().clone();
+            if naive_gas > BigUint::ZERO {
+                let gas_cost_in_token_out = quote.amount_out() - quote.amount_out_net_gas();
+                let new_gas_cost = &gas_cost_in_token_out * &refined_gas / &naive_gas;
+                let new_net = if new_gas_cost <= *quote.amount_out() {
+                    quote.amount_out() - &new_gas_cost
+                } else {
+                    BigUint::ZERO
+                };
+                quote.set_amount_out_net_gas(new_net);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn derive_strategy(quote: &OrderQuote) -> Strategy {
+    let Some(route) = quote.route() else { return Strategy::Single };
+    match route.swaps().len() {
+        1 => Strategy::Single,
+        _ if route
+            .swaps()
+            .iter()
+            .any(|s| *s.split() > 0.0) =>
+        {
+            Strategy::Split
+        }
+        _ => Strategy::Sequential,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -589,7 +647,8 @@ mod tests {
         let quote = result.unwrap();
         assert_eq!(quote.orders().len(), 1);
         assert_eq!(quote.orders()[0].status(), QuoteStatus::Success);
-        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(900u64));
+        // amount_out_net_gas is refined using estimate_gas_usage before ranking
+        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(837u64));
         assert!(!quote.orders()[0]
             .transaction()
             .unwrap()
@@ -618,8 +677,8 @@ mod tests {
 
         let quote = result.unwrap();
         assert_eq!(quote.orders().len(), 1);
-        // Should select pool_b's quote (higher amount_out_net_gas)
-        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(950u64));
+        // Pool B wins (higher refined amount_out_net_gas after estimate_gas_usage)
+        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(922u64));
         assert!(!quote.orders()[0]
             .transaction()
             .unwrap()


### PR DESCRIPTION
This is only done in the WorkerPoolRouter for the winning solution of each worker! Inside each worker, the ranking is done using the original naive gas estimation (just a sum of each swap simulated gas).

One thing to note: This implementation makes us create the Solution (encoding) objects twice:
1. Once for the gas refinement for all solutions from each worker
2. Once for the overall winner solution when we encode (existing code)  

Other approaches were tried to clean this up and convert only once but that lead to an even weirder design and having to pass the Solution objects in multiple places. Converting to Solution is not expensive at all, so I decided to use the simplest solution.
