### PR TITLE
feat(split-routing): add simulation utils for split-route optimisation

### DIFF
--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -12,7 +12,7 @@ use tycho_simulation::tycho_common::{
     Bytes,
 };
 
-use crate::{algorithm::AlgorithmError, feed::market_data::MarketState, types::ComponentId};
+use crate::{algorithm::AlgorithmError, feed::market_data::MarketDataView, types::ComponentId};
 
 pub(crate) struct HopDescriptor {
     pub(crate) component_id: ComponentId,
@@ -43,7 +43,7 @@ pub(crate) struct SimResult {
     pub(crate) marginal_price_product: f64,
 }
 
-/// Pool state overrides for reused pools in subsequent simulation/route searches.
+/// Pool state overrides for passing degraded states to `find_single_route`.
 #[derive(Default)]
 pub(crate) struct MarketOverrides(HashMap<ComponentId, Box<dyn ProtocolSim>>);
 
@@ -71,6 +71,12 @@ impl MarketOverrides {
     pub(crate) fn get(&self, id: &ComponentId) -> Option<&dyn ProtocolSim> {
         self.0.get(id).map(|b| b.as_ref())
     }
+}
+
+/// Wraps a sim so that `get_amount_out().gas` is always zero while amounts
+/// remain correct. Use for pools whose gas is already accounted for elsewhere.
+pub(crate) fn wrap_zero_gas(sim: Box<dyn ProtocolSim>) -> Box<dyn ProtocolSim> {
+    Box::new(ZeroGasSim(sim))
 }
 
 /// Wrapper that delegates all [`ProtocolSim`] calls unchanged except
@@ -265,14 +271,12 @@ pub(crate) fn fractions_to_amounts(
 /// near-zero input.
 pub(crate) fn compute_marginal_price_product(
     hops: &[HopDescriptor],
-    market: &MarketState,
-    overrides: &MarketOverrides,
+    market: &MarketDataView,
 ) -> Result<f64, AlgorithmError> {
     let mut product = 1.0;
     for hop in hops {
-        let sim = overrides
-            .get(&hop.component_id)
-            .or_else(|| market.get_simulation_state(&hop.component_id))
+        let sim = market
+            .get_simulation_state(&hop.component_id)
             .ok_or_else(|| AlgorithmError::DataNotFound {
                 kind: "simulation state",
                 id: Some(hop.component_id.clone()),
@@ -291,22 +295,19 @@ pub(crate) fn compute_marginal_price_product(
 /// Simulates a path hop-by-hop, threading output of each hop as input to the
 /// next.
 ///
-/// Checks `overrides` before falling back to the live market state for each
-/// hop. Returns the final output amount, raw gas sum, and marginal price
-/// product.
+/// Uses the overlay-aware `MarketDataView` for each hop's simulation state.
+/// Returns the final output amount, raw gas sum, and marginal price product.
 pub(crate) fn simulate_path(
     hops: &[HopDescriptor],
     amount_in: &BigUint,
-    market: &MarketState,
-    overrides: &MarketOverrides,
+    market: &MarketDataView,
 ) -> Result<SimResult, AlgorithmError> {
     let mut current_amount = amount_in.clone();
     let mut total_gas: u64 = 0;
 
     for hop in hops {
-        let sim = overrides
-            .get(&hop.component_id)
-            .or_else(|| market.get_simulation_state(&hop.component_id))
+        let sim = market
+            .get_simulation_state(&hop.component_id)
             .ok_or_else(|| AlgorithmError::DataNotFound {
                 kind: "simulation state",
                 id: Some(hop.component_id.clone()),
@@ -324,7 +325,7 @@ pub(crate) fn simulate_path(
         current_amount = result.amount;
     }
 
-    let marginal_price_product = compute_marginal_price_product(hops, market, overrides)?;
+    let marginal_price_product = compute_marginal_price_product(hops, market)?;
 
     Ok(SimResult { amount_out: current_amount, gas: total_gas, marginal_price_product })
 }
@@ -335,8 +336,7 @@ pub(crate) fn evaluate_total_output(
     paths: &[&[HopDescriptor]],
     fractions: &[f64],
     total_amount: &BigUint,
-    market: &MarketState,
-    overrides: &MarketOverrides,
+    market: &MarketDataView,
 ) -> Result<(BigUint, u64), AlgorithmError> {
     let amounts = fractions_to_amounts(total_amount, fractions)
         .map_err(|e| AlgorithmError::Other(e.to_string()))?;
@@ -353,9 +353,8 @@ pub(crate) fn evaluate_total_output(
         let mut current_amount = amount.clone();
 
         for hop in path.iter() {
-            let sim = overrides
-                .get(&hop.component_id)
-                .or_else(|| market.get_simulation_state(&hop.component_id))
+            let sim = market
+                .get_simulation_state(&hop.component_id)
                 .ok_or_else(|| AlgorithmError::DataNotFound {
                     kind: "simulation state",
                     id: Some(hop.component_id.clone()),
@@ -388,31 +387,31 @@ pub(crate) fn evaluate_total_output(
     Ok((total_out, total_gas))
 }
 
-/// Builds a post-swap view of the market after all paths in a single
-/// split-route solution have been executed.
+/// Builds post-swap pool states after all paths in a split-route solution
+/// have been executed.
 ///
 /// For example, if the current solution splits 1000 USDC→ETH across:
 ///   - Path 1: USDC→WETH via Uniswap (600 USDC)
 ///   - Path 2: USDC→WBTC→WETH via Curve+Balancer (400 USDC)
 ///
 /// this function simulates both swaps and returns overrides where Uniswap,
-/// Curve, and Balancer all reflect their post-swap reserves.
+/// Curve, and Balancer all reflect their post-swap reserves. Pass the result
+/// to `find_single_route` for the next iteration.
 ///
 /// Paths are processed in order so shared pools accumulate the effects of
 /// all prior paths.
 pub(crate) fn build_degraded_market(
     paths: &[&PathAllocation],
-    market: &MarketState,
+    market: &MarketDataView,
 ) -> MarketOverrides {
-    let mut states: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
+    let mut overrides = MarketOverrides::empty();
 
     for path in paths {
         let mut current_amount = path.amount_in.clone();
 
         for hop in &path.hops {
-            let sim = states
+            let sim = overrides
                 .get(&hop.component_id)
-                .map(|b| b.as_ref())
                 .or_else(|| market.get_simulation_state(&hop.component_id));
 
             let Some(sim) = sim else { break };
@@ -423,14 +422,10 @@ pub(crate) fn build_degraded_market(
             };
 
             current_amount = result.amount;
-            states.insert(hop.component_id.clone(), result.new_state);
+            overrides = overrides.with_override(hop.component_id.clone(), result.new_state);
         }
     }
 
-    let mut overrides = MarketOverrides::empty();
-    for (id, sim) in states {
-        overrides = overrides.with_override(id, sim);
-    }
     overrides
 }
 
@@ -439,6 +434,20 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::{
+        algorithm::test_utils::{component, token, ConstantProductSim, MockProtocolSim},
+        feed::market_data::{MarketData, MarketState},
+    };
+
+    fn make_market_data(pools: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketData {
+        let mut market = MarketState::new();
+        for (pool_id, tokens, sim) in pools {
+            market.upsert_components(std::iter::once(component(pool_id, &tokens)));
+            market.update_states([(pool_id.to_string(), sim)]);
+            market.upsert_tokens(tokens);
+        }
+        MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
+    }
 
     #[test]
     fn test_split_amount_exact_sum() {
@@ -524,30 +533,16 @@ mod tests {
 
     // ==================== Simulation Utility Tests ====================
 
-    use crate::{
-        algorithm::test_utils::{component, token, ConstantProductSim, MockProtocolSim},
-        feed::market_data::MarketState,
-    };
-
-    fn make_market(pools: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketState {
-        let mut market = MarketState::new();
-        for (pool_id, tokens, sim) in pools {
-            market.upsert_components(std::iter::once(component(pool_id, &tokens)));
-            market.update_states([(pool_id.to_string(), sim)]);
-            market.upsert_tokens(tokens);
-        }
-        market
-    }
-
-    #[test]
-    fn test_compute_marginal_price_product_single_hop() {
+    #[tokio::test]
+    async fn test_compute_marginal_price_product_single_hop() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market(vec![(
+        let market = make_market_data(vec![(
             "pool_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(MockProtocolSim::new(3.0)),
         )]);
+        let view = market.read().await;
 
         let hops = [HopDescriptor {
             component_id: "pool_ab".to_string(),
@@ -555,17 +550,16 @@ mod tests {
             token_out: token_b,
         }];
 
-        let product =
-            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
+        let product = compute_marginal_price_product(&hops, &view).unwrap();
         assert!((product - 3.0).abs() < f64::EPSILON, "expected 3.0, got {product}");
     }
 
-    #[test]
-    fn test_compute_marginal_price_product_multi_hop() {
+    #[tokio::test]
+    async fn test_compute_marginal_price_product_multi_hop() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
-        let market = make_market(vec![
+        let market = make_market_data(vec![
             (
                 "pool_ab",
                 vec![token_a.clone(), token_b.clone()],
@@ -577,6 +571,7 @@ mod tests {
                 Box::new(MockProtocolSim::new(4.0)),
             ),
         ]);
+        let view = market.read().await;
 
         let hops = [
             HopDescriptor {
@@ -591,17 +586,16 @@ mod tests {
             },
         ];
 
-        let product =
-            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
+        let product = compute_marginal_price_product(&hops, &view).unwrap();
         // 2.0 * 4.0 = 8.0
         assert!((product - 8.0).abs() < f64::EPSILON, "expected 8.0, got {product}");
     }
 
-    #[test]
-    fn test_compute_marginal_price_product_uses_overrides() {
+    #[tokio::test]
+    async fn test_compute_marginal_price_product_uses_overlay() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market(vec![(
+        let market = make_market_data(vec![(
             "pool_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(MockProtocolSim::new(3.0)),
@@ -613,22 +607,31 @@ mod tests {
             token_out: token_b,
         }];
 
-        // Override pool_ab with a different spot price.
-        let overrides = MarketOverrides::empty()
-            .with_override("pool_ab".to_string(), Box::new(MockProtocolSim::new(7.0)));
+        // Register an overlay with a different spot price.
+        let overlay = HashMap::from([(
+            "pool_ab".to_string(),
+            Box::new(MockProtocolSim::new(7.0)) as Box<dyn ProtocolSim>,
+        )]);
+        market
+            .register_labeled_state("degraded".to_string(), overlay, u64::MAX)
+            .await;
+        let view = market
+            .read_labeled(&"degraded".to_string())
+            .await
+            .unwrap();
 
-        let product = compute_marginal_price_product(&hops, &market, &overrides).unwrap();
+        let product = compute_marginal_price_product(&hops, &view).unwrap();
         assert!((product - 7.0).abs() < f64::EPSILON, "expected 7.0, got {product}");
     }
 
-    #[test]
-    fn test_simulate_path_correct_output() {
+    #[tokio::test]
+    async fn test_simulate_path_correct_output() {
         // 2-hop path A→B→C with spot prices 2.0 and 3.0.
         // Input 1000 should thread through: 1000*2=2000, 2000*3=6000.
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
-        let market = make_market(vec![
+        let market = make_market_data(vec![
             (
                 "pool_ab",
                 vec![token_a.clone(), token_b.clone()],
@@ -640,6 +643,7 @@ mod tests {
                 Box::new(MockProtocolSim::new(3.0)),
             ),
         ]);
+        let view = market.read().await;
 
         let hops = [
             HopDescriptor {
@@ -655,8 +659,7 @@ mod tests {
         ];
 
         let amount_in = BigUint::from(1000u64);
-        let overrides = MarketOverrides::empty();
-        let result = simulate_path(&hops, &amount_in, &market, &overrides).unwrap();
+        let result = simulate_path(&hops, &amount_in, &view).unwrap();
 
         assert_eq!(result.amount_out, BigUint::from(6000u64));
 
@@ -668,22 +671,17 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_market_overrides_with_zero_gas() {
+    #[tokio::test]
+    async fn test_zero_gas_overlay() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
         let sim_ab = MockProtocolSim::new(2.0).with_gas(100_000);
         let sim_bc = MockProtocolSim::new(3.0).with_gas(70_000);
-        let market = make_market(vec![
+        let market = make_market_data(vec![
             ("pool_ab", vec![token_a.clone(), token_b.clone()], Box::new(sim_ab.clone())),
             ("pool_bc", vec![token_b.clone(), token_c.clone()], Box::new(sim_bc.clone())),
         ]);
-
-        // Zero gas on pool_ab, leave pool_bc as a normal override.
-        let overrides = MarketOverrides::empty()
-            .with_zero_gas("pool_ab".to_string(), Box::new(sim_ab))
-            .with_override("pool_bc".to_string(), Box::new(sim_bc));
 
         let hops_ab = [HopDescriptor {
             component_id: "pool_ab".to_string(),
@@ -697,21 +695,37 @@ mod tests {
         }];
         let amount_in = BigUint::from(1000u64);
 
-        let normal_ab =
-            simulate_path(&hops_ab, &amount_in, &market, &MarketOverrides::empty()).unwrap();
-        let zero_gas_ab = simulate_path(&hops_ab, &amount_in, &market, &overrides).unwrap();
+        // No overlay: normal gas.
+        let normal_view = market.read().await;
+        let normal_ab = simulate_path(&hops_ab, &amount_in, &normal_view).unwrap();
+        drop(normal_view);
+
+        // Overlay: zero gas on pool_ab, normal override on pool_bc.
+        let overlay = HashMap::from([
+            ("pool_ab".to_string(), wrap_zero_gas(Box::new(sim_ab))),
+            ("pool_bc".to_string(), Box::new(sim_bc) as Box<dyn ProtocolSim>),
+        ]);
+        market
+            .register_labeled_state("test".to_string(), overlay, u64::MAX)
+            .await;
+        let overlay_view = market
+            .read_labeled(&"test".to_string())
+            .await
+            .unwrap();
+
+        let zero_gas_ab = simulate_path(&hops_ab, &amount_in, &overlay_view).unwrap();
 
         assert_eq!(normal_ab.amount_out, zero_gas_ab.amount_out);
         assert!(normal_ab.gas > 0, "normal gas should be non-zero");
-        assert_eq!(zero_gas_ab.gas, 0, "zero-gas override should report gas=0");
+        assert_eq!(zero_gas_ab.gas, 0, "zero-gas overlay should report gas=0");
 
         // pool_bc is a normal override — its gas should be unaffected.
-        let result_bc = simulate_path(&hops_bc, &amount_in, &market, &overrides).unwrap();
+        let result_bc = simulate_path(&hops_bc, &amount_in, &overlay_view).unwrap();
         assert_eq!(result_bc.gas, 70_000, "non-zero-gas override should keep its gas");
     }
 
-    #[test]
-    fn test_evaluate_total_output_two_paths() {
+    #[tokio::test]
+    async fn test_evaluate_total_output_two_paths() {
         // 50/50 split of 1000 across two parallel 1-hop paths:
         //
         //       500 -- pool_1 (price=2.0) --> 1000
@@ -723,7 +737,7 @@ mod tests {
         // total_gas = 50k + 60k = 110k
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market(vec![
+        let market = make_market_data(vec![
             (
                 "pool_1",
                 vec![token_a.clone(), token_b.clone()],
@@ -735,6 +749,7 @@ mod tests {
                 Box::new(MockProtocolSim::new(3.0).with_gas(60_000)),
             ),
         ]);
+        let view = market.read().await;
 
         let hops_1 = [HopDescriptor {
             component_id: "pool_1".to_string(),
@@ -750,17 +765,16 @@ mod tests {
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
         let total_amount = BigUint::from(1000u64);
-        let overrides = MarketOverrides::empty();
 
         let (total_out, total_gas) =
-            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
+            evaluate_total_output(&paths, &fractions, &total_amount, &view).unwrap();
 
         assert_eq!(total_out, BigUint::from(2500u64));
         assert_eq!(total_gas, 110_000);
     }
 
-    #[test]
-    fn test_evaluate_total_output_gas_deduplication() {
+    #[tokio::test]
+    async fn test_evaluate_total_output_gas_deduplication() {
         // Two paths share pool P1 (pre-split hop). P1's gas should be
         // counted once, not twice.
         //
@@ -774,7 +788,7 @@ mod tests {
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
         let token_d = token(0x0D, "D");
-        let market = make_market(vec![
+        let market = make_market_data(vec![
             (
                 "P1",
                 vec![token_a.clone(), token_b.clone()],
@@ -791,6 +805,7 @@ mod tests {
                 Box::new(MockProtocolSim::new(3.0).with_gas(70_000)),
             ),
         ]);
+        let view = market.read().await;
 
         // Path 1: A -> P1 -> B -> P2 -> C (uses P1 and P2)
         let hops_1 = [
@@ -818,17 +833,16 @@ mod tests {
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
         let total_amount = BigUint::from(1000u64);
-        let overrides = MarketOverrides::empty();
 
         let (_, total_gas) =
-            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
+            evaluate_total_output(&paths, &fractions, &total_amount, &view).unwrap();
 
         // P1 counted once: 100k + 50k + 70k = 220k
         assert_eq!(total_gas, 220_000);
     }
 
-    #[test]
-    fn test_gas_dedup_different_tokens() {
+    #[tokio::test]
+    async fn test_gas_dedup_different_tokens() {
         // A single 3-token pool used for two different token pairs is two
         // distinct hops — gas must be counted for each.
         //
@@ -838,11 +852,12 @@ mod tests {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
-        let market = make_market(vec![(
+        let market = make_market_data(vec![(
             "tripool",
             vec![token_a.clone(), token_b.clone(), token_c.clone()],
             Box::new(MockProtocolSim::new(1.0).with_gas(80_000)),
         )]);
+        let view = market.read().await;
 
         let hops_1 = [HopDescriptor {
             component_id: "tripool".to_string(),
@@ -858,20 +873,19 @@ mod tests {
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
         let total_amount = BigUint::from(1000u64);
-        let overrides = MarketOverrides::empty();
 
         let (_, total_gas) =
-            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
+            evaluate_total_output(&paths, &fractions, &total_amount, &view).unwrap();
 
         // Different token pairs on the same pool: 80k + 80k = 160k
         assert_eq!(total_gas, 160_000);
     }
 
-    #[test]
-    fn test_build_degraded_market_degrades_used_pools() {
+    #[tokio::test]
+    async fn test_build_degraded_market_degrades_used_pools() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market(vec![(
+        let market = make_market_data(vec![(
             "pool_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(ConstantProductSim {
@@ -880,6 +894,7 @@ mod tests {
                 gas: 50_000,
             }),
         )]);
+        let view = market.read().await;
 
         let allocation = PathAllocation {
             hops: vec![HopDescriptor {
@@ -893,18 +908,18 @@ mod tests {
             marginal_price_product: 2.0,
         };
 
-        let degraded = build_degraded_market(&[&allocation], &market);
-
         // xy=k: amount_out = amount_in * reserve_out / (reserve_in + amount_in)
         // Fresh pool (10000/20000): 100 * 20000 / (10000 + 100) = 198
         let probe = BigUint::from(100u64);
-        let fresh_out = market
+        let fresh_out = view
             .get_simulation_state("pool_ab")
             .unwrap()
             .get_amount_out(probe.clone(), &token_a, &token_b)
             .unwrap()
             .amount;
         assert_eq!(fresh_out, BigUint::from(198u64));
+
+        let degraded = build_degraded_market(&[&allocation], &view);
 
         // The 1000-in allocation produces 1000*20000/(10000+1000) = 1818 out,
         // shifting reserves to (10000+1000, 20000-1818) = (11000, 18182).

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use num_bigint::BigUint;
-use num_traits::Zero;
+use num_traits::{ToPrimitive, Zero};
 use tycho_simulation::tycho_common::{
     dto::ProtocolStateDelta,
     models::token::Token,
@@ -12,7 +12,7 @@ use tycho_simulation::tycho_common::{
     Bytes,
 };
 
-use crate::types::ComponentId;
+use crate::{algorithm::AlgorithmError, feed::market_data::MarketState, types::ComponentId};
 
 pub(crate) struct HopDescriptor {
     pub(crate) component_id: ComponentId,
@@ -261,6 +261,167 @@ pub(crate) fn fractions_to_amounts(
     Ok(amounts)
 }
 
+/// Product of spot prices along a path — approximates the exchange rate at
+/// near-zero input.
+pub(crate) fn compute_marginal_price_product(
+    hops: &[HopDescriptor],
+    market: &MarketState,
+) -> Result<f64, AlgorithmError> {
+    let mut product = 1.0;
+    for hop in hops {
+        let sim = market
+            .get_simulation_state(&hop.component_id)
+            .ok_or_else(|| AlgorithmError::DataNotFound {
+                kind: "simulation state",
+                id: Some(hop.component_id.clone()),
+            })?;
+        let price = sim
+            .spot_price(&hop.token_in, &hop.token_out)
+            .map_err(|e| AlgorithmError::SimulationFailed {
+                component_id: hop.component_id.clone(),
+                error: e.to_string(),
+            })?;
+        product *= price;
+    }
+    Ok(product)
+}
+
+/// Simulates a path hop-by-hop, threading output of each hop as input to the
+/// next.
+///
+/// Checks `overrides` before falling back to the live market state for each
+/// hop. Returns the final output amount, raw gas sum, and marginal price
+/// product.
+pub(crate) fn simulate_path(
+    hops: &[HopDescriptor],
+    amount_in: &BigUint,
+    market: &MarketState,
+    overrides: &MarketOverrides,
+) -> Result<SimResult, AlgorithmError> {
+    let mut current_amount = amount_in.clone();
+    let mut total_gas: u64 = 0;
+
+    for hop in hops {
+        let sim = overrides
+            .get(&hop.component_id)
+            .or_else(|| market.get_simulation_state(&hop.component_id))
+            .ok_or_else(|| AlgorithmError::DataNotFound {
+                kind: "simulation state",
+                id: Some(hop.component_id.clone()),
+            })?;
+
+        let result = sim
+            .get_amount_out(current_amount, &hop.token_in, &hop.token_out)
+            .map_err(|e| AlgorithmError::SimulationFailed {
+                component_id: hop.component_id.clone(),
+                error: e.to_string(),
+            })?;
+
+        // Cap at u64::MAX instead of panicking on overflow.
+        total_gas = total_gas.saturating_add(result.gas.to_u64().unwrap_or(u64::MAX));
+        current_amount = result.amount;
+    }
+
+    let marginal_price_product = compute_marginal_price_product(hops, market)?;
+
+    Ok(SimResult { amount_out: current_amount, gas: total_gas, marginal_price_product })
+}
+
+/// Simulates all paths at their current fractions and returns
+/// `(total_amount_out, total_gas)`. `paths[i]` corresponds to `fractions[i]`.
+pub(crate) fn evaluate_total_output(
+    paths: &[&[HopDescriptor]],
+    fractions: &[f64],
+    total_amount: &BigUint,
+    market: &MarketState,
+    overrides: &MarketOverrides,
+) -> Result<(BigUint, u64), AlgorithmError> {
+    let amounts = fractions_to_amounts(total_amount, fractions)
+        .map_err(|e| AlgorithmError::Other(e.to_string()))?;
+
+    let mut total_out = BigUint::zero();
+    let mut total_gas: u64 = 0;
+
+    for (path, amount) in paths.iter().zip(amounts.iter()) {
+        if amount.is_zero() {
+            continue;
+        }
+
+        let mut current_amount = amount.clone();
+
+        for hop in path.iter() {
+            let sim = overrides
+                .get(&hop.component_id)
+                .or_else(|| market.get_simulation_state(&hop.component_id))
+                .ok_or_else(|| AlgorithmError::DataNotFound {
+                    kind: "simulation state",
+                    id: Some(hop.component_id.clone()),
+                })?;
+
+            let result = sim
+                .get_amount_out(current_amount, &hop.token_in, &hop.token_out)
+                .map_err(|e| AlgorithmError::SimulationFailed {
+                    component_id: hop.component_id.clone(),
+                    error: e.to_string(),
+                })?;
+
+            // Cap at u64::MAX instead of panicking on overflow.
+            total_gas = total_gas.saturating_add(result.gas.to_u64().unwrap_or(u64::MAX));
+            current_amount = result.amount;
+        }
+
+        total_out += current_amount;
+    }
+
+    Ok((total_out, total_gas))
+}
+
+/// Builds a post-swap view of the market after all paths in a single
+/// split-route solution have been executed.
+///
+/// For example, if the current solution splits 1000 USDC→ETH across:
+///   - Path 1: USDC→WETH via Uniswap (600 USDC)
+///   - Path 2: USDC→WBTC→WETH via Curve+Balancer (400 USDC)
+///
+/// this function simulates both swaps and returns overrides where Uniswap,
+/// Curve, and Balancer all reflect their post-swap reserves.
+///
+/// Paths are processed in order so shared pools accumulate the effects of
+/// all prior paths.
+pub(crate) fn build_degraded_market(
+    paths: &[&PathAllocation],
+    market: &MarketState,
+) -> MarketOverrides {
+    let mut states: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
+
+    for path in paths {
+        let mut current_amount = path.amount_in.clone();
+
+        for hop in &path.hops {
+            let sim = states
+                .get(&hop.component_id)
+                .map(|b| b.as_ref())
+                .or_else(|| market.get_simulation_state(&hop.component_id));
+
+            let Some(sim) = sim else { break };
+
+            let Ok(result) = sim.get_amount_out(current_amount, &hop.token_in, &hop.token_out)
+            else {
+                break;
+            };
+
+            current_amount = result.amount;
+            states.insert(hop.component_id.clone(), result.new_state);
+        }
+    }
+
+    let mut overrides = MarketOverrides::empty();
+    for (id, sim) in states {
+        overrides = overrides.with_override(id, sim);
+    }
+    overrides
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
@@ -347,5 +508,326 @@ mod tests {
         let f = |x: f64| -(x - 0.3) * (x - 0.3);
         let result = golden_section_search(f, 0.0, 1.0, 100);
         assert!((result - 0.3).abs() < 1e-4, "expected ~0.3, got {result}");
+    }
+
+    // ==================== Simulation Utility Tests ====================
+
+    use crate::{
+        algorithm::test_utils::{component, token, ConstantProductSim, MockProtocolSim},
+        feed::market_data::MarketState,
+    };
+
+    fn make_market(pools: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketState {
+        let mut market = MarketState::new();
+        for (pool_id, tokens, sim) in pools {
+            market.upsert_components(std::iter::once(component(pool_id, &tokens)));
+            market.update_states([(pool_id.to_string(), sim)]);
+            market.upsert_tokens(tokens);
+        }
+        market
+    }
+
+    #[test]
+    fn test_compute_marginal_price_product_single_hop() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![(
+            "pool_ab",
+            vec![token_a.clone(), token_b.clone()],
+            Box::new(MockProtocolSim::new(3.0)),
+        )]);
+
+        let hops = [HopDescriptor {
+            component_id: "pool_ab".to_string(),
+            token_in: token_a,
+            token_out: token_b,
+        }];
+
+        let product = compute_marginal_price_product(&hops, &market).unwrap();
+        assert!((product - 3.0).abs() < f64::EPSILON, "expected 3.0, got {product}");
+    }
+
+    #[test]
+    fn test_compute_marginal_price_product_multi_hop() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let market = make_market(vec![
+            (
+                "pool_ab",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0)),
+            ),
+            (
+                "pool_bc",
+                vec![token_b.clone(), token_c.clone()],
+                Box::new(MockProtocolSim::new(4.0)),
+            ),
+        ]);
+
+        let hops = [
+            HopDescriptor {
+                component_id: "pool_ab".to_string(),
+                token_in: token_a,
+                token_out: token_b.clone(),
+            },
+            HopDescriptor {
+                component_id: "pool_bc".to_string(),
+                token_in: token_b,
+                token_out: token_c,
+            },
+        ];
+
+        let product = compute_marginal_price_product(&hops, &market).unwrap();
+        // 2.0 * 4.0 = 8.0
+        assert!((product - 8.0).abs() < f64::EPSILON, "expected 8.0, got {product}");
+    }
+
+    #[test]
+    fn test_simulate_path_correct_output() {
+        // 2-hop path A→B→C with spot prices 2.0 and 3.0.
+        // Input 1000 should thread through: 1000*2=2000, 2000*3=6000.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let market = make_market(vec![
+            (
+                "pool_ab",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0)),
+            ),
+            (
+                "pool_bc",
+                vec![token_b.clone(), token_c.clone()],
+                Box::new(MockProtocolSim::new(3.0)),
+            ),
+        ]);
+
+        let hops = [
+            HopDescriptor {
+                component_id: "pool_ab".to_string(),
+                token_in: token_a,
+                token_out: token_b.clone(),
+            },
+            HopDescriptor {
+                component_id: "pool_bc".to_string(),
+                token_in: token_b,
+                token_out: token_c,
+            },
+        ];
+
+        let amount_in = BigUint::from(1000u64);
+        let overrides = MarketOverrides::empty();
+        let result = simulate_path(&hops, &amount_in, &market, &overrides).unwrap();
+
+        assert_eq!(result.amount_out, BigUint::from(6000u64));
+
+        // spot_price(A→B) = 2.0, spot_price(B→C) = 3.0 → product = 6.0
+        assert!(
+            (result.marginal_price_product - 6.0).abs() < f64::EPSILON,
+            "expected marginal_price_product 6.0, got {}",
+            result.marginal_price_product
+        );
+    }
+
+    #[test]
+    fn test_market_overrides_with_zero_gas() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let sim_ab = MockProtocolSim::new(2.0).with_gas(100_000);
+        let sim_bc = MockProtocolSim::new(3.0).with_gas(70_000);
+        let market = make_market(vec![
+            ("pool_ab", vec![token_a.clone(), token_b.clone()], Box::new(sim_ab.clone())),
+            ("pool_bc", vec![token_b.clone(), token_c.clone()], Box::new(sim_bc.clone())),
+        ]);
+
+        // Zero gas on pool_ab, leave pool_bc as a normal override.
+        let overrides = MarketOverrides::empty()
+            .with_zero_gas("pool_ab".to_string(), Box::new(sim_ab))
+            .with_override("pool_bc".to_string(), Box::new(sim_bc));
+
+        let hops_ab = [HopDescriptor {
+            component_id: "pool_ab".to_string(),
+            token_in: token_a.clone(),
+            token_out: token_b.clone(),
+        }];
+        let hops_bc = [HopDescriptor {
+            component_id: "pool_bc".to_string(),
+            token_in: token_b,
+            token_out: token_c,
+        }];
+        let amount_in = BigUint::from(1000u64);
+
+        let normal_ab =
+            simulate_path(&hops_ab, &amount_in, &market, &MarketOverrides::empty()).unwrap();
+        let zero_gas_ab = simulate_path(&hops_ab, &amount_in, &market, &overrides).unwrap();
+
+        assert_eq!(normal_ab.amount_out, zero_gas_ab.amount_out);
+        assert!(normal_ab.gas > 0, "normal gas should be non-zero");
+        assert_eq!(zero_gas_ab.gas, 0, "zero-gas override should report gas=0");
+
+        // pool_bc is a normal override — its gas should be unaffected.
+        let result_bc = simulate_path(&hops_bc, &amount_in, &market, &overrides).unwrap();
+        assert_eq!(result_bc.gas, 70_000, "non-zero-gas override should keep its gas");
+    }
+
+    #[test]
+    fn test_evaluate_total_output_two_paths() {
+        // 50/50 split of 1000 across two parallel 1-hop paths:
+        //
+        //       500 -- pool_1 (price=2.0) --> 1000
+        //      /                                   \
+        //  1000                                     2500
+        //      \                                   /
+        //       500 -- pool_2 (price=3.0) --> 1500
+        //
+        // total_gas = 50k + 60k = 110k
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![
+            (
+                "pool_1",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0).with_gas(50_000)),
+            ),
+            (
+                "pool_2",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(3.0).with_gas(60_000)),
+            ),
+        ]);
+
+        let hops_1 = [HopDescriptor {
+            component_id: "pool_1".to_string(),
+            token_in: token_a.clone(),
+            token_out: token_b.clone(),
+        }];
+        let hops_2 = [HopDescriptor {
+            component_id: "pool_2".to_string(),
+            token_in: token_a,
+            token_out: token_b,
+        }];
+
+        let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
+        let fractions = [0.5, 0.5];
+        let total_amount = BigUint::from(1000u64);
+        let overrides = MarketOverrides::empty();
+
+        let (total_out, total_gas) =
+            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
+
+        assert_eq!(total_out, BigUint::from(2500u64));
+        assert_eq!(total_gas, 110_000);
+    }
+
+    #[test]
+    fn test_evaluate_total_output_gas_counts_every_hop() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let token_d = token(0x0D, "D");
+        let market = make_market(vec![
+            (
+                "P1",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0).with_gas(100_000)),
+            ),
+            (
+                "P2",
+                vec![token_b.clone(), token_c.clone()],
+                Box::new(MockProtocolSim::new(1.5).with_gas(50_000)),
+            ),
+            (
+                "P3",
+                vec![token_b.clone(), token_d.clone()],
+                Box::new(MockProtocolSim::new(3.0).with_gas(70_000)),
+            ),
+        ]);
+
+        // Path 1: A -> P1 -> B -> P2 -> C (uses P1 and P2)
+        let hops_1 = [
+            HopDescriptor {
+                component_id: "P1".to_string(),
+                token_in: token_a.clone(),
+                token_out: token_b.clone(),
+            },
+            HopDescriptor {
+                component_id: "P2".to_string(),
+                token_in: token_b.clone(),
+                token_out: token_c,
+            },
+        ];
+        // Path 2: A -> P1 -> B -> P3 -> D (uses P1 and P3)
+        let hops_2 = [
+            HopDescriptor {
+                component_id: "P1".to_string(),
+                token_in: token_a,
+                token_out: token_b.clone(),
+            },
+            HopDescriptor { component_id: "P3".to_string(), token_in: token_b, token_out: token_d },
+        ];
+
+        let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
+        let fractions = [0.5, 0.5];
+        let total_amount = BigUint::from(1000u64);
+        let overrides = MarketOverrides::empty();
+
+        let (_, total_gas) =
+            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
+
+        // Every hop counts: P1 + P2 + P1 + P3 = 100k + 50k + 100k + 70k
+        assert_eq!(total_gas, 320_000);
+    }
+
+    #[test]
+    fn test_build_degraded_market_degrades_used_pools() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![(
+            "pool_ab",
+            vec![token_a.clone(), token_b.clone()],
+            Box::new(ConstantProductSim {
+                reserve_0: BigUint::from(10_000u64),
+                reserve_1: BigUint::from(20_000u64),
+                gas: 50_000,
+            }),
+        )]);
+
+        let allocation = PathAllocation {
+            hops: vec![HopDescriptor {
+                component_id: "pool_ab".to_string(),
+                token_in: token_a.clone(),
+                token_out: token_b.clone(),
+            }],
+            flow_fraction: 1.0,
+            amount_in: BigUint::from(1000u64),
+            amount_out: BigUint::from(1818u64),
+            marginal_price_product: 2.0,
+        };
+
+        let degraded = build_degraded_market(&[&allocation], &market);
+
+        // xy=k: amount_out = amount_in * reserve_out / (reserve_in + amount_in)
+        // Fresh pool (10000/20000): 100 * 20000 / (10000 + 100) = 198
+        let probe = BigUint::from(100u64);
+        let fresh_out = market
+            .get_simulation_state("pool_ab")
+            .unwrap()
+            .get_amount_out(probe.clone(), &token_a, &token_b)
+            .unwrap()
+            .amount;
+        assert_eq!(fresh_out, BigUint::from(198u64));
+
+        // The 1000-in allocation produces 1000*20000/(10000+1000) = 1818 out,
+        // shifting reserves to (10000+1000, 20000-1818) = (11000, 18182).
+        // Degraded pool: 100 * 18182 / (11000 + 100) = 163
+        let degraded_out = degraded
+            .get(&"pool_ab".to_string())
+            .unwrap()
+            .get_amount_out(probe, &token_a, &token_b)
+            .unwrap()
+            .amount;
+        assert_eq!(degraded_out, BigUint::from(163u64));
     }
 }

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
@@ -341,6 +341,7 @@ pub(crate) fn evaluate_total_output(
 
     let mut total_out = BigUint::zero();
     let mut total_gas: u64 = 0;
+    let mut seen_hops: HashSet<(ComponentId, Bytes, Bytes)> = HashSet::new();
 
     for (path, amount) in paths.iter().zip(amounts.iter()) {
         if amount.is_zero() {
@@ -365,8 +366,17 @@ pub(crate) fn evaluate_total_output(
                     error: e.to_string(),
                 })?;
 
-            // Cap at u64::MAX instead of panicking on overflow.
-            total_gas = total_gas.saturating_add(result.gas.to_u64().unwrap_or(u64::MAX));
+            // Shared pre-split hops appear in multiple paths but are
+            // executed once on-chain — count gas only once per unique
+            // (pool, token_in, token_out).
+            let hop_key = (
+                hop.component_id.clone(),
+                hop.token_in.address.clone(),
+                hop.token_out.address.clone(),
+            );
+            if seen_hops.insert(hop_key) {
+                total_gas = total_gas.saturating_add(result.gas.to_u64().unwrap_or(u64::MAX));
+            }
             current_amount = result.amount;
         }
 
@@ -722,7 +732,16 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluate_total_output_gas_counts_every_hop() {
+    fn test_evaluate_total_output_gas_deduplication() {
+        // Two paths share pool P1 (pre-split hop). P1's gas should be
+        // counted once, not twice.
+        //
+        //              P2 (50k gas) --> C
+        //             /
+        //  A -- P1 --+
+        //             \
+        //              P3 (70k gas) --> D
+        //
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
@@ -776,8 +795,48 @@ mod tests {
         let (_, total_gas) =
             evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
 
-        // Every hop counts: P1 + P2 + P1 + P3 = 100k + 50k + 100k + 70k
-        assert_eq!(total_gas, 320_000);
+        // P1 counted once: 100k + 50k + 70k = 220k
+        assert_eq!(total_gas, 220_000);
+    }
+
+    #[test]
+    fn test_gas_dedup_different_tokens() {
+        // A single 3-token pool used for two different token pairs is two
+        // distinct hops — gas must be counted for each.
+        //
+        //  A -- TRIPOOL (A→B) --> B    (path 1)
+        //  B -- TRIPOOL (B→C) --> C    (path 2)
+        //
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let market = make_market(vec![(
+            "tripool",
+            vec![token_a.clone(), token_b.clone(), token_c.clone()],
+            Box::new(MockProtocolSim::new(1.0).with_gas(80_000)),
+        )]);
+
+        let hops_1 = [HopDescriptor {
+            component_id: "tripool".to_string(),
+            token_in: token_a,
+            token_out: token_b.clone(),
+        }];
+        let hops_2 = [HopDescriptor {
+            component_id: "tripool".to_string(),
+            token_in: token_b,
+            token_out: token_c,
+        }];
+
+        let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
+        let fractions = [0.5, 0.5];
+        let total_amount = BigUint::from(1000u64);
+        let overrides = MarketOverrides::empty();
+
+        let (_, total_gas) =
+            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
+
+        // Different token pairs on the same pool: 80k + 80k = 160k
+        assert_eq!(total_gas, 160_000);
     }
 
     #[test]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -400,7 +400,7 @@ pub(crate) fn evaluate_total_output(
 ///
 /// Paths are processed in order so shared pools accumulate the effects of
 /// all prior paths.
-pub(crate) fn build_degraded_market(
+pub(crate) fn build_post_swap_overrides(
     paths: &[&PathAllocation],
     market: &MarketDataView,
 ) -> MarketOverrides {
@@ -882,7 +882,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_build_degraded_market_degrades_used_pools() {
+    async fn test_build_post_swap_overrides_degrades_used_pools() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let market = make_market_data(vec![(
@@ -919,7 +919,7 @@ mod tests {
             .amount;
         assert_eq!(fresh_out, BigUint::from(198u64));
 
-        let degraded = build_degraded_market(&[&allocation], &view);
+        let degraded = build_post_swap_overrides(&[&allocation], &view);
 
         // The 1000-in allocation produces 1000*20000/(10000+1000) = 1818 out,
         // shifting reserves to (10000+1000, 20000-1818) = (11000, 18182).

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -266,11 +266,13 @@ pub(crate) fn fractions_to_amounts(
 pub(crate) fn compute_marginal_price_product(
     hops: &[HopDescriptor],
     market: &MarketState,
+    overrides: &MarketOverrides,
 ) -> Result<f64, AlgorithmError> {
     let mut product = 1.0;
     for hop in hops {
-        let sim = market
-            .get_simulation_state(&hop.component_id)
+        let sim = overrides
+            .get(&hop.component_id)
+            .or_else(|| market.get_simulation_state(&hop.component_id))
             .ok_or_else(|| AlgorithmError::DataNotFound {
                 kind: "simulation state",
                 id: Some(hop.component_id.clone()),
@@ -322,7 +324,7 @@ pub(crate) fn simulate_path(
         current_amount = result.amount;
     }
 
-    let marginal_price_product = compute_marginal_price_product(hops, market)?;
+    let marginal_price_product = compute_marginal_price_product(hops, market, overrides)?;
 
     Ok(SimResult { amount_out: current_amount, gas: total_gas, marginal_price_product })
 }
@@ -553,7 +555,8 @@ mod tests {
             token_out: token_b,
         }];
 
-        let product = compute_marginal_price_product(&hops, &market).unwrap();
+        let product =
+            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
         assert!((product - 3.0).abs() < f64::EPSILON, "expected 3.0, got {product}");
     }
 
@@ -588,9 +591,34 @@ mod tests {
             },
         ];
 
-        let product = compute_marginal_price_product(&hops, &market).unwrap();
+        let product =
+            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
         // 2.0 * 4.0 = 8.0
         assert!((product - 8.0).abs() < f64::EPSILON, "expected 8.0, got {product}");
+    }
+
+    #[test]
+    fn test_compute_marginal_price_product_uses_overrides() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![(
+            "pool_ab",
+            vec![token_a.clone(), token_b.clone()],
+            Box::new(MockProtocolSim::new(3.0)),
+        )]);
+
+        let hops = [HopDescriptor {
+            component_id: "pool_ab".to_string(),
+            token_in: token_a,
+            token_out: token_b,
+        }];
+
+        // Override pool_ab with a different spot price.
+        let overrides = MarketOverrides::empty()
+            .with_override("pool_ab".to_string(), Box::new(MockProtocolSim::new(7.0)));
+
+        let product = compute_marginal_price_product(&hops, &market, &overrides).unwrap();
+        assert!((product - 7.0).abs() < f64::EPSILON, "expected 7.0, got {product}");
     }
 
     #[test]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -411,15 +411,14 @@ pub(crate) fn build_post_swap_overrides(
     paths: &[&PathAllocation],
     market: &MarketState,
 ) -> MarketOverrides {
-    let mut states: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
+    let mut overrides = MarketOverrides::empty();
 
     for path in paths {
         let mut current_amount = path.amount_in.clone();
 
         for hop in &path.hops {
-            let sim = states
+            let sim = overrides
                 .get(&hop.component_id)
-                .map(|b| b.as_ref())
                 .or_else(|| market.get_simulation_state(&hop.component_id));
 
             let Some(sim) = sim else { break };
@@ -430,14 +429,10 @@ pub(crate) fn build_post_swap_overrides(
             };
 
             current_amount = result.amount;
-            states.insert(hop.component_id.clone(), result.new_state);
+            overrides = overrides.with_override(hop.component_id.clone(), result.new_state);
         }
     }
 
-    let mut overrides = MarketOverrides::empty();
-    for (id, sim) in states {
-        overrides = overrides.with_override(id, sim);
-    }
     overrides
 }
 

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -12,7 +12,7 @@ use tycho_simulation::tycho_common::{
     Bytes,
 };
 
-use crate::{algorithm::AlgorithmError, feed::market_data::MarketDataView, types::ComponentId};
+use crate::{algorithm::AlgorithmError, feed::market_data::MarketState, types::ComponentId};
 
 pub(crate) struct HopDescriptor {
     pub(crate) component_id: ComponentId,
@@ -271,12 +271,14 @@ pub(crate) fn fractions_to_amounts(
 /// near-zero input.
 pub(crate) fn compute_marginal_price_product(
     hops: &[HopDescriptor],
-    market: &MarketDataView,
+    market: &MarketState,
+    overrides: &MarketOverrides,
 ) -> Result<f64, AlgorithmError> {
     let mut product = 1.0;
     for hop in hops {
-        let sim = market
-            .get_simulation_state(&hop.component_id)
+        let sim = overrides
+            .get(&hop.component_id)
+            .or_else(|| market.get_simulation_state(&hop.component_id))
             .ok_or_else(|| AlgorithmError::DataNotFound {
                 kind: "simulation state",
                 id: Some(hop.component_id.clone()),
@@ -295,19 +297,22 @@ pub(crate) fn compute_marginal_price_product(
 /// Simulates a path hop-by-hop, threading output of each hop as input to the
 /// next.
 ///
-/// Uses the overlay-aware `MarketDataView` for each hop's simulation state.
-/// Returns the final output amount, raw gas sum, and marginal price product.
+/// Checks `overrides` before falling back to the live market state for each
+/// hop. Returns the final output amount, raw gas sum, and marginal price
+/// product.
 pub(crate) fn simulate_path(
     hops: &[HopDescriptor],
     amount_in: &BigUint,
-    market: &MarketDataView,
+    market: &MarketState,
+    overrides: &MarketOverrides,
 ) -> Result<SimResult, AlgorithmError> {
     let mut current_amount = amount_in.clone();
     let mut total_gas: u64 = 0;
 
     for hop in hops {
-        let sim = market
-            .get_simulation_state(&hop.component_id)
+        let sim = overrides
+            .get(&hop.component_id)
+            .or_else(|| market.get_simulation_state(&hop.component_id))
             .ok_or_else(|| AlgorithmError::DataNotFound {
                 kind: "simulation state",
                 id: Some(hop.component_id.clone()),
@@ -325,7 +330,7 @@ pub(crate) fn simulate_path(
         current_amount = result.amount;
     }
 
-    let marginal_price_product = compute_marginal_price_product(hops, market)?;
+    let marginal_price_product = compute_marginal_price_product(hops, market, overrides)?;
 
     Ok(SimResult { amount_out: current_amount, gas: total_gas, marginal_price_product })
 }
@@ -336,7 +341,8 @@ pub(crate) fn evaluate_total_output(
     paths: &[&[HopDescriptor]],
     fractions: &[f64],
     total_amount: &BigUint,
-    market: &MarketDataView,
+    market: &MarketState,
+    overrides: &MarketOverrides,
 ) -> Result<(BigUint, u64), AlgorithmError> {
     let amounts = fractions_to_amounts(total_amount, fractions)
         .map_err(|e| AlgorithmError::Other(e.to_string()))?;
@@ -353,8 +359,9 @@ pub(crate) fn evaluate_total_output(
         let mut current_amount = amount.clone();
 
         for hop in path.iter() {
-            let sim = market
-                .get_simulation_state(&hop.component_id)
+            let sim = overrides
+                .get(&hop.component_id)
+                .or_else(|| market.get_simulation_state(&hop.component_id))
                 .ok_or_else(|| AlgorithmError::DataNotFound {
                     kind: "simulation state",
                     id: Some(hop.component_id.clone()),
@@ -402,16 +409,17 @@ pub(crate) fn evaluate_total_output(
 /// all prior paths.
 pub(crate) fn build_post_swap_overrides(
     paths: &[&PathAllocation],
-    market: &MarketDataView,
+    market: &MarketState,
 ) -> MarketOverrides {
-    let mut overrides = MarketOverrides::empty();
+    let mut states: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
 
     for path in paths {
         let mut current_amount = path.amount_in.clone();
 
         for hop in &path.hops {
-            let sim = overrides
+            let sim = states
                 .get(&hop.component_id)
+                .map(|b| b.as_ref())
                 .or_else(|| market.get_simulation_state(&hop.component_id));
 
             let Some(sim) = sim else { break };
@@ -422,10 +430,14 @@ pub(crate) fn build_post_swap_overrides(
             };
 
             current_amount = result.amount;
-            overrides = overrides.with_override(hop.component_id.clone(), result.new_state);
+            states.insert(hop.component_id.clone(), result.new_state);
         }
     }
 
+    let mut overrides = MarketOverrides::empty();
+    for (id, sim) in states {
+        overrides = overrides.with_override(id, sim);
+    }
     overrides
 }
 
@@ -434,19 +446,16 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::{
-        algorithm::test_utils::{component, token, ConstantProductSim, MockProtocolSim},
-        feed::market_data::{MarketData, MarketState},
-    };
+    use crate::algorithm::test_utils::{component, token, ConstantProductSim, MockProtocolSim};
 
-    fn make_market_data(pools: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketData {
+    fn make_market(pools: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketState {
         let mut market = MarketState::new();
         for (pool_id, tokens, sim) in pools {
             market.upsert_components(std::iter::once(component(pool_id, &tokens)));
             market.update_states([(pool_id.to_string(), sim)]);
             market.upsert_tokens(tokens);
         }
-        MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
+        market
     }
 
     #[test]
@@ -533,16 +542,15 @@ mod tests {
 
     // ==================== Simulation Utility Tests ====================
 
-    #[tokio::test]
-    async fn test_compute_marginal_price_product_single_hop() {
+    #[test]
+    fn test_compute_marginal_price_product_single_hop() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market_data(vec![(
+        let market = make_market(vec![(
             "pool_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(MockProtocolSim::new(3.0)),
         )]);
-        let view = market.read().await;
 
         let hops = [HopDescriptor {
             component_id: "pool_ab".to_string(),
@@ -550,16 +558,17 @@ mod tests {
             token_out: token_b,
         }];
 
-        let product = compute_marginal_price_product(&hops, &view).unwrap();
+        let product =
+            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
         assert!((product - 3.0).abs() < f64::EPSILON, "expected 3.0, got {product}");
     }
 
-    #[tokio::test]
-    async fn test_compute_marginal_price_product_multi_hop() {
+    #[test]
+    fn test_compute_marginal_price_product_multi_hop() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
-        let market = make_market_data(vec![
+        let market = make_market(vec![
             (
                 "pool_ab",
                 vec![token_a.clone(), token_b.clone()],
@@ -571,7 +580,6 @@ mod tests {
                 Box::new(MockProtocolSim::new(4.0)),
             ),
         ]);
-        let view = market.read().await;
 
         let hops = [
             HopDescriptor {
@@ -586,16 +594,17 @@ mod tests {
             },
         ];
 
-        let product = compute_marginal_price_product(&hops, &view).unwrap();
+        let product =
+            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
         // 2.0 * 4.0 = 8.0
         assert!((product - 8.0).abs() < f64::EPSILON, "expected 8.0, got {product}");
     }
 
-    #[tokio::test]
-    async fn test_compute_marginal_price_product_uses_overlay() {
+    #[test]
+    fn test_compute_marginal_price_product_uses_overrides() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market_data(vec![(
+        let market = make_market(vec![(
             "pool_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(MockProtocolSim::new(3.0)),
@@ -607,31 +616,22 @@ mod tests {
             token_out: token_b,
         }];
 
-        // Register an overlay with a different spot price.
-        let overlay = HashMap::from([(
-            "pool_ab".to_string(),
-            Box::new(MockProtocolSim::new(7.0)) as Box<dyn ProtocolSim>,
-        )]);
-        market
-            .register_labeled_state("degraded".to_string(), overlay, u64::MAX)
-            .await;
-        let view = market
-            .read_labeled(&"degraded".to_string())
-            .await
-            .unwrap();
+        // Override pool_ab with a different spot price.
+        let overrides = MarketOverrides::empty()
+            .with_override("pool_ab".to_string(), Box::new(MockProtocolSim::new(7.0)));
 
-        let product = compute_marginal_price_product(&hops, &view).unwrap();
+        let product = compute_marginal_price_product(&hops, &market, &overrides).unwrap();
         assert!((product - 7.0).abs() < f64::EPSILON, "expected 7.0, got {product}");
     }
 
-    #[tokio::test]
-    async fn test_simulate_path_correct_output() {
+    #[test]
+    fn test_simulate_path_correct_output() {
         // 2-hop path A→B→C with spot prices 2.0 and 3.0.
         // Input 1000 should thread through: 1000*2=2000, 2000*3=6000.
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
-        let market = make_market_data(vec![
+        let market = make_market(vec![
             (
                 "pool_ab",
                 vec![token_a.clone(), token_b.clone()],
@@ -643,7 +643,6 @@ mod tests {
                 Box::new(MockProtocolSim::new(3.0)),
             ),
         ]);
-        let view = market.read().await;
 
         let hops = [
             HopDescriptor {
@@ -659,7 +658,8 @@ mod tests {
         ];
 
         let amount_in = BigUint::from(1000u64);
-        let result = simulate_path(&hops, &amount_in, &view).unwrap();
+        let overrides = MarketOverrides::empty();
+        let result = simulate_path(&hops, &amount_in, &market, &overrides).unwrap();
 
         assert_eq!(result.amount_out, BigUint::from(6000u64));
 
@@ -671,17 +671,22 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_zero_gas_overlay() {
+    #[test]
+    fn test_market_overrides_with_zero_gas() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
         let sim_ab = MockProtocolSim::new(2.0).with_gas(100_000);
         let sim_bc = MockProtocolSim::new(3.0).with_gas(70_000);
-        let market = make_market_data(vec![
+        let market = make_market(vec![
             ("pool_ab", vec![token_a.clone(), token_b.clone()], Box::new(sim_ab.clone())),
             ("pool_bc", vec![token_b.clone(), token_c.clone()], Box::new(sim_bc.clone())),
         ]);
+
+        // Zero gas on pool_ab, leave pool_bc as a normal override.
+        let overrides = MarketOverrides::empty()
+            .with_zero_gas("pool_ab".to_string(), Box::new(sim_ab))
+            .with_override("pool_bc".to_string(), Box::new(sim_bc));
 
         let hops_ab = [HopDescriptor {
             component_id: "pool_ab".to_string(),
@@ -695,37 +700,21 @@ mod tests {
         }];
         let amount_in = BigUint::from(1000u64);
 
-        // No overlay: normal gas.
-        let normal_view = market.read().await;
-        let normal_ab = simulate_path(&hops_ab, &amount_in, &normal_view).unwrap();
-        drop(normal_view);
-
-        // Overlay: zero gas on pool_ab, normal override on pool_bc.
-        let overlay = HashMap::from([
-            ("pool_ab".to_string(), wrap_zero_gas(Box::new(sim_ab))),
-            ("pool_bc".to_string(), Box::new(sim_bc) as Box<dyn ProtocolSim>),
-        ]);
-        market
-            .register_labeled_state("test".to_string(), overlay, u64::MAX)
-            .await;
-        let overlay_view = market
-            .read_labeled(&"test".to_string())
-            .await
-            .unwrap();
-
-        let zero_gas_ab = simulate_path(&hops_ab, &amount_in, &overlay_view).unwrap();
+        let normal_ab =
+            simulate_path(&hops_ab, &amount_in, &market, &MarketOverrides::empty()).unwrap();
+        let zero_gas_ab = simulate_path(&hops_ab, &amount_in, &market, &overrides).unwrap();
 
         assert_eq!(normal_ab.amount_out, zero_gas_ab.amount_out);
         assert!(normal_ab.gas > 0, "normal gas should be non-zero");
-        assert_eq!(zero_gas_ab.gas, 0, "zero-gas overlay should report gas=0");
+        assert_eq!(zero_gas_ab.gas, 0, "zero-gas override should report gas=0");
 
         // pool_bc is a normal override — its gas should be unaffected.
-        let result_bc = simulate_path(&hops_bc, &amount_in, &overlay_view).unwrap();
+        let result_bc = simulate_path(&hops_bc, &amount_in, &market, &overrides).unwrap();
         assert_eq!(result_bc.gas, 70_000, "non-zero-gas override should keep its gas");
     }
 
-    #[tokio::test]
-    async fn test_evaluate_total_output_two_paths() {
+    #[test]
+    fn test_evaluate_total_output_two_paths() {
         // 50/50 split of 1000 across two parallel 1-hop paths:
         //
         //       500 -- pool_1 (price=2.0) --> 1000
@@ -737,7 +726,7 @@ mod tests {
         // total_gas = 50k + 60k = 110k
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market_data(vec![
+        let market = make_market(vec![
             (
                 "pool_1",
                 vec![token_a.clone(), token_b.clone()],
@@ -749,7 +738,6 @@ mod tests {
                 Box::new(MockProtocolSim::new(3.0).with_gas(60_000)),
             ),
         ]);
-        let view = market.read().await;
 
         let hops_1 = [HopDescriptor {
             component_id: "pool_1".to_string(),
@@ -765,16 +753,17 @@ mod tests {
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
         let total_amount = BigUint::from(1000u64);
+        let overrides = MarketOverrides::empty();
 
         let (total_out, total_gas) =
-            evaluate_total_output(&paths, &fractions, &total_amount, &view).unwrap();
+            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
 
         assert_eq!(total_out, BigUint::from(2500u64));
         assert_eq!(total_gas, 110_000);
     }
 
-    #[tokio::test]
-    async fn test_evaluate_total_output_gas_deduplication() {
+    #[test]
+    fn test_evaluate_total_output_gas_deduplication() {
         // Two paths share pool P1 (pre-split hop). P1's gas should be
         // counted once, not twice.
         //
@@ -788,7 +777,7 @@ mod tests {
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
         let token_d = token(0x0D, "D");
-        let market = make_market_data(vec![
+        let market = make_market(vec![
             (
                 "P1",
                 vec![token_a.clone(), token_b.clone()],
@@ -805,7 +794,6 @@ mod tests {
                 Box::new(MockProtocolSim::new(3.0).with_gas(70_000)),
             ),
         ]);
-        let view = market.read().await;
 
         // Path 1: A -> P1 -> B -> P2 -> C (uses P1 and P2)
         let hops_1 = [
@@ -833,16 +821,17 @@ mod tests {
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
         let total_amount = BigUint::from(1000u64);
+        let overrides = MarketOverrides::empty();
 
         let (_, total_gas) =
-            evaluate_total_output(&paths, &fractions, &total_amount, &view).unwrap();
+            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
 
         // P1 counted once: 100k + 50k + 70k = 220k
         assert_eq!(total_gas, 220_000);
     }
 
-    #[tokio::test]
-    async fn test_gas_dedup_different_tokens() {
+    #[test]
+    fn test_gas_dedup_different_tokens() {
         // A single 3-token pool used for two different token pairs is two
         // distinct hops — gas must be counted for each.
         //
@@ -852,12 +841,11 @@ mod tests {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
-        let market = make_market_data(vec![(
+        let market = make_market(vec![(
             "tripool",
             vec![token_a.clone(), token_b.clone(), token_c.clone()],
             Box::new(MockProtocolSim::new(1.0).with_gas(80_000)),
         )]);
-        let view = market.read().await;
 
         let hops_1 = [HopDescriptor {
             component_id: "tripool".to_string(),
@@ -873,19 +861,20 @@ mod tests {
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
         let total_amount = BigUint::from(1000u64);
+        let overrides = MarketOverrides::empty();
 
         let (_, total_gas) =
-            evaluate_total_output(&paths, &fractions, &total_amount, &view).unwrap();
+            evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
 
         // Different token pairs on the same pool: 80k + 80k = 160k
         assert_eq!(total_gas, 160_000);
     }
 
-    #[tokio::test]
-    async fn test_build_post_swap_overrides_degrades_used_pools() {
+    #[test]
+    fn test_build_post_swap_overrides_degrades_used_pools() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
-        let market = make_market_data(vec![(
+        let market = make_market(vec![(
             "pool_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(ConstantProductSim {
@@ -894,7 +883,6 @@ mod tests {
                 gas: 50_000,
             }),
         )]);
-        let view = market.read().await;
 
         let allocation = PathAllocation {
             hops: vec![HopDescriptor {
@@ -908,18 +896,18 @@ mod tests {
             marginal_price_product: 2.0,
         };
 
+        let degraded = build_post_swap_overrides(&[&allocation], &market);
+
         // xy=k: amount_out = amount_in * reserve_out / (reserve_in + amount_in)
         // Fresh pool (10000/20000): 100 * 20000 / (10000 + 100) = 198
         let probe = BigUint::from(100u64);
-        let fresh_out = view
+        let fresh_out = market
             .get_simulation_state("pool_ab")
             .unwrap()
             .get_amount_out(probe.clone(), &token_a, &token_b)
             .unwrap()
             .amount;
         assert_eq!(fresh_out, BigUint::from(198u64));
-
-        let degraded = build_post_swap_overrides(&[&allocation], &view);
 
         // The 1000-in allocation produces 1000*20000/(10000+1000) = 1818 out,
         // shifting reserves to (10000+1000, 20000-1818) = (11000, 18182).


### PR DESCRIPTION
Implement hop-by-hop path simulation, marginal price computation, gas-deduplicated objective function, and degraded market builder for the upcoming split-routing algorithm (ENG-5845).