### PR TITLE
test(split-routing): add optimal_two_pool_output analytical bounds helper

### DIFF
--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -24,6 +24,8 @@ pub mod most_liquid;
 pub(crate) mod split_primitives;
 
 #[cfg(test)]
+pub mod split_test_harness;
+#[cfg(test)]
 pub mod test_utils;
 
 use std::{collections::HashSet, time::Duration};

--- a/fynd-core/src/algorithm/split_test_harness.rs
+++ b/fynd-core/src/algorithm/split_test_harness.rs
@@ -1,10 +1,10 @@
 //! Test helpers for split-routing algorithm scenarios.
 
 /// Returns `(fraction_for_pool_1, total_output)` — the theoretically optimal output when
-/// splitting `trade_amount` between two constant-product pools.
+/// splitting `trade_amount` between two constant-product pools with no fees.
 ///
-/// Negative allocations are clamped to `0` — a clamped value means the full trade routes through
-/// the other pool.
+/// Finds the split where both pools offer the same marginal rate on the last unit traded.
+/// Negative allocations are clamped to `0`.
 #[allow(dead_code)]
 pub(crate) fn optimal_two_pool_output(
     reserve_in_1: f64,
@@ -13,15 +13,6 @@ pub(crate) fn optimal_two_pool_output(
     reserve_out_2: f64,
     trade_amount: f64,
 ) -> (f64, f64) {
-    // The optimal split equates marginal prices across pools. Let `d = √(k1/k2)` where
-    // `k_i = reserve_in_i · reserve_out_i`. Solving the marginal-price-equality condition with
-    // `a_1 + a_2 = trade_amount` gives:
-    //
-    // ```text
-    // d   = sqrt((reserve_in_1 * reserve_out_1) / (reserve_in_2 * reserve_out_2))
-    // a_2 = (trade_amount + reserve_in_1 - d * reserve_in_2) / (d + 1)
-    // a_1 = trade_amount - a_2
-    // ```
     let d = ((reserve_in_1 * reserve_out_1) / (reserve_in_2 * reserve_out_2)).sqrt();
     let a2 =
         ((trade_amount + reserve_in_1 - d * reserve_in_2) / (d + 1.0)).clamp(0.0, trade_amount);
@@ -38,37 +29,37 @@ pub(crate) fn optimal_two_pool_output(
 mod tests {
     use super::*;
 
+    fn f64_eq(x: f64, y: f64) -> bool {
+        (x - y).abs() < 1e-9
+    }
+
     #[test]
     fn test_optimal_two_pool_output_symmetric() {
-        // Identical pools → d=1 → 50/50 split is always optimal.
+        // Identical pools → 50/50 split is always optimal
         let (fraction, _) =
             optimal_two_pool_output(10_000.0, 10_000.0, 10_000.0, 10_000.0, 1_000.0);
-        assert!(
-            (fraction - 0.5).abs() < 1e-9,
-            "symmetric pools: expected fraction 0.5, got {fraction}"
-        );
+        assert!(f64_eq(fraction, 0.5), "symmetric pools: expected fraction 0.5, got {fraction}");
     }
 
     #[test]
     fn test_optimal_two_pool_output_asymmetric() {
-        // Pool 1: reserve_in=100, reserve_out=400  →  k1=40_000, K1=200
-        // Pool 2: reserve_in=100, reserve_out=100  →  k2=10_000, K2=100
-        // d = sqrt(40_000/10_000) = 2
-        // a_2 = (400 + 100 - 2·100) / (2+1) = 300/3 = 100
-        // a_1 = 300  →  fraction = 300/400 = 0.75
-        //
-        // Verify optimality: marginal prices after split must be equal.
-        // Pool 1: k1 / (100+300)² = 40_000/160_000 = 0.25
-        // Pool 2: k2 / (100+100)² = 10_000/40_000  = 0.25  ✓
-        let (fraction, total_out) = optimal_two_pool_output(100.0, 400.0, 100.0, 100.0, 400.0);
+        // Pool 1: reserve_in=100, reserve_out=400
+        // Pool 2: reserve_in=100, reserve_out=100
+        // swap amount: 400
+        let (fraction, split_out) = optimal_two_pool_output(100.0, 400.0, 100.0, 100.0, 400.0);
+
+        // Verify the split is correct
+        assert!(f64_eq(fraction, 0.75), "expected fraction 0.75, got {fraction}");
+        assert!(f64_eq(split_out, 350.0), "expected split output 350.0, got {split_out}");
+
+        // Verify marginal prices are equal at the optimal split.
+        let pool_1_amount = fraction * 400.0;
+        let pool_2_amount = 400.0 - pool_1_amount;
+        let marginal_1 = (100.0 * 400.0) / (100.0 + pool_1_amount).powi(2);
+        let marginal_2 = (100.0 * 100.0) / (100.0 + pool_2_amount).powi(2);
         assert!(
-            (fraction - 0.75).abs() < 1e-9,
-            "asymmetric pools: expected fraction 0.75, got {fraction}"
-        );
-        // out_1 = 300·400/(100+300) = 300, out_2 = 100·100/(100+100) = 50
-        assert!(
-            (total_out - 350.0).abs() < 1e-9,
-            "asymmetric pools: expected total output 350.0, got {total_out}"
+            f64_eq(marginal_1, marginal_2),
+            "marginal prices should equalise at the optimum: {marginal_1} vs {marginal_2}"
         );
     }
 }

--- a/fynd-core/src/algorithm/split_test_harness.rs
+++ b/fynd-core/src/algorithm/split_test_harness.rs
@@ -1,0 +1,74 @@
+//! Test helpers for split-routing algorithm scenarios.
+
+/// Returns `(fraction_for_pool_1, total_output)` — the theoretically optimal output when
+/// splitting `trade_amount` between two constant-product pools.
+///
+/// Negative allocations are clamped to `0` — a clamped value means the full trade routes through
+/// the other pool.
+#[allow(dead_code)]
+pub(crate) fn optimal_two_pool_output(
+    reserve_in_1: f64,
+    reserve_out_1: f64,
+    reserve_in_2: f64,
+    reserve_out_2: f64,
+    trade_amount: f64,
+) -> (f64, f64) {
+    // The optimal split equates marginal prices across pools. Let `d = √(k1/k2)` where
+    // `k_i = reserve_in_i · reserve_out_i`. Solving the marginal-price-equality condition with
+    // `a_1 + a_2 = trade_amount` gives:
+    //
+    // ```text
+    // d   = sqrt((reserve_in_1 * reserve_out_1) / (reserve_in_2 * reserve_out_2))
+    // a_2 = (trade_amount + reserve_in_1 - d * reserve_in_2) / (d + 1)
+    // a_1 = trade_amount - a_2
+    // ```
+    let d = ((reserve_in_1 * reserve_out_1) / (reserve_in_2 * reserve_out_2)).sqrt();
+    let a2 =
+        ((trade_amount + reserve_in_1 - d * reserve_in_2) / (d + 1.0)).clamp(0.0, trade_amount);
+    let a1 = trade_amount - a2;
+
+    let fraction_1 = a1 / trade_amount;
+    let out_1 = a1 * reserve_out_1 / (reserve_in_1 + a1);
+    let out_2 = a2 * reserve_out_2 / (reserve_in_2 + a2);
+
+    (fraction_1, out_1 + out_2)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_optimal_two_pool_output_symmetric() {
+        // Identical pools → d=1 → 50/50 split is always optimal.
+        let (fraction, _) =
+            optimal_two_pool_output(10_000.0, 10_000.0, 10_000.0, 10_000.0, 1_000.0);
+        assert!(
+            (fraction - 0.5).abs() < 1e-9,
+            "symmetric pools: expected fraction 0.5, got {fraction}"
+        );
+    }
+
+    #[test]
+    fn test_optimal_two_pool_output_asymmetric() {
+        // Pool 1: reserve_in=100, reserve_out=400  →  k1=40_000, K1=200
+        // Pool 2: reserve_in=100, reserve_out=100  →  k2=10_000, K2=100
+        // d = sqrt(40_000/10_000) = 2
+        // a_2 = (400 + 100 - 2·100) / (2+1) = 300/3 = 100
+        // a_1 = 300  →  fraction = 300/400 = 0.75
+        //
+        // Verify optimality: marginal prices after split must be equal.
+        // Pool 1: k1 / (100+300)² = 40_000/160_000 = 0.25
+        // Pool 2: k2 / (100+100)² = 10_000/40_000  = 0.25  ✓
+        let (fraction, total_out) = optimal_two_pool_output(100.0, 400.0, 100.0, 100.0, 400.0);
+        assert!(
+            (fraction - 0.75).abs() < 1e-9,
+            "asymmetric pools: expected fraction 0.75, got {fraction}"
+        );
+        // out_1 = 300·400/(100+300) = 300, out_2 = 100·100/(100+100) = 50
+        assert!(
+            (total_out - 350.0).abs() < 1e-9,
+            "asymmetric pools: expected total output 350.0, got {total_out}"
+        );
+    }
+}


### PR DESCRIPTION
Analytically finds the optimal split between two Uniswap v2-like pools (ignoring fees for simplicity).