### PR TITLE
fix(encoding): Use proper eth marker

### DIFF
--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -220,18 +220,12 @@ impl Encoder {
         let min_amount_out = biguint_to_u256(fee_breakdown.min_amount_received());
         let native_address = &self.chain.native_token().address;
         let router_eth = Address::from_slice(ROUTER_ETH_ADDRESS.as_ref());
-        let raw_token_in = bytes_to_address(solution.token_in())?;
-        let raw_token_out = bytes_to_address(solution.token_out())?;
-        let token_in = if raw_token_in.as_slice() == native_address.as_ref() {
-            router_eth
-        } else {
-            raw_token_in
+        let to_router_address = |raw: Address| {
+            if raw.as_slice() == native_address.as_ref() { router_eth } else { raw }
         };
-        let token_out = if raw_token_out.as_slice() == native_address.as_ref() {
-            router_eth
-        } else {
-            raw_token_out
-        };
+
+        let token_in = to_router_address(bytes_to_address(solution.token_in())?);
+        let token_out = to_router_address(bytes_to_address(solution.token_out())?);
         let receiver = bytes_to_address(solution.receiver())?;
 
         let (permit, permit2_sig) = if let Some(p) = encoding_options.permit() {

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -13,6 +13,7 @@ use tycho_execution::encoding::{
         get_router_address,
         swap_encoder::swap_encoder_registry::SwapEncoderRegistry,
         utils::{biguint_to_u256, bytes_to_address},
+        ROUTER_ETH_ADDRESS,
     },
     models::{EncodedSolution, Solution, Swap},
     tycho_encoder::TychoEncoder,
@@ -217,8 +218,20 @@ impl Encoder {
             encoding_options.slippage(),
         );
         let min_amount_out = biguint_to_u256(fee_breakdown.min_amount_received());
-        let token_in = bytes_to_address(solution.token_in())?;
-        let token_out = bytes_to_address(solution.token_out())?;
+        let native_address = &self.chain.native_token().address;
+        let router_eth = Address::from_slice(ROUTER_ETH_ADDRESS.as_ref());
+        let raw_token_in = bytes_to_address(solution.token_in())?;
+        let raw_token_out = bytes_to_address(solution.token_out())?;
+        let token_in = if raw_token_in.as_slice() == native_address.as_ref() {
+            router_eth
+        } else {
+            raw_token_in
+        };
+        let token_out = if raw_token_out.as_slice() == native_address.as_ref() {
+            router_eth
+        } else {
+            raw_token_out
+        };
         let receiver = bytes_to_address(solution.receiver())?;
 
         let (permit, permit2_sig) = if let Some(p) = encoding_options.permit() {
@@ -320,14 +333,10 @@ impl Encoder {
             )));
         };
 
-        let native_address = &self.chain.native_token().address;
         let contract_interaction =
             Self::encode_input(encoded_solution.function_signature(), method_calldata);
-        let value = if *solution.token_in() == *native_address {
-            solution.amount_in().clone()
-        } else {
-            BigUint::ZERO
-        };
+        let value =
+            if token_in == router_eth { solution.amount_in().clone() } else { BigUint::ZERO };
         let transaction = Transaction::new(
             encoded_solution
                 .interacting_with()

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -221,7 +221,11 @@ impl Encoder {
         let native_address = &self.chain.native_token().address;
         let router_eth = Address::from_slice(ROUTER_ETH_ADDRESS.as_ref());
         let to_router_address = |raw: Address| {
-            if raw.as_slice() == native_address.as_ref() { router_eth } else { raw }
+            if raw.as_slice() == native_address.as_ref() {
+                router_eth
+            } else {
+                raw
+            }
         };
 
         let token_in = to_router_address(bytes_to_address(solution.token_in())?);

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -664,7 +664,7 @@ mod tests {
         assert_eq!(quote.orders().len(), 1);
         assert_eq!(quote.orders()[0].status(), QuoteStatus::Success);
         // amount_out_net_gas is refined using estimate_gas_usage before ranking
-        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(837u64));
+        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(873u64));
         assert!(!quote.orders()[0]
             .transaction()
             .unwrap()
@@ -694,7 +694,7 @@ mod tests {
         let quote = result.unwrap();
         assert_eq!(quote.orders().len(), 1);
         // Pool B wins (higher refined amount_out_net_gas after estimate_gas_usage)
-        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(922u64));
+        assert_eq!(*quote.orders()[0].amount_out_net_gas(), BigUint::from(938u64));
         assert!(!quote.orders()[0]
             .transaction()
             .unwrap()


### PR DESCRIPTION
- Easily done thanks to ROUTER_ETH_ADDRESS export from tycho-execution
- Needed to update test_encoder_new_fails_on_unsupported_chain since Arbitrum is now actually supported
- Update failing tests after gas updates (perhaps failing in base branch)