### PR TITLE
feat(benchmark): add audit subcommand for on-chain quote validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ scale_results*.json
 
 # fynd-gas-audit output artifacts
 tools/fynd-gas-audit/out/
+run_2hop_audit.sh
+audit_results*.json
+audit_*.log
+solver.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5514,9 +5514,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3377,9 +3377,11 @@ version = "0.81.1"
 dependencies = [
  "alloy",
  "anyhow",
+ "async-trait",
  "bytes",
  "clap",
  "fastrand",
+ "futures 0.3.32",
  "fynd-client",
  "fynd-rpc",
  "num-bigint",

--- a/fynd-rpc/src/protocols.rs
+++ b/fynd-rpc/src/protocols.rs
@@ -1,11 +1,19 @@
 //! Tycho protocol system discovery.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use tracing::info;
 use tycho_simulation::{
     tycho_client::rpc::{HttpRPCClient, HttpRPCClientOptions, ProtocolSystemsParams, RPCClient},
     tycho_common::models::Chain,
 };
+
+/// Expansion token: fetch every on-chain protocol system from Tycho.
+const ALL_ONCHAIN: &str = "all_onchain";
+/// Expansion token: like [`ALL_ONCHAIN`] but drop VM-simulated protocols (those prefixed `vm:`),
+/// keeping only native-Rust protocols.
+const NATIVE_ONCHAIN: &str = "native_onchain";
+/// Prefix marking a VM-simulated (EVM) protocol system.
+const VM_PREFIX: &str = "vm:";
 
 /// Fetches all available protocol systems from the Tycho RPC.
 pub async fn fetch_protocol_systems(
@@ -29,5 +37,51 @@ pub async fn fetch_protocol_systems(
         .protocol_systems()
         .to_vec();
     info!("Fetched {} protocol system(s) from Tycho RPC", protocols.len());
+    Ok(protocols)
+}
+
+/// Resolves a requested protocol list into concrete Tycho protocol systems.
+///
+/// Expansion tokens:
+/// - `all_onchain` (or an empty `requested` list) → fetch every on-chain protocol system.
+/// - `native_onchain` → fetch every on-chain protocol system, then drop the VM-simulated ones
+///   (those prefixed `vm:`), keeping only native-Rust protocols.
+///
+/// Explicit entries other than the expansion tokens (e.g. `rfq:bebop`, `uniswap_v3`) are appended
+/// if not already present. When no expansion token is given the list is returned unchanged.
+/// Returns an error if the resolved list is empty.
+pub async fn resolve_protocols(
+    tycho_url: &str,
+    auth_key: Option<&str>,
+    use_tls: bool,
+    chain: Chain,
+    requested: &[String],
+) -> Result<Vec<String>> {
+    let want_native = requested
+        .iter()
+        .any(|p| p == NATIVE_ONCHAIN);
+    let want_all = requested.is_empty() ||
+        requested
+            .iter()
+            .any(|p| p == ALL_ONCHAIN);
+
+    let protocols = if want_all || want_native {
+        let mut fetched = fetch_protocol_systems(tycho_url, auth_key, use_tls, chain).await?;
+        if want_native {
+            fetched.retain(|p| !p.starts_with(VM_PREFIX));
+        }
+        for p in requested {
+            if p != ALL_ONCHAIN && p != NATIVE_ONCHAIN && !fetched.contains(p) {
+                fetched.push(p.clone());
+            }
+        }
+        fetched
+    } else {
+        requested.to_vec()
+    };
+
+    if protocols.is_empty() {
+        bail!("no supported protocols found. Provide --protocols or check Tycho connectivity.");
+    }
     Ok(protocols)
 }

--- a/scripts/bench-remote.sh
+++ b/scripts/bench-remote.sh
@@ -21,6 +21,12 @@ POOL_CONFIG="${POOL_CONFIG:-single_pool.toml}"
 REQUESTS_FILE="${REQUESTS_FILE:-tools/benchmark/requests_set.json}"
 OUTPUT_FILE="${OUTPUT_FILE:-scale_results_remote.json}"
 RPC_URL="${RPC_URL:-}"
+MIN_TVL="${MIN_TVL:-}" # forwarded to `scale --min-tvl` when set; chain default otherwise
+# RFQ credentials forwarded to the remote so rfq:* protocols register. Empty when unused.
+BEBOP_USER="${BEBOP_USER:-}"
+BEBOP_KEY="${BEBOP_KEY:-}"
+HASHFLOW_USER="${HASHFLOW_USER:-}"
+HASHFLOW_KEY="${HASHFLOW_KEY:-}"
 VOLUME_SIZE="${VOLUME_SIZE:-60}" # GB, needs space for Rust toolchain + build
 KEY_NAME="bench-remote-$$"
 SG_NAME="bench-remote-sg-$$"
@@ -34,6 +40,10 @@ CLEANUP_ITEMS=()
 cleanup() {
 	echo ""
 	echo "=== Cleanup ==="
+	if [[ ${#CLEANUP_ITEMS[@]} -eq 0 ]]; then
+		echo "Nothing to clean up."
+		return
+	fi
 	for item in "${CLEANUP_ITEMS[@]}"; do
 		case "$item" in
 		instance:*)
@@ -154,7 +164,7 @@ PUBLIC_IP=$(aws ec2 describe-instances \
 	--output text)
 echo "Public IP: ${PUBLIC_IP}"
 
-SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o LogLevel=ERROR"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10 -o LogLevel=ERROR -o ServerAliveInterval=15 -o ServerAliveCountMax=8"
 SSH="ssh ${SSH_OPTS} -i ${KEY_FILE} ec2-user@${PUBLIC_IP}"
 SCP="scp ${SSH_OPTS} -i ${KEY_FILE}"
 
@@ -208,18 +218,29 @@ cargo build -p fynd-benchmark --release 2>&1 | tail -5
 echo "Build complete."
 BUILD_EOF
 
-# ---------- run benchmark ----------
+# ---------- run benchmark (detached + polled) ----------
 echo ""
 echo "=== Running scale benchmark ==="
-$SSH <<BENCH_EOF
+MIN_TVL_ARG=""
+if [[ -n "$MIN_TVL" ]]; then
+	MIN_TVL_ARG="--min-tvl ${MIN_TVL}"
+fi
+
+# Stage the benchmark command in a remote script so it survives SSH disconnects.
+$SSH "cat > ${REMOTE_DIR}/run_bench.sh" <<BENCH_EOF
+#!/usr/bin/env bash
 set -euo pipefail
 source "\$HOME/.cargo/env"
-cd ~/fynd
+cd ${REMOTE_DIR}
 
-RPC_URL="${RPC_URL}" RUST_LOG=info cargo run -p fynd-benchmark --release -- scale \\
+RPC_URL="${RPC_URL}" \\
+BEBOP_USER="${BEBOP_USER}" BEBOP_KEY="${BEBOP_KEY}" \\
+HASHFLOW_USER="${HASHFLOW_USER}" HASHFLOW_KEY="${HASHFLOW_KEY}" \\
+RUST_LOG=info cargo run -p fynd-benchmark --release -- scale \\
     --base-config "${POOL_CONFIG}" \\
     --worker-counts "${WORKER_COUNTS}" \\
     --protocols "${PROTOCOLS}" \\
+    ${MIN_TVL_ARG} \\
     --tycho-url "${TYCHO_URL}" \\
     --tycho-api-key "${TYCHO_API_KEY}" \\
     --http-port ${HTTP_PORT} \\
@@ -228,12 +249,47 @@ RPC_URL="${RPC_URL}" RUST_LOG=info cargo run -p fynd-benchmark --release -- scal
     --requests-file "${REQUESTS_FILE}" \\
     --warmup-secs ${WARMUP_SECS} \\
     --health-timeout-secs ${HEALTH_TIMEOUT} \\
-    --output-file "${OUTPUT_FILE}" 2>&1
+    --output-file "${OUTPUT_FILE}"
 BENCH_EOF
+
+# Launch detached: nohup keeps it alive if the SSH session drops; the exit code is
+# written to bench.done so the poll loop below can detect completion and success.
+$SSH "cd ${REMOTE_DIR} && rm -f bench.done bench.out && nohup bash -c 'bash run_bench.sh > bench.out 2>&1; echo \$? > bench.done' >/dev/null 2>&1 & echo launched"
+
+echo "Benchmark running remotely; polling for completion (reconnect-tolerant)..."
+BENCH_RC=""
+POLL_DEADLINE=$(($(date +%s) + 7200)) # 2h hard cap
+while :; do
+	if [[ $(date +%s) -gt $POLL_DEADLINE ]]; then
+		echo "ERROR: benchmark did not finish within 2h"
+		exit 1
+	fi
+	sleep 30
+	rc="$($SSH "cat ${REMOTE_DIR}/bench.done 2>/dev/null" 2>/dev/null || true)"
+	progress="$($SSH "tail -1 ${REMOTE_DIR}/bench.out 2>/dev/null" 2>/dev/null || true)"
+	if [[ -n "$progress" ]]; then
+		echo "  ... ${progress}"
+	fi
+	if [[ -n "$rc" ]]; then
+		BENCH_RC="$rc"
+		break
+	fi
+done
+
+echo "Remote benchmark exited with code ${BENCH_RC}"
 
 # ---------- fetch results ----------
 echo ""
 echo "=== Fetching results ==="
+# Always fetch the remote run log for diagnostics, even on failure.
+$SCP "ec2-user@${PUBLIC_IP}:${REMOTE_DIR}/bench.out" \
+	"${REPO_ROOT}/${OUTPUT_FILE%.json}.remote.log" 2>/dev/null || true
+
+if [[ "$BENCH_RC" != "0" ]]; then
+	echo "ERROR: remote benchmark failed (rc=${BENCH_RC}); see ${OUTPUT_FILE%.json}.remote.log"
+	exit 1
+fi
+
 $SCP "ec2-user@${PUBLIC_IP}:${REMOTE_DIR}/${OUTPUT_FILE}" \
 	"${REPO_ROOT}/${OUTPUT_FILE}"
 echo "Results saved to: ${REPO_ROOT}/${OUTPUT_FILE}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ use fynd_rpc::{
     builder::FyndRPCBuilder,
     config::{defaults, BlocklistConfig, WorkerPoolsConfig},
     parse_chain,
-    protocols::fetch_protocol_systems,
+    protocols::resolve_protocols,
 };
 mod cli;
 mod commands;
@@ -56,10 +56,7 @@ use tokio::{
 };
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use tycho_simulation::{
-    tycho_common::models::{Chain, TvlThresholdTier},
-    utils::default_blocklist,
-};
+use tycho_simulation::{tycho_common::models::TvlThresholdTier, utils::default_blocklist};
 
 fn main() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();
@@ -220,48 +217,6 @@ fn resolve_rpc_url(chain: &str, override_url: Option<&str>) -> Result<String, So
     }
 }
 
-/// Resolves the protocol list from `--protocols`.
-///
-/// - Empty → fetch all on-chain protocols from Tycho RPC.
-/// - Contains `"all_onchain"` → fetch all on-chain, then append any other explicit entries.
-/// - Otherwise → use as given (no network call).
-///
-/// Returns an error if the resolved list is empty.
-async fn resolve_protocols(
-    tycho_url: &str,
-    api_key: Option<&str>,
-    use_tls: bool,
-    chain: Chain,
-    requested: &[String],
-) -> Result<Vec<String>, SolverError> {
-    let needs_fetch = requested.is_empty() ||
-        requested
-            .iter()
-            .any(|p| p == "all_onchain");
-    let protocols = if needs_fetch {
-        let mut fetched = fetch_protocol_systems(tycho_url, api_key, use_tls, chain)
-            .await
-            .map_err(|e| {
-                SolverError::SetupError(format!("failed to fetch protocol systems: {e}"))
-            })?;
-        for p in requested {
-            if p != "all_onchain" && !fetched.contains(p) {
-                fetched.push(p.clone());
-            }
-        }
-        fetched
-    } else {
-        requested.to_vec()
-    };
-    if protocols.is_empty() {
-        return Err(SolverError::SetupError(
-            "no supported protocols found. Provide --protocols or check Tycho connectivity."
-                .to_string(),
-        ));
-    }
-    Ok(protocols)
-}
-
 /// Sets up the solver (loads config, parses chain, builds solver).
 /// Returns setup errors if any step fails.
 async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRPC, SolverError> {
@@ -298,7 +253,8 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
         chain,
         &args.protocols,
     )
-    .await?;
+    .await
+    .map_err(|e| SolverError::SetupError(format!("failed to resolve protocols: {e}")))?;
 
     info!(?protocols, "starting with {} protocol(s)", protocols.len());
 

--- a/tools/benchmark/CLAUDE.md
+++ b/tools/benchmark/CLAUDE.md
@@ -10,11 +10,101 @@ Three subcommands available via `cargo run -p fynd-benchmark --release --`:
 
 - **`compare`** — Compare output quality between two solver instances. Sends identical quote requests to both and reports differences in amount out (bps), net-of-gas output (server-side `amount_out_net_gas`), gas estimates, route selection, and status. Requires two solvers running on different ports (use git worktrees to run different branches simultaneously).
 
-- **`scale`** — Measure how solver throughput scales with worker thread count. Builds and tears down the solver in-process for each iteration; no external solver instance needed.
+- **`scale`** — Measure how solver throughput scales with worker thread count. Builds and tears down the solver in-process for each iteration; no external solver instance needed. `--protocols` accepts the `all_onchain` and `native_onchain` expansion tokens (the latter drops VM-simulated `vm:*` protocols), and `--min-tvl` sets the TVL floor — both resolved via the shared `fynd_rpc::protocols::resolve_protocols`.
 
 - **`download-trades`** — Download the full 10k aggregator trade dataset from GitHub Releases for use with `--requests-file`.
 
+- **`audit`** — Compare Fynd quote quality against external aggregators (Nordstern, KyberSwap, 0x). Runs over a trade dataset, records per-trade participant results (amount out, gas, protocols, route, eth_call on-chain validation), and writes a JSON report.
+
 Run `--help` on any subcommand for detailed options.
+
+## Running the Audit
+
+### Prerequisites
+
+1. **Build the release binary** (required — debug is too slow for vm:curve EVM simulation):
+   ```bash
+   cargo build -p fynd-benchmark --release
+   ```
+
+2. **Start the solver** with the `.env` vars sourced and RFQ protocols included:
+   ```bash
+   set -a && source .env && set +a
+   RUST_LOG=info ./target/release/fynd serve \
+     -w worker_pools_pfw3.toml \
+     --protocols all_onchain,rfq:bebop,rfq:hashflow \
+     > /tmp/fynd_solver.log 2>&1 &
+   ```
+   Wait until `/v1/health` returns `healthy: true` (~5–10 min for derived data).
+
+3. **Download the full trade dataset** (once):
+   ```bash
+   ./target/release/fynd-benchmark download-trades
+   ```
+
+### Standard full audit
+
+```bash
+TIMESTAMP=$(date +%Y%m%d_%H%M)
+./target/release/fynd-benchmark audit \
+  --fynd-url http://localhost:3000 \
+  --trade-data aggregator_trades_10k.json \
+  --rpc-url "$RPC_URL" \
+  --output "audit_results_${TIMESTAMP}.json" \
+  2>&1 | tee "audit_${TIMESTAMP}.log"
+```
+
+`--rpc-url` enables eth_call on-chain validation of every Fynd quote, populating `eth_call_amount_out`, `eth_call_gas_used`, and `gas_adjusted_diff_bps_onchain` in the output. **Always pass it** — omitting it leaves `gas_adjusted_diff_bps_onchain: null` for all trades.
+
+`$RPC_URL` is set by sourcing `.env` (see above). The `.env` file has the canonical node endpoint.
+
+### Targeted mini-audit (specific pairs)
+
+Create a trade-data file matching the dataset schema:
+```json
+[
+  {
+    "orders": [
+      {
+        "id": "",
+        "token_in": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "token_out": "<TOKEN_OUT>",
+        "amount": "10000000000",
+        "side": "sell",
+        "sender": "0x0000000000000000000000000000000000000001",
+        "receiver": null
+      }
+    ],
+    "options": { "timeout_ms": 5000, "min_responses": null, "max_gas": null }
+  }
+]
+```
+
+Then run:
+```bash
+./target/release/fynd-benchmark audit \
+  --fynd-url http://localhost:3000 \
+  --trade-data /tmp/my_pairs.json \
+  --rpc-url "$RPC_URL" \
+  --output /tmp/my_audit_out.json
+```
+
+### Reading results
+
+```python
+import json
+data = json.load(open("audit_results_TIMESTAMP.json"))
+for r in data["results"]:
+    for p in r["participants"]:
+        print(p["name"], p["raw_diff_bps"], p["gas_adjusted_diff_bps_onchain"])
+```
+
+Key fields per participant:
+- `protocols` — list of DEX protocols used
+- `route` — `[[protocol, pool_address], ...]` pairs (Fynd only)
+- `raw_diff_bps` — output diff vs Fynd ignoring gas
+- `gas_adjusted_diff_bps_reported` — diff using solver-reported gas estimates
+- `gas_adjusted_diff_bps_onchain` — diff using actual on-chain gas (requires `--rpc-url`)
 
 ## Module Overview
 
@@ -27,7 +117,7 @@ Run `--help` on any subcommand for detailed options.
 | `runner.rs` | Benchmark execution engine. Implements three strategies: sequential (one-at-a-time), fixed concurrency (semaphore-bounded), and rate-based (fire at fixed intervals). Returns timing vectors and order counts. |
 | `exporter.rs` | Statistics calculation (`TimingStats::from_measurements` — min/max/mean/median/p95/p99/stddev), ASCII histogram rendering, and JSON export of `BenchmarkResults`. |
 | `requests.rs` | Request generation and loading. Provides a default WETH→USDC request, loads embedded aggregator trades, downloads the full 10k dataset, and loads custom requests from a JSON file. |
-| `scale.rs` | `scale` subcommand handler. Builds and tears down an in-process Fynd instance for each worker-count iteration, runs load tests via `runner`, and exports scaling results to JSON. |
+| `scale.rs` | `scale` subcommand handler. Resolves protocols once via `resolve_protocols` (`all_onchain`/`native_onchain` expansion), then builds and tears down an in-process Fynd instance for each worker-count iteration (applying `--min-tvl`), runs load tests via `runner`, and exports scaling results to JSON. |
 
 ## Data Files
 

--- a/tools/benchmark/Cargo.toml
+++ b/tools/benchmark/Cargo.toml
@@ -19,7 +19,9 @@ alloy = { workspace = true }
 bytes = { workspace = true }
 num-bigint = { workspace = true }
 fastrand = "2.3"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
+async-trait = { workspace = true }
+futures = { workspace = true }
 
 [[bin]]
 name = "fynd-benchmark"

--- a/tools/benchmark/path_frank_wolfe_3hop.toml
+++ b/tools/benchmark/path_frank_wolfe_3hop.toml
@@ -1,0 +1,6 @@
+[pools.path_frank_wolfe_3_hops]
+algorithm = "path_frank_wolfe"
+num_workers = 3
+task_queue_capacity = 1000
+max_hops = 3
+timeout_ms = 1000

--- a/tools/benchmark/src/aggregator.rs
+++ b/tools/benchmark/src/aggregator.rs
@@ -73,6 +73,8 @@ pub struct AggregatorQuote {
     /// Encoded on-chain transaction. Present only when `fetch_calldata` was `true` and the
     /// aggregator has an encoding endpoint. `None` otherwise.
     pub calldata: Option<AggregatorCalldata>,
+    /// Pool-level route: `[protocol, component_id]` pairs (Fynd only; `None` for aggregators).
+    pub route: Option<Vec<[String; 2]>>,
 }
 
 impl AggregatorQuote {
@@ -151,8 +153,9 @@ struct NordsternTx {
 
 #[derive(Deserialize)]
 struct NordsternSwap {
+    // Nordstern returns fractional gas units (e.g. 162984.6); deserialise as f64, truncate later.
     #[serde(rename = "gasUnits", default)]
-    gas_units: Option<u64>,
+    gas_units: Option<f64>,
     route: Option<Vec<NordsternRouteItem>>,
 }
 
@@ -202,6 +205,7 @@ impl AggregatorClient for NordsternClient {
                 num_splits: None,
                 response_time_ms,
                 calldata: None,
+                route: None,
             });
         }
 
@@ -223,6 +227,7 @@ impl AggregatorClient for NordsternClient {
                     num_splits: None,
                     response_time_ms,
                     calldata: None,
+                    route: None,
                 });
             }
         };
@@ -236,6 +241,7 @@ impl AggregatorClient for NordsternClient {
         let gas_units: u64 = swaps
             .iter()
             .filter_map(|s| s.gas_units)
+            .map(|f| f as u64)
             .sum();
         let gas_units = (gas_units > 0).then_some(gas_units);
 
@@ -285,6 +291,7 @@ impl AggregatorClient for NordsternClient {
             num_splits,
             response_time_ms,
             calldata,
+            route: None,
         })
     }
 }
@@ -396,6 +403,7 @@ impl AggregatorClient for KyberswapClient {
                 num_splits: None,
                 response_time_ms,
                 calldata: None,
+                route: None,
             });
         }
 
@@ -414,6 +422,7 @@ impl AggregatorClient for KyberswapClient {
                 num_splits: None,
                 response_time_ms,
                 calldata: None,
+                route: None,
             });
         };
 
@@ -473,6 +482,7 @@ impl AggregatorClient for KyberswapClient {
             num_splits,
             response_time_ms,
             calldata,
+            route: None,
         })
     }
 }
@@ -648,6 +658,7 @@ impl AggregatorClient for ZeroExClient {
                 num_splits: None,
                 response_time_ms,
                 calldata: None,
+                route: None,
             });
         }
 
@@ -712,6 +723,7 @@ impl AggregatorClient for ZeroExClient {
             num_splits: None, // 0x route.fills is a flat list, not split-aware
             response_time_ms,
             calldata,
+            route: None,
         })
     }
 }
@@ -822,6 +834,7 @@ mod tests {
             num_splits: None,
             response_time_ms: 100,
             calldata: None,
+            route: None,
         };
         assert!(q.is_success());
     }
@@ -837,6 +850,7 @@ mod tests {
             num_splits: None,
             response_time_ms: 100,
             calldata: None,
+            route: None,
         };
         assert!(!q.is_success());
     }
@@ -852,6 +866,7 @@ mod tests {
             num_splits: None,
             response_time_ms: 50,
             calldata: None,
+            route: None,
         };
         assert!(!q.is_success());
     }

--- a/tools/benchmark/src/aggregator.rs
+++ b/tools/benchmark/src/aggregator.rs
@@ -1,0 +1,905 @@
+//! External aggregator clients for Fynd audit comparisons.
+//!
+//! Add a new aggregator by implementing [`AggregatorClient`] and constructing it in
+//! `audit::run`.
+
+use std::{collections::HashMap, fmt, time::Instant};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// Quote status returned by an external aggregator.
+///
+/// Use this enum rather than comparing status strings directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AggregatorStatus {
+    Success,
+    NoAmount,
+    NoRoute,
+    /// The aggregator returned an HTTP error response (4xx/5xx).
+    HttpError {
+        code: u16,
+        snippet: String,
+    },
+}
+
+impl fmt::Display for AggregatorStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Success => f.write_str("success"),
+            Self::NoAmount => f.write_str("no_amount"),
+            Self::NoRoute => f.write_str("no_route"),
+            Self::HttpError { code, snippet } => write!(f, "http_{code}: {snippet}"),
+        }
+    }
+}
+
+impl Serialize for AggregatorStatus {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&self.to_string())
+    }
+}
+
+/// On-chain transaction calldata returned by an aggregator for execution validation.
+#[derive(Debug, Clone, Serialize)]
+pub struct AggregatorCalldata {
+    /// Router / settlement contract address (hex with 0x prefix).
+    pub to: String,
+    /// ABI-encoded calldata (hex with 0x prefix).
+    pub data: String,
+    /// Native ETH value to send with the transaction (decimal string; usually `"0"`).
+    pub value: String,
+}
+
+/// A quote response from an external aggregator.
+#[derive(Debug, Clone, Serialize)]
+pub struct AggregatorQuote {
+    pub status: AggregatorStatus,
+    /// Output amount as a decimal string (token units).
+    pub amount_out: Option<String>,
+    /// Output amount net of gas costs (token units). Only populated by Fynd; `None` for all
+    /// other aggregators. Used as the baseline when computing gas-adjusted bps diffs.
+    pub amount_out_net_gas: Option<String>,
+    /// Total estimated gas units across all route legs.
+    pub gas_units: Option<u64>,
+    /// DEX names used in the route (e.g. `["uniswap_v3"]`).
+    pub protocols: Vec<String>,
+    /// Number of independent parallel sub-routes the aggregator split the order across.
+    /// `1` means a single path (no splitting). `None` when the aggregator does not expose
+    /// route structure (e.g. 0x `/price`).
+    pub num_splits: Option<usize>,
+    /// Wall-clock time from request dispatch to response body received.
+    pub response_time_ms: u64,
+    /// Encoded on-chain transaction. Present only when `fetch_calldata` was `true` and the
+    /// aggregator has an encoding endpoint. `None` otherwise.
+    pub calldata: Option<AggregatorCalldata>,
+}
+
+impl AggregatorQuote {
+    pub fn is_success(&self) -> bool {
+        self.status == AggregatorStatus::Success
+    }
+}
+
+/// Interface for any external DEX aggregator.
+#[async_trait]
+pub trait AggregatorClient: Send + Sync {
+    /// Short label used in output (e.g. `"nordstern"`).
+    fn name(&self) -> &str;
+
+    /// Request a sell-side quote. Returns `Err` for network or parse failures; routing
+    /// outcomes (no route, HTTP error from the aggregator) are encoded in the returned
+    /// quote's `status` field.
+    ///
+    /// When `wallet` is `Some(address)`, the implementation fetches the encoded on-chain
+    /// transaction (populating [`AggregatorQuote::calldata`]) and uses `address` as the
+    /// sender/recipient so that balance-delta validation reads the correct account.
+    /// Pass `None` when calldata is not needed.
+    async fn quote(
+        &self,
+        token_in: &str,
+        token_out: &str,
+        amount: &str,
+        wallet: Option<&str>,
+    ) -> anyhow::Result<AggregatorQuote>;
+}
+
+// ─── Nordstern Finance ────────────────────────────────────────────────────────
+
+/// Client for the Nordstern Finance aggregator API.
+///
+/// API: `GET /aggregator/{chain_id}?src=&dst=&amount=&from=`
+pub struct NordsternClient {
+    client: reqwest::Client,
+    base_url: String,
+    chain_id: u64,
+    /// Dummy sender; Nordstern requires `from` but we are only quoting.
+    from: String,
+}
+
+impl NordsternClient {
+    pub fn new(base_url: impl Into<String>, chain_id: u64) -> anyhow::Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(20))
+                .build()
+                .map_err(|e| anyhow::anyhow!("failed to build Nordstern HTTP client: {e}"))?,
+            base_url: base_url.into(),
+            chain_id,
+            from: "0x00000000000000000000000000000000badbabe".to_string(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct NordsternResponse {
+    /// Can be a JSON string or integer depending on Nordstern backend; we normalise to String.
+    #[serde(rename = "toAmount")]
+    to_amount: Option<serde_json::Value>,
+    swaps: Option<Vec<NordsternSwap>>,
+    /// Encoded transaction returned by Nordstern when a `from` address is supplied.
+    tx: Option<NordsternTx>,
+}
+
+#[derive(Deserialize)]
+struct NordsternTx {
+    to: Option<String>,
+    data: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct NordsternSwap {
+    #[serde(rename = "gasUnits", default)]
+    gas_units: Option<u64>,
+    route: Option<Vec<NordsternRouteItem>>,
+}
+
+#[derive(Deserialize)]
+struct NordsternRouteItem {
+    #[serde(rename = "type")]
+    dex: Option<String>,
+}
+
+#[async_trait]
+impl AggregatorClient for NordsternClient {
+    fn name(&self) -> &str {
+        "nordstern"
+    }
+
+    async fn quote(
+        &self,
+        token_in: &str,
+        token_out: &str,
+        amount: &str,
+        wallet: Option<&str>,
+    ) -> anyhow::Result<AggregatorQuote> {
+        let start = Instant::now();
+        let url = format!("{}/aggregator/{}", self.base_url, self.chain_id);
+        let from = wallet.unwrap_or(self.from.as_str());
+
+        let resp = self
+            .client
+            .get(&url)
+            .query(&[("src", token_in), ("dst", token_out), ("amount", amount), ("from", from)])
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("Nordstern request failed: {e}"))?;
+
+        let response_time_ms = start.elapsed().as_millis() as u64;
+
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            let snippet: String = body.chars().take(120).collect();
+            return Ok(AggregatorQuote {
+                status: AggregatorStatus::HttpError { code, snippet },
+                amount_out: None,
+                amount_out_net_gas: None,
+                gas_units: None,
+                protocols: vec![],
+                num_splits: None,
+                response_time_ms,
+                calldata: None,
+            });
+        }
+
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| anyhow::anyhow!("Nordstern read error: {e}"))?;
+        let data = match serde_json::from_str::<NordsternResponse>(&text) {
+            Ok(d) => d,
+            Err(_) => {
+                // Nordstern returns a pseudo-schema description (not valid JSON) for token
+                // pairs it doesn't support — treat that as no route rather than a hard error.
+                return Ok(AggregatorQuote {
+                    status: AggregatorStatus::NoRoute,
+                    amount_out: None,
+                    amount_out_net_gas: None,
+                    gas_units: None,
+                    protocols: vec![],
+                    num_splits: None,
+                    response_time_ms,
+                    calldata: None,
+                });
+            }
+        };
+
+        let swaps = data
+            .swaps
+            .as_deref()
+            .unwrap_or_default();
+        let num_splits = if swaps.is_empty() { None } else { Some(swaps.len()) };
+
+        let gas_units: u64 = swaps
+            .iter()
+            .filter_map(|s| s.gas_units)
+            .sum();
+        let gas_units = (gas_units > 0).then_some(gas_units);
+
+        let mut seen = std::collections::HashSet::new();
+        let protocols: Vec<String> = swaps
+            .iter()
+            .flat_map(|s| s.route.as_deref().unwrap_or_default())
+            .filter_map(|r| r.dex.clone())
+            .filter(|dex| seen.insert(dex.clone()))
+            .collect();
+
+        // Nordstern returns toAmount as either a JSON string or integer.
+        // A value of "0" means the aggregator has no route for this pair/amount.
+        let amount_out: Option<String> = data.to_amount.and_then(|v| {
+            let s = match v {
+                serde_json::Value::String(s) => s,
+                serde_json::Value::Number(n) => n.to_string(),
+                _ => return None,
+            };
+            if s == "0" {
+                None
+            } else {
+                Some(s)
+            }
+        });
+
+        let calldata = data.tx.and_then(|tx| {
+            Some(AggregatorCalldata {
+                to: tx.to?,
+                data: tx.data?,
+                value: tx
+                    .value
+                    .unwrap_or_else(|| "0".to_string()),
+            })
+        });
+
+        Ok(AggregatorQuote {
+            status: if amount_out.is_some() {
+                AggregatorStatus::Success
+            } else {
+                AggregatorStatus::NoAmount
+            },
+            amount_out,
+            amount_out_net_gas: None,
+            gas_units,
+            protocols,
+            num_splits,
+            response_time_ms,
+            calldata,
+        })
+    }
+}
+
+// ─── KyberSwap Aggregator ────────────────────────────────────────────────────
+
+/// Client for the KyberSwap Aggregator API.
+///
+/// API: `GET /{chain}/api/v1/routes?tokenIn=&tokenOut=&amountIn=`
+pub struct KyberswapClient {
+    client: reqwest::Client,
+    base_url: String,
+    chain: String,
+}
+
+impl KyberswapClient {
+    pub fn new(base_url: impl Into<String>, chain: impl Into<String>) -> anyhow::Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(20))
+                // KyberSwap sits behind Cloudflare; a browser UA avoids 403 challenges.
+                .user_agent("Mozilla/5.0 (compatible; fynd-benchmark/1.0)")
+                .build()
+                .map_err(|e| anyhow::anyhow!("failed to build KyberSwap HTTP client: {e}"))?,
+            base_url: base_url.into(),
+            chain: chain.into(),
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct KyberswapResponse {
+    data: Option<KyberswapData>,
+}
+
+#[derive(Deserialize)]
+struct KyberswapData {
+    #[serde(rename = "routeSummary")]
+    route_summary: KyberswapRouteSummary,
+}
+
+/// KyberSwap route summary — typed fields for the values we read plus a catch-all
+/// `extra` map that preserves all other fields for the `/route/build` POST body.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct KyberswapRouteSummary {
+    #[serde(default)]
+    pub gas: Option<String>,
+    pub amount_out: Option<String>,
+    /// Outer: parallel split paths. Inner: hops within each path.
+    pub route: Option<serde_json::Value>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct KyberswapBuildResponse {
+    data: Option<KyberswapBuildData>,
+}
+
+#[derive(Deserialize)]
+struct KyberswapBuildData {
+    /// ABI-encoded calldata.
+    data: String,
+    #[serde(rename = "routerAddress")]
+    router_address: String,
+    /// Encoded `msg.value` for native ETH swaps.
+    #[serde(default)]
+    value: Option<String>,
+}
+
+#[async_trait]
+impl AggregatorClient for KyberswapClient {
+    fn name(&self) -> &str {
+        "kyberswap"
+    }
+
+    async fn quote(
+        &self,
+        token_in: &str,
+        token_out: &str,
+        amount: &str,
+        wallet: Option<&str>,
+    ) -> anyhow::Result<AggregatorQuote> {
+        let start = Instant::now();
+        let url = format!("{}/{}/api/v1/routes", self.base_url, self.chain);
+
+        let resp = self
+            .client
+            .get(&url)
+            .header("X-Client-Id", "fynd-benchmark")
+            .query(&[("tokenIn", token_in), ("tokenOut", token_out), ("amountIn", amount)])
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("KyberSwap request failed: {e}"))?;
+
+        let response_time_ms = start.elapsed().as_millis() as u64;
+
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            let snippet: String = body.chars().take(120).collect();
+            return Ok(AggregatorQuote {
+                status: AggregatorStatus::HttpError { code, snippet },
+                amount_out: None,
+                amount_out_net_gas: None,
+                gas_units: None,
+                protocols: vec![],
+                num_splits: None,
+                response_time_ms,
+                calldata: None,
+            });
+        }
+
+        let body = resp
+            .json::<KyberswapResponse>()
+            .await
+            .map_err(|e| anyhow::anyhow!("KyberSwap parse error: {e}"))?;
+
+        let Some(data) = body.data else {
+            return Ok(AggregatorQuote {
+                status: AggregatorStatus::NoRoute,
+                amount_out: None,
+                amount_out_net_gas: None,
+                gas_units: None,
+                protocols: vec![],
+                num_splits: None,
+                response_time_ms,
+                calldata: None,
+            });
+        };
+
+        let rs = &data.route_summary;
+        let gas_units: Option<u64> = rs
+            .gas
+            .as_deref()
+            .and_then(|s| s.parse().ok())
+            .filter(|&v: &u64| v > 0);
+        let amount_out_str = rs.amount_out.as_deref().unwrap_or("");
+        let amount_out = if amount_out_str == "0" || amount_out_str.is_empty() {
+            None
+        } else {
+            Some(amount_out_str.to_string())
+        };
+
+        let route_outer = rs
+            .route
+            .as_ref()
+            .and_then(|v| v.as_array());
+        let num_splits = route_outer.map(|outer| outer.len().max(1));
+
+        let mut seen = std::collections::HashSet::new();
+        let protocols: Vec<String> = route_outer
+            .map(|outer| {
+                outer
+                    .iter()
+                    .filter_map(|inner| inner.as_array())
+                    .flatten()
+                    .filter_map(|hop| {
+                        hop.get("exchange")
+                            .and_then(|e| e.as_str())
+                    })
+                    .filter(|p| seen.insert(p.to_string()))
+                    .map(str::to_string)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let calldata = if let (Some(w), true) = (wallet, amount_out.is_some()) {
+            self.build_calldata(w, data.route_summary)
+                .await
+        } else {
+            None
+        };
+
+        Ok(AggregatorQuote {
+            status: if amount_out.is_some() {
+                AggregatorStatus::Success
+            } else {
+                AggregatorStatus::NoAmount
+            },
+            amount_out,
+            amount_out_net_gas: None,
+            gas_units,
+            protocols,
+            num_splits,
+            response_time_ms,
+            calldata,
+        })
+    }
+}
+
+impl KyberswapClient {
+    /// POST to `/route/build` to get the encoded transaction for a previously fetched route.
+    async fn build_calldata(
+        &self,
+        sender: &str,
+        route_summary: KyberswapRouteSummary,
+    ) -> Option<AggregatorCalldata> {
+        let build_url = format!("{}/{}/api/v1/route/build", self.base_url, self.chain);
+        let body = serde_json::json!({
+            "routeSummary": &route_summary,
+            "sender": sender,
+            "recipient": sender,
+            "slippageTolerance": 50,
+            "deadline": 9_999_999_999u64,
+        });
+        let resp = self
+            .client
+            .post(&build_url)
+            .header("X-Client-Id", "fynd-benchmark")
+            .json(&body)
+            .send()
+            .await
+            .ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        let built = resp
+            .json::<KyberswapBuildResponse>()
+            .await
+            .ok()?;
+        let d = built.data?;
+        Some(AggregatorCalldata {
+            to: d.router_address,
+            data: d.data,
+            value: d
+                .value
+                .unwrap_or_else(|| "0".to_string()),
+        })
+    }
+}
+
+// ─── 0x Protocol Swap API v2 ─────────────────────────────────────────────────
+
+/// Client for the 0x Swap API v2 `/price` endpoint (read-only, no taker required).
+///
+/// API: `GET /swap/allowance-holder/price?chainId=&sellToken=&buyToken=&sellAmount=`
+pub struct ZeroExClient {
+    client: reqwest::Client,
+    base_url: String,
+    chain_id: u64,
+}
+
+impl ZeroExClient {
+    pub fn new(
+        base_url: impl Into<String>,
+        chain_id: u64,
+        api_key: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        use reqwest::header::{HeaderMap, HeaderValue};
+        let api_key: String = api_key.into();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "0x-api-key",
+            HeaderValue::from_str(&api_key)
+                .map_err(|_| anyhow::anyhow!("ZRX_API_KEY contains invalid header characters"))?,
+        );
+        headers.insert("0x-version", HeaderValue::from_static("v2"));
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(20))
+                .default_headers(headers)
+                .build()
+                .map_err(|e| anyhow::anyhow!("failed to build 0x HTTP client: {e}"))?,
+            base_url: base_url.into(),
+            chain_id,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct ZeroExFees {
+    #[serde(rename = "zeroExFee")]
+    zero_ex_fee: Option<ZeroExFeeDetail>,
+}
+
+#[derive(Deserialize)]
+struct ZeroExFeeDetail {
+    amount: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ZeroExRoute {
+    fills: Option<Vec<ZeroExFill>>,
+}
+
+#[derive(Deserialize)]
+struct ZeroExFill {
+    source: Option<String>,
+}
+
+/// 0x `/quote` response — superset of `/price`, includes transaction calldata.
+#[derive(Deserialize)]
+struct ZeroExQuoteResponse {
+    #[serde(rename = "buyAmount")]
+    buy_amount: Option<String>,
+    fees: Option<ZeroExFees>,
+    route: Option<ZeroExRoute>,
+    gas: Option<String>,
+    transaction: Option<ZeroExTransaction>,
+}
+
+#[derive(Deserialize)]
+struct ZeroExTransaction {
+    to: Option<String>,
+    data: Option<String>,
+    #[serde(default)]
+    value: Option<String>,
+}
+
+/// Fallback taker for 0x `/quote` when no wallet is configured.
+/// Must be > 0x000000000000000000000000000000000000ffff per 0x API requirements.
+const ZEROX_DUMMY_TAKER: &str = "0x000000000000000000000000000000000001dead";
+
+#[async_trait]
+impl AggregatorClient for ZeroExClient {
+    fn name(&self) -> &str {
+        "0x"
+    }
+
+    async fn quote(
+        &self,
+        token_in: &str,
+        token_out: &str,
+        amount: &str,
+        wallet: Option<&str>,
+    ) -> anyhow::Result<AggregatorQuote> {
+        let start = Instant::now();
+        // Always use /quote — it returns amount, gas, route, and calldata in one call.
+        // /price is a strict subset and requires a second round-trip for calldata.
+        let url = format!("{}/swap/allowance-holder/quote", self.base_url);
+        let taker = wallet.unwrap_or(ZEROX_DUMMY_TAKER);
+
+        let resp = self
+            .client
+            .get(&url)
+            .query(&[
+                ("chainId", self.chain_id.to_string()),
+                ("sellToken", token_in.to_string()),
+                ("buyToken", token_out.to_string()),
+                ("sellAmount", amount.to_string()),
+                ("taker", taker.to_string()),
+            ])
+            .send()
+            .await
+            .map_err(|e| anyhow::anyhow!("0x request failed: {e}"))?;
+
+        let response_time_ms = start.elapsed().as_millis() as u64;
+
+        if !resp.status().is_success() {
+            let code = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            let snippet: String = body.chars().take(120).collect();
+            return Ok(AggregatorQuote {
+                status: AggregatorStatus::HttpError { code, snippet },
+                amount_out: None,
+                amount_out_net_gas: None,
+                gas_units: None,
+                protocols: vec![],
+                num_splits: None,
+                response_time_ms,
+                calldata: None,
+            });
+        }
+
+        let data = resp
+            .json::<ZeroExQuoteResponse>()
+            .await
+            .map_err(|e| anyhow::anyhow!("0x parse error: {e}"))?;
+
+        // 0x returns buyAmount net of their protocol fee. Add back zeroExFee.amount
+        // so we compare gross routing output (routing quality), not post-fee value.
+        let fee: u128 = data
+            .fees
+            .as_ref()
+            .and_then(|f| f.zero_ex_fee.as_ref())
+            .and_then(|f| f.amount.as_deref())
+            .and_then(|a| a.parse().ok())
+            .unwrap_or(0);
+        let amount_out = data
+            .buy_amount
+            .filter(|a| a != "0" && !a.is_empty())
+            .and_then(|a| a.parse::<u128>().ok())
+            .filter(|&v| v > 0)
+            .map(|v| (v + fee).to_string());
+
+        let mut seen = std::collections::HashSet::new();
+        let protocols: Vec<String> = data
+            .route
+            .as_ref()
+            .and_then(|r| r.fills.as_deref())
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|f| f.source.clone())
+            .filter(|s| seen.insert(s.clone()))
+            .collect();
+
+        let gas_units = data
+            .gas
+            .as_deref()
+            .and_then(|g| g.parse::<u64>().ok())
+            .filter(|&g| g > 0);
+
+        let calldata = data.transaction.and_then(|tx| {
+            Some(AggregatorCalldata {
+                to: tx.to?,
+                data: tx.data?,
+                value: tx
+                    .value
+                    .unwrap_or_else(|| "0".to_string()),
+            })
+        });
+
+        Ok(AggregatorQuote {
+            status: if amount_out.is_some() {
+                AggregatorStatus::Success
+            } else {
+                AggregatorStatus::NoAmount
+            },
+            amount_out,
+            amount_out_net_gas: None,
+            gas_units,
+            protocols,
+            num_splits: None, // 0x route.fills is a flat list, not split-aware
+            response_time_ms,
+            calldata,
+        })
+    }
+}
+
+// ─── bps comparison helpers ───────────────────────────────────────────────────
+
+/// Compare baseline vs another participant on raw output amounts, in basis points.
+///
+/// Positive = baseline delivers more output. `None` when amounts are zero or unparseable.
+pub fn raw_bps_diff(baseline: &str, other: &str) -> Option<f64> {
+    let b: f64 = baseline
+        .parse()
+        .ok()
+        .filter(|&v: &f64| v > 0.0)?;
+    let o: f64 = other
+        .parse()
+        .ok()
+        .filter(|&v: &f64| v > 0.0)?;
+    Some((b - o) / o * 10_000.0)
+}
+
+/// Compare baseline vs another participant net-of-gas, in basis points.
+///
+/// Derives the token-per-gas-unit price from the baseline's `(raw - net_gas) / gas_units`,
+/// then applies it to the other participant's gas units. Returns `None` when either gas
+/// figure is zero, when `baseline_net_gas` is absent, or when gas exceeds 5% of output.
+/// Call this twice with reported and on-chain gas values to keep the two measurements
+/// independent.
+pub fn gas_adjusted_bps_diff(
+    baseline_raw: &str,
+    baseline_net_gas: Option<&str>,
+    baseline_gas_units: u64,
+    other_raw: &str,
+    other_gas_units: u64,
+) -> Option<f64> {
+    let baseline_net_gas = baseline_net_gas?;
+    if baseline_gas_units == 0 || other_gas_units == 0 {
+        return None;
+    }
+    let b_raw: f64 = baseline_raw
+        .parse()
+        .ok()
+        .filter(|&v: &f64| v > 0.0)?;
+    let b_net: f64 = baseline_net_gas
+        .parse()
+        .ok()
+        .filter(|&v: &f64| v > 0.0)?;
+    let o_raw: f64 = other_raw
+        .parse()
+        .ok()
+        .filter(|&v: &f64| v > 0.0)?;
+
+    let gas_cost = b_raw - b_net;
+
+    // Skip trades where gas exceeds 5% of output — uneconomical and the bps math becomes noise.
+    if gas_cost * 20.0 > b_raw {
+        return None;
+    }
+
+    let token_per_gas = gas_cost / baseline_gas_units as f64;
+    let o_net = o_raw - (other_gas_units as f64 * token_per_gas);
+
+    if o_net <= 0.0 {
+        return None;
+    }
+    Some((b_net - o_net) / o_net * 10_000.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_bps_diff_fynd_better() {
+        let d = raw_bps_diff("10100", "10000").unwrap();
+        assert!((d - 100.0).abs() < 0.01, "expected 100 bps, got {d}");
+    }
+
+    #[test]
+    fn raw_bps_diff_agg_better() {
+        let d = raw_bps_diff("9900", "10000").unwrap();
+        assert!((d - (-100.0)).abs() < 0.01, "expected -100 bps, got {d}");
+    }
+
+    #[test]
+    fn raw_bps_diff_equal() {
+        assert_eq!(raw_bps_diff("10000", "10000"), Some(0.0));
+    }
+
+    #[test]
+    fn raw_bps_diff_zero_agg() {
+        assert_eq!(raw_bps_diff("10000", "0"), None);
+    }
+
+    #[test]
+    fn raw_bps_diff_invalid() {
+        assert_eq!(raw_bps_diff("abc", "10000"), None);
+    }
+
+    #[test]
+    fn aggregator_status_is_success_enum_match() {
+        let q = AggregatorQuote {
+            status: AggregatorStatus::Success,
+            amount_out: Some("1000".to_string()),
+            amount_out_net_gas: None,
+            gas_units: None,
+            protocols: vec![],
+            num_splits: None,
+            response_time_ms: 100,
+            calldata: None,
+        };
+        assert!(q.is_success());
+    }
+
+    #[test]
+    fn aggregator_status_no_amount_not_success() {
+        let q = AggregatorQuote {
+            status: AggregatorStatus::NoAmount,
+            amount_out: None,
+            amount_out_net_gas: None,
+            gas_units: None,
+            protocols: vec![],
+            num_splits: None,
+            response_time_ms: 100,
+            calldata: None,
+        };
+        assert!(!q.is_success());
+    }
+
+    #[test]
+    fn aggregator_status_http_error_not_success() {
+        let q = AggregatorQuote {
+            status: AggregatorStatus::HttpError { code: 429, snippet: "rate limited".to_string() },
+            amount_out: None,
+            amount_out_net_gas: None,
+            gas_units: None,
+            protocols: vec![],
+            num_splits: None,
+            response_time_ms: 50,
+            calldata: None,
+        };
+        assert!(!q.is_success());
+    }
+
+    #[test]
+    fn aggregator_status_serialises_to_string() {
+        assert_eq!(serde_json::to_string(&AggregatorStatus::Success).unwrap(), r#""success""#);
+        assert_eq!(serde_json::to_string(&AggregatorStatus::NoRoute).unwrap(), r#""no_route""#);
+        assert_eq!(
+            serde_json::to_string(&AggregatorStatus::HttpError {
+                code: 429,
+                snippet: "rate limited".to_string()
+            })
+            .unwrap(),
+            r#""http_429: rate limited""#
+        );
+    }
+
+    #[test]
+    fn kyberswap_route_summary_round_trips() {
+        let json = r#"{"gas":"150000","amountOut":"1000000","tokenIn":"0xabc","route":[[{"exchange":"uni_v3"}]]}"#;
+        let rs: KyberswapRouteSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(rs.gas.as_deref(), Some("150000"));
+        assert_eq!(rs.amount_out.as_deref(), Some("1000000"));
+        let back = serde_json::to_string(&rs).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&back).unwrap();
+        assert_eq!(v["gas"], "150000");
+        assert_eq!(v["amountOut"], "1000000");
+        assert_eq!(v["tokenIn"], "0xabc");
+    }
+
+    #[test]
+    fn kyberswap_route_summary_preserves_unknown_fields() {
+        let json = r#"{"gas":"100","amountOut":"500","slippage":50,"tokenIn":"0xfoo"}"#;
+        let rs: KyberswapRouteSummary = serde_json::from_str(json).unwrap();
+        let back = serde_json::to_value(&rs).unwrap();
+        assert_eq!(back["slippage"], 50);
+        assert_eq!(back["tokenIn"], "0xfoo");
+    }
+
+    #[test]
+    fn kyberswap_route_summary_missing_optional_fields() {
+        let json = r#"{"tokenIn":"0xabc","tokenOut":"0xdef"}"#;
+        let rs: KyberswapRouteSummary = serde_json::from_str(json).unwrap();
+        assert!(rs.gas.is_none());
+        assert!(rs.amount_out.is_none());
+        assert!(rs.route.is_none());
+        let back = serde_json::to_value(&rs).unwrap();
+        assert_eq!(back["tokenIn"], "0xabc");
+    }
+}

--- a/tools/benchmark/src/audit.rs
+++ b/tools/benchmark/src/audit.rs
@@ -1,0 +1,1600 @@
+//! `audit` subcommand — compare Fynd quotes against external DEX aggregators.
+//!
+//! Samples the top-N token pairs from the trade dataset, fires quotes at Fynd and
+//! each configured aggregator in parallel across multiple blocks, and writes a
+//! per-trade comparison table plus a console summary.
+
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use alloy::{
+    hex,
+    network::Ethereum,
+    primitives::{map::B256HashMap, Address, TxKind, B256, U256},
+    providers::{Provider, ProviderBuilder, RootProvider},
+    rpc::types::{
+        state::{AccountOverride, StateOverride},
+        BlockId, RpcBlockHash, TransactionRequest,
+    },
+    transports::{RpcError, TransportErrorKind},
+};
+use anyhow::{Context, Result};
+use bytes::Bytes;
+use clap::Parser;
+use fynd_client::{
+    EncodingOptions, FyndClient, FyndClientBuilder, Order, OrderSide, QuoteOptions, QuoteParams,
+    QuoteStatus, RetryConfig,
+};
+use num_bigint::BigUint;
+use serde::Serialize;
+use tokio::{
+    sync::{Mutex, Semaphore},
+    task::JoinSet,
+    time::sleep,
+};
+use tracing::{info, warn};
+
+use crate::{
+    aggregator::{
+        gas_adjusted_bps_diff, raw_bps_diff, AggregatorCalldata, AggregatorClient, AggregatorQuote,
+        AggregatorStatus, KyberswapClient, NordsternClient, ZeroExClient,
+    },
+    erc20,
+    pair_selector::{select_top_pairs, PairSpec},
+    requests::{load_all_embedded_templates, load_all_templates_from_file},
+};
+
+// ─── CLI args ─────────────────────────────────────────────────────────────────
+
+/// Compare Fynd quote performance against external DEX aggregators across multiple blocks.
+#[derive(Parser, Debug)]
+#[command(
+    about = "Audit Fynd quote quality against external aggregators",
+    long_about = "Audit Fynd quote quality against external aggregators.\n\n\
+        Samples the top-N token pairs from the trade dataset, fires quotes at both Fynd and \
+        the configured aggregator(s) for each (pair, amount) combination once per block, and \
+        writes a per-trade JSON table plus a per-pair console summary.\n\n\
+        Requires a healthy Fynd solver on --fynd-url."
+)]
+pub struct Args {
+    /// Fynd solver base URL.
+    #[arg(long, env = "FYND_URL", default_value = "http://localhost:3000")]
+    pub fynd_url: String,
+
+    /// Nordstern Finance base URL.
+    #[arg(long, default_value = "https://api.nordstern.finance")]
+    pub nordstern_url: String,
+
+    /// KyberSwap Aggregator API base URL.
+    #[arg(long, default_value = "https://aggregator-api.kyberswap.com")]
+    pub kyberswap_url: String,
+
+    /// KyberSwap chain slug (must match the URL path segment, e.g. "ethereum", "base").
+    #[arg(long, default_value = "ethereum")]
+    pub kyberswap_chain: String,
+
+    /// 0x Swap API v2 base URL.
+    #[arg(long, default_value = "https://api.0x.org")]
+    pub zerox_url: String,
+
+    /// 0x API key (env: ZRX_API_KEY).
+    #[arg(long, env = "ZRX_API_KEY", default_value = "")]
+    pub zerox_api_key: String,
+
+    /// EVM chain ID passed to aggregator APIs (1 = Ethereum mainnet).
+    #[arg(long, default_value_t = 1)]
+    pub chain_id: u64,
+
+    /// Number of blocks to spread trades across. The full trade list is divided into this
+    /// many chunks; each chunk fires on its own block. Larger values slow the run down but
+    /// keep per-block request counts low for rate-limited aggregator APIs.
+    #[arg(long, default_value_t = 10)]
+    pub blocks: usize,
+
+    /// Top-N token pairs ranked by trade frequency in the dataset.
+    #[arg(long, default_value_t = 25)]
+    pub top_pairs: usize,
+
+    /// Number of representative amounts per pair (evenly-spaced percentiles).
+    #[arg(long, default_value_t = 10)]
+    pub amounts_per_pair: usize,
+
+    /// Path to the 10k aggregator trade dataset (run `download-trades` to fetch it).
+    /// Falls back to the embedded 50-trade sample when omitted.
+    #[arg(long)]
+    pub trade_data: Option<String>,
+
+    /// Per-quote timeout in milliseconds for Fynd.
+    #[arg(long, default_value_t = 10_000)]
+    pub timeout_ms: u64,
+
+    /// Maximum parallel in-flight requests (controls load on aggregator APIs).
+    #[arg(long, default_value_t = 5)]
+    pub concurrency: usize,
+
+    /// Sample every Nth block. 1 = every block (~12 s apart), 5 = every ~60 s, etc.
+    /// Use a higher value for long runs to reduce aggregator API load.
+    #[arg(long, default_value_t = 1)]
+    pub block_stride: usize,
+
+    /// Minimum milliseconds between successive aggregator requests per aggregator.
+    /// Increase (e.g. 500) to stay well under rate limits on long runs.
+    #[arg(long, default_value_t = 0)]
+    pub aggregator_delay_ms: u64,
+
+    /// Path to write the full per-trade JSON results.
+    #[arg(long, default_value = "audit_results.json")]
+    pub output: String,
+
+    /// Ethereum RPC URL for eth_call validation of Fynd quotes.
+    ///
+    /// When set, each successful Fynd quote is re-executed via `eth_call` at the
+    /// quote block using state overrides to inject token balance and allowance.
+    /// The on-chain result is compared against Fynd's quoted `amount_out` and
+    /// stored as `eth_call_amount_out` / `eth_call_diff_bps` in the JSON output.
+    /// Omit to skip validation entirely.
+    #[arg(long, env = "RPC_URL")]
+    pub rpc_url: Option<String>,
+
+    /// Slippage tolerance passed to `EncodingOptions` when `--rpc-url` is set (basis points).
+    /// Controls the `min_amount_out` encoded in the router calldata.
+    #[arg(long, default_value_t = 50)]
+    pub eth_call_slippage_bps: u32,
+
+    /// Minimum approximate USD value for trade amounts sampled from the dataset.
+    ///
+    /// Trades below this threshold are excluded before percentile sampling, preventing
+    /// sub-dust amounts from appearing as representative test cases. Prices are
+    /// approximate and hardcoded for well-known tokens; unknown tokens are unaffected.
+    /// Set to 0 to disable filtering (default).
+    #[arg(long, default_value_t = 0.0)]
+    pub min_amount_usd: f64,
+
+    /// Upward adjustment applied to Fynd's eth_call amount-out (basis points).
+    ///
+    /// Scales the on-chain result up before storing `eth_call_amount_out` and recomputing
+    /// `eth_call_diff_bps`. Use this to simulate zero-fee output: e.g. 10 removes an
+    /// approximate 1 bps taker fee from the on-chain comparison.
+    #[arg(long, default_value_t = 0)]
+    pub eth_call_baseline_fee_bps: u32,
+}
+
+// ─── output types ─────────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct AuditOutput {
+    config: AuditConfig,
+    results: Vec<TradeResult>,
+}
+
+#[derive(Serialize)]
+struct AuditConfig {
+    fynd_url: String,
+    nordstern_url: String,
+    chain_id: u64,
+    top_pairs: usize,
+    amounts_per_pair: usize,
+    blocks_used: usize,
+    trades_per_block: usize,
+    block_stride: usize,
+    total_trades: usize,
+}
+
+/// Per-participant result — identical shape for Fynd and every external aggregator.
+///
+/// The first entry in `TradeResult::participants` is always `"fynd"` (the baseline).
+/// `amount_out_net_gas` is populated only by Fynd; all other aggregators leave it `null`.
+#[derive(Serialize)]
+struct ParticipantResult {
+    name: String,
+    status: String,
+    amount_out: Option<String>,
+    /// Net-of-gas output estimate (Fynd only; aggregators set this to `null`).
+    amount_out_net_gas: Option<String>,
+    /// Reported gas units (Fynd `gas_estimate` or aggregator self-reported gas).
+    gas_units: Option<u64>,
+    protocols: Vec<String>,
+    /// Parallel sub-routes (aggregators only; `null` for Fynd).
+    num_splits: Option<usize>,
+    /// Wall-clock time from request dispatch to first byte of response.
+    response_time_ms: Option<u64>,
+    /// Amount of `token_out` returned by `eth_call` at the quote block.
+    eth_call_amount_out: Option<String>,
+    /// Difference between `eth_call_amount_out` and `amount_out` in bps.
+    eth_call_diff_bps: Option<f64>,
+    /// Actual gas consumed by the swap as reported by `eth_simulateV1`.
+    eth_call_gas_used: Option<u64>,
+    /// Raw bps diff vs Fynd (positive = Fynd better). `null` for the Fynd entry itself.
+    raw_diff_bps: Option<f64>,
+    /// Gas-adjusted diff using self-reported gas (Fynd `gas_units` and aggregator `gas_units`).
+    gas_adjusted_diff_bps_reported: Option<f64>,
+    /// Gas-adjusted diff using on-chain gas from `eth_simulateV1`.
+    gas_adjusted_diff_bps_onchain: Option<f64>,
+}
+
+#[derive(Serialize)]
+struct TradeResult {
+    block_sample: usize,
+    /// Hex-encoded block hash at which all quotes and eth_calls were pinned.
+    block_hash: Option<String>,
+    pair: String,
+    token_in: String,
+    token_out: String,
+    amount_in: String,
+    /// Index into the percentile array (0 = min, amounts_per_pair-1 = max traded amount).
+    amount_percentile_idx: usize,
+    /// All participants: first entry is `"fynd"`, remainder are aggregators.
+    participants: Vec<ParticipantResult>,
+}
+
+// ─── internal task payload ────────────────────────────────────────────────────
+
+struct QuoteTask {
+    block_sample: usize,
+    pair: PairSpec,
+    amount: String,
+    amount_percentile_idx: usize,
+}
+
+// ─── eth_call validation ──────────────────────────────────────────────────────
+
+// ─── eth_simulateV1 helpers ───────────────────────────────────────────────────
+
+/// Sentinel address for the inline ETH-balance reader injected into eth_simulateV1 state.
+/// Chosen to be obviously synthetic and not a real mainnet contract.
+const ETH_BALANCE_READER_ADDR: Address = Address(alloy::primitives::FixedBytes([
+    0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0, 0xf0,
+    0xf0, 0xf0, 0xf0, 0xf0,
+]));
+
+/// EVM bytecode: CALLER BALANCE PUSH1 0 MSTORE PUSH1 32 PUSH1 0 RETURN
+/// Returns the ETH balance of the calling address as a uint256.
+const ETH_BALANCE_READER_CODE: [u8; 10] =
+    [0x33, 0x31, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+
+/// Validates quotes by re-executing encoded calldata via simulation at the relevant block,
+/// using state overrides to inject token balance and allowance.
+///
+/// Prefers `eth_simulateV1` (balance-delta: swap + `balanceOf` in one block) for an exact
+/// output amount independent of router ABI conventions. Falls back to a plain `eth_call`
+/// with return-data heuristics when the RPC does not support `eth_simulateV1`.
+struct EthCallRunner {
+    provider: Arc<RootProvider<Ethereum>>,
+    /// Fixed sender used in all audit quotes — overridden in state to hold sufficient balance.
+    sender: Address,
+    /// Per-token balance storage slot (probed once, cached for the run).
+    balance_slots: Arc<Mutex<HashMap<Address, B256>>>,
+    /// Per-(token, spender) allowance storage slot (probed once, cached for the run).
+    allowance_slots: Arc<Mutex<HashMap<(Address, Address), B256>>>,
+    /// Set to `false` after the first `eth_simulateV1` "method not found" error so subsequent
+    /// calls skip straight to the `eth_call` fallback without retrying.
+    simulate_supported: Arc<AtomicBool>,
+}
+
+impl EthCallRunner {
+    fn new(provider: RootProvider<Ethereum>) -> Self {
+        // Generate a fresh random address so it has no pre-existing token balances.
+        let mut bytes = [0u8; 20];
+        fastrand::fill(&mut bytes);
+        let sender = Address::from(bytes);
+        Self {
+            provider: Arc::new(provider),
+            sender,
+            balance_slots: Arc::new(Mutex::new(HashMap::new())),
+            allowance_slots: Arc::new(Mutex::new(HashMap::new())),
+            simulate_supported: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    fn sender_hex(&self) -> String {
+        format!("0x{}", hex::encode(self.sender.as_slice()))
+    }
+
+    /// Execute `calldata` against `router` at `block`, returning the actual `token_out`
+    /// amount received by `self.sender` and, when `eth_simulateV1` is used, the gas consumed.
+    ///
+    /// Tries `eth_simulateV1` first (balance-delta approach). Falls back to `eth_call` +
+    /// return-data parsing when the RPC does not support `eth_simulateV1`. Gas is `None`
+    /// on the fallback path.
+    async fn execute(
+        &self,
+        token_in: Address,
+        token_out: Address,
+        router: Address,
+        calldata: &[u8],
+        value: &BigUint,
+        block: B256,
+    ) -> anyhow::Result<Option<(BigUint, Option<u64>)>> {
+        if self
+            .simulate_supported
+            .load(Ordering::Relaxed)
+        {
+            match self
+                .try_simulate(token_in, token_out, router, calldata, value, block)
+                .await
+            {
+                Ok(result) => return Ok(result.map(|(amount, gas)| (amount, Some(gas)))),
+                Err(e) => {
+                    if is_method_not_found(&e) {
+                        self.simulate_supported
+                            .store(false, Ordering::Relaxed);
+                        warn!(
+                            "eth_simulateV1 not supported on this RPC — falling back to eth_call"
+                        );
+                    } else {
+                        warn!("eth_simulateV1 failed: {e}");
+                    }
+                }
+            }
+        }
+        let (amount_res, gas_res) = tokio::join!(
+            self.try_eth_call(token_in, router, calldata, value, block),
+            self.try_estimate_gas(token_in, router, calldata, value, block),
+        );
+        let gas = gas_res.ok().flatten();
+        amount_res.map(|opt| opt.map(|amount| (amount, gas)))
+    }
+
+    /// Run the swap and a balance measurement in the same simulated block via `eth_simulateV1`,
+    /// returning the exact amount of `token_out` received and the gas consumed by the swap call.
+    ///
+    /// For ERC-20 output: second call is `balanceOf(sender)` on the token contract.
+    /// For native ETH output: second call reads `sender`'s ETH balance via an inline helper
+    /// contract injected into the simulation state. Sender's ETH balance is zeroed and
+    /// `gasPrice=0` is set on the swap so that final balance == ETH received exactly.
+    /// This approach works for any router regardless of its return-data ABI conventions.
+    async fn try_simulate(
+        &self,
+        token_in: Address,
+        token_out: Address,
+        router: Address,
+        calldata: &[u8],
+        value: &BigUint,
+        block: B256,
+    ) -> anyhow::Result<Option<(BigUint, u64)>> {
+        let mut overrides = self
+            .build_overrides(token_in, router)
+            .await?;
+
+        let (swap_call_json, second_call_json) = if token_out == Address::ZERO {
+            // Zero the sender's ETH balance so (balance after swap) == ETH received.
+            // gasPrice=0 ensures gas cost doesn't reduce that delta.
+            // Inject a 10-byte balance-reader at a reserved address: calling it returns
+            // the caller's ETH balance as a uint256.
+            overrides.insert(
+                self.sender,
+                AccountOverride { balance: Some(U256::ZERO), ..Default::default() },
+            );
+            overrides.insert(
+                ETH_BALANCE_READER_ADDR,
+                AccountOverride {
+                    code: Some(alloy::primitives::Bytes(Bytes::from_static(
+                        &ETH_BALANCE_READER_CODE,
+                    ))),
+                    ..Default::default()
+                },
+            );
+            (
+                serde_json::json!({
+                    "from":     format!("0x{}", hex::encode(self.sender)),
+                    "to":       format!("0x{}", hex::encode(router)),
+                    "data":     format!("0x{}", hex::encode(calldata)),
+                    "value":    format!("0x{:x}", value),
+                    "gasPrice": "0x0",
+                }),
+                serde_json::json!({
+                    "from":     format!("0x{}", hex::encode(self.sender)),
+                    "to":       format!("0x{}", hex::encode(ETH_BALANCE_READER_ADDR)),
+                    "gasPrice": "0x0",
+                }),
+            )
+        } else {
+            // ERC-20 output: standard balanceOf(sender) on token_out.
+            let mut bal_data = vec![0x70u8, 0xa0, 0x82, 0x31];
+            bal_data.extend_from_slice(&[0u8; 12]);
+            bal_data.extend_from_slice(self.sender.as_slice());
+            (
+                serde_json::json!({
+                    "from":  format!("0x{}", hex::encode(self.sender)),
+                    "to":    format!("0x{}", hex::encode(router)),
+                    "data":  format!("0x{}", hex::encode(calldata)),
+                    "value": format!("0x{:x}", value),
+                }),
+                serde_json::json!({
+                    "from": "0x0000000000000000000000000000000000000000",
+                    "to":   format!("0x{}", hex::encode(token_out)),
+                    "data": format!("0x{}", hex::encode(&bal_data)),
+                }),
+            )
+        };
+
+        let state_overrides =
+            serde_json::to_value(&overrides).context("serialise state overrides")?;
+
+        let block_param = serde_json::json!({
+            "blockHash": format!("0x{}", hex::encode(block.as_slice())),
+            "requireCanonical": false,
+        });
+
+        let params = serde_json::json!([
+            {
+                "blockStateCalls": [{
+                    "stateOverrides": state_overrides,
+                    "calls": [swap_call_json, second_call_json]
+                }]
+            },
+            block_param
+        ]);
+
+        let result: serde_json::Value = self
+            .provider
+            .raw_request("eth_simulateV1".into(), params)
+            .await
+            .context("eth_simulateV1")?;
+
+        let calls = result
+            .get(0)
+            .and_then(|b| b.get("calls"))
+            .and_then(|c| c.as_array())
+            .ok_or_else(|| anyhow::anyhow!("eth_simulateV1: missing calls array in result"))?;
+
+        // Check that the swap call succeeded (status 0x1).
+        let swap_call_result = calls
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("eth_simulateV1: calls array is empty"))?;
+        let swap_ok = swap_call_result
+            .get("status")
+            .map(|s| s == "0x1" || s.as_u64() == Some(1))
+            .unwrap_or(false);
+        if !swap_ok {
+            warn!("eth_simulateV1: swap call reverted");
+            return Ok(None);
+        }
+
+        // gasUsed may be a hex string ("0x...") or a JSON integer depending on the RPC provider.
+        let gas_used = swap_call_result
+            .get("gasUsed")
+            .and_then(|g| {
+                g.as_str()
+                    .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+                    .or_else(|| g.as_u64())
+            })
+            .unwrap_or(0);
+
+        // Both paths use the same decoding: calls[1].returnData is a uint256 (ERC-20
+        // balance or ETH balance from the inline reader).
+        let amount_hex = calls
+            .get(1)
+            .and_then(|c| c.get("returnData"))
+            .and_then(|d| d.as_str())
+            .unwrap_or("0x");
+        let amount_bytes =
+            hex::decode(amount_hex.trim_start_matches("0x")).context("decode amount return")?;
+
+        if amount_bytes.len() >= 32 {
+            Ok(Some((BigUint::from_bytes_be(&amount_bytes[..32]), gas_used)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Fallback when `eth_simulateV1` is unavailable: plain `eth_call` with heuristic
+    /// return-data decoding.
+    async fn try_eth_call(
+        &self,
+        token_in: Address,
+        router: Address,
+        calldata: &[u8],
+        value: &BigUint,
+        block: B256,
+    ) -> anyhow::Result<Option<BigUint>> {
+        let overrides = self
+            .build_overrides(token_in, router)
+            .await?;
+
+        let value_u128: u128 = value.to_string().parse().unwrap_or(0);
+        let tx = TransactionRequest {
+            from: Some(self.sender),
+            to: Some(TxKind::Call(router)),
+            input: alloy::primitives::Bytes::copy_from_slice(calldata).into(),
+            value: Some(alloy::primitives::U256::from(value_u128)),
+            max_fee_per_gas: Some(0),
+            max_priority_fee_per_gas: Some(0),
+            ..Default::default()
+        };
+
+        let result = self
+            .provider
+            .call(tx)
+            .overrides(overrides)
+            .block(BlockId::Hash(RpcBlockHash {
+                block_hash: block,
+                require_canonical: Some(false),
+            }))
+            .await;
+
+        let return_data = match result {
+            Ok(d) => d,
+            Err(e) => {
+                warn!("eth_call at block {block} reverted: {e}");
+                return Ok(None);
+            }
+        };
+
+        Ok(parse_return_amount(&return_data))
+    }
+
+    /// Gas estimate via `eth_estimateGas` with state overrides.
+    ///
+    /// Used as a fallback when `eth_simulateV1` is unavailable. Returns the estimated gas
+    /// units including the 21 000-unit base transaction cost.
+    async fn try_estimate_gas(
+        &self,
+        token_in: Address,
+        router: Address,
+        calldata: &[u8],
+        value: &BigUint,
+        block: B256,
+    ) -> anyhow::Result<Option<u64>> {
+        let overrides = self
+            .build_overrides(token_in, router)
+            .await?;
+        let state_overrides =
+            serde_json::to_value(&overrides).context("serialise state overrides")?;
+
+        let block_param = serde_json::json!({
+            "blockHash": format!("0x{}", hex::encode(block.as_slice())),
+            "requireCanonical": false,
+        });
+
+        let params = serde_json::json!([
+            {
+                "from": format!("0x{}", hex::encode(self.sender)),
+                "to":   format!("0x{}", hex::encode(router)),
+                "data": format!("0x{}", hex::encode(calldata)),
+                "value": format!("0x{:x}", value),
+            },
+            block_param,
+            state_overrides,
+        ]);
+
+        let result: serde_json::Value = match self
+            .provider
+            .raw_request("eth_estimateGas".into(), params)
+            .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                warn!("eth_estimateGas at block {block} failed: {e}");
+                return Ok(None);
+            }
+        };
+
+        let gas = result
+            .as_str()
+            .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+            .or_else(|| result.as_u64());
+
+        Ok(gas)
+    }
+
+    /// Build a `StateOverride` that injects sufficient balance and allowance for `sender`
+    /// to spend `token_in` via `router`. Probes storage slots on first use and caches.
+    ///
+    /// Always injects a large ETH balance for `sender` so that `eth_simulateV1` can charge
+    /// gas without rejecting the transaction. For ERC-20 tokens the ERC-20 balance and
+    /// allowance storage slots are also overridden. For native ETH (zero address) only the
+    /// ETH balance override is needed.
+    async fn build_overrides(
+        &self,
+        token_in: Address,
+        router: Address,
+    ) -> anyhow::Result<StateOverride> {
+        // Use MAX >> 1: avoids triggering tokens that pack metadata into bit 255 (e.g. USDC).
+        let max_val = B256::from(U256::MAX >> 1);
+        let eth_balance = U256::MAX >> 1;
+
+        let mut overrides = StateOverride::default();
+
+        // Give sender unlimited ETH — required for eth_simulateV1 to charge gas without
+        // failing. Harmless for eth_call which does not deduct gas from the sender balance.
+        overrides.insert(
+            self.sender,
+            AccountOverride { balance: Some(eth_balance), ..Default::default() },
+        );
+
+        if token_in != Address::ZERO {
+            let balance_slot = self.balance_slot(token_in).await?;
+            let allowance_slot = self
+                .allowance_slot(token_in, router)
+                .await?;
+
+            let mut state_diff = B256HashMap::default();
+            state_diff.insert(balance_slot, max_val);
+            state_diff.insert(allowance_slot, max_val);
+
+            overrides.insert(
+                token_in,
+                AccountOverride { state_diff: Some(state_diff), ..Default::default() },
+            );
+        }
+
+        Ok(overrides)
+    }
+
+    async fn balance_slot(&self, token: Address) -> anyhow::Result<B256> {
+        {
+            let cache = self.balance_slots.lock().await;
+            if let Some(&slot) = cache.get(&token) {
+                return Ok(slot);
+            }
+        }
+        let slot = erc20::find_balance_slot(&self.provider, token, self.sender).await?;
+        self.balance_slots
+            .lock()
+            .await
+            .insert(token, slot);
+        Ok(slot)
+    }
+
+    async fn allowance_slot(&self, token: Address, spender: Address) -> anyhow::Result<B256> {
+        {
+            let cache = self.allowance_slots.lock().await;
+            if let Some(&slot) = cache.get(&(token, spender)) {
+                return Ok(slot);
+            }
+        }
+        let slot = erc20::find_allowance_slot(&self.provider, token, self.sender, spender).await?;
+        self.allowance_slots
+            .lock()
+            .await
+            .insert((token, spender), slot);
+        Ok(slot)
+    }
+}
+
+// ─── Fynd as AggregatorClient ─────────────────────────────────────────────────
+
+/// Wraps [`FyndClient`] so it participates in the same quote loop as external aggregators.
+///
+/// Kept separate from the solver `FyndClient` used for health-checks and block-waiting so
+/// those concerns don't bleed into the aggregator abstraction.
+struct FyndAggregator {
+    client: Arc<FyndClient>,
+    timeout_ms: u64,
+    encoding_slippage: f64,
+}
+
+#[async_trait::async_trait]
+impl AggregatorClient for FyndAggregator {
+    fn name(&self) -> &str {
+        "fynd"
+    }
+
+    async fn quote(
+        &self,
+        token_in: &str,
+        token_out: &str,
+        amount: &str,
+        wallet: Option<&str>,
+    ) -> anyhow::Result<AggregatorQuote> {
+        use std::time::Instant;
+        let start = Instant::now();
+
+        let params = make_quote_params(
+            token_in,
+            token_out,
+            amount,
+            self.timeout_ms,
+            wallet,
+            wallet
+                .is_some()
+                .then(|| EncodingOptions::new(self.encoding_slippage)),
+        )?;
+
+        let q = self
+            .client
+            .quote(params)
+            .await
+            .map_err(|e| anyhow::anyhow!("Fynd quote failed: {e}"))?;
+
+        let response_time_ms = start.elapsed().as_millis() as u64;
+        let success = q.status() == QuoteStatus::Success;
+
+        let protocols = q
+            .route()
+            .map(|r| {
+                r.swaps()
+                    .iter()
+                    .map(|s| s.protocol().to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let calldata = success
+            .then(|| q.transaction())
+            .flatten()
+            .and_then(|tx| {
+                if tx.to().len() != 20 {
+                    return None;
+                }
+                Some(AggregatorCalldata {
+                    to: format!("0x{}", hex::encode(tx.to())),
+                    data: format!("0x{}", hex::encode(tx.data())),
+                    value: tx.value().to_string(),
+                })
+            });
+
+        let nonzero_str = |s: String| (s != "0").then_some(s);
+
+        Ok(AggregatorQuote {
+            status: fynd_status_to_agg(q.status()),
+            amount_out: success
+                .then(|| nonzero_str(q.amount_out().to_string()))
+                .flatten(),
+            amount_out_net_gas: success
+                .then(|| nonzero_str(q.amount_out_net_gas().to_string()))
+                .flatten(),
+            gas_units: q
+                .gas_estimate()
+                .to_string()
+                .parse::<u64>()
+                .ok()
+                .filter(|&v| v > 0),
+            protocols,
+            num_splits: None,
+            response_time_ms,
+            calldata,
+        })
+    }
+}
+
+fn fynd_status_to_agg(status: QuoteStatus) -> AggregatorStatus {
+    match status {
+        QuoteStatus::Success => AggregatorStatus::Success,
+        QuoteStatus::NoRouteFound | QuoteStatus::InsufficientLiquidity => AggregatorStatus::NoRoute,
+        QuoteStatus::Timeout | QuoteStatus::NotReady | QuoteStatus::PriceCheckFailed => {
+            AggregatorStatus::NoAmount
+        }
+    }
+}
+
+// ─── entry point ──────────────────────────────────────────────────────────────
+
+pub async fn run(args: Args) -> Result<()> {
+    // Load trade dataset to derive pairs and amounts.
+    let trades = match &args.trade_data {
+        Some(path) => load_all_templates_from_file(path)
+            .map_err(|e| anyhow::anyhow!("failed to load trade data from {path}: {e}"))?,
+        None => {
+            warn!(
+                "No --trade-data provided; using embedded 50-trade sample. \
+                   Run `download-trades` for the full 10k dataset."
+            );
+            load_all_embedded_templates()
+        }
+    };
+
+    let pairs =
+        select_top_pairs(&trades, args.top_pairs, args.amounts_per_pair, args.min_amount_usd);
+    if pairs.is_empty() {
+        anyhow::bail!("no valid pairs found in trade dataset");
+    }
+
+    info!("Derived {} pairs from trade dataset ({} trades).", pairs.len(), trades.len());
+    for p in &pairs {
+        info!(
+            "  {} ({} amounts: {}..{})",
+            p.label,
+            p.amounts.len(),
+            p.amounts
+                .first()
+                .unwrap_or(&String::new()),
+            p.amounts
+                .last()
+                .unwrap_or(&String::new())
+        );
+    }
+
+    // Build the FyndClient — used for health-checks and block-waiting only.
+    let fynd = Arc::new(
+        FyndClientBuilder::new(&args.fynd_url, "")
+            .with_timeout(Duration::from_millis(args.timeout_ms))
+            .with_retry(RetryConfig::new(1, Duration::from_millis(0), Duration::from_millis(0)))
+            .build_quote_only()
+            .map_err(|e| anyhow::anyhow!("failed to build Fynd client: {e}"))?,
+    );
+
+    // Build the eth_call runner when --rpc-url is provided.
+    let eth_call_slippage = args.eth_call_slippage_bps as f64 / 10_000.0;
+    let eth_call_runner: Option<Arc<EthCallRunner>> = match &args.rpc_url {
+        Some(rpc_url) => {
+            let url = rpc_url
+                .parse::<reqwest::Url>()
+                .with_context(|| format!("invalid --rpc-url: {rpc_url}"))?;
+            let provider = ProviderBuilder::default().connect_http(url);
+            let runner = Arc::new(EthCallRunner::new(provider));
+            info!(
+                "eth_call validation enabled (rpc: {rpc_url}, sender: {}, slippage: {:.2}%)",
+                runner.sender_hex(),
+                eth_call_slippage * 100.0
+            );
+            Some(runner)
+        }
+        None => None,
+    };
+
+    // Fynd is the first participant (baseline); external aggregators follow.
+    let mut participants: Vec<Arc<dyn AggregatorClient>> = vec![Arc::new(FyndAggregator {
+        client: fynd.clone(),
+        timeout_ms: args.timeout_ms,
+        encoding_slippage: eth_call_slippage,
+    })];
+    participants.push(Arc::new(NordsternClient::new(&args.nordstern_url, args.chain_id)?));
+    participants.push(Arc::new(KyberswapClient::new(&args.kyberswap_url, &args.kyberswap_chain)?));
+    if !args.zerox_api_key.is_empty() {
+        participants.push(Arc::new(ZeroExClient::new(
+            &args.zerox_url,
+            args.chain_id,
+            &args.zerox_api_key,
+        )?));
+    }
+
+    // Health-check Fynd.
+    let health = fynd
+        .health()
+        .await
+        .context("Fynd health check failed — is the solver running?")?;
+    if !health.healthy() {
+        anyhow::bail!(
+            "Fynd solver is not healthy (last_update={}ms, pools={})",
+            health.last_update_ms(),
+            health.num_solver_pools()
+        );
+    }
+    info!(
+        "Fynd healthy — {} solver pools, last update {}ms ago.",
+        health.num_solver_pools(),
+        health.last_update_ms()
+    );
+
+    // Divide the full trade list into per-block chunks.
+    // Each trade fires exactly once on its assigned block, keeping per-block request
+    // counts low so we stay within aggregator rate limits.
+    let all_specs: Vec<(usize, usize)> = (0..pairs.len())
+        .flat_map(|pi| (0..pairs[pi].amounts.len()).map(move |ai| (pi, ai)))
+        .collect();
+
+    let total_trades = all_specs.len();
+    let n_blocks = args.blocks.min(total_trades).max(1);
+    let chunk_size = total_trades.div_ceil(n_blocks);
+    let chunks: Vec<&[(usize, usize)]> = all_specs.chunks(chunk_size).collect();
+    let actual_blocks = chunks.len();
+
+    info!(
+        "Spreading {} trades across {} blocks (~{} trades/block, ~{} agg requests/block).",
+        total_trades,
+        actual_blocks,
+        chunk_size,
+        chunk_size * (participants.len() - 1),
+    );
+
+    let mut all_results: Vec<TradeResult> = Vec::with_capacity(total_trades);
+
+    for (block_idx, chunk) in chunks.iter().enumerate() {
+        if block_idx == 0 {
+            info!("Waiting for first block…");
+            wait_for_fresh_block(&fynd).await?;
+        } else {
+            info!("Waiting for block {} of {}…", block_idx + 1, actual_blocks);
+            wait_for_next_sample(&fynd, args.block_stride).await?;
+        }
+
+        // Fetch the canonical block hash once for this batch so every quote and
+        // eth_call in the chunk is pinned to the same block state.
+        let quote_block: Option<B256> = if let Some(runner) = &eth_call_runner {
+            match runner
+                .provider
+                .get_block_by_number(Default::default())
+                .await
+            {
+                Ok(Some(block)) => Some(block.header.hash),
+                Ok(None) => {
+                    warn!("could not fetch latest block for eth_call validation");
+                    None
+                }
+                Err(e) => {
+                    warn!("could not fetch block for eth_call validation: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        info!("  Block ready — firing {} quote pairs…", chunk.len());
+
+        let sem = Arc::new(Semaphore::new(args.concurrency));
+        let mut jset: JoinSet<Result<TradeResult>> = JoinSet::new();
+
+        for &(pair_idx, amount_idx) in chunk.iter() {
+            let pair = pairs[pair_idx].clone();
+            let amount = pair.amounts[amount_idx].clone();
+            let participants = participants.clone();
+            let sem = sem.clone();
+            let block_sample = block_idx + 1;
+            let aggregator_delay_ms = args.aggregator_delay_ms;
+            let baseline_fee_bps = args.eth_call_baseline_fee_bps;
+            let runner = eth_call_runner.clone();
+
+            jset.spawn(async move {
+                let _permit = sem
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore acquire");
+                execute_trade(
+                    participants,
+                    QuoteTask { block_sample, pair, amount, amount_percentile_idx: amount_idx },
+                    TradeConfig {
+                        aggregator_delay_ms,
+                        eth_call_runner: runner,
+                        quote_block,
+                        baseline_fee_bps,
+                    },
+                )
+                .await
+            });
+        }
+
+        let mut block_results = 0usize;
+        while let Some(result) = jset.join_next().await {
+            match result {
+                Ok(Ok(trade)) => {
+                    all_results.push(trade);
+                    block_results += 1;
+                }
+                Ok(Err(e)) => warn!("trade task error: {e}"),
+                Err(e) => warn!("task panicked: {e}"),
+            }
+        }
+        info!("  Collected {block_results}/{} results.", chunk.len());
+    }
+
+    // Write JSON output.
+    let output = AuditOutput {
+        config: AuditConfig {
+            fynd_url: args.fynd_url.clone(),
+            nordstern_url: args.nordstern_url.clone(),
+            chain_id: args.chain_id,
+            top_pairs: args.top_pairs,
+            amounts_per_pair: args.amounts_per_pair,
+            blocks_used: actual_blocks,
+            trades_per_block: chunk_size,
+            block_stride: args.block_stride,
+            total_trades: all_results.len(),
+        },
+        results: all_results,
+    };
+
+    let json = serde_json::to_string_pretty(&output)?;
+    std::fs::write(&args.output, &json)?;
+    info!("Full results saved to: {}", args.output);
+
+    print_summary(&output.results);
+
+    Ok(())
+}
+
+// ─── per-trade execution ───────────────────────────────────────────────────────
+
+struct TradeConfig {
+    aggregator_delay_ms: u64,
+    eth_call_runner: Option<Arc<EthCallRunner>>,
+    quote_block: Option<B256>,
+    baseline_fee_bps: u32,
+}
+
+async fn execute_trade(
+    participants: Vec<Arc<dyn AggregatorClient>>,
+    task: QuoteTask,
+    cfg: TradeConfig,
+) -> Result<TradeResult> {
+    let TradeConfig { aggregator_delay_ms, eth_call_runner, quote_block, baseline_fee_bps } = cfg;
+
+    // When validation is enabled all calldata must route to the runner's sender so the
+    // balance-delta check in try_simulate reads the right account.
+    let wallet: Option<String> = eth_call_runner
+        .as_ref()
+        .map(|r| r.sender_hex());
+
+    // Fire all participants concurrently; delay all except the first (Fynd) to rate-limit
+    // external aggregator APIs.
+    let futs: Vec<_> = participants
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            let p = p.clone();
+            let token_in = task.pair.token_in.clone();
+            let token_out = task.pair.token_out.clone();
+            let amount = task.amount.clone();
+            let wallet = wallet.clone();
+            async move {
+                if i > 0 && aggregator_delay_ms > 0 {
+                    sleep(Duration::from_millis(aggregator_delay_ms)).await;
+                }
+                let name = p.name().to_string();
+                let result = p
+                    .quote(&token_in, &token_out, &amount, wallet.as_deref())
+                    .await;
+                (name, result)
+            }
+        })
+        .collect();
+
+    let raw_results: Vec<(String, anyhow::Result<AggregatorQuote>)> =
+        futures::future::join_all(futs).await;
+
+    // Run eth_call validation for all participants that carry calldata.
+    let eth_calls: Vec<(Option<String>, Option<f64>, Option<u64>)> =
+        futures::future::join_all(raw_results.iter().map(|(_, r)| {
+            let (calldata, quoted) = match r.as_ref().ok() {
+                Some(q) => (q.calldata.as_ref(), q.amount_out.as_deref()),
+                None => (None, None),
+            };
+            run_eth_call_for_calldata(
+                calldata,
+                quoted,
+                eth_call_runner.as_deref(),
+                &task.pair.token_in,
+                &task.pair.token_out,
+                quote_block,
+            )
+        }))
+        .await;
+
+    // Baseline is participants[0] (Fynd). Diffs for index > 0 are vs the baseline.
+    let (baseline_amount, baseline_net_gas, baseline_gas_u, baseline_eth_call_gas) =
+        match raw_results.first() {
+            Some((_, Ok(q))) if q.is_success() => (
+                q.amount_out
+                    .as_deref()
+                    .unwrap_or("0")
+                    .to_string(),
+                q.amount_out_net_gas.clone(),
+                q.gas_units.unwrap_or(0),
+                eth_calls
+                    .first()
+                    .and_then(|(_, _, g)| *g),
+            ),
+            _ => (String::new(), None, 0, None),
+        };
+    // Fee-adjusted Fynd eth_call amount — used only for the gas-adjusted onchain diff so
+    // that the onchain comparison reflects what Fynd would return without taker fees.
+    let baseline_ec_fee_adj: String = eth_calls
+        .first()
+        .and_then(|(amt, _, _)| amt.as_deref())
+        .map(|s| {
+            if baseline_fee_bps > 0 {
+                s.parse::<BigUint>()
+                    .ok()
+                    .map(|v| (v * (10_000u32 + baseline_fee_bps) / 10_000u32).to_string())
+                    .unwrap_or_else(|| s.to_string())
+            } else {
+                s.to_string()
+            }
+        })
+        .unwrap_or_default();
+    let baseline_ok = !baseline_amount.is_empty() && baseline_amount != "0";
+
+    let participant_results: Vec<ParticipantResult> = raw_results
+        .into_iter()
+        .zip(eth_calls)
+        .enumerate()
+        .map(|(idx, ((name, result), (ec_amount, ec_diff, ec_gas)))| {
+            // For the baseline (Fynd), optionally scale up the eth_call result to simulate
+            // zero-fee output. Recomputes ec_diff against the (unchanged) quoted amount_out.
+            let (ec_amount, ec_diff) = if idx == 0 && baseline_fee_bps > 0 {
+                let parsed_actual: Option<BigUint> = ec_amount
+                    .as_deref()
+                    .and_then(|s| s.parse().ok());
+                match parsed_actual {
+                    Some(actual) => {
+                        let scaled = &actual * (10_000u32 + baseline_fee_bps) / 10_000u32;
+                        let new_diff = result
+                            .as_ref()
+                            .ok()
+                            .and_then(|q| q.amount_out.as_deref())
+                            .and_then(|s| s.parse::<BigUint>().ok())
+                            .filter(|q| *q > BigUint::ZERO)
+                            .and_then(|q| eth_call_bps_diff(&scaled, &q));
+                        (Some(scaled.to_string()), new_diff)
+                    }
+                    None => (ec_amount, ec_diff),
+                }
+            } else {
+                (ec_amount, ec_diff)
+            };
+
+            let (raw_diff, gas_reported, gas_onchain) = if idx > 0 && baseline_ok {
+                if let Ok(q) = &result {
+                    if q.is_success() {
+                        let other_raw = q.amount_out.as_deref().unwrap_or("0");
+                        (
+                            raw_bps_diff(&baseline_amount, other_raw),
+                            gas_adjusted_bps_diff(
+                                &baseline_amount,
+                                baseline_net_gas.as_deref(),
+                                baseline_gas_u,
+                                other_raw,
+                                q.gas_units.unwrap_or(0),
+                            ),
+                            gas_adjusted_bps_diff(
+                                &baseline_ec_fee_adj,
+                                baseline_net_gas.as_deref(),
+                                baseline_eth_call_gas.unwrap_or(0),
+                                ec_amount.as_deref().unwrap_or("0"),
+                                ec_gas.unwrap_or(0),
+                            ),
+                        )
+                    } else {
+                        (None, None, None)
+                    }
+                } else {
+                    (None, None, None)
+                }
+            } else {
+                (None, None, None)
+            };
+
+            match result {
+                Ok(q) => ParticipantResult {
+                    name,
+                    status: q.status.to_string(),
+                    amount_out: q.amount_out,
+                    amount_out_net_gas: q.amount_out_net_gas,
+                    gas_units: q.gas_units,
+                    protocols: q.protocols,
+                    num_splits: q.num_splits,
+                    response_time_ms: Some(q.response_time_ms),
+                    eth_call_amount_out: ec_amount,
+                    eth_call_diff_bps: ec_diff,
+                    eth_call_gas_used: ec_gas,
+                    raw_diff_bps: raw_diff,
+                    gas_adjusted_diff_bps_reported: gas_reported,
+                    gas_adjusted_diff_bps_onchain: gas_onchain,
+                },
+                Err(e) => {
+                    warn!("participant {name} request failed: {e:#}");
+                    ParticipantResult {
+                        name,
+                        status: format!("error: {e}"),
+                        amount_out: None,
+                        amount_out_net_gas: None,
+                        gas_units: None,
+                        protocols: vec![],
+                        num_splits: None,
+                        response_time_ms: None,
+                        eth_call_amount_out: None,
+                        eth_call_diff_bps: None,
+                        eth_call_gas_used: None,
+                        raw_diff_bps: None,
+                        gas_adjusted_diff_bps_reported: None,
+                        gas_adjusted_diff_bps_onchain: None,
+                    }
+                }
+            }
+        })
+        .collect();
+
+    Ok(TradeResult {
+        block_sample: task.block_sample,
+        block_hash: quote_block.map(|h| format!("0x{}", hex::encode(h.as_slice()))),
+        pair: task.pair.label.clone(),
+        token_in: task.pair.token_in,
+        token_out: task.pair.token_out,
+        amount_in: task.amount,
+        amount_percentile_idx: task.amount_percentile_idx,
+        participants: participant_results,
+    })
+}
+
+// ─── eth_call helper ─────────────────────────────────────────────────────────
+
+/// Decode a 0x-prefixed hex string into a 20-byte `Address`, returning `None` on any error.
+fn parse_address_hex(hex: &str) -> Option<Address> {
+    let bytes = hex::decode(hex.trim_start_matches("0x")).ok()?;
+    (bytes.len() == 20).then(|| Address::from_slice(&bytes))
+}
+
+/// Returns `true` when `e` indicates that the called JSON-RPC method does not exist on this RPC.
+///
+/// Prefers the standard error code `-32601` (method not found). Falls back to narrow
+/// phrase matching for providers that return non-standard error shapes.
+fn is_method_not_found(e: &anyhow::Error) -> bool {
+    // Walk the anyhow error chain and try to downcast to a typed RPC error.
+    for cause in e.chain() {
+        if let Some(rpc) = cause.downcast_ref::<RpcError<TransportErrorKind>>() {
+            return matches!(rpc, RpcError::ErrorResp(p) if p.code == -32601);
+        }
+    }
+    // Fallback for providers that surface the error as plain text.
+    let msg = e.to_string().to_ascii_lowercase();
+    msg.contains("method not found") || msg.contains("does not exist")
+}
+
+/// Run eth_call validation for a participant that carries encoded calldata.
+///
+/// Returns `(eth_call_amount_out, eth_call_diff_bps, eth_call_gas_used)`. All `None` when
+/// the runner is absent, calldata is absent, addresses are invalid, or the call reverts.
+async fn run_eth_call_for_calldata(
+    calldata: Option<&AggregatorCalldata>,
+    quoted_amount: Option<&str>,
+    runner: Option<&EthCallRunner>,
+    token_in_hex: &str,
+    token_out_hex: &str,
+    block: Option<B256>,
+) -> (Option<String>, Option<f64>, Option<u64>) {
+    let Some(runner) = runner else {
+        return (None, None, None);
+    };
+    let Some(block) = block else {
+        return (None, None, None);
+    };
+    let Some(cd) = calldata else {
+        return (None, None, None);
+    };
+
+    let Some(token_in) = parse_address_hex(token_in_hex) else {
+        warn!("eth_call: invalid token_in address {token_in_hex}");
+        return (None, None, None);
+    };
+    let Some(token_out) = parse_address_hex(token_out_hex) else {
+        warn!("eth_call: invalid token_out address {token_out_hex}");
+        return (None, None, None);
+    };
+
+    // Aggregators use 0xeeee…eeee as a sentinel for native ETH; normalise to zero address
+    // so build_overrides skips the ERC-20 slot probe and try_simulate uses the ETH path.
+    let eth_sentinel = Address::from([0xeeu8; 20]);
+    let token_in = if token_in == eth_sentinel { Address::ZERO } else { token_in };
+    let token_out = if token_out == eth_sentinel { Address::ZERO } else { token_out };
+
+    let Some(router) = parse_address_hex(&cd.to) else {
+        warn!("eth_call: invalid router address '{}'", cd.to);
+        return (None, None, None);
+    };
+
+    let calldata_bytes = hex::decode(cd.data.trim_start_matches("0x")).unwrap_or_default();
+    let value: BigUint = cd.value.parse().unwrap_or_default();
+
+    match runner
+        .execute(token_in, token_out, router, &calldata_bytes, &value, block)
+        .await
+    {
+        Ok(Some((actual, gas_used))) => {
+            let diff_bps = quoted_amount
+                .and_then(|q| q.parse::<BigUint>().ok())
+                .filter(|q| *q > BigUint::ZERO)
+                .and_then(|q| eth_call_bps_diff(&actual, &q));
+            (Some(actual.to_string()), diff_bps, gas_used)
+        }
+        Ok(None) => (None, None, None),
+        Err(e) => {
+            warn!("eth_call validation failed: {e}");
+            (None, None, None)
+        }
+    }
+}
+
+// ─── block-detection helpers ──────────────────────────────────────────────────
+
+/// Poll until `last_update_ms < 3 s`, indicating a fresh block just processed.
+async fn wait_for_fresh_block(fynd: &FyndClient) -> Result<()> {
+    loop {
+        sleep(Duration::from_millis(500)).await;
+        let health = fynd
+            .health()
+            .await
+            .context("health check failed while waiting for block")?;
+        if health.last_update_ms() < 3_000 {
+            return Ok(());
+        }
+    }
+}
+
+/// Poll until `last_update_ms > 8 s` so the next `wait_for_fresh_block` catches a new block.
+async fn wait_until_stale(fynd: &FyndClient) -> Result<()> {
+    loop {
+        sleep(Duration::from_secs(2)).await;
+        let health = fynd
+            .health()
+            .await
+            .context("health check failed while waiting for stale")?;
+        if health.last_update_ms() > 8_000 {
+            return Ok(());
+        }
+    }
+}
+
+/// Wait until stale, then skip `stride - 1` additional Ethereum block periods (~12 s each),
+/// then sync to the next fresh block. With stride=1 this is identical to the original behaviour.
+async fn wait_for_next_sample(fynd: &FyndClient, stride: usize) -> Result<()> {
+    wait_until_stale(fynd).await?;
+    if stride > 1 {
+        sleep(Duration::from_secs(12 * (stride - 1) as u64)).await;
+    }
+    wait_for_fresh_block(fynd).await
+}
+
+// ─── summary printing ─────────────────────────────────────────────────────────
+
+fn print_summary(results: &[TradeResult]) {
+    let total = results.len();
+    info!("{}", "=".repeat(80));
+    info!("  FYND AUDIT RESULTS  ({total} trades)");
+    info!("{}", "=".repeat(80));
+
+    let baseline_name: String = results
+        .iter()
+        .find_map(|r| {
+            r.participants
+                .first()
+                .map(|p| p.name.clone())
+        })
+        .unwrap_or_else(|| "fynd".to_string());
+
+    // Collect unique non-baseline participant names, sorted.
+    let agg_names: Vec<String> = results
+        .iter()
+        .flat_map(|r| r.participants.iter())
+        .filter(|p| p.name != baseline_name)
+        .map(|p| p.name.clone())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    for name in &agg_names {
+        info!("\n  vs {name}:");
+
+        let agg_rows: Vec<&ParticipantResult> = results
+            .iter()
+            .flat_map(|r| r.participants.iter())
+            .filter(|p| &p.name == name)
+            .collect();
+
+        let raw_diffs: Vec<f64> = agg_rows
+            .iter()
+            .filter_map(|a| a.raw_diff_bps)
+            .collect();
+        let gas_reported_diffs: Vec<f64> = agg_rows
+            .iter()
+            .filter_map(|a| a.gas_adjusted_diff_bps_reported)
+            .collect();
+        let gas_onchain_diffs: Vec<f64> = agg_rows
+            .iter()
+            .filter_map(|a| a.gas_adjusted_diff_bps_onchain)
+            .collect();
+
+        if raw_diffs.is_empty() {
+            info!("    No comparable trades.");
+            continue;
+        }
+
+        let summarise = |diffs: &[f64]| -> (usize, usize, f64, f64) {
+            let n = diffs.len();
+            let wins = diffs
+                .iter()
+                .filter(|&&d| d > 0.0)
+                .count();
+            let avg = diffs.iter().sum::<f64>() / n as f64;
+            let mut s = diffs.to_vec();
+            s.sort_by(|a, b| {
+                a.partial_cmp(b)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let med = s[n / 2];
+            (n, wins, avg, med)
+        };
+
+        let (rn, rw, ravg, rmed) = summarise(&raw_diffs);
+        info!(
+            "    Raw (no gas):       Fynd better {rw}/{rn} ({:.1}%)  avg {ravg:+.2} bps  median {rmed:+.2} bps",
+            rw as f64 / rn as f64 * 100.0
+        );
+
+        if gas_reported_diffs.is_empty() {
+            info!("    Gas-adj (reported): (no reported gas data)");
+        } else {
+            let (gn, gw, gavg, gmed) = summarise(&gas_reported_diffs);
+            info!(
+                "    Gas-adj (reported): Fynd better {gw}/{gn} ({:.1}%)  avg {gavg:+.2} bps  median {gmed:+.2} bps",
+                gw as f64 / gn as f64 * 100.0
+            );
+        }
+
+        if gas_onchain_diffs.is_empty() {
+            info!("    Gas-adj (onchain):  (no on-chain gas data)");
+        } else {
+            let (gn, gw, gavg, gmed) = summarise(&gas_onchain_diffs);
+            info!(
+                "    Gas-adj (onchain):  Fynd better {gw}/{gn} ({:.1}%)  avg {gavg:+.2} bps  median {gmed:+.2} bps",
+                gw as f64 / gn as f64 * 100.0
+            );
+        }
+
+        // Per-pair breakdown.
+        info!("\n  Per-pair breakdown:");
+        let mut pairs: Vec<&str> = results
+            .iter()
+            .map(|r| r.pair.as_str())
+            .collect();
+        pairs.sort_unstable();
+        pairs.dedup();
+
+        info!(
+            "  {:<30}  {:>5}  {:>5}  {:>10}  {:>12}  {:>12}",
+            "Pair", "n", "Win%", "Raw med", "Gas-rep med", "Gas-chain med"
+        );
+        info!("  {}", "-".repeat(80));
+
+        for pair in &pairs {
+            let rows: Vec<&ParticipantResult> = results
+                .iter()
+                .filter(|r| r.pair.as_str() == *pair)
+                .flat_map(|r| r.participants.iter())
+                .filter(|p| &p.name == name)
+                .collect();
+
+            let pr: Vec<f64> = rows
+                .iter()
+                .filter_map(|a| a.raw_diff_bps)
+                .collect();
+            if pr.is_empty() {
+                continue;
+            }
+
+            let med_of = |vals: &mut Vec<f64>| -> Option<f64> {
+                if vals.is_empty() {
+                    return None;
+                }
+                vals.sort_by(|a, b| {
+                    a.partial_cmp(b)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                Some(vals[vals.len() / 2])
+            };
+
+            let pn = pr.len();
+            let pw = pr.iter().filter(|&&d| d > 0.0).count();
+            let mut sr = pr.clone();
+            let rmed = med_of(&mut sr).unwrap_or(0.0);
+
+            let mut pg_rep: Vec<f64> = rows
+                .iter()
+                .filter_map(|a| a.gas_adjusted_diff_bps_reported)
+                .collect();
+            let mut pg_chain: Vec<f64> = rows
+                .iter()
+                .filter_map(|a| a.gas_adjusted_diff_bps_onchain)
+                .collect();
+
+            let fmt_med = |v: Option<f64>| match v {
+                Some(x) => format!("{:>+12.2}", x),
+                None => "         n/a".to_string(),
+            };
+
+            info!(
+                "  {:<30}  {:>5}  {:>4.1}%  {:>+10.2}  {}  {}",
+                pair,
+                pn,
+                pw as f64 / pn as f64 * 100.0,
+                rmed,
+                fmt_med(med_of(&mut pg_rep)),
+                fmt_med(med_of(&mut pg_chain)),
+            );
+        }
+    }
+
+    info!("\n{}", "=".repeat(80));
+}
+
+// ─── quote helpers ────────────────────────────────────────────────────────────
+
+/// Some trade datasets use 0xeeee…eeee as a sentinel for native ETH; Fynd expects ZERO_ADDRESS.
+const ETH_SENTINEL: &str = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+const ZERO_ADDRESS: &str = "0x0000000000000000000000000000000000000000";
+
+fn fynd_addr(addr: &str) -> &str {
+    if addr.eq_ignore_ascii_case(ETH_SENTINEL) {
+        ZERO_ADDRESS
+    } else {
+        addr
+    }
+}
+
+fn make_quote_params(
+    token_in: &str,
+    token_out: &str,
+    amount: &str,
+    timeout_ms: u64,
+    sender_hex: Option<&str>,
+    encoding: Option<EncodingOptions>,
+) -> anyhow::Result<QuoteParams> {
+    let sender = parse_addr(sender_hex.unwrap_or("0x0000000000000000000000000000000000000001"))?;
+    let order = Order::new(
+        parse_addr(fynd_addr(token_in))?,
+        parse_addr(fynd_addr(token_out))?,
+        BigUint::from_str(amount).unwrap_or_default(),
+        OrderSide::Sell,
+        sender,
+        None,
+    );
+    let opts = QuoteOptions::default().with_timeout_ms(timeout_ms);
+    let opts = match encoding {
+        Some(enc) => opts.with_encoding_options(enc),
+        None => opts,
+    };
+    Ok(QuoteParams::new(order, opts))
+}
+
+fn parse_addr(hex_str: &str) -> anyhow::Result<Bytes> {
+    let stripped = hex_str
+        .strip_prefix("0x")
+        .unwrap_or(hex_str);
+    hex::decode(stripped)
+        .map(Bytes::from)
+        .map_err(|_| anyhow::anyhow!("bad address '{hex_str}'"))
+}
+
+/// Extract `uint256 amountOut` from raw `eth_call` return bytes.
+///
+/// Most routers return a bare `uint256` as the first word. The 0x AllowanceHolder wraps
+/// the inner swap result in ABI-encoded `bytes memory`, so the layout is:
+///   word 0: offset = 0x20 (32)
+///   word 1: inner length
+///   word 2: inner uint256 amountOut
+///
+/// When the first word equals 32 and the data is long enough, we skip the ABI wrapper.
+fn parse_return_amount(data: &[u8]) -> Option<BigUint> {
+    if data.len() < 32 {
+        return None;
+    }
+    // Detect ABI `bytes memory` wrapper: first word is exactly 0x0000…0020.
+    if data.len() >= 96 && data[..31] == [0u8; 31] && data[31] == 0x20 {
+        let inner = BigUint::from_bytes_be(&data[64..96]);
+        if inner > BigUint::ZERO {
+            return Some(inner);
+        }
+    }
+    Some(BigUint::from_bytes_be(&data[..32]))
+}
+
+/// Diff between `eth_call` on-chain result and Fynd's quoted amount, in basis points.
+///
+/// Positive = on-chain result exceeds quoted amount (Fynd was conservative).
+/// Negative = on-chain result is less than quoted (Fynd was optimistic).
+/// `None` when either amount is zero.
+fn eth_call_bps_diff(actual: &BigUint, quoted: &BigUint) -> Option<f64> {
+    if *actual == BigUint::ZERO || *quoted == BigUint::ZERO {
+        return None;
+    }
+    let a: f64 = actual
+        .to_string()
+        .parse()
+        .unwrap_or(0.0);
+    let q: f64 = quoted
+        .to_string()
+        .parse()
+        .unwrap_or(0.0);
+    if q == 0.0 {
+        return None;
+    }
+    Some((a - q) / q * 10_000.0)
+}

--- a/tools/benchmark/src/audit.rs
+++ b/tools/benchmark/src/audit.rs
@@ -201,6 +201,8 @@ struct ParticipantResult {
     /// Reported gas units (Fynd `gas_estimate` or aggregator self-reported gas).
     gas_units: Option<u64>,
     protocols: Vec<String>,
+    /// Pool-level route: `[protocol, component_id]` pairs for each swap leg (Fynd only).
+    route: Option<Vec<[String; 2]>>,
     /// Parallel sub-routes (aggregators only; `null` for Fynd).
     num_splits: Option<usize>,
     /// Wall-clock time from request dispatch to first byte of response.
@@ -718,6 +720,13 @@ impl AggregatorClient for FyndAggregator {
             })
             .unwrap_or_default();
 
+        let fynd_route = q.route().map(|r| {
+            r.swaps()
+                .iter()
+                .map(|s| [s.protocol().to_string(), s.component_id().to_string()])
+                .collect()
+        });
+
         let calldata = success
             .then(|| q.transaction())
             .flatten()
@@ -752,6 +761,7 @@ impl AggregatorClient for FyndAggregator {
             num_splits: None,
             response_time_ms,
             calldata,
+            route: fynd_route,
         })
     }
 }
@@ -805,7 +815,7 @@ pub async fn run(args: Args) -> Result<()> {
 
     // Build the FyndClient — used for health-checks and block-waiting only.
     let fynd = Arc::new(
-        FyndClientBuilder::new(&args.fynd_url, "")
+        FyndClientBuilder::new(&args.fynd_url)
             .with_timeout(Duration::from_millis(args.timeout_ms))
             .with_retry(RetryConfig::new(1, Duration::from_millis(0), Duration::from_millis(0)))
             .build_quote_only()
@@ -1161,6 +1171,7 @@ async fn execute_trade(
                     amount_out_net_gas: q.amount_out_net_gas,
                     gas_units: q.gas_units,
                     protocols: q.protocols,
+                    route: q.route,
                     num_splits: q.num_splits,
                     response_time_ms: Some(q.response_time_ms),
                     eth_call_amount_out: ec_amount,
@@ -1179,6 +1190,7 @@ async fn execute_trade(
                         amount_out_net_gas: None,
                         gas_units: None,
                         protocols: vec![],
+                        route: None,
                         num_splits: None,
                         response_time_ms: None,
                         eth_call_amount_out: None,

--- a/tools/benchmark/src/erc20.rs
+++ b/tools/benchmark/src/erc20.rs
@@ -1,0 +1,257 @@
+//! ERC-20 helpers: balance/allowance storage slot detection via eth_call + state overrides.
+//!
+//! Identical logic to `fynd-swap-cli/src/erc20.rs` — duplicated here because
+//! `fynd-swap-cli` is a binary crate and cannot be depended upon.
+
+use alloy::{
+    network::Ethereum,
+    primitives::{keccak256, map::B256HashMap, Address, Bytes as AlloyBytes, TxKind, B256, U256},
+    providers::{Provider, RootProvider},
+    rpc::types::{
+        state::{AccountOverride, StateOverride},
+        TransactionRequest,
+    },
+    sol,
+    sol_types::SolCall,
+};
+use anyhow::bail;
+
+sol! {
+    interface IERC20 {
+        function balanceOf(address account) external view returns (uint256);
+        function allowance(address owner, address spender) external view returns (uint256);
+    }
+}
+
+const MAX_PROBE_SLOT: u64 = 20;
+
+/// Sentinel written to a candidate storage slot during balance/allowance probing.
+///
+/// Deliberately avoids high bits so tokens that mask upper bits (e.g. USDC packs a
+/// blacklist flag in bit 255) still return this value exactly, enabling an exact-match check.
+const PROBE_SENTINEL: U256 = U256::from_limbs([0xdead_beef, 0, 0, 0]);
+
+/// OZ v5 ERC-20 namespaced storage location for `_balances` (field 0 of `ERC20Storage`).
+///
+/// Computed as `keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC20")) - 1)) &
+/// ~bytes32(uint256(0xff))`. Tokens using OpenZeppelin Upgradeable 5.x store their `_balances`
+/// mapping here instead of slot 0.
+const OZ_V5_BALANCES_NS: B256 =
+    B256::new(alloy::hex!("52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace00"));
+
+/// OZ v5 `_allowances` is field 1 in `ERC20Storage`, so namespace + 1.
+const OZ_V5_ALLOWANCES_NS: B256 =
+    B256::new(alloy::hex!("52c63247e1f47db19d5ce0460030c497f067ca4cebf71ba98eeadabe20bace01"));
+
+/// Compute `keccak256(abi.encode(holder, position))` for a standard Solidity `mapping(address =>
+/// ...)` at `position`.
+pub fn balance_slot_at(holder: Address, position: u64) -> B256 {
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(holder.as_slice());
+    buf[56..64].copy_from_slice(&position.to_be_bytes());
+    keccak256(buf)
+}
+
+/// Compute the balance slot using a full 32-byte mapping base slot (e.g. OZ v5 namespace).
+fn balance_slot_at_b256(holder: Address, base: B256) -> B256 {
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(holder.as_slice());
+    buf[32..64].copy_from_slice(base.as_slice());
+    keccak256(buf)
+}
+
+/// Compute `keccak256(abi.encode(spender, keccak256(abi.encode(owner, position))))` for
+/// a standard Solidity `mapping(address => mapping(address => ...))` at `position`.
+pub fn allowance_slot_at(owner: Address, spender: Address, position: u64) -> B256 {
+    let inner = balance_slot_at(owner, position);
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(spender.as_slice());
+    buf[32..64].copy_from_slice(inner.as_slice());
+    keccak256(buf)
+}
+
+/// Compute the allowance slot using a full 32-byte mapping base slot (e.g. OZ v5 namespace).
+fn allowance_slot_at_b256(owner: Address, spender: Address, base: B256) -> B256 {
+    let inner = balance_slot_at_b256(owner, base);
+    let mut buf = [0u8; 64];
+    buf[12..32].copy_from_slice(spender.as_slice());
+    buf[32..64].copy_from_slice(inner.as_slice());
+    keccak256(buf)
+}
+
+pub fn state_override_single(contract: Address, slot: B256, value: B256) -> StateOverride {
+    let mut state_diff = B256HashMap::default();
+    state_diff.insert(slot, value);
+    let mut overrides = StateOverride::default();
+    overrides
+        .insert(contract, AccountOverride { state_diff: Some(state_diff), ..Default::default() });
+    overrides
+}
+
+/// Find the storage slot that holds the ERC-20 balance of `holder` in `token`.
+///
+/// Returns the full computed slot (`B256`) so callers can write directly to it via
+/// `state_diff`. Probes standard Solidity mapping positions 0..=20, then falls through to
+/// the OpenZeppelin v5 namespaced storage layout used by upgradeable ERC-20 proxies.
+pub async fn find_balance_slot(
+    provider: &RootProvider<Ethereum>,
+    token: Address,
+    holder: Address,
+) -> anyhow::Result<B256> {
+    let calldata = IERC20::balanceOfCall { account: holder }.abi_encode();
+    let sentinel = B256::from(PROBE_SENTINEL);
+
+    // Standard Solidity mapping layout: keccak256(abi.encode(holder, position)).
+    for position in 0..=MAX_PROBE_SLOT {
+        let slot = balance_slot_at(holder, position);
+        let result = provider
+            .call(TransactionRequest {
+                to: Some(TxKind::Call(token)),
+                input: AlloyBytes::from(calldata.clone()).into(),
+                ..Default::default()
+            })
+            .overrides(state_override_single(token, slot, sentinel))
+            .await?;
+        if result.len() >= 32 && result[..32] == *sentinel.as_slice() {
+            return Ok(slot);
+        }
+    }
+
+    // OZ v5 namespaced storage: _balances is at keccak256(abi.encode(holder, ERC20_NS)).
+    let oz_slot = balance_slot_at_b256(holder, OZ_V5_BALANCES_NS);
+    let result = provider
+        .call(TransactionRequest {
+            to: Some(TxKind::Call(token)),
+            input: AlloyBytes::from(calldata).into(),
+            ..Default::default()
+        })
+        .overrides(state_override_single(token, oz_slot, sentinel))
+        .await?;
+    if result.len() >= 32 && result[..32] == *sentinel.as_slice() {
+        return Ok(oz_slot);
+    }
+
+    bail!(
+        "could not detect balance slot for {token:#x} (tried standard 0..={MAX_PROBE_SLOT} \
+         and OZ v5 namespace); the token may use a non-standard storage layout"
+    )
+}
+
+/// Find the storage slot that holds the ERC-20 allowance of `owner` for `spender` in `token`.
+///
+/// Returns the full computed slot (`B256`). Probes standard Solidity nested-mapping positions
+/// 0..=20, then the OpenZeppelin v5 namespaced layout.
+pub async fn find_allowance_slot(
+    provider: &RootProvider<Ethereum>,
+    token: Address,
+    owner: Address,
+    spender: Address,
+) -> anyhow::Result<B256> {
+    let calldata = IERC20::allowanceCall { owner, spender }.abi_encode();
+    let sentinel = B256::from(PROBE_SENTINEL);
+
+    for position in 0..=MAX_PROBE_SLOT {
+        let slot = allowance_slot_at(owner, spender, position);
+        let result = provider
+            .call(TransactionRequest {
+                to: Some(TxKind::Call(token)),
+                input: AlloyBytes::from(calldata.clone()).into(),
+                ..Default::default()
+            })
+            .overrides(state_override_single(token, slot, sentinel))
+            .await?;
+        if result.len() >= 32 && result[..32] == *sentinel.as_slice() {
+            return Ok(slot);
+        }
+    }
+
+    // OZ v5 namespace: _allowances is field 1 of ERC20Storage → base = ERC20_NS + 1.
+    let oz_slot = allowance_slot_at_b256(owner, spender, OZ_V5_ALLOWANCES_NS);
+    let result = provider
+        .call(TransactionRequest {
+            to: Some(TxKind::Call(token)),
+            input: AlloyBytes::from(calldata).into(),
+            ..Default::default()
+        })
+        .overrides(state_override_single(token, oz_slot, sentinel))
+        .await?;
+    if result.len() >= 32 && result[..32] == *sentinel.as_slice() {
+        return Ok(oz_slot);
+    }
+
+    bail!(
+        "could not detect allowance slot for {token:#x} (tried standard 0..={MAX_PROBE_SLOT} \
+         and OZ v5 namespace); the token may use a non-standard storage layout"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::hex;
+
+    use super::*;
+
+    #[test]
+    fn balance_slot_zero_address_position_zero() {
+        let slot = balance_slot_at(Address::ZERO, 0);
+        let expected = hex!("ad3228b676f7d3cd4284a5443f17f1962b36e491b30a40b2405849e597ba5fb5");
+        assert_eq!(slot.0, expected);
+    }
+
+    #[test]
+    fn balance_slot_usdc_position_zero() {
+        let usdc: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            .parse()
+            .unwrap();
+        let slot = balance_slot_at(usdc, 0);
+        let expected = hex!("c6521c8ea4247e8beb499344e591b9401fb2807ff9997dd598fd9e56c73a264d");
+        assert_eq!(slot.0, expected);
+    }
+
+    #[test]
+    fn balance_slot_position_changes_output() {
+        let usdc: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            .parse()
+            .unwrap();
+        let slot0 = balance_slot_at(usdc, 0);
+        let slot1 = balance_slot_at(usdc, 1);
+        let expected1 = hex!("84893e0f271e5f8233d24aa85ba38e0d2ed8f0fc8f608c286ccee51e6c35dd6e");
+        assert_ne!(slot0, slot1, "different positions must yield different slots");
+        assert_eq!(slot1.0, expected1);
+    }
+
+    #[test]
+    fn allowance_slot_usdc_weth_position_zero() {
+        let usdc: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            .parse()
+            .unwrap();
+        let weth: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            .parse()
+            .unwrap();
+        let slot = allowance_slot_at(usdc, weth, 0);
+        let expected = hex!("7b7d28f4178b11583278450af3b85d49a04fd0597c53f7ed3fbfac3750fde37d");
+        assert_eq!(slot.0, expected);
+    }
+
+    #[test]
+    fn allowance_slot_differs_from_balance_slot() {
+        let usdc: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            .parse()
+            .unwrap();
+        let weth: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            .parse()
+            .unwrap();
+        assert_ne!(balance_slot_at(usdc, 0), allowance_slot_at(usdc, weth, 0));
+    }
+
+    #[test]
+    fn allowance_slot_is_not_symmetric() {
+        let usdc: Address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+            .parse()
+            .unwrap();
+        let weth: Address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+            .parse()
+            .unwrap();
+        assert_ne!(balance_slot_at(usdc, 0), allowance_slot_at(weth, usdc, 0));
+    }
+}

--- a/tools/benchmark/src/main.rs
+++ b/tools/benchmark/src/main.rs
@@ -3,10 +3,14 @@
 //! Dispatches to the `load` (latency/throughput) and `compare`
 //! (output-quality diff) subcommands.
 
+mod aggregator;
+mod audit;
 mod benchmark;
 mod compare;
 mod config;
+mod erc20;
 mod exporter;
+mod pair_selector;
 mod requests;
 mod runner;
 mod scale;
@@ -36,6 +40,8 @@ enum Command {
     DownloadTrades(DownloadTradesArgs),
     /// Benchmark throughput scaling across different worker counts
     Scale(scale::Args),
+    /// Compare Fynd quote performance against external DEX aggregators
+    Audit(audit::Args),
 }
 
 /// Download the full 10k aggregator trade dataset for benchmarking.
@@ -61,6 +67,7 @@ async fn main() -> anyhow::Result<()> {
             .await
             .map_err(|e| anyhow::anyhow!("{e}")),
         Command::Scale(args) => scale::run(args).await,
+        Command::Audit(args) => audit::run(args).await,
     }
 }
 

--- a/tools/benchmark/src/pair_selector.rs
+++ b/tools/benchmark/src/pair_selector.rs
@@ -1,0 +1,255 @@
+//! Select the top-N token pairs and representative amounts from a trade dataset.
+//!
+//! Used by the `audit` subcommand to derive what to benchmark from the existing
+//! aggregator trade dataset rather than requiring separate configuration.
+
+use std::collections::HashMap;
+
+use num_bigint::BigUint;
+
+use crate::requests::{lookup_symbol, SwapRequest};
+
+/// A token pair with pre-computed representative trade amounts.
+#[derive(Debug, Clone)]
+pub struct PairSpec {
+    /// Human-readable label, e.g. `"WETH → USDC"`.
+    pub label: String,
+    /// Checksummed (or lower-case) ERC-20 address of the sell token.
+    pub token_in: String,
+    /// Checksummed (or lower-case) ERC-20 address of the buy token.
+    pub token_out: String,
+    /// `amounts_per_pair` representative amounts derived from percentiles of real trades.
+    pub amounts: Vec<String>,
+}
+
+/// Returns `(decimals, approx_usd_price_per_whole_token)` for well-known tokens.
+///
+/// Prices are intentionally rough — within an order of magnitude is sufficient to give a
+/// sensible USD floor. Returns `None` for unknown tokens, which bypasses the filter.
+fn token_usd_price(addr: &str) -> Option<(u32, f64)> {
+    match addr {
+        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2" => Some((18, 2_500.0)), // WETH
+        "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" => Some((18, 2_500.0)), // ETH
+        "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" => Some((6, 1.0)),      // USDC
+        "0xdac17f958d2ee523a2206206994597c13d831ec7" => Some((6, 1.0)),      // USDT
+        "0x6b175474e89094c44da98b954eedeac495271d0f" => Some((18, 1.0)),     // DAI
+        "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599" => Some((8, 95_000.0)), // WBTC
+        "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9" => Some((18, 200.0)),   // AAVE
+        "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984" => Some((18, 10.0)),    // UNI
+        "0x514910771af9ca656af840dff83e8264ecf986ca" => Some((18, 15.0)),    // LINK
+        "0x6982508145454ce325ddbe47a25d4ec3d2311933" => Some((18, 0.000015)), // PEPE
+        "0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce" => Some((18, 0.00002)), // SHIB
+        "0x6810e776880c02933d47db1b9fc05908e5386b96" => Some((18, 150.0)),   // GNO
+        _ => None,
+    }
+}
+
+/// Returns whether `raw_amount` of `token_addr` meets the minimum USD threshold.
+///
+/// Always returns `true` for unknown tokens (no price data available, keep without filtering).
+fn meets_min_usd(token_addr: &str, raw_amount: &BigUint, min_usd: f64) -> bool {
+    if min_usd <= 0.0 {
+        return true;
+    }
+    let Some((decimals, usd_price)) = token_usd_price(token_addr) else {
+        return true;
+    };
+    let amount_f64: f64 = raw_amount
+        .to_string()
+        .parse()
+        .unwrap_or(f64::MAX);
+    let usd_value = amount_f64 / 10f64.powi(decimals as i32) * usd_price;
+    usd_value >= min_usd
+}
+
+/// Derive the top-`top_n` pairs by trade frequency and compute `amounts_per_pair` percentile
+/// amounts per pair from the supplied trade dataset.
+///
+/// Pairs are kept direction-specific: WETH→USDC and USDC→WETH are counted separately.
+/// When the dataset has fewer than `top_n` unique pairs, all pairs are returned.
+///
+/// `min_amount_usd` drops individual trades below the approximate USD threshold from the
+/// amount distribution before computing percentiles. Set to `0.0` to disable.
+pub fn select_top_pairs(
+    trades: &[SwapRequest],
+    top_n: usize,
+    amounts_per_pair: usize,
+    min_amount_usd: f64,
+) -> Vec<PairSpec> {
+    // Accumulate all trade amounts per (token_in, token_out) pair.
+    let mut pair_amounts: HashMap<(String, String), Vec<BigUint>> = HashMap::new();
+    for trade in trades {
+        let key = (trade.token_in_addr().to_lowercase(), trade.token_out_addr().to_lowercase());
+        if let Ok(amount) = trade.raw_amount().parse::<BigUint>() {
+            if amount > BigUint::default() && meets_min_usd(&key.0, &amount, min_amount_usd) {
+                pair_amounts
+                    .entry(key)
+                    .or_default()
+                    .push(amount);
+            }
+        }
+    }
+
+    // Sort by trade count descending, then by (token_in, token_out) for determinism.
+    let mut ranked: Vec<_> = pair_amounts.into_iter().collect();
+    ranked.sort_by(|a, b| {
+        b.1.len()
+            .cmp(&a.1.len())
+            .then_with(|| a.0.cmp(&b.0))
+    });
+
+    ranked
+        .into_iter()
+        .take(top_n)
+        .map(|((token_in, token_out), mut amounts)| {
+            amounts.sort_unstable();
+            let in_sym = lookup_symbol(&token_in);
+            let out_sym = lookup_symbol(&token_out);
+            PairSpec {
+                label: format!("{in_sym} → {out_sym}"),
+                amounts: percentile_sample(&amounts, amounts_per_pair),
+                token_in,
+                token_out,
+            }
+        })
+        .collect()
+}
+
+/// Sample `n` values at evenly-spaced percentiles from a pre-sorted slice.
+///
+/// With `n = 10` this produces the 0th, ~11th, ~22nd … 100th percentile values,
+/// giving a representative spread across the real trade-size distribution.
+fn percentile_sample(sorted: &[BigUint], n: usize) -> Vec<String> {
+    if sorted.is_empty() || n == 0 {
+        return vec![];
+    }
+    let n = n.max(1);
+    (0..n)
+        .map(|i| {
+            let frac = if n == 1 { 0.5_f64 } else { i as f64 / (n - 1) as f64 };
+            let idx = ((sorted.len() - 1) as f64 * frac).round() as usize;
+            sorted[idx.min(sorted.len() - 1)].to_string()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_trade(token_in: &str, token_out: &str, amount: &str) -> SwapRequest {
+        use crate::requests::load_request_templates;
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("pair_selector_test_{}.json", fastrand::u64(..)));
+        let content = serde_json::json!([{
+            "orders": [{
+                "token_in": token_in,
+                "token_out": token_out,
+                "amount": amount,
+                "side": "sell",
+                "sender": "0x0000000000000000000000000000000000000001"
+            }]
+        }]);
+        std::fs::write(&path, content.to_string()).unwrap();
+        let mut reqs = load_request_templates(path.to_str().unwrap(), 5000).unwrap();
+        std::fs::remove_file(&path).ok();
+        reqs.remove(0)
+    }
+
+    #[test]
+    fn percentile_sample_single() {
+        assert_eq!(percentile_sample(&[BigUint::from(100u32)], 1), vec!["100"]);
+    }
+
+    #[test]
+    fn percentile_sample_endpoints() {
+        let nums: Vec<BigUint> = [10u32, 20, 30, 40, 50]
+            .map(BigUint::from)
+            .to_vec();
+        let s = percentile_sample(&nums, 2);
+        assert_eq!(s, vec!["10", "50"]);
+    }
+
+    #[test]
+    fn percentile_sample_n_greater_than_data() {
+        let nums: Vec<BigUint> = [10u32, 20].map(BigUint::from).to_vec();
+        let s = percentile_sample(&nums, 5);
+        assert_eq!(s.len(), 5);
+        // Min and max must always be included.
+        assert_eq!(s[0], "10");
+        assert_eq!(s[4], "20");
+    }
+
+    #[test]
+    fn select_top_pairs_ranks_by_frequency() {
+        let weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+        let usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+        let dai = "0x6b175474e89094c44da98b954eedeac495271d0f";
+
+        let trades = vec![
+            make_trade(weth, usdc, "1000000000000000000"),
+            make_trade(weth, usdc, "2000000000000000000"),
+            make_trade(weth, usdc, "3000000000000000000"),
+            make_trade(weth, dai, "500000000000000000"),
+        ];
+
+        let pairs = select_top_pairs(&trades, 2, 3, 0.0);
+        assert_eq!(pairs.len(), 2);
+        // WETH→USDC has 3 trades and should rank first.
+        assert_eq!(pairs[0].token_in, weth);
+        assert_eq!(pairs[0].token_out, usdc);
+        assert_eq!(pairs[0].amounts.len(), 3);
+    }
+
+    #[test]
+    fn select_top_pairs_respects_top_n_cap() {
+        let weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+        let usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+        let trades = vec![make_trade(weth, usdc, "1000000000000000000")];
+        let pairs = select_top_pairs(&trades, 10, 1, 0.0);
+        // Only 1 unique pair exists.
+        assert_eq!(pairs.len(), 1);
+    }
+
+    #[test]
+    fn select_top_pairs_empty_input() {
+        let pairs = select_top_pairs(&[], 10, 10, 0.0);
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn min_amount_usd_filters_dust() {
+        let weth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
+        let usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+        // dust: 0.001 WETH ≈ $2.50, below $250 threshold
+        let dust = "1000000000000000";
+        // real: 0.1 WETH ≈ $250, at threshold
+        let real = "100000000000000000";
+        let trades = vec![make_trade(weth, usdc, dust), make_trade(weth, usdc, real)];
+        // Without filter: both amounts included
+        let pairs_all = select_top_pairs(&trades, 1, 2, 0.0);
+        assert_eq!(pairs_all[0].amounts.len(), 2);
+        // With $250 filter: only the real amount survives; percentile_sample still returns n
+        // values but all are the same (single-point distribution).
+        let pairs_filtered = select_top_pairs(&trades, 1, 2, 250.0);
+        assert_eq!(pairs_filtered[0].amounts.len(), 2);
+        assert!(pairs_filtered[0]
+            .amounts
+            .iter()
+            .all(|a| a == real));
+        // The dust amount must not appear.
+        assert!(!pairs_filtered[0]
+            .amounts
+            .contains(&dust.to_string()));
+    }
+
+    #[test]
+    fn min_amount_usd_unknown_token_passes_through() {
+        let unknown = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+        let usdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+        // tiny raw amount — but unknown token, so no price to check
+        let trades = vec![make_trade(unknown, usdc, "1")];
+        let pairs = select_top_pairs(&trades, 1, 1, 250.0);
+        assert_eq!(pairs.len(), 1, "unknown token should not be filtered");
+    }
+}

--- a/tools/benchmark/src/requests.rs
+++ b/tools/benchmark/src/requests.rs
@@ -3,7 +3,7 @@
 //! Provides a default WETH→USDC swap, random generation from an embedded
 //! token-pair set (`pairs.json`), and loading from user-supplied JSON files.
 
-use std::str::FromStr;
+use std::{str::FromStr, sync::OnceLock};
 
 use alloy::hex;
 use bytes::Bytes;
@@ -40,6 +40,10 @@ impl SwapRequest {
 
     pub fn token_out_addr(&self) -> &str {
         &self.token_out_addr
+    }
+
+    pub fn raw_amount(&self) -> &str {
+        &self.raw_amount
     }
 
     pub fn to_quote_params(&self) -> QuoteParams {
@@ -84,8 +88,12 @@ struct Token {
     address: String,
 }
 
-fn load_pairs_file() -> PairsFile {
-    serde_json::from_str(PAIRS_JSON).unwrap_or_else(|e| panic!("failed to parse pairs.json: {e}"))
+fn load_pairs_file() -> &'static PairsFile {
+    static PAIRS: OnceLock<PairsFile> = OnceLock::new();
+    PAIRS.get_or_init(|| {
+        serde_json::from_str(PAIRS_JSON)
+            .unwrap_or_else(|e| panic!("failed to parse embedded pairs.json: {e}"))
+    })
 }
 
 fn symbol_for_address(addr: &str, tokens: &[Token]) -> String {
@@ -202,6 +210,48 @@ pub fn load_embedded_trades(
         .map(|_| all[fastrand::usize(..all.len())].clone())
         .collect();
     Ok(requests)
+}
+
+/// Return a human-readable token symbol for an address using the embedded `pairs.json`.
+/// Falls back to a truncated address when the token is not in the list.
+pub fn lookup_symbol(addr: &str) -> String {
+    let file = load_pairs_file();
+    symbol_for_address(addr, &file.tokens)
+}
+
+/// Load all templates from a file without random sampling.
+///
+/// Used for pair-distribution analysis where the full dataset is needed.
+pub fn load_all_templates_from_file(
+    path: &str,
+) -> Result<Vec<SwapRequest>, Box<dyn std::error::Error>> {
+    load_request_templates(path, 5000)
+}
+
+/// Load all 50 embedded aggregator trades deterministically (no random sampling).
+///
+/// Used for pair-distribution analysis when no external dataset is provided.
+pub fn load_all_embedded_templates() -> Vec<SwapRequest> {
+    let Ok(templates) = serde_json::from_str::<Vec<FileRequest>>(TRADES_SAMPLE_JSON) else {
+        return vec![];
+    };
+    let file = load_pairs_file();
+    templates
+        .iter()
+        .filter_map(|tmpl| {
+            let order = tmpl.orders.first()?;
+            let in_sym = symbol_for_address(&order.token_in, &file.tokens);
+            let out_sym = symbol_for_address(&order.token_out, &file.tokens);
+            Some(SwapRequest {
+                label: format!("{} {in_sym} -> {out_sym}", order.amount),
+                token_in_addr: order.token_in.clone(),
+                token_out_addr: order.token_out.clone(),
+                raw_amount: order.amount.clone(),
+                sender_addr: order.sender.clone(),
+                timeout_ms: 5000,
+            })
+        })
+        .collect()
 }
 
 /// Download the full 10k aggregator trade dataset from GitHub Releases.

--- a/tools/benchmark/src/scale.rs
+++ b/tools/benchmark/src/scale.rs
@@ -18,6 +18,7 @@ use fynd_rpc::{
     builder::{FyndRPC, FyndRPCBuilder},
     config::{PoolConfig, WorkerPoolsConfig},
     parse_chain,
+    protocols::resolve_protocols,
 };
 use serde::Serialize;
 use tracing::info;
@@ -45,9 +46,15 @@ pub struct Args {
     #[arg(long)]
     pub worker_counts: String,
 
-    /// Comma-separated protocols for the solver
+    /// Comma-separated protocols for the solver. Supports the `all_onchain` and `native_onchain`
+    /// expansion tokens (the latter drops VM-simulated `vm:*` protocols).
     #[arg(long)]
     pub protocols: String,
+
+    /// Minimum TVL threshold in native token (e.g. ETH). Components below this threshold are
+    /// removed from the market data. Defaults to the chain-specific value when unset.
+    #[arg(long)]
+    pub min_tvl: Option<f64>,
 
     /// Tycho WebSocket URL
     #[arg(long, default_value = "localhost:4242")]
@@ -166,14 +173,10 @@ fn build_solver(
     args: &Args,
     pool_name: &str,
     pool_config: &PoolConfig,
+    protocols: &[String],
     workers: usize,
 ) -> Result<FyndRPC> {
     let chain = parse_chain(&args.chain)?;
-    let protocols: Vec<String> = args
-        .protocols
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .collect();
     let rpc_url = match args.rpc_url.clone() {
         Some(url) => url,
         None => fynd_rpc::config::defaults::default_rpc_url(&args.chain)
@@ -188,9 +191,12 @@ fn build_solver(
     let pools = HashMap::from([(pool_name.to_string(), pool)]);
 
     let mut builder =
-        FyndRPCBuilder::new(chain, pools, args.tycho_url.clone(), rpc_url, protocols)?
+        FyndRPCBuilder::new(chain, pools, args.tycho_url.clone(), rpc_url, protocols.to_vec())?
             .http_port(args.http_port);
 
+    if let Some(min_tvl) = args.min_tvl {
+        builder = builder.min_tvl(min_tvl);
+    }
     if let Some(ref key) = args.tycho_api_key {
         builder = builder.tycho_api_key(key.clone());
     }
@@ -286,6 +292,25 @@ pub async fn run(args: Args) -> Result<()> {
     info!("Worker counts: {:?}", worker_counts);
     info!("Requests per run: {}", args.num_requests);
 
+    // Resolve protocols once (expands `all_onchain` / `native_onchain` via a Tycho RPC call)
+    // and reuse the concrete list for every worker-count iteration.
+    let chain = parse_chain(&args.chain)?;
+    let requested: Vec<String> = args
+        .protocols
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let protocols = resolve_protocols(
+        &args.tycho_url,
+        args.tycho_api_key.as_deref(),
+        !args.disable_tls,
+        chain,
+        &requested,
+    )
+    .await?;
+    info!("Resolved {} protocol(s)", protocols.len());
+
     let requests = load_requests(args.requests_file.as_deref())?;
     let solver_url = format!("http://127.0.0.1:{}", args.http_port);
 
@@ -294,7 +319,7 @@ pub async fn run(args: Args) -> Result<()> {
     for &workers in &worker_counts {
         println!("\n--- Testing with {} worker(s) ---\n", workers);
 
-        let fynd = build_solver(&args, &pool_name, &pool_config, workers)
+        let fynd = build_solver(&args, &pool_name, &pool_config, &protocols, workers)
             .with_context(|| format!("failed to build solver with {workers} workers"))?;
         let handle = fynd.server_handle();
         let server_task = tokio::spawn(fynd.run());


### PR DESCRIPTION
## Summary

- Adds an `audit` subcommand to `fynd-benchmark` that fetches quotes from Fynd and external aggregators (KyberSwap, Nordstern, 0x) for a set of token pairs, then re-executes each quote on-chain via `eth_simulateV1` to measure the real amount received
- ERC-20 state-override support handles both standard Solidity mapping layouts (slots 0–20) and OpenZeppelin v5 namespaced storage
- Native ETH output is validated by injecting a 10-byte EVM balance-reader contract into simulation state; zeroing sender balance and setting `gasPrice=0` ensures the result equals ETH received exactly
- Nordstern non-JSON pseudo-schema responses (returned for unsupported pairs) are treated as `NoRoute` instead of propagating as errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)