### PR TITLE
feat(split routing): Implement build_split_route 

### DIFF
--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -22,6 +22,22 @@ pub(crate) struct HopDescriptor {
     pub(crate) component_id: ComponentId,
     pub(crate) token_in: Token,
     pub(crate) token_out: Token,
+    /// Per-hop output amount, populated by the solving algorithm.
+    pub(crate) amount_out: BigUint,
+    /// Per-hop gas estimate, populated by the solving algorithm.
+    pub(crate) gas: BigUint,
+}
+
+impl HopDescriptor {
+    pub(crate) fn new(component_id: ComponentId, token_in: Token, token_out: Token) -> Self {
+        Self { component_id, token_in, token_out, amount_out: BigUint::ZERO, gas: BigUint::ZERO }
+    }
+
+    pub(crate) fn with_amounts(mut self, amount_out: BigUint, gas: BigUint) -> Self {
+        self.amount_out = amount_out;
+        self.gas = gas;
+        self
+    }
 }
 
 /// A fully-simulated path allocation.
@@ -444,6 +460,8 @@ struct SplitSwap {
     hop: HopDescriptor,
     split: f64,
     amount_in: BigUint,
+    amount_out: BigUint,
+    gas: BigUint,
 }
 
 /// Merge shared hops across paths, summing their flow fractions, and return
@@ -461,15 +479,20 @@ fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>>
                 hop.token_out.address.clone(),
             );
             hops.entry(key)
-                .and_modify(|h| h.split += path.flow_fraction)
+                .and_modify(|h| {
+                    h.split += path.flow_fraction;
+                    h.amount_out += &hop.amount_out;
+                })
                 .or_insert(SplitSwap {
-                    hop: HopDescriptor {
-                        component_id: hop.component_id.clone(),
-                        token_in: hop.token_in.clone(),
-                        token_out: hop.token_out.clone(),
-                    },
+                    hop: HopDescriptor::new(
+                        hop.component_id.clone(),
+                        hop.token_in.clone(),
+                        hop.token_out.clone(),
+                    ),
                     split: path.flow_fraction,
                     amount_in: BigUint::ZERO,
+                    amount_out: hop.amount_out.clone(),
+                    gas: hop.gas.clone(),
                 });
         }
     }
@@ -531,8 +554,8 @@ pub(crate) fn build_split_route(
 ) -> Result<Route, AlgorithmError> {
     let mut hops_by_token = merge_shared_hops(paths);
 
-    let mut queue = VecDeque::new();
-    queue.push_back(order.token_in().clone());
+    let mut pending_tokens = VecDeque::new();
+    pending_tokens.push_back(order.token_in().clone());
 
     let mut available: HashMap<Bytes, BigUint> = HashMap::new();
     available.insert(order.token_in().clone(), order.amount().clone());
@@ -540,11 +563,10 @@ pub(crate) fn build_split_route(
     let mut swaps = Vec::new();
     let mut route_tokens: HashMap<Bytes, Token> = HashMap::new();
     let mut visited: HashSet<Bytes> = HashSet::new();
-    let mut state_overrides = MarketOverrides::empty();
 
-    // BFS from the source token: at each token, simulate outgoing hops,
-    // build Swap objects, and track post-swap pool states for downstream hops.
-    while let Some(token_addr) = queue.pop_front() {
+    // BFS from the source token: at each token, assemble Swap objects from
+    // pre-computed hop amounts (populated by the solving algorithm).
+    while let Some(token_addr) = pending_tokens.pop_front() {
         // Converging paths (e.g. B→D and C→D) add D to the queue twice — skip duplicates.
         if !visited.insert(token_addr.clone()) {
             continue;
@@ -558,63 +580,48 @@ pub(crate) fn build_split_route(
             .cloned()
             .unwrap_or_default();
 
-        for SplitSwap {
-            hop: HopDescriptor { component_id, token_in, token_out },
-            split,
-            amount_in,
-        } in apply_remainder_convention(group, &total)
-        {
-            let sim = state_overrides
-                .get(&component_id)
-                .or_else(|| market.get_simulation_state(&component_id))
+        for split_swap in apply_remainder_convention(group, &total) {
+            let sim = market
+                .get_simulation_state(&split_swap.hop.component_id)
                 .ok_or_else(|| AlgorithmError::DataNotFound {
                     kind: "simulation state",
-                    id: Some(component_id.clone()),
+                    id: Some(split_swap.hop.component_id.clone()),
                 })?;
 
             let component = market
-                .get_component(&component_id)
+                .get_component(&split_swap.hop.component_id)
                 .ok_or_else(|| AlgorithmError::DataNotFound {
                     kind: "protocol component",
-                    id: Some(component_id.clone()),
+                    id: Some(split_swap.hop.component_id.clone()),
                 })?;
 
-            // Simulate to obtain amount_out, gas, and post-swap state needed by Swap.
-            let result = sim
-                .get_amount_out(amount_in.clone(), &token_in, &token_out)
-                .map_err(|e| AlgorithmError::SimulationFailed {
-                    component_id: component_id.clone(),
-                    error: e.to_string(),
-                })?;
-
-            let in_addr = token_in.address.clone();
-            let out_addr = token_out.address.clone();
+            let in_addr = split_swap.hop.token_in.address.clone();
+            let out_addr = split_swap.hop.token_out.address.clone();
+            *available
+                .entry(out_addr.clone())
+                .or_default() += &split_swap.amount_out;
             swaps.push(
                 Swap::new(
-                    component_id.clone(),
+                    split_swap.hop.component_id,
                     component.protocol_system.clone(),
                     in_addr.clone(),
                     out_addr.clone(),
-                    amount_in,
-                    result.amount.clone(),
-                    result.gas,
+                    split_swap.amount_in,
+                    split_swap.amount_out,
+                    split_swap.gas,
                     component.clone(),
                     sim.clone_box(),
                 )
-                .with_split(split),
+                .with_split(split_swap.split),
             );
             route_tokens
                 .entry(in_addr)
-                .or_insert(token_in);
+                .or_insert(split_swap.hop.token_in);
             route_tokens
                 .entry(out_addr.clone())
-                .or_insert(token_out);
-            state_overrides = state_overrides.with_override(component_id, result.new_state);
-            *available
-                .entry(out_addr.clone())
-                .or_default() += &result.amount;
+                .or_insert(split_swap.hop.token_out);
             if !visited.contains(&out_addr) {
-                queue.push_back(out_addr);
+                pending_tokens.push_back(out_addr);
             }
         }
     }
@@ -736,11 +743,7 @@ mod tests {
             Box::new(MockProtocolSim::new(3.0)),
         )]);
 
-        let hops = [HopDescriptor {
-            component_id: "pool_ab".to_string(),
-            token_in: token_a,
-            token_out: token_b,
-        }];
+        let hops = [HopDescriptor::new("pool_ab".to_string(), token_a, token_b)];
 
         let product =
             compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
@@ -766,16 +769,8 @@ mod tests {
         ]);
 
         let hops = [
-            HopDescriptor {
-                component_id: "pool_ab".to_string(),
-                token_in: token_a,
-                token_out: token_b.clone(),
-            },
-            HopDescriptor {
-                component_id: "pool_bc".to_string(),
-                token_in: token_b,
-                token_out: token_c,
-            },
+            HopDescriptor::new("pool_ab".to_string(), token_a, token_b.clone()),
+            HopDescriptor::new("pool_bc".to_string(), token_b, token_c),
         ];
 
         let product =
@@ -794,11 +789,7 @@ mod tests {
             Box::new(MockProtocolSim::new(3.0)),
         )]);
 
-        let hops = [HopDescriptor {
-            component_id: "pool_ab".to_string(),
-            token_in: token_a,
-            token_out: token_b,
-        }];
+        let hops = [HopDescriptor::new("pool_ab".to_string(), token_a, token_b)];
 
         // Override pool_ab with a different spot price.
         let overrides = MarketOverrides::empty()
@@ -829,16 +820,8 @@ mod tests {
         ]);
 
         let hops = [
-            HopDescriptor {
-                component_id: "pool_ab".to_string(),
-                token_in: token_a,
-                token_out: token_b.clone(),
-            },
-            HopDescriptor {
-                component_id: "pool_bc".to_string(),
-                token_in: token_b,
-                token_out: token_c,
-            },
+            HopDescriptor::new("pool_ab".to_string(), token_a, token_b.clone()),
+            HopDescriptor::new("pool_bc".to_string(), token_b, token_c),
         ];
 
         let amount_in = BigUint::from(1000u64);
@@ -872,16 +855,8 @@ mod tests {
             .with_zero_gas("pool_ab".to_string(), Box::new(sim_ab))
             .with_override("pool_bc".to_string(), Box::new(sim_bc));
 
-        let hops_ab = [HopDescriptor {
-            component_id: "pool_ab".to_string(),
-            token_in: token_a.clone(),
-            token_out: token_b.clone(),
-        }];
-        let hops_bc = [HopDescriptor {
-            component_id: "pool_bc".to_string(),
-            token_in: token_b,
-            token_out: token_c,
-        }];
+        let hops_ab = [HopDescriptor::new("pool_ab".to_string(), token_a.clone(), token_b.clone())];
+        let hops_bc = [HopDescriptor::new("pool_bc".to_string(), token_b, token_c)];
         let amount_in = BigUint::from(1000u64);
 
         let normal_ab =
@@ -923,16 +898,8 @@ mod tests {
             ),
         ]);
 
-        let hops_1 = [HopDescriptor {
-            component_id: "pool_1".to_string(),
-            token_in: token_a.clone(),
-            token_out: token_b.clone(),
-        }];
-        let hops_2 = [HopDescriptor {
-            component_id: "pool_2".to_string(),
-            token_in: token_a,
-            token_out: token_b,
-        }];
+        let hops_1 = [HopDescriptor::new("pool_1".to_string(), token_a.clone(), token_b.clone())];
+        let hops_2 = [HopDescriptor::new("pool_2".to_string(), token_a, token_b)];
 
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
@@ -981,25 +948,13 @@ mod tests {
 
         // Path 1: A -> P1 -> B -> P2 -> C (uses P1 and P2)
         let hops_1 = [
-            HopDescriptor {
-                component_id: "P1".to_string(),
-                token_in: token_a.clone(),
-                token_out: token_b.clone(),
-            },
-            HopDescriptor {
-                component_id: "P2".to_string(),
-                token_in: token_b.clone(),
-                token_out: token_c,
-            },
+            HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone()),
+            HopDescriptor::new("P2".to_string(), token_b.clone(), token_c),
         ];
         // Path 2: A -> P1 -> B -> P3 -> D (uses P1 and P3)
         let hops_2 = [
-            HopDescriptor {
-                component_id: "P1".to_string(),
-                token_in: token_a,
-                token_out: token_b.clone(),
-            },
-            HopDescriptor { component_id: "P3".to_string(), token_in: token_b, token_out: token_d },
+            HopDescriptor::new("P1".to_string(), token_a, token_b.clone()),
+            HopDescriptor::new("P3".to_string(), token_b, token_d),
         ];
 
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
@@ -1031,16 +986,8 @@ mod tests {
             Box::new(MockProtocolSim::new(1.0).with_gas(80_000)),
         )]);
 
-        let hops_1 = [HopDescriptor {
-            component_id: "tripool".to_string(),
-            token_in: token_a,
-            token_out: token_b.clone(),
-        }];
-        let hops_2 = [HopDescriptor {
-            component_id: "tripool".to_string(),
-            token_in: token_b,
-            token_out: token_c,
-        }];
+        let hops_1 = [HopDescriptor::new("tripool".to_string(), token_a, token_b.clone())];
+        let hops_2 = [HopDescriptor::new("tripool".to_string(), token_b, token_c)];
 
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
@@ -1069,11 +1016,7 @@ mod tests {
         )]);
 
         let allocation = PathAllocation {
-            hops: vec![HopDescriptor {
-                component_id: "pool_ab".to_string(),
-                token_in: token_a.clone(),
-                token_out: token_b.clone(),
-            }],
+            hops: vec![HopDescriptor::new("pool_ab".to_string(), token_a.clone(), token_b.clone())],
             flow_fraction: 1.0,
             amount_in: BigUint::from(1000u64),
             amount_out: BigUint::from(1818u64),
@@ -1117,16 +1060,8 @@ mod tests {
         let paths = vec![
             PathAllocation {
                 hops: vec![
-                    HopDescriptor {
-                        component_id: "P1".to_string(),
-                        token_in: token_a.clone(),
-                        token_out: token_b.clone(),
-                    },
-                    HopDescriptor {
-                        component_id: "P2".to_string(),
-                        token_in: token_b.clone(),
-                        token_out: token_c.clone(),
-                    },
+                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone()),
+                    HopDescriptor::new("P2".to_string(), token_b.clone(), token_c.clone()),
                 ],
                 flow_fraction: 0.6,
                 amount_in: BigUint::from(600u64),
@@ -1135,16 +1070,8 @@ mod tests {
             },
             PathAllocation {
                 hops: vec![
-                    HopDescriptor {
-                        component_id: "P1".to_string(),
-                        token_in: token_a.clone(),
-                        token_out: token_b.clone(),
-                    },
-                    HopDescriptor {
-                        component_id: "P3".to_string(),
-                        token_in: token_b.clone(),
-                        token_out: token_c.clone(),
-                    },
+                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone()),
+                    HopDescriptor::new("P3".to_string(), token_b.clone(), token_c.clone()),
                 ],
                 flow_fraction: 0.4,
                 amount_in: BigUint::from(400u64),
@@ -1177,22 +1104,18 @@ mod tests {
 
         let group = vec![
             SplitSwap {
-                hop: HopDescriptor {
-                    component_id: "pool1".to_string(),
-                    token_in: token_a.clone(),
-                    token_out: token_b.clone(),
-                },
+                hop: HopDescriptor::new("pool1".to_string(), token_a.clone(), token_b.clone()),
                 split: 0.7,
                 amount_in: BigUint::ZERO,
+                amount_out: BigUint::ZERO,
+                gas: BigUint::ZERO,
             },
             SplitSwap {
-                hop: HopDescriptor {
-                    component_id: "pool2".to_string(),
-                    token_in: token_a.clone(),
-                    token_out: token_b.clone(),
-                },
+                hop: HopDescriptor::new("pool2".to_string(), token_a.clone(), token_b.clone()),
                 split: 0.3,
                 amount_in: BigUint::ZERO,
+                amount_out: BigUint::ZERO,
+                gas: BigUint::ZERO,
             },
         ];
 
@@ -1226,35 +1149,39 @@ mod tests {
         ]);
         let ord = order(&token_a, &token_b, 1000, OrderSide::Sell);
 
+        let gas = BigUint::from(50_000u64);
         let paths = vec![
             PathAllocation {
-                hops: vec![HopDescriptor {
-                    component_id: "pool1".to_string(),
-                    token_in: token_a.clone(),
-                    token_out: token_b.clone(),
-                }],
+                hops: vec![HopDescriptor::new(
+                    "pool1".to_string(),
+                    token_a.clone(),
+                    token_b.clone(),
+                )
+                .with_amounts(BigUint::from(1000u64), gas.clone())],
                 flow_fraction: 0.5,
                 amount_in: BigUint::from(500u64),
                 amount_out: BigUint::from(1000u64),
                 marginal_price_product: 2.0,
             },
             PathAllocation {
-                hops: vec![HopDescriptor {
-                    component_id: "pool2".to_string(),
-                    token_in: token_a.clone(),
-                    token_out: token_b.clone(),
-                }],
+                hops: vec![HopDescriptor::new(
+                    "pool2".to_string(),
+                    token_a.clone(),
+                    token_b.clone(),
+                )
+                .with_amounts(BigUint::from(900u64), gas.clone())],
                 flow_fraction: 0.3,
                 amount_in: BigUint::from(300u64),
                 amount_out: BigUint::from(900u64),
                 marginal_price_product: 3.0,
             },
             PathAllocation {
-                hops: vec![HopDescriptor {
-                    component_id: "pool3".to_string(),
-                    token_in: token_a.clone(),
-                    token_out: token_b.clone(),
-                }],
+                hops: vec![HopDescriptor::new(
+                    "pool3".to_string(),
+                    token_a.clone(),
+                    token_b.clone(),
+                )
+                .with_amounts(BigUint::from(800u64), gas)],
                 flow_fraction: 0.2,
                 amount_in: BigUint::from(200u64),
                 amount_out: BigUint::from(800u64),
@@ -1296,18 +1223,13 @@ mod tests {
         ]);
         let ord = order(&token_a, &token_c, 1000, OrderSide::Sell);
 
+        let gas = BigUint::from(50_000u64);
         let paths = vec![PathAllocation {
             hops: vec![
-                HopDescriptor {
-                    component_id: "pool_ab".to_string(),
-                    token_in: token_a.clone(),
-                    token_out: token_b.clone(),
-                },
-                HopDescriptor {
-                    component_id: "pool_bc".to_string(),
-                    token_in: token_b,
-                    token_out: token_c,
-                },
+                HopDescriptor::new("pool_ab".to_string(), token_a.clone(), token_b.clone())
+                    .with_amounts(BigUint::from(2000u64), gas.clone()),
+                HopDescriptor::new("pool_bc".to_string(), token_b, token_c)
+                    .with_amounts(BigUint::from(6000u64), gas),
             ],
             flow_fraction: 1.0,
             amount_in: BigUint::from(1000u64),
@@ -1343,19 +1265,14 @@ mod tests {
         ]);
         let ord = order(&token_a, &token_c, 1000, OrderSide::Sell);
 
+        let gas = BigUint::from(50_000u64);
         let paths = vec![
             PathAllocation {
                 hops: vec![
-                    HopDescriptor {
-                        component_id: "P1".to_string(),
-                        token_in: token_a.clone(),
-                        token_out: token_b.clone(),
-                    },
-                    HopDescriptor {
-                        component_id: "P2".to_string(),
-                        token_in: token_b.clone(),
-                        token_out: token_c.clone(),
-                    },
+                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())
+                        .with_amounts(BigUint::from(1400u64), gas.clone()),
+                    HopDescriptor::new("P2".to_string(), token_b.clone(), token_c.clone())
+                        .with_amounts(BigUint::from(4200u64), gas.clone()),
                 ],
                 flow_fraction: 0.7,
                 amount_in: BigUint::from(700u64),
@@ -1364,16 +1281,10 @@ mod tests {
             },
             PathAllocation {
                 hops: vec![
-                    HopDescriptor {
-                        component_id: "P1".to_string(),
-                        token_in: token_a.clone(),
-                        token_out: token_b.clone(),
-                    },
-                    HopDescriptor {
-                        component_id: "P3".to_string(),
-                        token_in: token_b.clone(),
-                        token_out: token_c.clone(),
-                    },
+                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())
+                        .with_amounts(BigUint::from(600u64), gas.clone()),
+                    HopDescriptor::new("P3".to_string(), token_b.clone(), token_c.clone())
+                        .with_amounts(BigUint::from(2400u64), gas),
                 ],
                 flow_fraction: 0.3,
                 amount_in: BigUint::from(300u64),
@@ -1388,13 +1299,18 @@ mod tests {
         // Exactly 3 swaps: one combined A→B, two divergent B→C.
         assert_eq!(swaps.len(), 3, "expected 3 swaps, got {}", swaps.len());
 
-        // First swap: combined A→B via P1 with the full order amount.
+        // First swap: combined A→B via P1 — amount_out is sum of per-path outputs.
         let ab_swap = &swaps[0];
         assert_eq!(ab_swap.component_id(), "P1");
         assert_eq!(
             *ab_swap.amount_in(),
             BigUint::from(1000u64),
             "A→B swap amount_in should equal sum of both paths"
+        );
+        assert_eq!(
+            *ab_swap.amount_out(),
+            BigUint::from(2000u64),
+            "A→B amount_out should be sum of per-path outputs (1400+600)"
         );
         assert_eq!(*ab_swap.split(), 0.0, "only swap at A→B should be remainder");
 
@@ -1443,19 +1359,14 @@ mod tests {
         ]);
         let ord = order(&token_a, &token_z, 1000, OrderSide::Sell);
 
+        let gas = BigUint::from(50_000u64);
         let paths = vec![
             PathAllocation {
                 hops: vec![
-                    HopDescriptor {
-                        component_id: "pool_ab".to_string(),
-                        token_in: token_a.clone(),
-                        token_out: token_b.clone(),
-                    },
-                    HopDescriptor {
-                        component_id: "pool_bz".to_string(),
-                        token_in: token_b,
-                        token_out: token_z.clone(),
-                    },
+                    HopDescriptor::new("pool_ab".to_string(), token_a.clone(), token_b.clone())
+                        .with_amounts(BigUint::from(1200u64), gas.clone()),
+                    HopDescriptor::new("pool_bz".to_string(), token_b, token_z.clone())
+                        .with_amounts(BigUint::from(4800u64), gas.clone()),
                 ],
                 flow_fraction: 0.6,
                 amount_in: BigUint::from(600u64),
@@ -1464,16 +1375,10 @@ mod tests {
             },
             PathAllocation {
                 hops: vec![
-                    HopDescriptor {
-                        component_id: "pool_ac".to_string(),
-                        token_in: token_a.clone(),
-                        token_out: token_c.clone(),
-                    },
-                    HopDescriptor {
-                        component_id: "pool_cz".to_string(),
-                        token_in: token_c,
-                        token_out: token_z,
-                    },
+                    HopDescriptor::new("pool_ac".to_string(), token_a.clone(), token_c.clone())
+                        .with_amounts(BigUint::from(1200u64), gas.clone()),
+                    HopDescriptor::new("pool_cz".to_string(), token_c, token_z)
+                        .with_amounts(BigUint::from(6000u64), gas),
                 ],
                 flow_fraction: 0.4,
                 amount_in: BigUint::from(400u64),

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -482,6 +482,8 @@ fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>>
                 .and_modify(|h| {
                     h.split += path.flow_fraction;
                     h.amount_out += &hop.amount_out;
+                    // Gas is not summed: swapping more on the same pool does not
+                    // increase gas compared to swapping less.
                 })
                 .or_insert(SplitSwap {
                     hop: HopDescriptor::new(
@@ -1053,6 +1055,12 @@ mod tests {
     #[test]
     fn test_merge_shared_hops_combines_fractions() {
         // Two paths share the first hop A→B via P1; second hops diverge.
+        //
+        //                P2
+        //               /    \
+        //  A -- P1 --> B      C
+        //               \    /
+        //                P3
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
@@ -1252,7 +1260,7 @@ mod tests {
         //
         //                  P2 (price=3) --> C
         //                 /
-        //  A -- P1 (2) --+
+        //  A -- P1 (2) --B
         //                 \
         //                  P3 (price=4) --> C
         let token_a = token(0x0A, "A");
@@ -1312,7 +1320,11 @@ mod tests {
             BigUint::from(2000u64),
             "A→B amount_out should be sum of per-path outputs (1400+600)"
         );
-        assert_eq!(*ab_swap.split(), 0.0, "only swap at A→B should be remainder");
+        assert_eq!(
+            *ab_swap.split(),
+            0.0,
+            "A→B is the sole swap in its group, so it gets the remainder convention (split = 0.0)"
+        );
 
         // B→C swaps: P2 (0.7) first, P3 (0.3) last.
         assert_eq!(swaps[1].component_id(), "P2");
@@ -1326,11 +1338,11 @@ mod tests {
         // Paths A→B→Z and A→C→Z: source-level split with different
         // intermediate tokens.
         //
-        //       pool_ab --> B -- pool_bz --> Z
-        //      /
-        //  A --
-        //      \
-        //       pool_ac --> C -- pool_cz --> Z
+        //       pool_ab --> B -- pool_bz
+        //      /                         \
+        //  A --                           Z
+        //      \                         /
+        //       pool_ac --> C -- pool_cz
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use num_bigint::BigUint;
 use num_traits::{ToPrimitive, Zero};
@@ -12,7 +12,11 @@ use tycho_simulation::tycho_common::{
     Bytes,
 };
 
-use crate::{algorithm::AlgorithmError, feed::market_data::MarketState, types::ComponentId};
+use crate::{
+    algorithm::AlgorithmError,
+    feed::market_data::MarketState,
+    types::{ComponentId, Order, Route, Swap},
+};
 
 pub(crate) struct HopDescriptor {
     pub(crate) component_id: ComponentId,
@@ -436,12 +440,197 @@ pub(crate) fn build_post_swap_overrides(
     overrides
 }
 
+struct SplitSwap {
+    hop: HopDescriptor,
+    split: f64,
+    amount_in: BigUint,
+}
+
+/// Merge shared hops across paths, summing their flow fractions, and return
+/// them grouped by `token_in` (sorted by fraction descending within each
+/// group).
+fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>> {
+    type HopKey = (ComponentId, Bytes, Bytes);
+    let mut hops: HashMap<HopKey, SplitSwap> = HashMap::new();
+
+    for path in paths {
+        for hop in &path.hops {
+            let key: HopKey = (
+                hop.component_id.clone(),
+                hop.token_in.address.clone(),
+                hop.token_out.address.clone(),
+            );
+            hops.entry(key)
+                .and_modify(|h| h.split += path.flow_fraction)
+                .or_insert(SplitSwap {
+                    hop: HopDescriptor {
+                        component_id: hop.component_id.clone(),
+                        token_in: hop.token_in.clone(),
+                        token_out: hop.token_out.clone(),
+                    },
+                    split: path.flow_fraction,
+                    amount_in: BigUint::ZERO,
+                });
+        }
+    }
+
+    let mut hops_by_token: HashMap<Bytes, Vec<SplitSwap>> = HashMap::new();
+    for (_, swap) in hops {
+        hops_by_token
+            .entry(swap.hop.token_in.address.clone())
+            .or_default()
+            .push(swap);
+    }
+    for group in hops_by_token.values_mut() {
+        group.sort_by(|a, b| {
+            b.split
+                .partial_cmp(&a.split)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+    hops_by_token
+}
+
+/// Assign each hop in a group its input amount and final split value using the
+/// tycho-execution remainder convention: last hop (smallest fraction) gets
+/// `split = 0.0`.
+fn apply_remainder_convention(
+    mut hops: Vec<SplitSwap>,
+    total_available: &BigUint,
+) -> Vec<SplitSwap> {
+    let len = hops.len();
+    let fraction_total: f64 = hops.iter().map(|h| h.split).sum();
+
+    let normalized: Vec<f64> = hops
+        .iter()
+        .map(|h| h.split / fraction_total)
+        .collect();
+    let amounts = fractions_to_amounts(total_available, &normalized)
+        .unwrap_or_else(|_| vec![total_available.clone()]);
+
+    for (i, (swap, amount)) in hops.iter_mut().zip(amounts).enumerate() {
+        swap.amount_in = amount;
+        swap.split = if i == len - 1 { 0.0 } else { normalized[i] };
+    }
+    hops
+}
+
+/// Assembles a [`Route`] from split-route path allocations with shared-hop
+/// deduplication.
+///
+/// Paths may share pool hops (same `component_id`, `token_in`, `token_out`).
+/// When they do, this function emits one combined swap rather than duplicates.
+/// Within each group of swaps sharing a `token_in`, the tycho-execution
+/// remainder convention is applied: sorted by fraction descending, all but the
+/// last receive their explicit split fraction, while the last gets
+/// `split = 0.0` (meaning "use all remaining balance").
+pub(crate) fn build_split_route(
+    paths: &[PathAllocation],
+    market: &MarketState,
+    order: &Order,
+) -> Result<Route, AlgorithmError> {
+    let mut hops_by_token = merge_shared_hops(paths);
+
+    let mut queue = VecDeque::new();
+    queue.push_back(order.token_in().clone());
+
+    let mut available: HashMap<Bytes, BigUint> = HashMap::new();
+    available.insert(order.token_in().clone(), order.amount().clone());
+
+    let mut swaps = Vec::new();
+    let mut route_tokens: HashMap<Bytes, Token> = HashMap::new();
+    let mut visited: HashSet<Bytes> = HashSet::new();
+    let mut state_overrides = MarketOverrides::empty();
+
+    // BFS from the source token: at each token, simulate outgoing hops,
+    // build Swap objects, and track post-swap pool states for downstream hops.
+    while let Some(token_addr) = queue.pop_front() {
+        // Converging paths (e.g. B→D and C→D) add D to the queue twice — skip duplicates.
+        if !visited.insert(token_addr.clone()) {
+            continue;
+        }
+        // Terminal tokens (e.g. the final output) have no outgoing swaps.
+        let Some(group) = hops_by_token.remove(&token_addr) else {
+            continue;
+        };
+        let total = available
+            .get(&token_addr)
+            .cloned()
+            .unwrap_or_default();
+
+        for SplitSwap {
+            hop: HopDescriptor { component_id, token_in, token_out },
+            split,
+            amount_in,
+        } in apply_remainder_convention(group, &total)
+        {
+            let sim = state_overrides
+                .get(&component_id)
+                .or_else(|| market.get_simulation_state(&component_id))
+                .ok_or_else(|| AlgorithmError::DataNotFound {
+                    kind: "simulation state",
+                    id: Some(component_id.clone()),
+                })?;
+
+            let component = market
+                .get_component(&component_id)
+                .ok_or_else(|| AlgorithmError::DataNotFound {
+                    kind: "protocol component",
+                    id: Some(component_id.clone()),
+                })?;
+
+            // Simulate to obtain amount_out, gas, and post-swap state needed by Swap.
+            let result = sim
+                .get_amount_out(amount_in.clone(), &token_in, &token_out)
+                .map_err(|e| AlgorithmError::SimulationFailed {
+                    component_id: component_id.clone(),
+                    error: e.to_string(),
+                })?;
+
+            let in_addr = token_in.address.clone();
+            let out_addr = token_out.address.clone();
+            swaps.push(
+                Swap::new(
+                    component_id.clone(),
+                    component.protocol_system.clone(),
+                    in_addr.clone(),
+                    out_addr.clone(),
+                    amount_in,
+                    result.amount.clone(),
+                    result.gas,
+                    component.clone(),
+                    sim.clone_box(),
+                )
+                .with_split(split),
+            );
+            route_tokens
+                .entry(in_addr)
+                .or_insert(token_in);
+            route_tokens
+                .entry(out_addr.clone())
+                .or_insert(token_out);
+            state_overrides = state_overrides.with_override(component_id, result.new_state);
+            *available
+                .entry(out_addr.clone())
+                .or_default() += &result.amount;
+            if !visited.contains(&out_addr) {
+                queue.push_back(out_addr);
+            }
+        }
+    }
+
+    Ok(Route::new(swaps, route_tokens))
+}
+
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
     use super::*;
-    use crate::algorithm::test_utils::{component, token, ConstantProductSim, MockProtocolSim};
+    use crate::{
+        algorithm::test_utils::{component, order, token, ConstantProductSim, MockProtocolSim},
+        types::OrderSide,
+    };
 
     fn make_market(pools: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketState {
         let mut market = MarketState::new();
@@ -914,5 +1103,410 @@ mod tests {
             .unwrap()
             .amount;
         assert_eq!(degraded_out, BigUint::from(163u64));
+    }
+
+    // ==================== merge / allocate Tests ====================
+
+    #[test]
+    fn test_merge_shared_hops_combines_fractions() {
+        // Two paths share the first hop A→B via P1; second hops diverge.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+
+        let paths = vec![
+            PathAllocation {
+                hops: vec![
+                    HopDescriptor {
+                        component_id: "P1".to_string(),
+                        token_in: token_a.clone(),
+                        token_out: token_b.clone(),
+                    },
+                    HopDescriptor {
+                        component_id: "P2".to_string(),
+                        token_in: token_b.clone(),
+                        token_out: token_c.clone(),
+                    },
+                ],
+                flow_fraction: 0.6,
+                amount_in: BigUint::from(600u64),
+                amount_out: BigUint::from(3600u64),
+                marginal_price_product: 6.0,
+            },
+            PathAllocation {
+                hops: vec![
+                    HopDescriptor {
+                        component_id: "P1".to_string(),
+                        token_in: token_a.clone(),
+                        token_out: token_b.clone(),
+                    },
+                    HopDescriptor {
+                        component_id: "P3".to_string(),
+                        token_in: token_b.clone(),
+                        token_out: token_c.clone(),
+                    },
+                ],
+                flow_fraction: 0.4,
+                amount_in: BigUint::from(400u64),
+                amount_out: BigUint::from(1600u64),
+                marginal_price_product: 4.0,
+            },
+        ];
+
+        let hops_by_token = merge_shared_hops(&paths);
+
+        // Group at A: one merged hop (P1, fraction = 0.6 + 0.4 = 1.0).
+        let group_a = &hops_by_token[&token_a.address];
+        assert_eq!(group_a.len(), 1);
+        assert_eq!(group_a[0].hop.component_id, "P1");
+        assert!((group_a[0].split - 1.0).abs() < f64::EPSILON);
+
+        // Group at B: two hops (P2 and P3), sorted descending by fraction.
+        let group_b = &hops_by_token[&token_b.address];
+        assert_eq!(group_b.len(), 2);
+        assert_eq!(group_b[0].hop.component_id, "P2");
+        assert!((group_b[0].split - 0.6).abs() < f64::EPSILON);
+        assert_eq!(group_b[1].hop.component_id, "P3");
+        assert!((group_b[1].split - 0.4).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_apply_remainder_convention_splits_and_amounts() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+
+        let group = vec![
+            SplitSwap {
+                hop: HopDescriptor {
+                    component_id: "pool1".to_string(),
+                    token_in: token_a.clone(),
+                    token_out: token_b.clone(),
+                },
+                split: 0.7,
+                amount_in: BigUint::ZERO,
+            },
+            SplitSwap {
+                hop: HopDescriptor {
+                    component_id: "pool2".to_string(),
+                    token_in: token_a.clone(),
+                    token_out: token_b.clone(),
+                },
+                split: 0.3,
+                amount_in: BigUint::ZERO,
+            },
+        ];
+
+        let result = apply_remainder_convention(group, &BigUint::from(1000u64));
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].split, 0.7);
+        assert_eq!(result[0].amount_in, BigUint::from(700u64));
+        assert_eq!(result[1].split, 0.0);
+        assert_eq!(result[1].amount_in, BigUint::from(300u64));
+    }
+
+    // ==================== build_split_route Tests ====================
+
+    #[test]
+    fn test_build_split_route_remainder_convention() {
+        // 3 paths splitting at source: last swap at the split point must
+        // have split=0.0.
+        //
+        //       500 -- pool1 (price=2) --> 1000
+        //      /
+        //  1000---- 300 -- pool2 (price=3) -->  900
+        //      \
+        //       200 -- pool3 (price=4) -->  800
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![
+            ("pool1", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("pool2", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(3.0))),
+            ("pool3", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(4.0))),
+        ]);
+        let ord = order(&token_a, &token_b, 1000, OrderSide::Sell);
+
+        let paths = vec![
+            PathAllocation {
+                hops: vec![HopDescriptor {
+                    component_id: "pool1".to_string(),
+                    token_in: token_a.clone(),
+                    token_out: token_b.clone(),
+                }],
+                flow_fraction: 0.5,
+                amount_in: BigUint::from(500u64),
+                amount_out: BigUint::from(1000u64),
+                marginal_price_product: 2.0,
+            },
+            PathAllocation {
+                hops: vec![HopDescriptor {
+                    component_id: "pool2".to_string(),
+                    token_in: token_a.clone(),
+                    token_out: token_b.clone(),
+                }],
+                flow_fraction: 0.3,
+                amount_in: BigUint::from(300u64),
+                amount_out: BigUint::from(900u64),
+                marginal_price_product: 3.0,
+            },
+            PathAllocation {
+                hops: vec![HopDescriptor {
+                    component_id: "pool3".to_string(),
+                    token_in: token_a.clone(),
+                    token_out: token_b.clone(),
+                }],
+                flow_fraction: 0.2,
+                amount_in: BigUint::from(200u64),
+                amount_out: BigUint::from(800u64),
+                marginal_price_product: 4.0,
+            },
+        ];
+
+        let route = build_split_route(&paths, &market, &ord).unwrap();
+        let swaps = route.swaps();
+
+        assert_eq!(swaps.len(), 3);
+
+        // Sorted descending: pool1 (0.5), pool2 (0.3), pool3 (0.2).
+        assert_eq!(swaps[0].component_id(), "pool1");
+        assert_eq!(*swaps[0].split(), 0.5);
+        assert_eq!(swaps[1].component_id(), "pool2");
+        assert_eq!(*swaps[1].split(), 0.3);
+        assert_eq!(swaps[2].component_id(), "pool3");
+        assert_eq!(*swaps[2].split(), 0.0);
+    }
+
+    #[test]
+    fn test_build_split_route_single_path() {
+        // Single path A→B→C: all splits must be 0.0.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let market = make_market(vec![
+            (
+                "pool_ab",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0)),
+            ),
+            (
+                "pool_bc",
+                vec![token_b.clone(), token_c.clone()],
+                Box::new(MockProtocolSim::new(3.0)),
+            ),
+        ]);
+        let ord = order(&token_a, &token_c, 1000, OrderSide::Sell);
+
+        let paths = vec![PathAllocation {
+            hops: vec![
+                HopDescriptor {
+                    component_id: "pool_ab".to_string(),
+                    token_in: token_a.clone(),
+                    token_out: token_b.clone(),
+                },
+                HopDescriptor {
+                    component_id: "pool_bc".to_string(),
+                    token_in: token_b,
+                    token_out: token_c,
+                },
+            ],
+            flow_fraction: 1.0,
+            amount_in: BigUint::from(1000u64),
+            amount_out: BigUint::from(6000u64),
+            marginal_price_product: 6.0,
+        }];
+
+        let route = build_split_route(&paths, &market, &ord).unwrap();
+        let swaps = route.swaps();
+
+        assert_eq!(swaps.len(), 2);
+        for swap in swaps {
+            assert_eq!(*swap.split(), 0.0, "single path should produce all-zero splits");
+        }
+    }
+
+    #[test]
+    fn test_build_split_route_shared_first_pool() {
+        // Two paths sharing pool P1 at A→B, diverging at B→C (P2 vs P3).
+        //
+        //                  P2 (price=3) --> C
+        //                 /
+        //  A -- P1 (2) --+
+        //                 \
+        //                  P3 (price=4) --> C
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let market = make_market(vec![
+            ("P1", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("P2", vec![token_b.clone(), token_c.clone()], Box::new(MockProtocolSim::new(3.0))),
+            ("P3", vec![token_b.clone(), token_c.clone()], Box::new(MockProtocolSim::new(4.0))),
+        ]);
+        let ord = order(&token_a, &token_c, 1000, OrderSide::Sell);
+
+        let paths = vec![
+            PathAllocation {
+                hops: vec![
+                    HopDescriptor {
+                        component_id: "P1".to_string(),
+                        token_in: token_a.clone(),
+                        token_out: token_b.clone(),
+                    },
+                    HopDescriptor {
+                        component_id: "P2".to_string(),
+                        token_in: token_b.clone(),
+                        token_out: token_c.clone(),
+                    },
+                ],
+                flow_fraction: 0.7,
+                amount_in: BigUint::from(700u64),
+                amount_out: BigUint::from(4200u64),
+                marginal_price_product: 6.0,
+            },
+            PathAllocation {
+                hops: vec![
+                    HopDescriptor {
+                        component_id: "P1".to_string(),
+                        token_in: token_a.clone(),
+                        token_out: token_b.clone(),
+                    },
+                    HopDescriptor {
+                        component_id: "P3".to_string(),
+                        token_in: token_b.clone(),
+                        token_out: token_c.clone(),
+                    },
+                ],
+                flow_fraction: 0.3,
+                amount_in: BigUint::from(300u64),
+                amount_out: BigUint::from(1200u64),
+                marginal_price_product: 8.0,
+            },
+        ];
+
+        let route = build_split_route(&paths, &market, &ord).unwrap();
+        let swaps = route.swaps();
+
+        // Exactly 3 swaps: one combined A→B, two divergent B→C.
+        assert_eq!(swaps.len(), 3, "expected 3 swaps, got {}", swaps.len());
+
+        // First swap: combined A→B via P1 with the full order amount.
+        let ab_swap = &swaps[0];
+        assert_eq!(ab_swap.component_id(), "P1");
+        assert_eq!(
+            *ab_swap.amount_in(),
+            BigUint::from(1000u64),
+            "A→B swap amount_in should equal sum of both paths"
+        );
+        assert_eq!(*ab_swap.split(), 0.0, "only swap at A→B should be remainder");
+
+        // B→C swaps: P2 (0.7) first, P3 (0.3) last.
+        assert_eq!(swaps[1].component_id(), "P2");
+        assert_eq!(*swaps[1].split(), 0.7);
+        assert_eq!(swaps[2].component_id(), "P3");
+        assert_eq!(*swaps[2].split(), 0.0);
+    }
+
+    #[test]
+    fn test_build_split_route_source_level_split_different_intermediates() {
+        // Paths A→B→Z and A→C→Z: source-level split with different
+        // intermediate tokens.
+        //
+        //       pool_ab --> B -- pool_bz --> Z
+        //      /
+        //  A --
+        //      \
+        //       pool_ac --> C -- pool_cz --> Z
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let token_z = token(0x1A, "Z");
+        let market = make_market(vec![
+            (
+                "pool_ab",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0)),
+            ),
+            (
+                "pool_ac",
+                vec![token_a.clone(), token_c.clone()],
+                Box::new(MockProtocolSim::new(3.0)),
+            ),
+            (
+                "pool_bz",
+                vec![token_b.clone(), token_z.clone()],
+                Box::new(MockProtocolSim::new(4.0)),
+            ),
+            (
+                "pool_cz",
+                vec![token_c.clone(), token_z.clone()],
+                Box::new(MockProtocolSim::new(5.0)),
+            ),
+        ]);
+        let ord = order(&token_a, &token_z, 1000, OrderSide::Sell);
+
+        let paths = vec![
+            PathAllocation {
+                hops: vec![
+                    HopDescriptor {
+                        component_id: "pool_ab".to_string(),
+                        token_in: token_a.clone(),
+                        token_out: token_b.clone(),
+                    },
+                    HopDescriptor {
+                        component_id: "pool_bz".to_string(),
+                        token_in: token_b,
+                        token_out: token_z.clone(),
+                    },
+                ],
+                flow_fraction: 0.6,
+                amount_in: BigUint::from(600u64),
+                amount_out: BigUint::from(4800u64),
+                marginal_price_product: 8.0,
+            },
+            PathAllocation {
+                hops: vec![
+                    HopDescriptor {
+                        component_id: "pool_ac".to_string(),
+                        token_in: token_a.clone(),
+                        token_out: token_c.clone(),
+                    },
+                    HopDescriptor {
+                        component_id: "pool_cz".to_string(),
+                        token_in: token_c,
+                        token_out: token_z,
+                    },
+                ],
+                flow_fraction: 0.4,
+                amount_in: BigUint::from(400u64),
+                amount_out: BigUint::from(6000u64),
+                marginal_price_product: 15.0,
+            },
+        ];
+
+        let route = build_split_route(&paths, &market, &ord).unwrap();
+        let swaps = route.swaps();
+
+        assert_eq!(swaps.len(), 4, "expected 4 swaps (2 source + 2 intermediate)");
+
+        // Source-level split: pool_ab (0.6) first, pool_ac (0.4) last.
+        assert_eq!(swaps[0].component_id(), "pool_ab");
+        assert_eq!(*swaps[0].split(), 0.6);
+        assert_eq!(*swaps[0].amount_in(), BigUint::from(600u64));
+        assert_eq!(*swaps[0].amount_out(), BigUint::from(1200u64));
+
+        assert_eq!(swaps[1].component_id(), "pool_ac");
+        assert_eq!(*swaps[1].split(), 0.0);
+        assert_eq!(*swaps[1].amount_in(), BigUint::from(400u64));
+        assert_eq!(*swaps[1].amount_out(), BigUint::from(1200u64));
+
+        // Intermediate swaps: single hops from B and C, all split=0.0.
+        assert_eq!(swaps[2].component_id(), "pool_bz");
+        assert_eq!(*swaps[2].split(), 0.0);
+        assert_eq!(*swaps[2].amount_in(), BigUint::from(1200u64));
+        assert_eq!(*swaps[2].amount_out(), BigUint::from(4800u64));
+
+        assert_eq!(swaps[3].component_id(), "pool_cz");
+        assert_eq!(*swaps[3].split(), 0.0);
+        assert_eq!(*swaps[3].amount_in(), BigUint::from(1200u64));
+        assert_eq!(*swaps[3].amount_out(), BigUint::from(6000u64));
     }
 }

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -492,6 +492,7 @@ fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>>
                         hop.token_out.clone(),
                     ),
                     split: path.flow_fraction,
+                    // Set later by assign_splits_and_amounts.
                     amount_in: BigUint::ZERO,
                     amount_out: hop.amount_out.clone(),
                     gas: hop.gas.clone(),
@@ -516,10 +517,10 @@ fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>>
     hops_by_token
 }
 
-/// Assign each hop in a group its input amount and final split value using the
-/// tycho-execution remainder convention: last hop (smallest fraction) gets
-/// `split = 0.0`.
-fn apply_remainder_convention(
+/// Normalize fractions within a group, convert them to input amounts, and
+/// assign final split values using the tycho-execution remainder convention
+/// (last hop gets `split = 0.0`).
+fn assign_splits_and_amounts(
     mut hops: Vec<SplitSwap>,
     total_available: &BigUint,
 ) -> Vec<SplitSwap> {
@@ -582,7 +583,7 @@ pub(crate) fn build_split_route(
             .cloned()
             .unwrap_or_default();
 
-        for split_swap in apply_remainder_convention(group, &total) {
+        for split_swap in assign_splits_and_amounts(group, &total) {
             let sim = market
                 .get_simulation_state(&split_swap.hop.component_id)
                 .ok_or_else(|| AlgorithmError::DataNotFound {
@@ -1106,7 +1107,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_remainder_convention_splits_and_amounts() {
+    fn test_assign_splits_and_amounts_splits_and_amounts() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
 
@@ -1127,7 +1128,7 @@ mod tests {
             },
         ];
 
-        let result = apply_remainder_convention(group, &BigUint::from(1000u64));
+        let result = assign_splits_and_amounts(group, &BigUint::from(1000u64));
 
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].split, 0.7);
@@ -1137,7 +1138,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_remainder_convention_single_hop() {
+    fn test_assign_splits_and_amounts_single_hop() {
         // A single hop receives the entire amount with split = 0.0.
         //
         //  1000 -- pool1 (split=0.0) --> B
@@ -1153,7 +1154,7 @@ mod tests {
         }];
 
         let total = BigUint::from(1000u64);
-        let result = apply_remainder_convention(group, &total);
+        let result = assign_splits_and_amounts(group, &total);
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].split, 0.0);

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -23,19 +23,19 @@ pub(crate) struct HopDescriptor {
     pub(crate) token_in: Token,
     pub(crate) token_out: Token,
     /// Per-hop output amount, populated by the solving algorithm.
-    pub(crate) amount_out: BigUint,
+    pub(crate) amount_out: Option<BigUint>,
     /// Per-hop gas estimate, populated by the solving algorithm.
-    pub(crate) gas: BigUint,
+    pub(crate) gas: Option<BigUint>,
 }
 
 impl HopDescriptor {
     pub(crate) fn new(component_id: ComponentId, token_in: Token, token_out: Token) -> Self {
-        Self { component_id, token_in, token_out, amount_out: BigUint::ZERO, gas: BigUint::ZERO }
+        Self { component_id, token_in, token_out, amount_out: None, gas: None }
     }
 
     pub(crate) fn with_amounts(mut self, amount_out: BigUint, gas: BigUint) -> Self {
-        self.amount_out = amount_out;
-        self.gas = gas;
+        self.amount_out = Some(amount_out);
+        self.gas = Some(gas);
         self
     }
 }
@@ -467,7 +467,9 @@ struct SplitSwap {
 /// Merge shared hops across paths, summing their flow fractions, and return
 /// them grouped by `token_in` (sorted by fraction descending within each
 /// group).
-fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>> {
+fn merge_shared_hops(
+    paths: &[PathAllocation],
+) -> Result<HashMap<Bytes, Vec<SplitSwap>>, AlgorithmError> {
     type HopKey = (ComponentId, Bytes, Bytes);
     let mut hops: HashMap<HopKey, SplitSwap> = HashMap::new();
 
@@ -478,10 +480,24 @@ fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>>
                 hop.token_in.address.clone(),
                 hop.token_out.address.clone(),
             );
+            let hop_amount_out =
+                hop.amount_out
+                    .clone()
+                    .ok_or_else(|| AlgorithmError::DataNotFound {
+                        kind: "hop amount_out",
+                        id: Some(hop.component_id.clone()),
+                    })?;
+            let hop_gas = hop
+                .gas
+                .clone()
+                .ok_or_else(|| AlgorithmError::DataNotFound {
+                    kind: "hop gas",
+                    id: Some(hop.component_id.clone()),
+                })?;
             hops.entry(key)
                 .and_modify(|h| {
                     h.split += path.flow_fraction;
-                    h.amount_out += &hop.amount_out;
+                    h.amount_out += &hop_amount_out;
                     // Gas is not summed: swapping more on the same pool does not
                     // increase gas compared to swapping less.
                 })
@@ -494,8 +510,8 @@ fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>>
                     split: path.flow_fraction,
                     // Set later by assign_splits_and_amounts.
                     amount_in: BigUint::ZERO,
-                    amount_out: hop.amount_out.clone(),
-                    gas: hop.gas.clone(),
+                    amount_out: hop_amount_out,
+                    gas: hop_gas,
                 });
         }
     }
@@ -514,7 +530,7 @@ fn merge_shared_hops(paths: &[PathAllocation]) -> HashMap<Bytes, Vec<SplitSwap>>
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
     }
-    hops_by_token
+    Ok(hops_by_token)
 }
 
 /// Normalize fractions within a group, convert them to input amounts, and
@@ -555,7 +571,7 @@ pub(crate) fn build_split_route(
     market: &MarketState,
     order: &Order,
 ) -> Result<Route, AlgorithmError> {
-    let mut hops_by_token = merge_shared_hops(paths);
+    let mut hops_by_token = merge_shared_hops(paths)?;
 
     let mut pending_tokens = VecDeque::new();
     pending_tokens.push_back(order.token_in().clone());
@@ -1066,11 +1082,14 @@ mod tests {
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
 
+        let gas = BigUint::from(50_000u64);
         let paths = vec![
             PathAllocation {
                 hops: vec![
-                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone()),
-                    HopDescriptor::new("P2".to_string(), token_b.clone(), token_c.clone()),
+                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())
+                        .with_amounts(BigUint::from(1200u64), gas.clone()),
+                    HopDescriptor::new("P2".to_string(), token_b.clone(), token_c.clone())
+                        .with_amounts(BigUint::from(3600u64), gas.clone()),
                 ],
                 flow_fraction: 0.6,
                 amount_in: BigUint::from(600u64),
@@ -1079,8 +1098,10 @@ mod tests {
             },
             PathAllocation {
                 hops: vec![
-                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone()),
-                    HopDescriptor::new("P3".to_string(), token_b.clone(), token_c.clone()),
+                    HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())
+                        .with_amounts(BigUint::from(800u64), gas.clone()),
+                    HopDescriptor::new("P3".to_string(), token_b.clone(), token_c.clone())
+                        .with_amounts(BigUint::from(1600u64), gas),
                 ],
                 flow_fraction: 0.4,
                 amount_in: BigUint::from(400u64),
@@ -1089,7 +1110,7 @@ mod tests {
             },
         ];
 
-        let hops_by_token = merge_shared_hops(&paths);
+        let hops_by_token = merge_shared_hops(&paths).unwrap();
 
         // Group at A: one merged hop (P1, fraction = 0.6 + 0.4 = 1.0).
         let group_a = &hops_by_token[&token_a.address];

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -1136,6 +1136,30 @@ mod tests {
         assert_eq!(result[1].amount_in, BigUint::from(300u64));
     }
 
+    #[test]
+    fn test_apply_remainder_convention_single_hop() {
+        // A single hop receives the entire amount with split = 0.0.
+        //
+        //  1000 -- pool1 (split=0.0) --> B
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+
+        let group = vec![SplitSwap {
+            hop: HopDescriptor::new("pool1".to_string(), token_a, token_b),
+            split: 1.0,
+            amount_in: BigUint::ZERO,
+            amount_out: BigUint::ZERO,
+            gas: BigUint::ZERO,
+        }];
+
+        let total = BigUint::from(1000u64);
+        let result = apply_remainder_convention(group, &total);
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].split, 0.0);
+        assert_eq!(result[0].amount_in, total);
+    }
+
     // ==================== build_split_route Tests ====================
 
     #[test]


### PR DESCRIPTION
[Task](https://propeller-heads.atlassian.net/browse/ENG-5846)

Assembles a Route from split-route path allocations, deduplicating shared pool hops into a single combined swap. Emits swaps in BFS topological order (from the first token) with the tycho-execution remainder convention (last swap per split point gets split=0.0).