### PR TITLE
feat(fynd-core): add build_with_pending for embedded pending-block simulation

### DIFF
--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -2,7 +2,8 @@ use std::{collections::HashSet, time::Duration};
 
 use tycho_simulation::tycho_common::models::Chain;
 
-pub(crate) mod events;
+/// Market events broadcast by the Tycho feed on every block update.
+pub mod events;
 pub(crate) mod gas;
 /// Shared market data store (`MarketState`, `MarketData`).
 pub mod market_data;

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -11,7 +11,7 @@ use tokio::{sync::broadcast, task::JoinHandle};
 use tokio_stream::StreamExt;
 use tracing::{debug, info, instrument, span, trace, Instrument, Level};
 use tycho_simulation::{
-    evm::stream::ProtocolStreamBuilder,
+    evm::{pending::PendingBlockProcessor, stream::ProtocolStreamBuilder},
     protocol::models::Update,
     rfq::stream::RFQStreamBuilder,
     tycho_client::feed::{component_tracker::ComponentFilter, SynchronizerState},
@@ -238,6 +238,103 @@ impl TychoFeed {
                             return Err(DataFeedError::StreamError(format!("RFQ task panicked: {}", e)));
                         }
                     }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Like [`run`](Self::run) but calls [`ProtocolStreamBuilder::build_with_pending`]
+    /// and delivers the [`PendingBlockProcessor`] via `pending_tx` before entering the
+    /// stream loop.
+    ///
+    /// The oneshot fires after token loading and stream setup, but before the first
+    /// block is processed. If the receiver has already been dropped the processor is
+    /// discarded and the feed continues normally (degraded mode, no pending updates).
+    ///
+    /// RFQ protocols are not supported with this method.
+    pub(crate) async fn run_with_pending(
+        self,
+        pending_tx: oneshot::Sender<PendingBlockProcessor>,
+    ) -> Result<(), DataFeedError> {
+        if self
+            .config
+            .protocols
+            .iter()
+            .any(|p| p.starts_with("rfq:"))
+        {
+            return Err(DataFeedError::Config(
+                "run_with_pending does not support RFQ protocols".to_string(),
+            ));
+        }
+
+        info!(
+            tycho_url = %self.config.tycho_url,
+            protocols = ?self.config.protocols,
+            "Starting Data Feed (with pending)..."
+        );
+
+        let tycho_api_key = self
+            .config
+            .tycho_api_key
+            .clone()
+            .or_else(|| std::env::var("TYCHO_API_KEY").ok());
+
+        let all_tokens = load_all_tokens(
+            self.config.tycho_url.as_str(),
+            !self.config.use_tls,
+            tycho_api_key.as_deref(),
+            true,
+            self.config.chain,
+            Some(self.config.min_token_quality),
+            self.config.traded_n_days_ago,
+        )
+        .await
+        .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+
+        debug!("Loaded {} tokens from Tycho", all_tokens.len());
+
+        let (mut protocol_stream, pending) = register_exchanges(
+            ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
+                .skip_state_decode_failures(true),
+            ComponentFilter::with_tvl_range(
+                self.config.min_tvl / self.config.tvl_buffer_ratio,
+                self.config.min_tvl,
+            )
+            .blocklist(
+                self.config
+                    .blocklisted_components
+                    .clone(),
+            ),
+            &self.config.protocols,
+        )?
+        .auth_key(self.config.tycho_api_key.clone())
+        .skip_state_decode_failures(true)
+        .min_token_quality(self.config.min_token_quality as u32)
+        .set_tokens(all_tokens)
+        .await
+        .build_with_pending()
+        .await
+        .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+
+        if pending_tx.send(pending).is_err() {
+            tracing::warn!(
+                "PendingBlockProcessor receiver dropped before send; continuing without pending \
+                 updates"
+            );
+        }
+
+        loop {
+            match protocol_stream.next().await {
+                Some(msg) => {
+                    let msg = msg.map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+                    self.refresh_gas_price().await?;
+                    self.handle_tycho_message(msg).await?;
+                }
+                None => {
+                    info!("Protocol stream ended");
+                    break;
                 }
             }
         }

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -66,9 +66,8 @@ impl TychoFeed {
         self.event_tx.subscribe()
     }
 
-    /// Returns an additional event sender. Currently only used for testing.
-    #[cfg(test)]
-    pub fn event_sender_clone(&self) -> broadcast::Sender<MarketEvent> {
+    /// Returns a clone of the event sender.
+    pub(crate) fn event_sender(&self) -> broadcast::Sender<MarketEvent> {
         self.event_tx.clone()
     }
 
@@ -705,7 +704,7 @@ mod tests {
         let mut sub2 = feed.subscribe();
 
         // Get event sender
-        let sender = feed.event_sender_clone();
+        let sender = feed.event_sender();
 
         sender
             .send(MarketEvent::MarketUpdated {

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::{sync::{broadcast, oneshot}, task::JoinHandle};
 use tokio_stream::StreamExt;
 use tracing::{debug, info, instrument, span, trace, Instrument, Level};
 use tycho_simulation::{
@@ -388,7 +388,6 @@ impl TychoFeed {
                         Some(msg) => {
                             trace!("Received message from protocol stream: {:?}", msg);
                             let msg = msg.map_err(|e| DataFeedError::StreamError(e.to_string()))?;
-                            self.refresh_gas_price().await?;
                             self.handle_tycho_message(msg).await?;
                         }
                         None => {

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -15,6 +15,7 @@ use tycho_simulation::{
     protocol::models::Update,
     rfq::stream::RFQStreamBuilder,
     tycho_client::feed::{component_tracker::ComponentFilter, SynchronizerState},
+    tycho_common::traits::TxDeltaIndexer,
     tycho_core::Bytes,
     utils::load_all_tokens,
 };
@@ -257,6 +258,7 @@ impl TychoFeed {
     pub(crate) async fn run_with_pending(
         self,
         pending_tx: oneshot::Sender<PendingBlockProcessor>,
+        pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
     ) -> Result<(), DataFeedError> {
         if self
             .config
@@ -295,7 +297,7 @@ impl TychoFeed {
 
         debug!("Loaded {} tokens from Tycho", all_tokens.len());
 
-        let (mut protocol_stream, pending) = register_exchanges(
+        let mut stream_builder = register_exchanges(
             ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
                 .skip_state_decode_failures(true),
             ComponentFilter::with_tvl_range(
@@ -313,10 +315,18 @@ impl TychoFeed {
         .skip_state_decode_failures(true)
         .min_token_quality(self.config.min_token_quality as u32)
         .set_tokens(all_tokens)
-        .await
-        .build_with_pending()
-        .await
-        .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+        .await;
+
+        for (extractor, indexer) in pending_indexers {
+            stream_builder = stream_builder
+                .with_pending_indexer(&extractor, indexer)
+                .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+        }
+
+        let (mut protocol_stream, pending) = stream_builder
+            .build_with_pending()
+            .await
+            .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
 
         if pending_tx.send(pending).is_err() {
             tracing::warn!(

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -254,23 +254,13 @@ impl TychoFeed {
     /// block is processed. If the receiver has already been dropped the processor is
     /// discarded and the feed continues normally (degraded mode, no pending updates).
     ///
-    /// RFQ protocols are not supported with this method.
+    /// RFQ protocols in the config are silently ignored; only on-chain EVM protocols
+    /// are connected to the `PendingBlockProcessor`.
     pub(crate) async fn run_with_pending(
         self,
         pending_tx: oneshot::Sender<PendingBlockProcessor>,
         pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
     ) -> Result<(), DataFeedError> {
-        if self
-            .config
-            .protocols
-            .iter()
-            .any(|p| p.starts_with("rfq:"))
-        {
-            return Err(DataFeedError::Config(
-                "run_with_pending does not support RFQ protocols".to_string(),
-            ));
-        }
-
         info!(
             tycho_url = %self.config.tycho_url,
             protocols = ?self.config.protocols,

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -255,8 +255,8 @@ impl TychoFeed {
     /// only "channel closed". If the receiver has already been dropped the processor is
     /// discarded and the feed continues normally.
     ///
-    /// RFQ protocols in the config are silently ignored; only on-chain EVM protocols
-    /// are connected to the `PendingBlockProcessor`.
+    /// RFQ protocols are handled alongside the EVM stream, identical to [`run`](Self::run).
+    /// The `PendingBlockProcessor` only covers EVM on-chain state.
     pub(crate) async fn run_with_pending(
         self,
         pending_tx: oneshot::Sender<Result<PendingBlockProcessor, String>>,
@@ -318,7 +318,7 @@ impl TychoFeed {
         .auth_key(self.config.tycho_api_key.clone())
         .skip_state_decode_failures(true)
         .min_token_quality(self.config.min_token_quality as u32)
-        .set_tokens(all_tokens)
+        .set_tokens(all_tokens.clone())
         .await;
 
         for (extractor, indexer) in pending_indexers {
@@ -351,16 +351,84 @@ impl TychoFeed {
             );
         }
 
+        // Spawn RFQ stream (same as run()) — runs alongside the EVM pending stream.
+        let (mut rfq_rx, mut rfq_handle) = if self
+            .config
+            .protocols
+            .iter()
+            .any(|p| p.starts_with("rfq:"))
+        {
+            let rfq_tokens: HashSet<Bytes> = all_tokens.keys().cloned().collect();
+            let rfq_stream_builder = register_rfq(
+                RFQStreamBuilder::new()
+                    .set_tokens(all_tokens)
+                    .await,
+                self.config.chain,
+                self.config.min_tvl,
+                &self.config.protocols,
+                rfq_tokens,
+            )?;
+            let (rfq_tx, rfq_rx) = tokio::sync::mpsc::channel(64);
+            let rfq_handle: JoinHandle<Result<(), DataFeedError>> = tokio::spawn(async move {
+                rfq_stream_builder
+                    .build(rfq_tx)
+                    .await
+                    .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+                Ok(())
+            });
+            (Some(rfq_rx), Some(rfq_handle))
+        } else {
+            (None, None)
+        };
+
         loop {
-            match protocol_stream.next().await {
-                Some(msg) => {
-                    let msg = msg.map_err(|e| DataFeedError::StreamError(e.to_string()))?;
-                    self.refresh_gas_price().await?;
-                    self.handle_tycho_message(msg).await?;
+            tokio::select! {
+                msg = protocol_stream.next() => {
+                    match msg {
+                        Some(msg) => {
+                            trace!("Received message from protocol stream: {:?}", msg);
+                            let msg = msg.map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+                            self.refresh_gas_price().await?;
+                            self.handle_tycho_message(msg).await?;
+                        }
+                        None => {
+                            info!("Protocol stream ended");
+                            break;
+                        }
+                    }
                 }
-                None => {
-                    info!("Protocol stream ended");
-                    break;
+                msg = async {
+                    if let Some(rx) = &mut rfq_rx { rx.recv().await }
+                    else { std::future::pending().await }
+                } => {
+                    match msg {
+                        Some(msg) => {
+                            trace!("Received message from RFQ stream: {:?}", msg);
+                            self.handle_tycho_message(msg).await?;
+                        }
+                        None => {
+                            info!("RFQ stream ended");
+                            break;
+                        }
+                    }
+                }
+                rfq_result = async {
+                    if let Some(handle) = &mut rfq_handle { handle.await }
+                    else { std::future::pending().await }
+                } => {
+                    match rfq_result {
+                        Ok(Ok(())) => {
+                            return Err(DataFeedError::StreamError(
+                                "RFQ stream task ended unexpectedly".to_string(),
+                            ));
+                        }
+                        Ok(Err(e)) => {
+                            return Err(DataFeedError::StreamError(format!("RFQ stream error: {e}")));
+                        }
+                        Err(e) => {
+                            return Err(DataFeedError::StreamError(format!("RFQ task panicked: {e}")));
+                        }
+                    }
                 }
             }
         }

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -247,18 +247,19 @@ impl TychoFeed {
     }
 
     /// Like [`run`](Self::run) but calls [`ProtocolStreamBuilder::build_with_pending`]
-    /// and delivers the [`PendingBlockProcessor`] via `pending_tx` before entering the
-    /// stream loop.
+    /// and delivers the [`PendingBlockProcessor`] (or a setup error) via `pending_tx`
+    /// before entering the stream loop.
     ///
-    /// The oneshot fires after token loading and stream setup, but before the first
-    /// block is processed. If the receiver has already been dropped the processor is
-    /// discarded and the feed continues normally (degraded mode, no pending updates).
+    /// If setup fails before the processor can be created, the error message is sent
+    /// through the channel so the caller can surface the root cause instead of seeing
+    /// only "channel closed". If the receiver has already been dropped the processor is
+    /// discarded and the feed continues normally.
     ///
     /// RFQ protocols in the config are silently ignored; only on-chain EVM protocols
     /// are connected to the `PendingBlockProcessor`.
     pub(crate) async fn run_with_pending(
         self,
-        pending_tx: oneshot::Sender<PendingBlockProcessor>,
+        pending_tx: oneshot::Sender<Result<PendingBlockProcessor, String>>,
         pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
     ) -> Result<(), DataFeedError> {
         info!(
@@ -273,7 +274,7 @@ impl TychoFeed {
             .clone()
             .or_else(|| std::env::var("TYCHO_API_KEY").ok());
 
-        let all_tokens = load_all_tokens(
+        let all_tokens = match load_all_tokens(
             self.config.tycho_url.as_str(),
             !self.config.use_tls,
             tycho_api_key.as_deref(),
@@ -283,11 +284,18 @@ impl TychoFeed {
             self.config.traded_n_days_ago,
         )
         .await
-        .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+        {
+            Ok(t) => t,
+            Err(e) => {
+                let e = DataFeedError::StreamError(e.to_string());
+                let _ = pending_tx.send(Err(e.to_string()));
+                return Err(e);
+            }
+        };
 
         debug!("Loaded {} tokens from Tycho", all_tokens.len());
 
-        let mut stream_builder = register_exchanges(
+        let mut stream_builder = match register_exchanges(
             ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
                 .skip_state_decode_failures(true),
             ComponentFilter::with_tvl_range(
@@ -300,7 +308,13 @@ impl TychoFeed {
                     .clone(),
             ),
             &self.config.protocols,
-        )?
+        ) {
+            Ok(sb) => sb,
+            Err(e) => {
+                let _ = pending_tx.send(Err(e.to_string()));
+                return Err(e);
+            }
+        }
         .auth_key(self.config.tycho_api_key.clone())
         .skip_state_decode_failures(true)
         .min_token_quality(self.config.min_token_quality as u32)
@@ -308,17 +322,29 @@ impl TychoFeed {
         .await;
 
         for (extractor, indexer) in pending_indexers {
-            stream_builder = stream_builder
-                .with_pending_indexer(&extractor, indexer)
-                .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+            stream_builder = match stream_builder.with_pending_indexer(&extractor, indexer) {
+                Ok(sb) => sb,
+                Err(e) => {
+                    let e = DataFeedError::StreamError(e.to_string());
+                    let _ = pending_tx.send(Err(e.to_string()));
+                    return Err(e);
+                }
+            };
         }
 
-        let (mut protocol_stream, pending) = stream_builder
+        let (mut protocol_stream, pending) = match stream_builder
             .build_with_pending()
             .await
-            .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+        {
+            Ok(pair) => pair,
+            Err(e) => {
+                let e = DataFeedError::StreamError(e.to_string());
+                let _ = pending_tx.send(Err(e.to_string()));
+                return Err(e);
+            }
+        };
 
-        if pending_tx.send(pending).is_err() {
+        if pending_tx.send(Ok(pending)).is_err() {
             tracing::warn!(
                 "PendingBlockProcessor receiver dropped before send; continuing without pending \
                  updates"

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -7,7 +7,10 @@
 
 use std::collections::HashSet;
 
-use tokio::{sync::{broadcast, oneshot}, task::JoinHandle};
+use tokio::{
+    sync::{broadcast, oneshot},
+    task::JoinHandle,
+};
 use tokio_stream::StreamExt;
 use tracing::{debug, info, instrument, span, trace, Instrument, Level};
 use tycho_simulation::{

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -55,7 +55,10 @@ pub use price_guard::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
 pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
-pub use tycho_simulation::evm::pending::{PendingBlockProcessor, PendingError, PendingUpdate};
+pub use tycho_simulation::{
+    evm::pending::{PendingBlockProcessor, PendingError, PendingUpdate},
+    tycho_common::traits::TxDeltaIndexer,
+};
 pub use types::{
     BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, FeeBreakdown, Order, OrderQuote,
     OrderSide, OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions,

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -55,6 +55,7 @@ pub use price_guard::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
 pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
+pub use tycho_simulation::evm::pending::{PendingBlockProcessor, PendingError, PendingUpdate};
 pub use types::{
     BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, FeeBreakdown, Order, OrderQuote,
     OrderSide, OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions,

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -55,10 +55,17 @@ pub use price_guard::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
 pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
-pub use tycho_simulation::{
-    evm::pending::{PendingBlockProcessor, PendingError, PendingUpdate},
-    tycho_common::traits::TxDeltaIndexer,
-};
+/// Processes ephemeral pending bundles against live Tycho market state. Obtained by calling
+/// [`FyndBuilder::build_with_pending`](solver::FyndBuilder::build_with_pending).
+pub use tycho_simulation::evm::pending::PendingBlockProcessor;
+/// Error type produced by [`PendingBlockProcessor`] when simulating a pending bundle.
+pub use tycho_simulation::evm::pending::PendingError;
+/// A pending transaction bundle passed to [`PendingBlockProcessor`] for simulation.
+pub use tycho_simulation::evm::pending::PendingUpdate;
+/// Implement this trait and register it via
+/// [`FyndBuilder::with_pending_indexer`](solver::FyndBuilder::with_pending_indexer)
+/// to receive raw transaction deltas during pending-block simulation.
+pub use tycho_simulation::tycho_common::traits::TxDeltaIndexer;
 pub use types::{
     BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, FeeBreakdown, Order, OrderQuote,
     OrderSide, OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions,

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -18,7 +18,7 @@ use tokio::{sync::broadcast, task::JoinHandle};
 use tycho_execution::encoding::evm::swap_encoder::swap_encoder_registry::SwapEncoderRegistry;
 use tycho_simulation::{
     evm::pending::PendingBlockProcessor,
-    tycho_common::{models::Chain, Bytes},
+    tycho_common::{models::Chain, traits::TxDeltaIndexer, Bytes},
     tycho_core::models::Address,
     tycho_ethereum::rpc::EthereumRpcClient,
 };
@@ -340,6 +340,7 @@ pub struct FyndBuilder {
     pools: Vec<PoolEntry>,
     price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
+    pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
 }
 
 impl FyndBuilder {
@@ -372,6 +373,7 @@ impl FyndBuilder {
             pools: Vec::new(),
             price_guard_enabled: false,
             price_providers: Vec::new(),
+            pending_indexers: Vec::new(),
         }
     }
 
@@ -527,6 +529,21 @@ impl FyndBuilder {
     /// [`build`](Self::build) with the shared market data.
     pub fn register_price_provider(mut self, provider: Box<dyn PriceProvider>) -> Self {
         self.price_providers.push(provider);
+        self
+    }
+
+    /// Registers a [`TxDeltaIndexer`] for ephemeral pending-block simulation.
+    ///
+    /// `extractor` is the protocol synchronizer name (e.g. `"uniswap_v3"`). Only has effect
+    /// when calling [`build_with_pending`](Self::build_with_pending). VM protocols (prefix
+    /// `"vm:"`) are rejected by the underlying stream builder at build time.
+    pub fn with_pending_indexer(
+        mut self,
+        extractor: impl Into<String>,
+        indexer: Box<dyn TxDeltaIndexer>,
+    ) -> Self {
+        self.pending_indexers
+            .push((extractor.into(), indexer));
         self
     }
 
@@ -914,9 +931,10 @@ impl FyndBuilder {
 
         let (pending_tx, pending_rx) = tokio::sync::oneshot::channel::<PendingBlockProcessor>();
 
+        let pending_indexers = self.pending_indexers;
         let feed_handle = tokio::spawn(async move {
             if let Err(e) = tycho_feed
-                .run_with_pending(pending_tx)
+                .run_with_pending(pending_tx, pending_indexers)
                 .await
             {
                 tracing::error!(error = %e, "tycho feed error");

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -277,10 +277,14 @@ pub enum SolverBuildError {
     /// [`FyndBuilder::build`] was called without configuring any worker pools.
     #[error("no worker pools configured")]
     NoPools,
-    /// The pending-processor oneshot closed before the processor was delivered.
+    /// The feed task failed before delivering the [`PendingBlockProcessor`].
     ///
-    /// This typically means `TychoFeed::run_with_pending` returned an error
-    /// before sending the processor.
+    /// The inner string is the `DataFeedError` message from `TychoFeed::run_with_pending`
+    /// (e.g. "failed to load tokens: connection refused").
+    #[error("feed setup failed before delivering pending processor: {0}")]
+    FeedSetup(String),
+    /// The pending-processor oneshot closed without delivering a value, meaning the feed task
+    /// panicked rather than returning an error through the channel.
     #[error("pending processor channel closed before processor was delivered")]
     PendingChannelClosed,
 }
@@ -929,7 +933,8 @@ impl FyndBuilder {
             router = router.with_price_guard(price_guard);
         }
 
-        let (pending_tx, pending_rx) = tokio::sync::oneshot::channel::<PendingBlockProcessor>();
+        let (pending_tx, pending_rx) =
+            tokio::sync::oneshot::channel::<Result<PendingBlockProcessor, String>>();
 
         let pending_indexers = self.pending_indexers;
         let feed_handle = tokio::spawn(async move {
@@ -955,7 +960,8 @@ impl FyndBuilder {
 
         let pending = pending_rx
             .await
-            .map_err(|_| SolverBuildError::PendingChannelClosed)?;
+            .map_err(|_| SolverBuildError::PendingChannelClosed)?
+            .map_err(SolverBuildError::FeedSetup)?;
 
         Ok((
             Solver {

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -28,8 +28,11 @@ use crate::{
     derived::{ComputationManager, ComputationManagerConfig, SharedDerivedDataRef},
     encoding::encoder::Encoder,
     feed::{
-        events::MarketEventHandler, gas::GasPriceFetcher, market_data::MarketData,
-        tycho_feed::TychoFeed, TychoFeedConfig,
+        events::{MarketEvent, MarketEventHandler},
+        gas::GasPriceFetcher,
+        market_data::MarketData,
+        tycho_feed::TychoFeed,
+        TychoFeedConfig,
     },
     graph::EdgeWeightUpdaterWithDerived,
     price_guard::{
@@ -318,6 +321,24 @@ struct CustomPoolEntry {
     configure: Box<dyn FnOnce(WorkerPoolBuilder) -> WorkerPoolBuilder + Send>,
 }
 
+/// All components produced by [`FyndBuilder::assemble_components`], consumed by
+/// [`FyndBuilder::build`] and [`FyndBuilder::build_with_pending`].
+struct BuiltComponents {
+    tycho_feed: TychoFeed,
+    gas_price_fetcher: GasPriceFetcher<EthereumRpcClient>,
+    computation_manager: ComputationManager,
+    computation_event_rx: broadcast::Receiver<MarketEvent>,
+    computation_shutdown_tx: broadcast::Sender<()>,
+    computation_shutdown_rx: broadcast::Receiver<()>,
+    router: WorkerPoolRouter,
+    worker_pools: Vec<WorkerPool>,
+    market_data: MarketData,
+    derived_data: SharedDerivedDataRef,
+    chain: Chain,
+    router_address: Bytes,
+    pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
+}
+
 /// Builder for assembling the full solver pipeline.
 ///
 /// Configures the Tycho market-data feed, gas price fetcher, derived-data
@@ -588,12 +609,9 @@ impl FyndBuilder {
         Ok(self)
     }
 
-    /// Assembles and starts all solver components.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SolverBuildError`] if any component fails to initialize.
-    pub fn build(mut self) -> Result<Solver, SolverBuildError> {
+    /// Constructs all components shared between [`build`](Self::build) and
+    /// [`build_with_pending`](Self::build_with_pending).
+    fn assemble_components(mut self) -> Result<BuiltComponents, SolverBuildError> {
         if self.pools.is_empty() {
             return Err(SolverBuildError::NoPools);
         }
@@ -623,7 +641,7 @@ impl FyndBuilder {
         let ethereum_client = EthereumRpcClient::new(self.rpc_url.as_str())
             .map_err(|e| SolverBuildError::RpcClient(e.to_string()))?;
 
-        let mut gas_price_fetcher =
+        let gas_price_fetcher =
             GasPriceFetcher::new(ethereum_client, market_data.clone(), self.gas_refresh_interval);
 
         let tycho_feed = TychoFeed::new(tycho_feed_config, market_data.clone());
@@ -744,33 +762,56 @@ impl FyndBuilder {
             router = router.with_price_guard(price_guard);
         }
 
-        let feed_handle = tokio::spawn(async move {
-            if let Err(e) = tycho_feed.run().await {
-                tracing::error!(error = %e, "tycho feed error");
-            }
-        });
-
-        let gas_price_handle = tokio::spawn(async move {
-            gas_price_fetcher.run().await;
-        });
-
-        let computation_handle = tokio::spawn(async move {
-            computation_manager
-                .run(computation_event_rx, computation_shutdown_rx)
-                .await;
-        });
-
-        Ok(Solver {
+        Ok(BuiltComponents {
+            tycho_feed,
+            gas_price_fetcher,
+            computation_manager,
+            computation_event_rx,
+            computation_shutdown_tx,
+            computation_shutdown_rx,
             router,
             worker_pools,
             market_data,
             derived_data,
+            chain,
+            router_address,
+            pending_indexers: self.pending_indexers,
+        })
+    }
+
+    /// Assembles and starts all solver components.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SolverBuildError`] if any component fails to initialize.
+    pub fn build(self) -> Result<Solver, SolverBuildError> {
+        let mut c = self.assemble_components()?;
+
+        let feed_handle = tokio::spawn(async move {
+            if let Err(e) = c.tycho_feed.run().await {
+                tracing::error!(error = %e, "tycho feed error");
+            }
+        });
+        let gas_price_handle = tokio::spawn(async move {
+            c.gas_price_fetcher.run().await;
+        });
+        let computation_handle = tokio::spawn(async move {
+            c.computation_manager
+                .run(c.computation_event_rx, c.computation_shutdown_rx)
+                .await;
+        });
+
+        Ok(Solver {
+            router: c.router,
+            worker_pools: c.worker_pools,
+            market_data: c.market_data,
+            derived_data: c.derived_data,
             feed_handle,
             gas_price_handle,
             computation_handle,
-            computation_shutdown_tx,
-            chain,
-            router_address,
+            computation_shutdown_tx: c.computation_shutdown_tx,
+            chain: c.chain,
+            router_address: c.router_address,
         })
     }
 
@@ -786,175 +827,29 @@ impl FyndBuilder {
     /// Returns [`SolverBuildError`] if any component fails to initialize or the pending
     /// channel closes before delivering the processor (e.g. token loading failed).
     pub async fn build_with_pending(
-        mut self,
+        self,
     ) -> Result<(Solver, PendingBlockProcessor), SolverBuildError> {
-        if self.pools.is_empty() {
-            return Err(SolverBuildError::NoPools);
-        }
-
-        if self.price_providers.is_empty() {
-            self = self.add_default_price_providers();
-        }
-
-        let market_data = MarketData::new_shared();
-
-        let tycho_feed_config = TychoFeedConfig::new(
-            self.tycho_url,
-            self.chain,
-            self.tycho_api_key,
-            self.tycho_use_tls,
-            self.protocols,
-            self.min_tvl,
-        )
-        .tvl_buffer_ratio(self.tvl_buffer_ratio)
-        .gas_refresh_interval(self.gas_refresh_interval)
-        .reconnect_delay(self.reconnect_delay)
-        .min_token_quality(self.min_token_quality)
-        .traded_n_days_ago(self.traded_n_days_ago)
-        .blocklisted_components(self.blocklisted_components);
-
-        let ethereum_client = EthereumRpcClient::new(self.rpc_url.as_str())
-            .map_err(|e| SolverBuildError::RpcClient(e.to_string()))?;
-
-        let (mut gas_price_fetcher, gas_price_worker_signal_tx) =
-            GasPriceFetcher::new(ethereum_client, market_data.clone());
-
-        let mut tycho_feed = TychoFeed::new(tycho_feed_config, market_data.clone());
-        tycho_feed = tycho_feed.with_gas_price_worker_signal_tx(gas_price_worker_signal_tx);
-
-        let gas_token = native_token(&self.chain).map_err(|_| SolverBuildError::GasToken)?;
-        let computation_config = ComputationManagerConfig::new()
-            .with_gas_token(gas_token)
-            .with_depth_slippage_threshold(DEFAULT_DEPTH_SLIPPAGE_THRESHOLD);
-        let (computation_manager, _) =
-            ComputationManager::new(computation_config, market_data.clone())
-                .map_err(|e| SolverBuildError::ComputationManager(e.to_string()))?;
-
-        let derived_data: SharedDerivedDataRef = computation_manager.store();
-        let derived_event_tx = computation_manager.event_sender();
-
-        let computation_event_rx = tycho_feed.subscribe();
-        let (computation_shutdown_tx, computation_shutdown_rx) = broadcast::channel(1);
-
-        let mut solver_pool_handles: Vec<SolverPoolHandle> = Vec::new();
-        let mut worker_pools: Vec<WorkerPool> = Vec::new();
-
-        for pool_entry in self.pools {
-            let pool_event_rx = tycho_feed.subscribe();
-            let derived_rx = derived_event_tx.subscribe();
-
-            let (worker_pool, task_handle) = match pool_entry {
-                PoolEntry::BuiltIn {
-                    name,
-                    algorithm,
-                    num_workers,
-                    task_queue_capacity,
-                    min_hops,
-                    max_hops,
-                    timeout_ms,
-                    max_routes,
-                    connector_tokens,
-                } => {
-                    let mut algo_cfg = AlgorithmConfig::new(
-                        min_hops,
-                        max_hops,
-                        Duration::from_millis(timeout_ms),
-                        max_routes,
-                    )?;
-                    if let Some(tokens) = connector_tokens {
-                        algo_cfg = algo_cfg.with_connector_tokens(tokens);
-                    }
-                    WorkerPoolBuilder::new()
-                        .name(name)
-                        .algorithm(algorithm)
-                        .algorithm_config(algo_cfg)
-                        .num_workers(num_workers)
-                        .task_queue_capacity(task_queue_capacity)
-                        .build(
-                            market_data.clone(),
-                            Arc::clone(&derived_data),
-                            pool_event_rx,
-                            derived_rx,
-                        )?
-                }
-                PoolEntry::Custom(custom) => {
-                    let algo_cfg = AlgorithmConfig::new(
-                        custom.min_hops,
-                        custom.max_hops,
-                        Duration::from_millis(custom.timeout_ms),
-                        custom.max_routes,
-                    )?;
-                    let builder = WorkerPoolBuilder::new()
-                        .name(custom.name)
-                        .algorithm_config(algo_cfg)
-                        .num_workers(custom.num_workers)
-                        .task_queue_capacity(custom.task_queue_capacity);
-                    let builder = (custom.configure)(builder);
-                    builder.build(
-                        market_data.clone(),
-                        Arc::clone(&derived_data),
-                        pool_event_rx,
-                        derived_rx,
-                    )?
-                }
-            };
-
-            solver_pool_handles.push(SolverPoolHandle::new(worker_pool.name(), task_handle));
-            worker_pools.push(worker_pool);
-        }
-
-        let encoder = match self.encoder {
-            Some(enc) => enc,
-            None => {
-                let registry = SwapEncoderRegistry::new(self.chain)
-                    .add_default_encoders(None)
-                    .map_err(|e| SolverBuildError::Encoder(e.to_string()))?;
-                Encoder::new(self.chain, registry)
-                    .map_err(|e| SolverBuildError::Encoder(e.to_string()))?
-            }
-        };
-
-        let chain = self.chain;
-        let router_address = encoder.router_address().clone();
-
-        let router_config = WorkerPoolRouterConfig::default()
-            .with_timeout(self.router_timeout)
-            .with_min_responses(self.router_min_responses);
-        let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
-
-        if self.price_guard_enabled {
-            let mut registry = PriceProviderRegistry::new();
-            let mut worker_handles = Vec::new();
-            for mut provider in self.price_providers {
-                worker_handles.push(provider.start(market_data.clone()));
-                registry = registry.register(provider);
-            }
-            let price_guard = PriceGuard::new(registry, worker_handles);
-            router = router.with_price_guard(price_guard);
-        }
+        let mut c = self.assemble_components()?;
 
         let (pending_tx, pending_rx) =
             tokio::sync::oneshot::channel::<Result<PendingBlockProcessor, String>>();
 
-        let pending_indexers = self.pending_indexers;
+        let pending_indexers = c.pending_indexers;
         let feed_handle = tokio::spawn(async move {
-            if let Err(e) = tycho_feed
+            if let Err(e) = c
+                .tycho_feed
                 .run_with_pending(pending_tx, pending_indexers)
                 .await
             {
                 tracing::error!(error = %e, "tycho feed error");
             }
         });
-
         let gas_price_handle = tokio::spawn(async move {
-            if let Err(e) = gas_price_fetcher.run().await {
-                tracing::error!(error = %e, "gas price fetcher error");
-            }
+            c.gas_price_fetcher.run().await;
         });
-
         let computation_handle = tokio::spawn(async move {
-            computation_manager
-                .run(computation_event_rx, computation_shutdown_rx)
+            c.computation_manager
+                .run(c.computation_event_rx, c.computation_shutdown_rx)
                 .await;
         });
 
@@ -965,16 +860,16 @@ impl FyndBuilder {
 
         Ok((
             Solver {
-                router,
-                worker_pools,
-                market_data,
-                derived_data,
+                router: c.router,
+                worker_pools: c.worker_pools,
+                market_data: c.market_data,
+                derived_data: c.derived_data,
                 feed_handle,
                 gas_price_handle,
                 computation_handle,
-                computation_shutdown_tx,
-                chain,
-                router_address,
+                computation_shutdown_tx: c.computation_shutdown_tx,
+                chain: c.chain,
+                router_address: c.router_address,
             },
             pending,
         ))

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{sync::broadcast, task::JoinHandle};
 use tycho_execution::encoding::evm::swap_encoder::swap_encoder_registry::SwapEncoderRegistry;
 use tycho_simulation::{
+    evm::pending::PendingBlockProcessor,
     tycho_common::{models::Chain, Bytes},
     tycho_core::models::Address,
     tycho_ethereum::rpc::EthereumRpcClient,
@@ -276,6 +277,12 @@ pub enum SolverBuildError {
     /// [`FyndBuilder::build`] was called without configuring any worker pools.
     #[error("no worker pools configured")]
     NoPools,
+    /// The pending-processor oneshot closed before the processor was delivered.
+    ///
+    /// This typically means `TychoFeed::run_with_pending` returned an error
+    /// before sending the processor.
+    #[error("pending processor channel closed before processor was delivered")]
+    PendingChannelClosed,
 }
 
 /// Internal pool entry — either a built-in algorithm (by name) or a custom one.
@@ -744,6 +751,209 @@ impl FyndBuilder {
             chain,
             router_address,
         })
+    }
+
+    /// Assembles and starts all solver components, also returning a [`PendingBlockProcessor`]
+    /// for ephemeral bundle simulation against the live Tycho market state.
+    ///
+    /// Identical to [`build`](Self::build) except the feed task runs via
+    /// `TychoFeed::run_with_pending`. The `PendingBlockProcessor` is delivered after
+    /// token loading, before the first block is processed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SolverBuildError`] if any component fails to initialize or the pending
+    /// channel closes before delivering the processor (e.g. token loading failed).
+    pub async fn build_with_pending(
+        mut self,
+    ) -> Result<(Solver, PendingBlockProcessor), SolverBuildError> {
+        if self.pools.is_empty() {
+            return Err(SolverBuildError::NoPools);
+        }
+
+        if self.price_providers.is_empty() {
+            self = self.add_default_price_providers();
+        }
+
+        let market_data = MarketData::new_shared();
+
+        let tycho_feed_config = TychoFeedConfig::new(
+            self.tycho_url,
+            self.chain,
+            self.tycho_api_key,
+            self.tycho_use_tls,
+            self.protocols,
+            self.min_tvl,
+        )
+        .tvl_buffer_ratio(self.tvl_buffer_ratio)
+        .gas_refresh_interval(self.gas_refresh_interval)
+        .reconnect_delay(self.reconnect_delay)
+        .min_token_quality(self.min_token_quality)
+        .traded_n_days_ago(self.traded_n_days_ago)
+        .blocklisted_components(self.blocklisted_components);
+
+        let ethereum_client = EthereumRpcClient::new(self.rpc_url.as_str())
+            .map_err(|e| SolverBuildError::RpcClient(e.to_string()))?;
+
+        let (mut gas_price_fetcher, gas_price_worker_signal_tx) =
+            GasPriceFetcher::new(ethereum_client, market_data.clone());
+
+        let mut tycho_feed = TychoFeed::new(tycho_feed_config, market_data.clone());
+        tycho_feed = tycho_feed.with_gas_price_worker_signal_tx(gas_price_worker_signal_tx);
+
+        let gas_token = native_token(&self.chain).map_err(|_| SolverBuildError::GasToken)?;
+        let computation_config = ComputationManagerConfig::new()
+            .with_gas_token(gas_token)
+            .with_depth_slippage_threshold(DEFAULT_DEPTH_SLIPPAGE_THRESHOLD);
+        let (computation_manager, _) =
+            ComputationManager::new(computation_config, market_data.clone())
+                .map_err(|e| SolverBuildError::ComputationManager(e.to_string()))?;
+
+        let derived_data: SharedDerivedDataRef = computation_manager.store();
+        let derived_event_tx = computation_manager.event_sender();
+
+        let computation_event_rx = tycho_feed.subscribe();
+        let (computation_shutdown_tx, computation_shutdown_rx) = broadcast::channel(1);
+
+        let mut solver_pool_handles: Vec<SolverPoolHandle> = Vec::new();
+        let mut worker_pools: Vec<WorkerPool> = Vec::new();
+
+        for pool_entry in self.pools {
+            let pool_event_rx = tycho_feed.subscribe();
+            let derived_rx = derived_event_tx.subscribe();
+
+            let (worker_pool, task_handle) = match pool_entry {
+                PoolEntry::BuiltIn {
+                    name,
+                    algorithm,
+                    num_workers,
+                    task_queue_capacity,
+                    min_hops,
+                    max_hops,
+                    timeout_ms,
+                    max_routes,
+                    connector_tokens,
+                } => {
+                    let mut algo_cfg = AlgorithmConfig::new(
+                        min_hops,
+                        max_hops,
+                        Duration::from_millis(timeout_ms),
+                        max_routes,
+                    )?;
+                    if let Some(tokens) = connector_tokens {
+                        algo_cfg = algo_cfg.with_connector_tokens(tokens);
+                    }
+                    WorkerPoolBuilder::new()
+                        .name(name)
+                        .algorithm(algorithm)
+                        .algorithm_config(algo_cfg)
+                        .num_workers(num_workers)
+                        .task_queue_capacity(task_queue_capacity)
+                        .build(
+                            market_data.clone(),
+                            Arc::clone(&derived_data),
+                            pool_event_rx,
+                            derived_rx,
+                        )?
+                }
+                PoolEntry::Custom(custom) => {
+                    let algo_cfg = AlgorithmConfig::new(
+                        custom.min_hops,
+                        custom.max_hops,
+                        Duration::from_millis(custom.timeout_ms),
+                        custom.max_routes,
+                    )?;
+                    let builder = WorkerPoolBuilder::new()
+                        .name(custom.name)
+                        .algorithm_config(algo_cfg)
+                        .num_workers(custom.num_workers)
+                        .task_queue_capacity(custom.task_queue_capacity);
+                    let builder = (custom.configure)(builder);
+                    builder.build(
+                        market_data.clone(),
+                        Arc::clone(&derived_data),
+                        pool_event_rx,
+                        derived_rx,
+                    )?
+                }
+            };
+
+            solver_pool_handles.push(SolverPoolHandle::new(worker_pool.name(), task_handle));
+            worker_pools.push(worker_pool);
+        }
+
+        let encoder = match self.encoder {
+            Some(enc) => enc,
+            None => {
+                let registry = SwapEncoderRegistry::new(self.chain)
+                    .add_default_encoders(None)
+                    .map_err(|e| SolverBuildError::Encoder(e.to_string()))?;
+                Encoder::new(self.chain, registry)
+                    .map_err(|e| SolverBuildError::Encoder(e.to_string()))?
+            }
+        };
+
+        let chain = self.chain;
+        let router_address = encoder.router_address().clone();
+
+        let router_config = WorkerPoolRouterConfig::default()
+            .with_timeout(self.router_timeout)
+            .with_min_responses(self.router_min_responses);
+        let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
+
+        if self.price_guard_enabled {
+            let mut registry = PriceProviderRegistry::new();
+            let mut worker_handles = Vec::new();
+            for mut provider in self.price_providers {
+                worker_handles.push(provider.start(market_data.clone()));
+                registry = registry.register(provider);
+            }
+            let price_guard = PriceGuard::new(registry, worker_handles);
+            router = router.with_price_guard(price_guard);
+        }
+
+        let (pending_tx, pending_rx) = tokio::sync::oneshot::channel::<PendingBlockProcessor>();
+
+        let feed_handle = tokio::spawn(async move {
+            if let Err(e) = tycho_feed
+                .run_with_pending(pending_tx)
+                .await
+            {
+                tracing::error!(error = %e, "tycho feed error");
+            }
+        });
+
+        let gas_price_handle = tokio::spawn(async move {
+            if let Err(e) = gas_price_fetcher.run().await {
+                tracing::error!(error = %e, "gas price fetcher error");
+            }
+        });
+
+        let computation_handle = tokio::spawn(async move {
+            computation_manager
+                .run(computation_event_rx, computation_shutdown_rx)
+                .await;
+        });
+
+        let pending = pending_rx
+            .await
+            .map_err(|_| SolverBuildError::PendingChannelClosed)?;
+
+        Ok((
+            Solver {
+                router,
+                worker_pools,
+                market_data,
+                derived_data,
+                feed_handle,
+                gas_price_handle,
+                computation_handle,
+                computation_shutdown_tx,
+                chain,
+                router_address,
+            },
+            pending,
+        ))
     }
 }
 

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -337,6 +337,7 @@ struct BuiltComponents {
     chain: Chain,
     router_address: Bytes,
     pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
+    market_event_tx: broadcast::Sender<MarketEvent>,
 }
 
 /// Builder for assembling the full solver pipeline.
@@ -645,6 +646,7 @@ impl FyndBuilder {
             GasPriceFetcher::new(ethereum_client, market_data.clone(), self.gas_refresh_interval);
 
         let tycho_feed = TychoFeed::new(tycho_feed_config, market_data.clone());
+        let market_event_tx = tycho_feed.event_sender();
 
         let gas_token = native_token(&self.chain).map_err(|_| SolverBuildError::GasToken)?;
         let computation_config = ComputationManagerConfig::new()
@@ -776,6 +778,7 @@ impl FyndBuilder {
             chain,
             router_address,
             pending_indexers: self.pending_indexers,
+            market_event_tx,
         })
     }
 
@@ -812,6 +815,7 @@ impl FyndBuilder {
             computation_shutdown_tx: c.computation_shutdown_tx,
             chain: c.chain,
             router_address: c.router_address,
+            market_event_tx: c.market_event_tx,
         })
     }
 
@@ -870,6 +874,7 @@ impl FyndBuilder {
                 computation_shutdown_tx: c.computation_shutdown_tx,
                 chain: c.chain,
                 router_address: c.router_address,
+                market_event_tx: c.market_event_tx,
             },
             pending,
         ))
@@ -888,6 +893,7 @@ pub struct Solver {
     computation_shutdown_tx: broadcast::Sender<()>,
     chain: Chain,
     router_address: Bytes,
+    market_event_tx: broadcast::Sender<MarketEvent>,
 }
 
 impl Solver {
@@ -899,6 +905,14 @@ impl Solver {
     /// Returns a clone of the shared derived data reference.
     pub fn derived_data(&self) -> SharedDerivedDataRef {
         Arc::clone(&self.derived_data)
+    }
+
+    /// Returns a new receiver for [`MarketEvent`]s broadcast by the Tycho feed.
+    ///
+    /// Each call returns an independent receiver. Events are broadcast on every block update.
+    /// Receivers created after a block has been processed will miss that block's event.
+    pub fn subscribe_market_events(&self) -> broadcast::Receiver<crate::feed::events::MarketEvent> {
+        self.market_event_tx.subscribe()
     }
 
     /// Submits a [`QuoteRequest`] to the worker pools and returns the best [`Quote`].

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -252,7 +252,7 @@ pub struct WaitReadyError {
     timeout_ms: u64,
 }
 
-/// Error returned by [`FyndBuilder::build`].
+/// Error returned by [`FyndBuilder::build`] and [`FyndBuilder::build_with_pending`].
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum SolverBuildError {

--- a/fynd-rpc/src/protocols.rs
+++ b/fynd-rpc/src/protocols.rs
@@ -7,7 +7,7 @@ use tycho_simulation::{
     tycho_common::models::Chain,
 };
 
-/// Fetches all available protocol systems from the Tycho RPC, handling pagination.
+/// Fetches all available protocol systems from the Tycho RPC.
 pub async fn fetch_protocol_systems(
     tycho_url: &str,
     auth_key: Option<&str>,


### PR DESCRIPTION
## Why

`FyndBuilder` wraps `ProtocolStreamBuilder` internally but always called `build()`, which discards the `PendingBlockProcessor`. There was no way for embedding callers to obtain one — the interface to configure and receive a `PendingBlockProcessor` was entirely missing from Fynd's public API.

Without this, block builders and other embedders who need to simulate candidate transaction bundles against live pool state had to open a second Tycho WebSocket connection themselves, defeating the point of using Fynd as an embedded library.

## Changes

**Core feature**

- Upgrades tycho-simulation 0.258.0 → 0.300.5 (required for the `evm::pending` module). Updates `fynd-rpc/src/protocols.rs` for the new `ProtocolSystemsParams` API in tycho-client 0.300.5.
- Adds `FyndBuilder::build_with_pending() -> Result<(Solver, PendingBlockProcessor), SolverBuildError>`: async variant of `build()` that calls `ProtocolStreamBuilder::build_with_pending()` internally and returns the processor alongside the solver.
- Adds `FyndBuilder::with_pending_indexer(extractor, indexer)` so callers can attach a `Box<dyn TxDeltaIndexer>` before calling `build_with_pending()`, mirroring `ProtocolStreamBuilder::with_pending_indexer`.
- Re-exports `PendingBlockProcessor`, `PendingError`, `PendingUpdate`, and `TxDeltaIndexer` from the crate root with contextualizing doc comments.

**Fixup commits**

- Removes an RFQ guard that incorrectly rejected `build_with_pending` when RFQ protocols were configured. RFQ streams are now handled alongside the EVM pending stream, identical to `run()`.
- Changes the pending oneshot channel type to `Result<PendingBlockProcessor, String>` so feed setup failures (e.g. token loading errors) surface the root cause as `SolverBuildError::FeedSetup` instead of the opaque `PendingChannelClosed`.
- Fixes the `SolverBuildError` enum-level doc to mention `build_with_pending` as a source of `PendingChannelClosed`.
- Extracts the ~150 lines of shared setup code from `build()` and `build_with_pending()` into a private `assemble_components() -> BuiltComponents` helper so future changes to the builder only need to be made in one place.

## Usage

```rust
let (solver, pending) = FyndBuilder::new(chain, tycho_url, rpc_url, protocols, min_tvl)
    .tycho_api_key(key)
    .algorithm("most_liquid")
    .build_with_pending()
    .await?;

// Per block iteration:
let update = pending.generate_pending_update(txs, header, label)?;
solver.register_labeled_state(label, update);
let quote = solver.quote(request).await?;
```
