### PR TITLE
feat(split-routing): add math utilities for split-route optimisation

### DIFF
--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -143,8 +143,8 @@ impl ProtocolSim for ZeroGasSim {
 
 /// Find the `x` in `[lo, hi]` that maximises `f(x)` using golden-section search.
 ///
-/// Assumes `f` is roughly unimodal. `max_evals` controls the number of function
-/// evaluations (higher = more precise but slower).
+/// Assumes `f` is roughly unimodal (has one maximum). `max_evals` controls the
+/// number of function evaluations (higher = more precise but slower).
 pub(crate) fn golden_section_search(
     f: impl Fn(f64) -> f64,
     mut lo: f64,
@@ -187,21 +187,24 @@ pub(crate) fn golden_section_search(
 ///
 /// Both values always sum exactly to `total` — no tokens lost to rounding.
 pub(crate) fn split_amount(total: &BigUint, fraction: f64) -> (BigUint, BigUint) {
+    let clamped = fraction.clamp(0.0, 1.0);
     // Scale fraction to fixed-point with 18 decimal digits of precision.
     let scale: u64 = 1_000_000_000_000_000_000;
-    let numerator = (fraction * scale as f64) as u64;
+    let numerator = (clamped * scale as f64) as u64;
     let part = (total * BigUint::from(numerator)) / BigUint::from(scale);
     let remainder = total - &part;
     (part, remainder)
 }
 
 /// Errors from split-routing math utilities.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub(crate) enum SplitMathError {
     #[error("fractions slice must not be empty")]
     EmptyFractions,
     #[error("all fractions are zero, cannot normalize")]
     AllZeroFractions,
+    #[error("fractions must not be negative")]
+    NegativeFraction,
 }
 
 /// Normalize a slice of fractions so they sum to 1.0.
@@ -214,6 +217,9 @@ pub(crate) fn normalize_fractions(fractions: &mut [f64]) -> Result<(), SplitMath
     if fractions.is_empty() {
         return Err(SplitMathError::EmptyFractions);
     }
+    if fractions.iter().any(|&f| f < 0.0) {
+        return Err(SplitMathError::NegativeFraction);
+    }
     let sum: f64 = fractions.iter().sum();
     if sum == 0.0 {
         return Err(SplitMathError::AllZeroFractions);
@@ -224,10 +230,21 @@ pub(crate) fn normalize_fractions(fractions: &mut [f64]) -> Result<(), SplitMath
     Ok(())
 }
 
-/// Convert fractions (summing to 1.0) into `BigUint` amounts summing exactly to `total`.
+/// Convert fractions (summing to 1.0) into `BigUint` amounts summing exactly
+/// to `total`.
 ///
 /// The last element absorbs any rounding remainder so the sum is exact.
-pub(crate) fn fractions_to_amounts(total: &BigUint, fractions: &[f64]) -> Vec<BigUint> {
+///
+/// # Errors
+///
+/// Returns [`SplitMathError::EmptyFractions`] if `fractions` is empty.
+pub(crate) fn fractions_to_amounts(
+    total: &BigUint,
+    fractions: &[f64],
+) -> Result<Vec<BigUint>, SplitMathError> {
+    if fractions.is_empty() {
+        return Err(SplitMathError::EmptyFractions);
+    }
     let n = fractions.len();
     let mut amounts = Vec::with_capacity(n);
     let mut running_sum = BigUint::zero();
@@ -240,7 +257,7 @@ pub(crate) fn fractions_to_amounts(total: &BigUint, fractions: &[f64]) -> Vec<Bi
 
     // Last element gets the remainder to guarantee exact sum.
     amounts.push(total - &running_sum);
-    amounts
+    Ok(amounts)
 }
 
 #[cfg(test)]
@@ -271,13 +288,36 @@ mod tests {
     }
 
     #[test]
+    fn test_split_amount_clamps_above_one() {
+        let total = BigUint::from(1_000_000_000_000_000_000_u64);
+        let (part, remainder) = split_amount(&total, 1.5);
+        assert_eq!(part, total);
+        assert!(remainder.is_zero());
+    }
+
+    #[test]
+    fn test_split_amount_clamps_negative() {
+        let total = BigUint::from(1_000_000_000_000_000_000_u64);
+        let (part, remainder) = split_amount(&total, -0.5);
+        assert!(part.is_zero());
+        assert_eq!(remainder, total);
+    }
+
+    #[test]
     fn test_fractions_to_amounts_exact_sum() {
         let total = BigUint::from(999_999_999_999_999_999_u64);
         let fractions = [0.3, 0.5, 0.2];
-        let amounts = fractions_to_amounts(&total, &fractions);
+        let amounts = fractions_to_amounts(&total, &fractions).unwrap();
         assert_eq!(amounts.len(), 3);
         let sum: BigUint = amounts.iter().sum();
         assert_eq!(sum, total, "amounts must sum exactly to total");
+    }
+
+    #[test]
+    fn test_fractions_to_amounts_empty() {
+        let total = BigUint::from(1_000_u64);
+        let err = fractions_to_amounts(&total, &[]).unwrap_err();
+        assert_eq!(err, SplitMathError::EmptyFractions);
     }
 
     #[rstest]
@@ -293,10 +333,11 @@ mod tests {
     #[rstest]
     #[case::empty(&[], SplitMathError::EmptyFractions)]
     #[case::all_zeros(&[0.0, 0.0, 0.0], SplitMathError::AllZeroFractions)]
+    #[case::negative(&[-0.5, 0.5], SplitMathError::NegativeFraction)]
     fn test_normalize_fractions_invalid(#[case] input: &[f64], #[case] expected: SplitMathError) {
         let mut fractions = input.to_vec();
         let err = normalize_fractions(&mut fractions).unwrap_err();
-        assert_eq!(err.to_string(), expected.to_string());
+        assert_eq!(err, expected);
     }
 
     #[test]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -186,6 +186,7 @@ pub(crate) fn golden_section_search(
 /// Split `total` into `(part, remainder)` where `part ≈ total * fraction`.
 ///
 /// Both values always sum exactly to `total` — no tokens lost to rounding.
+/// `fraction` is clamped to `[0.0, 1.0]` before use.
 pub(crate) fn split_amount(total: &BigUint, fraction: f64) -> (BigUint, BigUint) {
     let clamped = fraction.clamp(0.0, 1.0);
     // Scale fraction to fixed-point with 18 decimal digits of precision.

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use num_bigint::BigUint;
+use num_traits::Zero;
 use tycho_simulation::tycho_common::{
     dto::ProtocolStateDelta,
     models::token::Token,
@@ -137,5 +138,172 @@ impl ProtocolSim for ZeroGasSim {
             .downcast_ref::<Self>()
             .map(|o| self.0.eq(&*o.0))
             .unwrap_or(false)
+    }
+}
+
+/// Find the `x` in `[lo, hi]` that maximises `f(x)` using golden-section search.
+///
+/// Assumes `f` is roughly unimodal. `max_evals` controls the number of function
+/// evaluations (higher = more precise but slower).
+pub(crate) fn golden_section_search(
+    f: impl Fn(f64) -> f64,
+    mut lo: f64,
+    mut hi: f64,
+    max_evals: usize,
+) -> f64 {
+    let inv_phi = (5_f64.sqrt() - 1.0) / 2.0;
+
+    let mut x1 = hi - inv_phi * (hi - lo);
+    let mut x2 = lo + inv_phi * (hi - lo);
+    let mut f1 = f(x1);
+    let mut f2 = f(x2);
+    // Two evaluations consumed so far.
+    let remaining = max_evals.saturating_sub(2);
+
+    for _ in 0..remaining {
+        if f1 < f2 {
+            lo = x1;
+            x1 = x2;
+            f1 = f2;
+            x2 = lo + inv_phi * (hi - lo);
+            f2 = f(x2);
+        } else {
+            hi = x2;
+            x2 = x1;
+            f2 = f1;
+            x1 = hi - inv_phi * (hi - lo);
+            f1 = f(x1);
+        }
+    }
+
+    if f1 >= f2 {
+        x1
+    } else {
+        x2
+    }
+}
+
+/// Split `total` into `(part, remainder)` where `part ≈ total * fraction`.
+///
+/// Both values always sum exactly to `total` — no tokens lost to rounding.
+pub(crate) fn split_amount(total: &BigUint, fraction: f64) -> (BigUint, BigUint) {
+    // Scale fraction to fixed-point with 18 decimal digits of precision.
+    let scale: u64 = 1_000_000_000_000_000_000;
+    let numerator = (fraction * scale as f64) as u64;
+    let part = (total * BigUint::from(numerator)) / BigUint::from(scale);
+    let remainder = total - &part;
+    (part, remainder)
+}
+
+/// Errors from split-routing math utilities.
+#[derive(Debug, Clone, thiserror::Error)]
+pub(crate) enum SplitMathError {
+    #[error("fractions slice must not be empty")]
+    EmptyFractions,
+    #[error("all fractions are zero, cannot normalize")]
+    AllZeroFractions,
+}
+
+/// Normalize a slice of fractions so they sum to 1.0.
+///
+/// # Errors
+///
+/// Returns [`SplitMathError::EmptyFractions`] if the slice is empty, or
+/// [`SplitMathError::AllZeroFractions`] if every element is zero.
+pub(crate) fn normalize_fractions(fractions: &mut [f64]) -> Result<(), SplitMathError> {
+    if fractions.is_empty() {
+        return Err(SplitMathError::EmptyFractions);
+    }
+    let sum: f64 = fractions.iter().sum();
+    if sum == 0.0 {
+        return Err(SplitMathError::AllZeroFractions);
+    }
+    for f in fractions.iter_mut() {
+        *f /= sum;
+    }
+    Ok(())
+}
+
+/// Convert fractions (summing to 1.0) into `BigUint` amounts summing exactly to `total`.
+///
+/// The last element absorbs any rounding remainder so the sum is exact.
+pub(crate) fn fractions_to_amounts(total: &BigUint, fractions: &[f64]) -> Vec<BigUint> {
+    let n = fractions.len();
+    let mut amounts = Vec::with_capacity(n);
+    let mut running_sum = BigUint::zero();
+
+    for &frac in &fractions[..n - 1] {
+        let (part, _) = split_amount(total, frac);
+        running_sum += &part;
+        amounts.push(part);
+    }
+
+    // Last element gets the remainder to guarantee exact sum.
+    amounts.push(total - &running_sum);
+    amounts
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[test]
+    fn test_split_amount_exact_sum() {
+        let total = BigUint::from(1_000_000_000_000_000_000_u64);
+        for fraction in [0.1, 0.5, 0.9, 0.999] {
+            let (part, remainder) = split_amount(&total, fraction);
+            assert_eq!(
+                &part + &remainder,
+                total,
+                "part + remainder must equal total for fraction={fraction}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_split_amount_edge_fraction_zero() {
+        let total = BigUint::from(1_000_000_000_000_000_000_u64);
+        let (part, remainder) = split_amount(&total, 0.0);
+        assert!(part.is_zero());
+        assert_eq!(remainder, total);
+    }
+
+    #[test]
+    fn test_fractions_to_amounts_exact_sum() {
+        let total = BigUint::from(999_999_999_999_999_999_u64);
+        let fractions = [0.3, 0.5, 0.2];
+        let amounts = fractions_to_amounts(&total, &fractions);
+        assert_eq!(amounts.len(), 3);
+        let sum: BigUint = amounts.iter().sum();
+        assert_eq!(sum, total, "amounts must sum exactly to total");
+    }
+
+    #[rstest]
+    #[case::already_normalized(&[0.3, 0.5, 0.2])]
+    #[case::drift(&[0.33, 0.33, 0.33])]
+    fn test_normalize_fractions(#[case] input: &[f64]) {
+        let mut fractions = input.to_vec();
+        normalize_fractions(&mut fractions).unwrap();
+        let sum: f64 = fractions.iter().sum();
+        assert!((sum - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[rstest]
+    #[case::empty(&[], SplitMathError::EmptyFractions)]
+    #[case::all_zeros(&[0.0, 0.0, 0.0], SplitMathError::AllZeroFractions)]
+    fn test_normalize_fractions_invalid(#[case] input: &[f64], #[case] expected: SplitMathError) {
+        let mut fractions = input.to_vec();
+        let err = normalize_fractions(&mut fractions).unwrap_err();
+        assert_eq!(err.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_golden_section_finds_maximum() {
+        // Maximize -(x - 0.3)^2; true maximum at x = 0.3.
+        let f = |x: f64| -(x - 0.3) * (x - 0.3);
+        let result = golden_section_search(f, 0.0, 1.0, 100);
+        assert!((result - 0.3).abs() < 1e-4, "expected ~0.3, got {result}");
     }
 }


### PR DESCRIPTION
Implements golden_section_search, split_amount, normalize_fractions, and fractions_to_amounts in split_primitives.rs.

Note: The task description mentions "Panics if the slice is empty or all zeros.", but I don't think this was on purpose - we wouldn't like our code to panic. normalize_fractions returns Result<(), SplitMathError> instead.

[Task](https://propeller-heads.atlassian.net/browse/ENG-5844)