### PR TITLE
feat(encoding): allow client to patch calldata signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7492,9 +7492,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.300.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39fe09e2e8c5e9ad7e78cfecf4838daaf3e334c8ebb178cd26b3b3a3ad98be7f"
+version = "0.301.0"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=592da60b1#592da60b1d08f508dc8aff6a74a869b76e9f7bcc"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7522,9 +7521,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.300.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305ad860280fd53c63d729fe2a313a73370aa587f4556a1259c34ac98d320495"
+version = "0.301.0"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=592da60b1#592da60b1d08f508dc8aff6a74a869b76e9f7bcc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7549,9 +7547,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.300.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f381953d5009758cab49b0007c1f7c4fb5514cdfef5c3f8c58fcb67cd0124c"
+version = "0.301.0"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=592da60b1#592da60b1d08f508dc8aff6a74a869b76e9f7bcc"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7571,9 +7568,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.300.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96786b4c393f77c75dc5c281970b68cb6d98d3140bad80f897d290b52c7c312"
+version = "0.301.0"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=592da60b1#592da60b1d08f508dc8aff6a74a869b76e9f7bcc"
 dependencies = [
  "alloy",
  "chrono",
@@ -7592,9 +7588,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.300.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd509cb6acbb8e6e51bb592ee119e72d033eb1c362156322eb8869f6c8dd297f"
+version = "0.301.0"
+source = "git+https://github.com/propeller-heads/tycho-indexer.git?rev=592da60b1#592da60b1d08f508dc8aff6a74a869b76e9f7bcc"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,9 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 
 # Tycho
-tycho-simulation = "0.300.5"
-tycho-execution = "0.300.5"
+# TODO switch back before merging
+tycho-simulation = { git = "https://github.com/propeller-heads/tycho-indexer.git", rev = "592da60b1" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho-indexer.git", rev = "592da60b1" }
 typetag = "0.2"
 
 # Graph algorithms

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -293,15 +293,6 @@
             "description": "Client's portion of the fee (after the router takes its share).",
             "example": "2800000"
           },
-          "client_fee_signature_offset": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "description": "Byte offset of the client fee signature within `Transaction.data`.\nClients use this to overwrite the placeholder signature with the real one after signing the\nEIP-712 hash (see [`swaps_hash`](Self::swaps_hash)).",
-            "example": null,
-            "minimum": 0
-          },
           "max_slippage": {
             "type": "string",
             "description": "Maximum slippage: (amount_out - router_fee - client_fee) * slippage.",
@@ -839,6 +830,15 @@
           "data"
         ],
         "properties": {
+          "client_fee_signature_offset": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Byte offset of the client fee signature within `data`.\nClients use this to overwrite the placeholder signature with the real one.",
+            "example": null,
+            "minimum": 0
+          },
           "data": {
             "type": "string",
             "description": "ABI-encoded calldata as hex string.",

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -293,6 +293,15 @@
             "description": "Client's portion of the fee (after the router takes its share).",
             "example": "2800000"
           },
+          "client_fee_signature_offset": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Byte offset of the client fee signature within `Transaction.data`.\nClients use this to overwrite the placeholder signature with the real one after signing the\nEIP-712 hash (see [`swaps_hash`](Self::swaps_hash)).",
+            "example": null,
+            "minimum": 0
+          },
           "max_slippage": {
             "type": "string",
             "description": "Maximum slippage: (amount_out - router_fee - client_fee) * slippage.",

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -162,7 +162,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Step 3: patch the real signature into the calldata.
-    let quote = quote.with_client_fee_signature(&sig.as_bytes()[..]);
+    let quote = quote.with_client_fee_signature(&sig.as_bytes()[..])?;
     // [doc:end client-fee-rust]
 
     println!("amount_in:  {}", quote.amount_in());

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // [doc:start client-fee-rust]
-    // Step 1: request a quote with unsigned client fee params.
+    // Step 1: request a quote using unsigned client fee params.
     // The server encodes the full calldata and returns `swaps_hash`
     // in the fee breakdown and `signature_offset` in the transaction
     // so the client can patch the real signature in.

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -9,7 +9,7 @@
 //! The EIP-712 `ClientFee` type hash includes swap-specific fields (`amountIn`,
 //! `tokenIn`, `tokenOut`, `minAmountOut`, `receiver`, `bytes swaps`) that are
 //! only known after the server has encoded the transaction. The server returns
-//! `swaps_hash` and `signature_offset` in the fee breakdown so the client can
+//! `swaps_hash` in the fee breakdown and `signature_offset` in the transaction so the client can
 //! sign and patch the calldata locally:
 //!
 //! 1. Request a quote with unsigned client fee params (empty signature).
@@ -112,9 +112,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // [doc:start client-fee-rust]
     // Step 1: request a quote with unsigned client fee params.
-    // The server encodes the full calldata and returns `swaps_hash` +
-    // `signature_offset` in the fee breakdown so the client can patch
-    // the real signature in.
+    // The server encodes the full calldata and returns `swaps_hash`
+    // in the fee breakdown and `signature_offset` in the transaction
+    // so the client can patch the real signature in.
     let fee = ClientFeeParams::new(
         FEE_BPS,
         Bytes::copy_from_slice(fee_receiver.as_slice()),

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -8,12 +8,14 @@
 //!
 //! The EIP-712 `ClientFee` type hash includes swap-specific fields (`amountIn`,
 //! `tokenIn`, `tokenOut`, `minAmountOut`, `receiver`, `bytes swaps`) that are
-//! only known after the server has encoded the transaction. This requires a
-//! two-step flow:
-//! 1. Request a quote with unsigned client fee params → receive `fee_breakdown` containing
-//!    `swaps_hash` and `min_amount_received`.
-//! 2. Sign the full 10-field EIP-712 hash.
-//! 3. Re-request the quote with the valid signature and execute.
+//! only known after the server has encoded the transaction. The server returns
+//! `swaps_hash` and `signature_offset` in the fee breakdown so the client can
+//! sign and patch the calldata locally:
+//!
+//! 1. Request a quote with unsigned client fee params (empty signature).
+//! 2. Sign the full 10-field EIP-712 hash using `swaps_hash` from the response.
+//! 3. Patch the signature into the calldata via `quote.with_client_fee_signature()`.
+//! 4. Execute.
 //!
 //! ## Run with Anvil (mocked accounts)
 //!
@@ -109,10 +111,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // [doc:start client-fee-rust]
-    // The EIP-712 ClientFee type hash includes swap-specific fields that are
-    // only known after encoding. Step 1: request an unsigned quote to obtain
-    // `swaps_hash` and `min_amount_received` from the fee breakdown.
-    let fee_unsigned = ClientFeeParams::new(
+    // Step 1: request a quote with unsigned client fee params.
+    // The server encodes the full calldata and returns `swaps_hash` +
+    // `signature_offset` in the fee breakdown so the client can patch
+    // the real signature in.
+    let fee = ClientFeeParams::new(
         FEE_BPS,
         Bytes::copy_from_slice(fee_receiver.as_slice()),
         BigUint::ZERO,
@@ -126,36 +129,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Bytes::copy_from_slice(sender.as_slice()),
         None,
     );
-    let quote_unsigned = client
+    let quote = client
         .quote(QuoteParams::new(
-            order.clone(),
+            order,
             QuoteOptions::default()
                 .with_timeout_ms(5_000)
-                .with_encoding_options(
-                    EncodingOptions::new(SLIPPAGE).with_client_fee(fee_unsigned),
-                ),
+                .with_encoding_options(EncodingOptions::new(SLIPPAGE).with_client_fee(fee.clone())),
         ))
         .await?;
 
-    let fee_breakdown = quote_unsigned
+    let fee_breakdown = quote
         .fee_breakdown()
-        .ok_or("no fee breakdown in unsigned quote")?;
+        .ok_or("no fee breakdown in quote")?;
     let swaps_hash = fee_breakdown
         .swaps_hash()
-        .ok_or("no swaps_hash in fee breakdown — server must support client fee signing")?;
+        .ok_or("no swaps_hash — server must support client fee signing")?;
 
     // Step 2: sign the full 10-field EIP-712 ClientFee hash.
     // receiver defaults to sender when the order has no explicit receiver.
-    let fee = ClientFeeParams::new(
-        FEE_BPS,
-        Bytes::copy_from_slice(fee_receiver.as_slice()),
-        BigUint::ZERO,
-        u64::MAX,
-    );
     let hash = fee.eip712_signing_hash(
         chain_id,
         &router_address,
-        quote_unsigned.amount_in(),
+        quote.amount_in(),
         &Bytes::copy_from_slice(sell_token.as_slice()),
         &Bytes::copy_from_slice(buy_token.as_slice()),
         fee_breakdown.min_amount_received(),
@@ -166,19 +161,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .sign_hash(&B256::from(hash))
         .await?;
 
-    // Step 3: re-request the quote with the valid signature attached.
-    let encoding_options = EncodingOptions::new(SLIPPAGE)
-        .with_client_fee(fee.with_signature(Bytes::copy_from_slice(&sig.as_bytes()[..])));
+    // Step 3: patch the real signature into the calldata.
+    let quote = quote.with_client_fee_signature(&sig.as_bytes()[..]);
     // [doc:end client-fee-rust]
-
-    let quote = client
-        .quote(QuoteParams::new(
-            order,
-            QuoteOptions::default()
-                .with_timeout_ms(5_000)
-                .with_encoding_options(encoding_options),
-        ))
-        .await?;
 
     println!("amount_in:  {}", quote.amount_in());
     println!("amount_out: {}", quote.amount_out());

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -236,7 +236,6 @@ fn order_quote_to_quote(
             fb.max_slippage().clone(),
             fb.min_amount_received().clone(),
             swaps_hash,
-            fb.client_fee_signature_offset(),
         )
     });
     Ok(Quote::new(
@@ -259,11 +258,15 @@ fn order_quote_to_quote(
 
 impl From<dto::Transaction> for Transaction {
     fn from(dt: dto::Transaction) -> Self {
-        Transaction::new(
+        let mut tx = Transaction::new(
             bytes::Bytes::copy_from_slice(dt.to().as_ref()),
             dt.value().clone(),
             dt.data().to_vec(),
-        )
+        );
+        if let Some(offset) = dt.client_fee_signature_offset() {
+            tx.client_fee_signature_offset = Some(offset);
+        }
+        tx
     }
 }
 

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -236,6 +236,7 @@ fn order_quote_to_quote(
             fb.max_slippage().clone(),
             fb.min_amount_received().clone(),
             swaps_hash,
+            fb.client_fee_signature_offset(),
         )
     });
     Ok(Quote::new(

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -380,7 +380,8 @@ impl EncodingOptions {
 pub struct Transaction {
     to: Bytes,
     value: BigUint,
-    data: Vec<u8>,
+    pub(crate) data: Vec<u8>,
+    pub(crate) client_fee_signature_offset: Option<usize>,
 }
 
 impl Transaction {
@@ -390,7 +391,7 @@ impl Transaction {
     /// - `value`: native token value to send with the transaction.
     /// - `data`: ABI-encoded calldata.
     pub fn new(to: Bytes, value: BigUint, data: Vec<u8>) -> Self {
-        Self { to, value, data }
+        Self { to, value, data, client_fee_signature_offset: None }
     }
 
     /// Router contract address (20 raw bytes).
@@ -406,6 +407,11 @@ impl Transaction {
     /// ABI-encoded calldata.
     pub fn data(&self) -> &[u8] {
         &self.data
+    }
+
+    /// Byte offset of the client fee signature within `data`.
+    pub fn client_fee_signature_offset(&self) -> Option<usize> {
+        self.client_fee_signature_offset
     }
 }
 
@@ -758,8 +764,6 @@ pub struct FeeBreakdown {
     min_amount_received: BigUint,
     /// keccak256 of the ABI-encoded swap bytes. Use this for EIP-712 signing.
     swaps_hash: Option<[u8; 32]>,
-    /// Byte offset of the client fee signature within the TychoRouter calldata
-    signature_offset: Option<usize>,
 }
 
 impl FeeBreakdown {
@@ -769,16 +773,8 @@ impl FeeBreakdown {
         max_slippage: BigUint,
         min_amount_received: BigUint,
         swaps_hash: Option<[u8; 32]>,
-        signature_offset: Option<usize>,
     ) -> Self {
-        Self {
-            router_fee,
-            client_fee,
-            max_slippage,
-            min_amount_received,
-            swaps_hash,
-            signature_offset,
-        }
+        Self { router_fee, client_fee, max_slippage, min_amount_received, swaps_hash }
     }
 
     /// Router protocol fee (fee on output + router's share of client fee).
@@ -809,14 +805,6 @@ impl FeeBreakdown {
     /// [`ClientFeeParams::eip712_signing_hash`] in the two-step signing flow.
     pub fn swaps_hash(&self) -> Option<&[u8; 32]> {
         self.swaps_hash.as_ref()
-    }
-
-    /// Byte offset of the client fee signature within `Transaction.data`.
-    ///
-    /// Use this with [`Quote::with_client_fee_signature`] to patch the real
-    /// EIP-712 signature into the calldata after signing.
-    pub fn signature_offset(&self) -> Option<usize> {
-        self.signature_offset
     }
 }
 
@@ -951,27 +939,22 @@ impl Quote {
     /// Use this after a single quote request:
     ///
     /// 1. Request a quote with unsigned [`ClientFeeParams`] (empty signature).
-    /// 2. Read [`FeeBreakdown::swaps_hash`] and [`FeeBreakdown::signature_offset`] from the
-    ///    response.
+    /// 2. Read [`FeeBreakdown::swaps_hash`] from the response.
     /// 3. Sign the 10-field EIP-712 hash using [`ClientFeeParams::eip712_signing_hash`].
     /// 4. Call this method to patch the signature into the calldata.
     /// 5. Execute the transaction.
     ///
     /// # Panics
     ///
-    /// Panics if the quote has no transaction, no fee breakdown, or no
-    /// `signature_offset`.
+    /// Panics if the quote has no transaction or no `client_fee_signature_offset`.
     pub fn with_client_fee_signature(mut self, signature: &[u8]) -> Self {
-        let offset = self
-            .fee_breakdown
-            .as_ref()
-            .expect("fee_breakdown required for signature patching")
-            .signature_offset()
-            .expect("signature_offset required for signature patching");
         let tx = self
             .transaction
             .as_mut()
             .expect("transaction required for signature patching");
+        let offset = tx
+            .client_fee_signature_offset()
+            .expect("client_fee_signature_offset required for signature patching");
         tx.data[offset..offset + signature.len()].copy_from_slice(signature);
         self
     }

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -758,6 +758,8 @@ pub struct FeeBreakdown {
     min_amount_received: BigUint,
     /// keccak256 of the ABI-encoded swap bytes. Use this for EIP-712 signing.
     swaps_hash: Option<[u8; 32]>,
+    /// Byte offset of the client fee signature within the TychoRouter calldata
+    signature_offset: Option<usize>,
 }
 
 impl FeeBreakdown {
@@ -767,8 +769,16 @@ impl FeeBreakdown {
         max_slippage: BigUint,
         min_amount_received: BigUint,
         swaps_hash: Option<[u8; 32]>,
+        signature_offset: Option<usize>,
     ) -> Self {
-        Self { router_fee, client_fee, max_slippage, min_amount_received, swaps_hash }
+        Self {
+            router_fee,
+            client_fee,
+            max_slippage,
+            min_amount_received,
+            swaps_hash,
+            signature_offset,
+        }
     }
 
     /// Router protocol fee (fee on output + router's share of client fee).
@@ -799,6 +809,14 @@ impl FeeBreakdown {
     /// [`ClientFeeParams::eip712_signing_hash`] in the two-step signing flow.
     pub fn swaps_hash(&self) -> Option<&[u8; 32]> {
         self.swaps_hash.as_ref()
+    }
+
+    /// Byte offset of the client fee signature within `Transaction.data`.
+    ///
+    /// Use this with [`Quote::with_client_fee_signature`] to patch the real
+    /// EIP-712 signature into the calldata after signing.
+    pub fn signature_offset(&self) -> Option<usize> {
+        self.signature_offset
     }
 }
 
@@ -925,6 +943,37 @@ impl Quote {
     /// Populated by [`FyndClient::quote`](crate::FyndClient::quote). Returns `0` if not set.
     pub fn solve_time_ms(&self) -> u64 {
         self.solve_time_ms
+    }
+
+    /// Patches the 65-byte client fee EIP-712 signature into the transaction
+    /// calldata at the offset returned by the server.
+    ///
+    /// Use this after a single quote request:
+    ///
+    /// 1. Request a quote with unsigned [`ClientFeeParams`] (empty signature).
+    /// 2. Read [`FeeBreakdown::swaps_hash`] and [`FeeBreakdown::signature_offset`] from the
+    ///    response.
+    /// 3. Sign the 10-field EIP-712 hash using [`ClientFeeParams::eip712_signing_hash`].
+    /// 4. Call this method to patch the signature into the calldata.
+    /// 5. Execute the transaction.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the quote has no transaction, no fee breakdown, or no
+    /// `signature_offset`.
+    pub fn with_client_fee_signature(mut self, signature: &[u8]) -> Self {
+        let offset = self
+            .fee_breakdown
+            .as_ref()
+            .expect("fee_breakdown required for signature patching")
+            .signature_offset()
+            .expect("signature_offset required for signature patching");
+        let tx = self
+            .transaction
+            .as_mut()
+            .expect("transaction required for signature patching");
+        tx.data[offset..offset + signature.len()].copy_from_slice(signature);
+        self
     }
 
     /// Create a new [`Quote`].

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -5,7 +5,7 @@ use alloy::{
 use bytes::Bytes;
 use num_bigint::BigUint;
 
-use crate::mapping::biguint_to_u256;
+use crate::{error::FyndError, mapping::biguint_to_u256};
 
 // ============================================================================
 // ENCODING TYPES
@@ -944,19 +944,26 @@ impl Quote {
     /// 4. Call this method to patch the signature into the calldata.
     /// 5. Execute the transaction.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the quote has no transaction or no `client_fee_signature_offset`.
-    pub fn with_client_fee_signature(mut self, signature: &[u8]) -> Self {
+    /// Returns [`FyndError::Protocol`] if the quote has no transaction or no
+    /// `client_fee_signature_offset`.
+    pub fn with_client_fee_signature(mut self, signature: &[u8]) -> Result<Self, FyndError> {
         let tx = self
             .transaction
             .as_mut()
-            .expect("transaction required for signature patching");
+            .ok_or_else(|| {
+                FyndError::Protocol("transaction required for signature patching".into())
+            })?;
         let offset = tx
             .client_fee_signature_offset()
-            .expect("client_fee_signature_offset required for signature patching");
+            .ok_or_else(|| {
+                FyndError::Protocol(
+                    "client_fee_signature_offset required for signature patching".into(),
+                )
+            })?;
         tx.data[offset..offset + signature.len()].copy_from_slice(signature);
-        self
+        Ok(self)
     }
 
     /// Create a new [`Quote`].

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -171,6 +171,13 @@ export interface components {
              */
             client_fee: string;
             /**
+             * @description Byte offset of the client fee signature within `Transaction.data`.
+             *     Clients use this to overwrite the placeholder signature with the real one after signing the
+             *     EIP-712 hash (see [`swaps_hash`](Self::swaps_hash)).
+             * @example null
+             */
+            client_fee_signature_offset?: number | null;
+            /**
              * @description Maximum slippage: (amount_out - router_fee - client_fee) * slippage.
              * @example 3496850
              */

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -171,13 +171,6 @@ export interface components {
              */
             client_fee: string;
             /**
-             * @description Byte offset of the client fee signature within `Transaction.data`.
-             *     Clients use this to overwrite the placeholder signature with the real one after signing the
-             *     EIP-712 hash (see [`swaps_hash`](Self::swaps_hash)).
-             * @example null
-             */
-            client_fee_signature_offset?: number | null;
-            /**
              * @description Maximum slippage: (amount_out - router_fee - client_fee) * slippage.
              * @example 3496850
              */
@@ -528,6 +521,12 @@ export interface components {
         };
         /** @description An encoded EVM transaction ready to be submitted on-chain. */
         Transaction: {
+            /**
+             * @description Byte offset of the client fee signature within `data`.
+             *     Clients use this to overwrite the placeholder signature with the real one.
+             * @example null
+             */
+            client_fee_signature_offset?: number | null;
             /**
              * @description ABI-encoded calldata as hex string.
              * @example 0x1234567890abcdef

--- a/docs/guides/client-fees.md
+++ b/docs/guides/client-fees.md
@@ -118,23 +118,58 @@ const opts = withClientFee(encodingOptions(0.005), {...feeParams, signature});
 
 {% tab title="Rust" %}
 ```rust
-    // Build the fee params (without signature).
+    // Step 1: request a quote with unsigned client fee params.
+    // The server encodes the full calldata and returns `swaps_hash` +
+    // `signature_offset` in the fee breakdown so the client can patch
+    // the real signature in.
     let fee = ClientFeeParams::new(
         FEE_BPS,
         Bytes::copy_from_slice(fee_receiver.as_slice()),
         BigUint::ZERO,
         u64::MAX,
     );
+    let order = Order::new(
+        Bytes::copy_from_slice(sell_token.as_slice()),
+        Bytes::copy_from_slice(buy_token.as_slice()),
+        BigUint::from(SELL_AMOUNT),
+        OrderSide::Sell,
+        Bytes::copy_from_slice(sender.as_slice()),
+        None,
+    );
+    let quote = client
+        .quote(QuoteParams::new(
+            order,
+            QuoteOptions::default()
+                .with_timeout_ms(5_000)
+                .with_encoding_options(EncodingOptions::new(SLIPPAGE).with_client_fee(fee.clone())),
+        ))
+        .await?;
 
-    // Compute the EIP-712 signing hash and sign it with the fee receiver's key.
-    let hash = fee.eip712_signing_hash(chain_id, &router_address)?;
+    let fee_breakdown = quote
+        .fee_breakdown()
+        .ok_or("no fee breakdown in quote")?;
+    let swaps_hash = fee_breakdown
+        .swaps_hash()
+        .ok_or("no swaps_hash — server must support client fee signing")?;
+
+    // Step 2: sign the full 10-field EIP-712 ClientFee hash.
+    // receiver defaults to sender when the order has no explicit receiver.
+    let hash = fee.eip712_signing_hash(
+        chain_id,
+        &router_address,
+        quote.amount_in(),
+        &Bytes::copy_from_slice(sell_token.as_slice()),
+        &Bytes::copy_from_slice(buy_token.as_slice()),
+        fee_breakdown.min_amount_received(),
+        &Bytes::copy_from_slice(sender.as_slice()),
+        swaps_hash,
+    )?;
     let sig = fee_signer
         .sign_hash(&B256::from(hash))
         .await?;
 
-    // Attach the signature and wire it into encoding options.
-    let fee = fee.with_signature(Bytes::copy_from_slice(&sig.as_bytes()[..]));
-    let encoding_options = EncodingOptions::new(SLIPPAGE).with_client_fee(fee);
+    // Step 3: patch the real signature into the calldata.
+    let quote = quote.with_client_fee_signature(&sig.as_bytes()[..]);
 ```
 
 See the full working example: [`clients/rust/examples/swap_client_fee.rs`](../../clients/rust/examples/swap_client_fee.rs)

--- a/docs/guides/client-fees.md
+++ b/docs/guides/client-fees.md
@@ -119,9 +119,9 @@ const opts = withClientFee(encodingOptions(0.005), {...feeParams, signature});
 {% tab title="Rust" %}
 ```rust
     // Step 1: request a quote using unsigned client fee params.
-    // The server encodes the full calldata and returns `swaps_hash` +
-    // `signature_offset` in the fee breakdown so the client can patch
-    // the real signature in.
+    // The server encodes the full calldata and returns `swaps_hash`
+    // in the fee breakdown and `signature_offset` in the transaction
+    // so the client can patch the real signature in.
     let fee = ClientFeeParams::new(
         FEE_BPS,
         Bytes::copy_from_slice(fee_receiver.as_slice()),

--- a/docs/guides/client-fees.md
+++ b/docs/guides/client-fees.md
@@ -118,7 +118,7 @@ const opts = withClientFee(encodingOptions(0.005), {...feeParams, signature});
 
 {% tab title="Rust" %}
 ```rust
-    // Step 1: request a quote with unsigned client fee params.
+    // Step 1: request a quote using unsigned client fee params.
     // The server encodes the full calldata and returns `swaps_hash` +
     // `signature_offset` in the fee breakdown so the client can patch
     // the real signature in.
@@ -169,7 +169,7 @@ const opts = withClientFee(encodingOptions(0.005), {...feeParams, signature});
         .await?;
 
     // Step 3: patch the real signature into the calldata.
-    let quote = quote.with_client_fee_signature(&sig.as_bytes()[..]);
+    let quote = quote.with_client_fee_signature(&sig.as_bytes()[..])?;
 ```
 
 See the full working example: [`clients/rust/examples/swap_client_fee.rs`](../../clients/rust/examples/swap_client_fee.rs)

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -255,16 +255,19 @@ impl Encoder {
             (None, vec![])
         };
 
-        // Use a known placeholder so find_signature_offset can locate it reliably.
-        // The client overwrites these bytes with the real signature after signing.
-        let sig_placeholder = vec![0x42u8; 65];
         let client_fee_params = if let Some(fee) = encoding_options.client_fee_params() {
             (
                 fee.bps(),
                 bytes_to_address(fee.receiver())?,
                 biguint_to_u256(fee.max_contribution()),
                 U256::from(fee.deadline()),
-                sig_placeholder.clone(),
+                // Pad to 65 bytes so the ABI encoding always reserves room for
+                // the client to patch the real EIP-712 signature after signing.
+                {
+                    let mut sig = fee.signature().to_vec();
+                    sig.resize(65, 0);
+                    sig
+                },
             )
         } else {
             (0u16, Address::ZERO, U256::ZERO, U256::MAX, vec![])
@@ -341,13 +344,8 @@ impl Encoder {
             .client_fee_params()
             .is_some()
         {
-            if let Some(offset) =
-                Self::find_signature_offset(&contract_interaction, &sig_placeholder)
-            {
-                fee_breakdown.with_signature_offset(offset)
-            } else {
-                fee_breakdown
-            }
+            let offset = encoded_solution.client_fee_signature_offset();
+            fee_breakdown.with_signature_offset(offset)
         } else {
             fee_breakdown
         };
@@ -384,30 +382,6 @@ impl Encoder {
         }
         call_data.extend(encoded_args);
         call_data
-    }
-
-    /// Finds the byte offset of `sig_bytes` within `calldata`.
-    ///
-    /// Returns `None` if the signature is not found or appears more than once
-    /// (ambiguous match).
-    fn find_signature_offset(calldata: &[u8], sig_bytes: &[u8]) -> Option<usize> {
-        if sig_bytes.is_empty() {
-            return None;
-        }
-        let mut found = None;
-        for (i, window) in calldata
-            .windows(sig_bytes.len())
-            .enumerate()
-        {
-            if window == sig_bytes {
-                if found.is_some() {
-                    // Ambiguous — signature pattern appears more than once
-                    return None;
-                }
-                found = Some(i);
-            }
-        }
-        found
     }
 
     /// Mirrors the on-chain `FeeCalculator.calculateFee` using identical integer arithmetic.
@@ -760,13 +734,8 @@ mod tests {
             .unwrap();
 
         let fb = result[0].fee_breakdown().unwrap();
-        let offset = fb
-            .signature_offset()
+        fb.signature_offset()
             .expect("signature_offset must be present with client fee");
-
-        // The server always encodes with the internal placeholder [0x42; 65]
-        let calldata = result[0].transaction().unwrap().data();
-        assert_eq!(&calldata[offset..offset + 65], &[0x42u8; 65]);
     }
 
     #[tokio::test]

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -255,13 +255,16 @@ impl Encoder {
             (None, vec![])
         };
 
+        // Use a known placeholder so find_signature_offset can locate it reliably.
+        // The client overwrites these bytes with the real signature after signing.
+        let sig_placeholder = vec![0x42u8; 65];
         let client_fee_params = if let Some(fee) = encoding_options.client_fee_params() {
             (
                 fee.bps(),
                 bytes_to_address(fee.receiver())?,
                 biguint_to_u256(fee.max_contribution()),
                 U256::from(fee.deadline()),
-                fee.signature().to_vec(),
+                sig_placeholder.clone(),
             )
         } else {
             (0u16, Address::ZERO, U256::ZERO, U256::MAX, vec![])
@@ -333,6 +336,22 @@ impl Encoder {
 
         let contract_interaction =
             Self::encode_input(encoded_solution.function_signature(), method_calldata);
+
+        let fee_breakdown = if encoding_options
+            .client_fee_params()
+            .is_some()
+        {
+            if let Some(offset) =
+                Self::find_signature_offset(&contract_interaction, &sig_placeholder)
+            {
+                fee_breakdown.with_signature_offset(offset)
+            } else {
+                fee_breakdown
+            }
+        } else {
+            fee_breakdown
+        };
+
         let value =
             if token_in == router_eth { solution.amount_in().clone() } else { BigUint::ZERO };
         let transaction = Transaction::new(
@@ -365,6 +384,30 @@ impl Encoder {
         }
         call_data.extend(encoded_args);
         call_data
+    }
+
+    /// Finds the byte offset of `sig_bytes` within `calldata`.
+    ///
+    /// Returns `None` if the signature is not found or appears more than once
+    /// (ambiguous match).
+    fn find_signature_offset(calldata: &[u8], sig_bytes: &[u8]) -> Option<usize> {
+        if sig_bytes.is_empty() {
+            return None;
+        }
+        let mut found = None;
+        for (i, window) in calldata
+            .windows(sig_bytes.len())
+            .enumerate()
+        {
+            if window == sig_bytes {
+                if found.is_some() {
+                    // Ambiguous — signature pattern appears more than once
+                    return None;
+                }
+                found = Some(i);
+            }
+        }
+        found
     }
 
     /// Mirrors the on-chain `FeeCalculator.calculateFee` using identical integer arithmetic.
@@ -690,5 +733,83 @@ mod tests {
             .unwrap();
 
         assert!(result[0].transaction().is_some());
+    }
+
+    // ==================== Signature Offset Tests ====================
+
+    fn make_client_fee(bps: u16) -> crate::ClientFeeParams {
+        crate::ClientFeeParams::new(
+            bps,
+            Bytes::from(make_address(0xBB).as_ref()),
+            BigUint::from(0u64),
+            1_893_456_000u64,
+            Bytes::from(vec![]),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_encode_with_client_fee_returns_signature_offset() {
+        let encoder = real_encoder();
+        let quote = make_order_quote()
+            .with_route(make_route_with_tokens(&[(make_address(0x01), make_address(0x02))]));
+        let opts = EncodingOptions::new(0.01).with_client_fee_params(make_client_fee(100));
+
+        let result = encoder
+            .encode(vec![quote], opts)
+            .await
+            .unwrap();
+
+        let fb = result[0].fee_breakdown().unwrap();
+        let offset = fb
+            .signature_offset()
+            .expect("signature_offset must be present with client fee");
+
+        // The server always encodes with the internal placeholder [0x42; 65]
+        let calldata = result[0].transaction().unwrap().data();
+        assert_eq!(&calldata[offset..offset + 65], &[0x42u8; 65]);
+    }
+
+    #[tokio::test]
+    async fn test_encode_without_client_fee_has_no_signature_offset() {
+        let encoder = real_encoder();
+        let quote = make_order_quote()
+            .with_route(make_route_with_tokens(&[(make_address(0x01), make_address(0x02))]));
+        let opts = EncodingOptions::new(0.01);
+
+        let result = encoder
+            .encode(vec![quote], opts)
+            .await
+            .unwrap();
+
+        let fb = result[0].fee_breakdown().unwrap();
+        assert!(fb.signature_offset().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_signature_offset_allows_patching() {
+        let encoder = real_encoder();
+        let real_sig = vec![0xFF; 65];
+        let quote = make_order_quote()
+            .with_route(make_route_with_tokens(&[(make_address(0x01), make_address(0x02))]));
+        let opts = EncodingOptions::new(0.01).with_client_fee_params(make_client_fee(100));
+
+        let result = encoder
+            .encode(vec![quote], opts)
+            .await
+            .unwrap();
+
+        let offset = result[0]
+            .fee_breakdown()
+            .unwrap()
+            .signature_offset()
+            .unwrap();
+
+        let mut calldata = result[0]
+            .transaction()
+            .unwrap()
+            .data()
+            .to_vec();
+        calldata[offset..offset + 65].copy_from_slice(&real_sig);
+        assert_eq!(&calldata[offset..offset + 65], &real_sig[..]);
     }
 }

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -340,25 +340,22 @@ impl Encoder {
         let contract_interaction =
             Self::encode_input(encoded_solution.function_signature(), method_calldata);
 
-        let fee_breakdown = if encoding_options
-            .client_fee_params()
-            .is_some()
-        {
-            let offset = encoded_solution.client_fee_signature_offset();
-            fee_breakdown.with_signature_offset(offset)
-        } else {
-            fee_breakdown
-        };
-
         let value =
             if token_in == router_eth { solution.amount_in().clone() } else { BigUint::ZERO };
-        let transaction = Transaction::new(
+        let mut transaction = Transaction::new(
             encoded_solution
                 .interacting_with()
                 .clone(),
             value,
             contract_interaction,
         );
+        if encoding_options
+            .client_fee_params()
+            .is_some()
+        {
+            let offset = encoded_solution.client_fee_signature_offset();
+            transaction = transaction.with_client_fee_signature_offset(offset);
+        }
         Ok((transaction, fee_breakdown))
     }
 
@@ -733,9 +730,9 @@ mod tests {
             .await
             .unwrap();
 
-        let fb = result[0].fee_breakdown().unwrap();
-        fb.signature_offset()
-            .expect("signature_offset must be present with client fee");
+        let tx = result[0].transaction().unwrap();
+        tx.client_fee_signature_offset()
+            .expect("client_fee_signature_offset must be present with client fee");
     }
 
     #[tokio::test]
@@ -750,8 +747,10 @@ mod tests {
             .await
             .unwrap();
 
-        let fb = result[0].fee_breakdown().unwrap();
-        assert!(fb.signature_offset().is_none());
+        let tx = result[0].transaction().unwrap();
+        assert!(tx
+            .client_fee_signature_offset()
+            .is_none());
     }
 
     #[tokio::test]
@@ -767,17 +766,12 @@ mod tests {
             .await
             .unwrap();
 
-        let offset = result[0]
-            .fee_breakdown()
-            .unwrap()
-            .signature_offset()
+        let tx = result[0].transaction().unwrap();
+        let offset = tx
+            .client_fee_signature_offset()
             .unwrap();
 
-        let mut calldata = result[0]
-            .transaction()
-            .unwrap()
-            .data()
-            .to_vec();
+        let mut calldata = tx.data().to_vec();
         calldata[offset..offset + 65].copy_from_slice(&real_sig);
         assert_eq!(&calldata[offset..offset + 65], &real_sig[..]);
     }

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -254,10 +254,6 @@ pub struct FeeBreakdown {
     /// Clients use this to compute the 10-field EIP-712 signing hash for the client fee.
     #[serde(skip)]
     swaps_hash: Option<[u8; 32]>,
-    /// Byte offset of the client fee signature within `Transaction.data`.
-    /// Clients use this to patch the 65-byte EIP-712 signature into the calldata.
-    #[serde(skip)]
-    signature_offset: Option<usize>,
 }
 
 impl FeeBreakdown {
@@ -268,25 +264,12 @@ impl FeeBreakdown {
         max_slippage: BigUint,
         min_amount_received: BigUint,
     ) -> Self {
-        Self {
-            router_fee,
-            client_fee,
-            max_slippage,
-            min_amount_received,
-            swaps_hash: None,
-            signature_offset: None,
-        }
+        Self { router_fee, client_fee, max_slippage, min_amount_received, swaps_hash: None }
     }
 
     /// Attaches the keccak256 hash of the encoded swap bytes.
     pub fn with_swaps_hash(mut self, hash: [u8; 32]) -> Self {
         self.swaps_hash = Some(hash);
-        self
-    }
-
-    /// Attaches the byte offset of the client fee signature within the calldata.
-    pub fn with_signature_offset(mut self, offset: usize) -> Self {
-        self.signature_offset = Some(offset);
         self
     }
 
@@ -314,12 +297,6 @@ impl FeeBreakdown {
     /// Used by clients to construct the full 10-field EIP-712 `ClientFee` signing hash.
     pub fn swaps_hash(&self) -> Option<&[u8; 32]> {
         self.swaps_hash.as_ref()
-    }
-
-    /// Byte offset of the client fee signature within `Transaction.data`.
-    /// Clients use this to overwrite the placeholder signature with the real one.
-    pub fn signature_offset(&self) -> Option<usize> {
-        self.signature_offset
     }
 }
 
@@ -1364,12 +1341,22 @@ pub struct Transaction {
     value: num_bigint::BigUint,
     /// ABI-encoded calldata.
     data: Vec<u8>,
+    /// Byte offset of the client fee signature within `data`.
+    /// Clients use this to patch the 65-byte EIP-712 signature into the calldata.
+    #[serde(skip)]
+    client_fee_signature_offset: Option<usize>,
 }
 
 impl Transaction {
     /// Creates a new transaction.
     pub fn new(to: Bytes, value: BigUint, data: Vec<u8>) -> Self {
-        Self { to, value, data }
+        Self { to, value, data, client_fee_signature_offset: None }
+    }
+
+    /// Attaches the byte offset of the client fee signature within the calldata.
+    pub fn with_client_fee_signature_offset(mut self, offset: usize) -> Self {
+        self.client_fee_signature_offset = Some(offset);
+        self
     }
 
     /// Returns the contract address to call.
@@ -1385,6 +1372,11 @@ impl Transaction {
     /// Returns the ABI-encoded calldata.
     pub fn data(&self) -> &[u8] {
         &self.data
+    }
+
+    /// Byte offset of the client fee signature within `data`.
+    pub fn client_fee_signature_offset(&self) -> Option<usize> {
+        self.client_fee_signature_offset
     }
 }
 

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -254,6 +254,10 @@ pub struct FeeBreakdown {
     /// Clients use this to compute the 10-field EIP-712 signing hash for the client fee.
     #[serde(skip)]
     swaps_hash: Option<[u8; 32]>,
+    /// Byte offset of the client fee signature within `Transaction.data`.
+    /// Clients use this to patch the 65-byte EIP-712 signature into the calldata.
+    #[serde(skip)]
+    signature_offset: Option<usize>,
 }
 
 impl FeeBreakdown {
@@ -264,12 +268,25 @@ impl FeeBreakdown {
         max_slippage: BigUint,
         min_amount_received: BigUint,
     ) -> Self {
-        Self { router_fee, client_fee, max_slippage, min_amount_received, swaps_hash: None }
+        Self {
+            router_fee,
+            client_fee,
+            max_slippage,
+            min_amount_received,
+            swaps_hash: None,
+            signature_offset: None,
+        }
     }
 
     /// Attaches the keccak256 hash of the encoded swap bytes.
     pub fn with_swaps_hash(mut self, hash: [u8; 32]) -> Self {
         self.swaps_hash = Some(hash);
+        self
+    }
+
+    /// Attaches the byte offset of the client fee signature within the calldata.
+    pub fn with_signature_offset(mut self, offset: usize) -> Self {
+        self.signature_offset = Some(offset);
         self
     }
 
@@ -297,6 +314,12 @@ impl FeeBreakdown {
     /// Used by clients to construct the full 10-field EIP-712 `ClientFee` signing hash.
     pub fn swaps_hash(&self) -> Option<&[u8; 32]> {
         self.swaps_hash.as_ref()
+    }
+
+    /// Byte offset of the client fee signature within `Transaction.data`.
+    /// Clients use this to overwrite the placeholder signature with the real one.
+    pub fn signature_offset(&self) -> Option<usize> {
+        self.signature_offset
     }
 }
 

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -411,12 +411,6 @@ pub struct FeeBreakdown {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = json!(null)))]
     swaps_hash: Option<Bytes>,
-    /// Byte offset of the client fee signature within `Transaction.data`.
-    /// Clients use this to overwrite the placeholder signature with the real one after signing the
-    /// EIP-712 hash (see [`swaps_hash`](Self::swaps_hash)).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "openapi", schema(example = json!(null)))]
-    client_fee_signature_offset: Option<usize>,
 }
 
 impl FeeBreakdown {
@@ -444,12 +438,6 @@ impl FeeBreakdown {
     /// included in the request. Use this to construct the EIP-712 `ClientFee` signing hash.
     pub fn swaps_hash(&self) -> Option<&Bytes> {
         self.swaps_hash.as_ref()
-    }
-
-    /// Byte offset of the client fee signature within `Transaction.data`.
-    /// Clients use this to overwrite the placeholder with the real signature.
-    pub fn client_fee_signature_offset(&self) -> Option<usize> {
-        self.client_fee_signature_offset
     }
 }
 
@@ -1310,12 +1298,17 @@ pub struct Transaction {
     #[cfg_attr(feature = "openapi", schema(value_type = String, example = "0x1234567890abcdef"))]
     #[serde(serialize_with = "serialize_bytes_hex", deserialize_with = "deserialize_bytes_hex")]
     data: Vec<u8>,
+    /// Byte offset of the client fee signature within `data`.
+    /// Clients use this to overwrite the placeholder signature with the real one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = json!(null)))]
+    client_fee_signature_offset: Option<usize>,
 }
 
 impl Transaction {
     /// Create a new transaction.
     pub fn new(to: Bytes, value: BigUint, data: Vec<u8>) -> Self {
-        Self { to, value, data }
+        Self { to, value, data, client_fee_signature_offset: None }
     }
 
     /// Contract address to call.
@@ -1331,6 +1324,11 @@ impl Transaction {
     /// ABI-encoded calldata.
     pub fn data(&self) -> &[u8] {
         &self.data
+    }
+
+    /// Byte offset of the client fee signature within `data`.
+    pub fn client_fee_signature_offset(&self) -> Option<usize> {
+        self.client_fee_signature_offset
     }
 }
 
@@ -1796,6 +1794,7 @@ mod conversions {
                 to: core.to().clone().into(),
                 value: core.value().clone(),
                 data: core.data().to_vec(),
+                client_fee_signature_offset: core.client_fee_signature_offset(),
             }
         }
     }
@@ -1811,7 +1810,6 @@ mod conversions {
                 max_slippage: core.max_slippage().clone(),
                 min_amount_received: core.min_amount_received().clone(),
                 swaps_hash,
-                client_fee_signature_offset: core.signature_offset(),
             }
         }
     }

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -411,6 +411,12 @@ pub struct FeeBreakdown {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[cfg_attr(feature = "openapi", schema(value_type = Option<String>, example = json!(null)))]
     swaps_hash: Option<Bytes>,
+    /// Byte offset of the client fee signature within `Transaction.data`.
+    /// Clients use this to overwrite the placeholder signature with the real one after signing the
+    /// EIP-712 hash (see [`swaps_hash`](Self::swaps_hash)).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "openapi", schema(example = json!(null)))]
+    client_fee_signature_offset: Option<usize>,
 }
 
 impl FeeBreakdown {
@@ -438,6 +444,12 @@ impl FeeBreakdown {
     /// included in the request. Use this to construct the EIP-712 `ClientFee` signing hash.
     pub fn swaps_hash(&self) -> Option<&Bytes> {
         self.swaps_hash.as_ref()
+    }
+
+    /// Byte offset of the client fee signature within `Transaction.data`.
+    /// Clients use this to overwrite the placeholder with the real signature.
+    pub fn client_fee_signature_offset(&self) -> Option<usize> {
+        self.client_fee_signature_offset
     }
 }
 
@@ -1799,6 +1811,7 @@ mod conversions {
                 max_slippage: core.max_slippage().clone(),
                 min_amount_received: core.min_amount_received().clone(),
                 swaps_hash,
+                client_fee_signature_offset: core.signature_offset(),
             }
         }
     }


### PR DESCRIPTION
The updated EIP-712 ClientFee type hash includes swap-specific fields (amountIn, tokenIn, tokenOut, minAmountOut, receiver, swaps) that are only known after the server encodes the transaction. This creates a chicken-and-egg problem: the signature covers the swaps, but the calldata includes the signature.

The encoder now returns the byte offset of the client fee signature within the calldata (via Transaction::signature_offset). Clients request a quote with a placeholder signature, sign using swaps_hash from the response, and patch the 65 bytes at the returned offset. Single request, no server-side state.

This signature is returned via `tycho-execution` so that any potential future changes in the router contract are responsibility of the `tycho-execution` crate and does not need to touch fynd.

Necessary change in tycho-execution: https://github.com/propeller-heads/tycho-indexer/pull/1046