### PR TITLE
feat: add split route validation

### DIFF
--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -2217,6 +2217,24 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_split_topology_with_all_zero_splits() {
+        // Diamond topology but all split fractions are 0.0.
+        // is_split() returns false, so validate_sequential_route() runs
+        // and rejects the route (connectivity breaks at the second A→ swap).
+        //   ┌──[0.0]── B ──┐
+        // A │               D
+        //   └──[0.0]── C ──┘
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.0), // A→B
+            make_split_swap(0x01, 0x03, 0.0), // A→C
+            make_swap(0x02, 0x04, 490, 480),  // B→D
+            make_swap(0x03, 0x04, 490, 480),  // C→D
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        assert!(route.validate().is_err());
+    }
+
+    #[test]
     fn test_is_split_detection() {
         // A → B                     (no split)
         let route_single = make_route(vec![(0x01, 0x02)]);

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1356,6 +1356,13 @@ fn validate_cycles(
     terminal_token: &Address,
 ) -> Result<(), RouteValidationError> {
     let is_round_trip = first_token == terminal_token;
+    if is_round_trip && swaps_by_token_in.len() <= 1 {
+        return Err(RouteValidationError::UnsupportedCycle {
+            token: first_token.clone(),
+            first: first_token.clone(),
+            last: terminal_token.clone(),
+        });
+    }
     let mut seen_back_edge_group = false;
     let mut earlier_inputs: HashSet<&Address> = HashSet::new();
     for (token_in, group) in swaps_by_token_in {
@@ -1978,6 +1985,20 @@ mod tests {
             make_split_swap(0x01, 0x06, 0.0),                // A→F (remainder)
             make_swap(0x05, 0x06, 270, 260),                 // E→F
             make_swap(0x06, 0x01, 810, 800),                 // F→A
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::UnsupportedCycle { .. }));
+    }
+
+    #[test]
+    fn test_validate_split_single_group_round_trip() {
+        //   ┌──[50%]──┐
+        // A │         │ A   ERROR: single group cycling back to start
+        //   └──[rem]──┘
+        let swaps = vec![
+            make_split_swap(0x01, 0x01, 0.5), // A→A
+            make_split_swap(0x01, 0x01, 0.0), // A→A (remainder)
         ];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1830,7 +1830,9 @@ mod tests {
 
     #[test]
     fn test_validate_interior_split_valid() {
-        // A→B sequential, then B→C parallel with remainder convention
+        //     ┌──[50%]──┐
+        // A → B         C
+        //     └──[rem]──┘
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.0),
             make_split_swap(0x02, 0x03, 0.5),
@@ -1842,7 +1844,9 @@ mod tests {
 
     #[test]
     fn test_validate_interior_split_no_remainder() {
-        // A→B, then B→C parallel but last swap has nonzero split (no remainder)
+        //     ┌──[50%]──┐
+        // A → B         C   ERROR: last swap has split=0.3, not 0.0
+        //     └──[30%]──┘
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.0),
             make_split_swap(0x02, 0x03, 0.5),
@@ -1855,7 +1859,9 @@ mod tests {
 
     #[test]
     fn test_validate_interior_split_sum_exceeds_one() {
-        // A→B, then B→C parallel with explicit splits summing >= 1.0
+        //     ┌──[60%]──┐
+        // A → B──[50%]──C   ERROR: 0.6 + 0.5 ≥ 1.0
+        //     └──[rem]──┘
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.0),
             make_split_swap(0x02, 0x03, 0.6),
@@ -1869,7 +1875,9 @@ mod tests {
 
     #[test]
     fn test_validate_source_split_valid() {
-        // Two parallel legs from A through different intermediates, converging on D
+        //   ┌──[50%]── B ──┐
+        // A │               D
+        //   └──[rem]── C ──┘
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.5),
             make_split_swap(0x01, 0x03, 0.0),
@@ -1882,8 +1890,9 @@ mod tests {
 
     #[test]
     fn test_validate_diamond_split_valid() {
-        // Diamond: A splits to B and D via different intermediates, both converge on C.
-        // A→B (60%), B→C, A→D (remainder), D→C
+        //   ┌──[60%]── B ──┐
+        // A │               C
+        //   └──[rem]── D ──┘
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.6), // A→B, 60%
             make_swap(0x02, 0x03, 590, 580),  // B→C
@@ -1896,7 +1905,7 @@ mod tests {
 
     #[test]
     fn test_validate_split_single_swap_nonzero_split() {
-        // A single swap for a given token_in must have split == 0.0
+        // A ──[50%]── B   ERROR: single swap must have split=0.0
         let swaps = vec![make_split_swap(0x01, 0x02, 0.5)];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();
@@ -1905,7 +1914,9 @@ mod tests {
 
     #[test]
     fn test_validate_split_dead_end() {
-        // A splits to B and C, but the paths don't converge — B→D diverges
+        //   ┌──[50%]── B → D   ERROR: dead end, D not consumed
+        // A │
+        //   └──[rem]── C → E   (terminal)
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.5), // A→B
             make_split_swap(0x01, 0x03, 0.0), // A→C
@@ -1919,7 +1930,9 @@ mod tests {
 
     #[test]
     fn test_validate_split_cycle() {
-        // Both split paths converge back to B, creating a cycle
+        //     ┌──[50%]── C ──┐
+        // A → B               → B   ERROR: C→B and D→B cycle back
+        //     └──[rem]── D ──┘
         let swaps = vec![
             make_swap(0x01, 0x02, 1000, 990),                // A→B
             make_swap(0x02, 0x03, 990, 980).with_split(0.5), // B→C
@@ -1934,7 +1947,9 @@ mod tests {
 
     #[test]
     fn test_validate_split_round_trip_valid() {
-        // A splits to B and C, both converge on D, then D→A (round-trip).
+        //   ┌──[50%]── B ──┐
+        // A │               D → A   (round-trip back to start)
+        //   └──[rem]── C ──┘
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.5), // A→B
             make_split_swap(0x01, 0x03, 0.0), // A→C
@@ -1948,9 +1963,12 @@ mod tests {
 
     #[test]
     fn test_validate_split_multi_back_edge_groups() {
-        // A→B→D→A→F→A and A→C→D→E→F→A — two groups (D and F) produce
-        // back-edges to A, which means A is visited more than twice.
-        // A→F merges into group A so splits must account for all three.
+        //   ┌──[30%]── B ──┐       ┌──[rem]──┐
+        // A ┤               D──→A──┤          F──→A
+        //   └──[30%]── C ──┘       └──── E ──┘
+        //                    ↑                  ↑
+        //              back-edge 1        back-edge 2
+        //         ERROR: two groups cycle back to A
         let swaps = vec![
             make_split_swap(0x01, 0x02, 0.3),                // A→B
             make_split_swap(0x01, 0x03, 0.3),                // A→C
@@ -1969,8 +1987,9 @@ mod tests {
 
     #[test]
     fn test_validate_split_terminal_is_group_input() {
-        // A→C→B→C: terminal C is also a group input, creating a cycle.
-        // Not a round-trip (first=A ≠ terminal=C).
+        //     ┌──[50%]── B ──┐
+        // A → C               → C   ERROR: B→C and D→C cycle back
+        //     └──[rem]── D ──┘       (not a round-trip: first=A ≠ terminal=C)
         let swaps = vec![
             make_swap(0x01, 0x03, 1000, 990),                // A→C
             make_swap(0x03, 0x02, 990, 980).with_split(0.5), // C→B
@@ -2200,15 +2219,17 @@ mod tests {
 
     #[test]
     fn test_is_split_detection() {
-        // Single hop, no split
+        // A → B                     (no split)
         let route_single = make_route(vec![(0x01, 0x02)]);
         assert!(!route_single.is_split());
 
-        // Multi-hop, no split
+        // A → B → C                 (no split)
         let route_multi = make_route(vec![(0x01, 0x02), (0x02, 0x03)]);
         assert!(!route_multi.is_split());
 
-        // Interior split: A→B single, B→C through two parallel pools
+        //     ┌──[60%]──┐
+        // A → B         C           (interior split)
+        //     └──[rem]──┘
         let swaps_interior = vec![
             make_swap(0x01, 0x02, 1000, 990),                // A→B, no split
             make_swap(0x02, 0x03, 594, 580).with_split(0.6), // B→C via P2, 60%
@@ -2217,7 +2238,9 @@ mod tests {
         let route_interior = Route::new(swaps_interior, HashMap::new());
         assert!(route_interior.is_split());
 
-        // Source-level split: two routes with different intermediates
+        //   ┌──[60%]── B ──┐
+        // A │               C       (source-level split)
+        //   └──[rem]── D ──┘
         let swaps_source = vec![
             make_swap(0x01, 0x02, 600, 590).with_split(0.6), // A→B, 60%
             make_swap(0x02, 0x03, 590, 580),                 // B→C

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1149,7 +1149,16 @@ impl Route {
         if self.is_split() {
             return self.validate_split_route();
         }
+        self.validate_sequential_route()
+    }
 
+    /// Validates a sequential (non-split) route.
+    ///
+    /// Checks:
+    /// - Consecutive swaps are connected (output token == next input token)
+    /// - No token appears more than once unless it is both the first and last
+    ///   token (simple round-trip cycle)
+    fn validate_sequential_route(&self) -> Result<(), RouteValidationError> {
         for window in self.swaps.windows(2) {
             if window[0].token_out != window[1].token_in {
                 return Err(RouteValidationError::DisconnectedSwaps {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1198,6 +1198,8 @@ impl Route {
     ///   `split == 0.0` (remainder), and the sum must be strictly less than `1.0`
     /// - BFS connectivity: outputs of each group connect to inputs of the next
     fn validate_split_route(&self) -> Result<(), RouteValidationError> {
+        // Group swaps by their input token. Each group represents a split
+        // (parallel swaps sharing the same token_in), not a sequential path.
         let mut group_index: HashMap<Address, usize> = HashMap::new();
         let mut groups: Vec<(Address, Vec<&Swap>)> = Vec::new();
         for swap in &self.swaps {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1209,18 +1209,18 @@ impl Route {
     fn validate_split_route(&self) -> Result<(), RouteValidationError> {
         // Group swaps by their input token. Each group represents a split
         // (parallel swaps sharing the same token_in), not a sequential path.
-        let mut group_index: HashMap<Address, usize> = HashMap::new();
-        let mut groups: Vec<(Address, Vec<&Swap>)> = Vec::new();
+        let mut token_in_to_index: HashMap<Address, usize> = HashMap::new();
+        let mut swaps_by_token_in: Vec<(Address, Vec<&Swap>)> = Vec::new();
         for swap in &self.swaps {
-            if let Some(&idx) = group_index.get(&swap.token_in) {
-                groups[idx].1.push(swap);
+            if let Some(&idx) = token_in_to_index.get(&swap.token_in) {
+                swaps_by_token_in[idx].1.push(swap);
             } else {
-                group_index.insert(swap.token_in.clone(), groups.len());
-                groups.push((swap.token_in.clone(), vec![swap]));
+                token_in_to_index.insert(swap.token_in.clone(), swaps_by_token_in.len());
+                swaps_by_token_in.push((swap.token_in.clone(), vec![swap]));
             }
         }
 
-        for (token_in, group) in &groups {
+        for (token_in, group) in &swaps_by_token_in {
             if group.len() == 1 {
                 if group[0].split != 0.0 {
                     return Err(RouteValidationError::InvalidSplit {
@@ -1271,21 +1271,21 @@ impl Route {
 
         // BFS connectivity: starting from the first group's token_in,
         // expand through swap outputs to verify all group inputs are reachable.
-        let first_token = &groups[0].0;
+        let first_token = &swaps_by_token_in[0].0;
         let mut reachable: HashSet<&Address> = HashSet::new();
         reachable.insert(first_token);
-        let mut queue: VecDeque<&Address> = VecDeque::new();
-        queue.push_back(first_token);
-        while let Some(token) = queue.pop_front() {
-            if let Some(&idx) = group_index.get(token) {
-                for swap in &groups[idx].1 {
+        let mut tokens_to_visit: VecDeque<&Address> = VecDeque::new();
+        tokens_to_visit.push_back(first_token);
+        while let Some(token) = tokens_to_visit.pop_front() {
+            if let Some(&idx) = token_in_to_index.get(token) {
+                for swap in &swaps_by_token_in[idx].1 {
                     if reachable.insert(&swap.token_out) {
-                        queue.push_back(&swap.token_out);
+                        tokens_to_visit.push_back(&swap.token_out);
                     }
                 }
             }
         }
-        for (token_in, _) in &groups {
+        for (token_in, _) in &swaps_by_token_in {
             if !reachable.contains(token_in) {
                 return Err(RouteValidationError::DisconnectedGroup {
                     token_in: token_in.clone(),
@@ -1296,7 +1296,7 @@ impl Route {
 
         let terminal_token = &self.swaps[self.swaps.len() - 1].token_out;
 
-        let non_first_input_tokens: HashSet<&Address> = groups
+        let non_first_input_tokens: HashSet<&Address> = swaps_by_token_in
             .iter()
             .skip(1)
             .map(|(token_in, _)| token_in)
@@ -1304,7 +1304,7 @@ impl Route {
 
         // Dead-end detection: every swap output must either feed a later group
         // or be the terminal output token.
-        for (_, group) in &groups {
+        for (_, group) in &swaps_by_token_in {
             for swap in group {
                 if !non_first_input_tokens.contains(&swap.token_out) &&
                     &swap.token_out != terminal_token
@@ -1327,7 +1327,7 @@ impl Route {
         let is_round_trip = first_token == terminal_token;
         let mut seen_back_edge_group = false;
         let mut earlier_inputs: HashSet<&Address> = HashSet::new();
-        for (token_in, group) in &groups {
+        for (token_in, group) in &swaps_by_token_in {
             earlier_inputs.insert(token_in);
             let mut group_has_back_edge = false;
             for swap in group {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1310,7 +1310,7 @@ fn validate_bfs_connectivity(
     }
     for (token_in, _) in swaps_by_token_in {
         if !reachable.contains(token_in) {
-            return Err(RouteValidationError::DisconnectedBranchCollection {
+            return Err(RouteValidationError::DisconnectedSplitStart {
                 token_in: token_in.clone(),
                 start_token: first_token.clone(),
             });
@@ -1339,7 +1339,7 @@ fn validate_dead_ends(
         .flat_map(|(_, swaps)| swaps)
     {
         if !non_first_input_tokens.contains(&swap.token_out) && &swap.token_out != terminal_token {
-            return Err(RouteValidationError::DeadEndOutput {
+            return Err(RouteValidationError::DisconnectedSplitEnd {
                 token_out: swap.token_out.clone(),
                 terminal_token: terminal_token.clone(),
             });
@@ -1429,10 +1429,10 @@ pub enum RouteValidationError {
     /// in the route and not the terminal token.
     #[non_exhaustive]
     #[error(
-        "dead-end output: {token_out} is not consumed by any later step \
+        "disconnected split end: {token_out} is not consumed by any later step \
          in the route and is not the terminal token {terminal_token}"
     )]
-    DeadEndOutput {
+    DisconnectedSplitEnd {
         /// The output token that leads nowhere.
         token_out: Address,
         /// The route's terminal token.
@@ -1441,10 +1441,10 @@ pub enum RouteValidationError {
     /// A split's input token is not reachable from the route's start token.
     #[non_exhaustive]
     #[error(
-        "disconnected split: input {token_in} is not reachable \
+        "disconnected split start: input {token_in} is not reachable \
          from start token {start_token}"
     )]
-    DisconnectedBranchCollection {
+    DisconnectedSplitStart {
         /// Input token of the unreachable split.
         token_in: Address,
         /// The route's start token.
@@ -1921,7 +1921,7 @@ mod tests {
         ];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();
-        assert!(matches!(err, RouteValidationError::DisconnectedBranchCollection { .. }));
+        assert!(matches!(err, RouteValidationError::DisconnectedSplitStart { .. }));
     }
 
     #[test]
@@ -1937,7 +1937,7 @@ mod tests {
         ];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();
-        assert!(matches!(err, RouteValidationError::DeadEndOutput { .. }));
+        assert!(matches!(err, RouteValidationError::DisconnectedSplitEnd { .. }));
     }
 
     #[test]

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1330,19 +1330,18 @@ fn validate_dead_ends(
     non_first_input_tokens: &HashSet<&Address>,
     terminal_token: &Address,
 ) -> Result<(), RouteValidationError> {
-    for (_, group) in swaps_by_token_in {
-        for swap in group {
-            if !non_first_input_tokens.contains(&swap.token_out) &&
-                &swap.token_out != terminal_token
-            {
-                return Err(RouteValidationError::InvalidSplit {
-                    reason: format!(
-                        "swap output {} is a dead end — not consumed by any \
-                         later group and not the terminal token {terminal_token}",
-                        swap.token_out
-                    ),
-                });
-            }
+    for swap in swaps_by_token_in
+        .iter()
+        .flat_map(|(_, swaps)| swaps)
+    {
+        if !non_first_input_tokens.contains(&swap.token_out) && &swap.token_out != terminal_token {
+            return Err(RouteValidationError::InvalidSplit {
+                reason: format!(
+                    "swap output {} is a dead end — not consumed by any \
+                     later group and not the terminal token {terminal_token}",
+                    swap.token_out
+                ),
+            });
         }
     }
     Ok(())

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1325,7 +1325,10 @@ fn validate_dead_ends(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
     swaps: &[Swap],
 ) -> Result<(), RouteValidationError> {
-    let terminal_token = &swaps[swaps.len() - 1].token_out;
+    let terminal_token = &swaps
+        .last()
+        .ok_or(RouteValidationError::EmptyRoute)?
+        .token_out;
     let non_first_input_tokens: HashSet<&Address> = swaps_by_token_in
         .iter()
         .skip(1)
@@ -1353,7 +1356,10 @@ fn validate_cycles(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
     swaps: &[Swap],
 ) -> Result<(), RouteValidationError> {
-    let terminal_token = &swaps[swaps.len() - 1].token_out;
+    let terminal_token = &swaps
+        .last()
+        .ok_or(RouteValidationError::EmptyRoute)?
+        .token_out;
     let first_token = &swaps_by_token_in[0].0;
     let is_round_trip = first_token == terminal_token;
     if is_round_trip && swaps_by_token_in.len() <= 1 {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1226,16 +1226,8 @@ impl Route {
         validate_split_amounts(&swaps_by_token_in)?;
         validate_bfs_connectivity(&swaps_by_token_in, &token_in_to_index)?;
 
-        let first_token = &swaps_by_token_in[0].0;
-        let terminal_token = &self.swaps[self.swaps.len() - 1].token_out;
-        let non_first_input_tokens: HashSet<&Address> = swaps_by_token_in
-            .iter()
-            .skip(1)
-            .map(|(token_in, _)| token_in)
-            .collect();
-
-        validate_dead_ends(&swaps_by_token_in, &non_first_input_tokens, terminal_token)?;
-        validate_cycles(&swaps_by_token_in, first_token, terminal_token)?;
+        validate_dead_ends(&swaps_by_token_in, &self.swaps)?;
+        validate_cycles(&swaps_by_token_in, &self.swaps)?;
 
         Ok(())
     }
@@ -1331,21 +1323,22 @@ fn validate_bfs_connectivity(
 /// collection or be the terminal output token.
 fn validate_dead_ends(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
-    non_first_input_tokens: &HashSet<&Address>,
-    terminal_token: &Address,
+    swaps: &[Swap],
 ) -> Result<(), RouteValidationError> {
+    let terminal_token = &swaps[swaps.len() - 1].token_out;
+    let non_first_input_tokens: HashSet<&Address> = swaps_by_token_in
+        .iter()
+        .skip(1)
+        .map(|(token_in, _)| token_in)
+        .collect();
     for swap in swaps_by_token_in
         .iter()
         .flat_map(|(_, swaps)| swaps)
     {
         if !non_first_input_tokens.contains(&swap.token_out) && &swap.token_out != terminal_token {
-            return Err(RouteValidationError::InvalidSplit {
-                reason: format!(
-                    "swap output {} is a dead end — not consumed by any \
-                     later branch collection and not the terminal token \
-                     {terminal_token}",
-                    swap.token_out
-                ),
+            return Err(RouteValidationError::DeadEndOutput {
+                token_out: swap.token_out.clone(),
+                terminal_token: terminal_token.clone(),
             });
         }
     }
@@ -1358,9 +1351,10 @@ fn validate_dead_ends(
 /// collection — a single-collection round-trip is always rejected.
 fn validate_cycles(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
-    first_token: &Address,
-    terminal_token: &Address,
+    swaps: &[Swap],
 ) -> Result<(), RouteValidationError> {
+    let terminal_token = &swaps[swaps.len() - 1].token_out;
+    let first_token = &swaps_by_token_in[0].0;
     let is_round_trip = first_token == terminal_token;
     if is_round_trip && swaps_by_token_in.len() <= 1 {
         return Err(RouteValidationError::UnsupportedCycle {
@@ -1423,6 +1417,19 @@ pub enum RouteValidationError {
     InvalidSplit {
         /// Human-readable description of the violation.
         reason: String,
+    },
+    /// A swap output token is a dead end — not consumed by any later branch
+    /// collection and not the terminal token.
+    #[non_exhaustive]
+    #[error(
+        "dead-end output: {token_out} is not consumed by any later branch \
+         collection and is not the terminal token {terminal_token}"
+    )]
+    DeadEndOutput {
+        /// The output token that leads nowhere.
+        token_out: Address,
+        /// The route's terminal token.
+        terminal_token: Address,
     },
     /// A branch collection's input token is not reachable from the route's
     /// start token.
@@ -1924,7 +1931,7 @@ mod tests {
         ];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();
-        assert!(matches!(err, RouteValidationError::InvalidSplit { .. }));
+        assert!(matches!(err, RouteValidationError::DeadEndOutput { .. }));
     }
 
     #[test]

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -14,7 +14,7 @@
 //! - [`Route`] - Sequence of swaps to execute
 //! - [`Swap`] - A single swap on a specific protocol
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
@@ -1146,6 +1146,9 @@ impl Route {
         if self.swaps.is_empty() {
             return Err(RouteValidationError::EmptyRoute);
         }
+        if self.is_split() {
+            return self.validate_split_route();
+        }
 
         for window in self.swaps.windows(2) {
             if window[0].token_out != window[1].token_in {
@@ -1175,6 +1178,172 @@ impl Route {
                         last: last_token.clone(),
                     });
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns `true` if the route contains any swaps with non-zero split
+    /// fractions.
+    pub fn is_split(&self) -> bool {
+        self.swaps.iter().any(|s| s.split > 0.0)
+    }
+
+    /// Validates a split route.
+    ///
+    /// Groups swaps by `token_in`, then checks:
+    /// - Single-swap groups: `split` must be `0.0`
+    /// - Multi-swap groups: all but the last must have `0.0 < split < 1.0`, the last must have
+    ///   `split == 0.0` (remainder), and the sum must be strictly less than `1.0`
+    /// - BFS connectivity: outputs of each group connect to inputs of the next
+    fn validate_split_route(&self) -> Result<(), RouteValidationError> {
+        let mut group_index: HashMap<Address, usize> = HashMap::new();
+        let mut groups: Vec<(Address, Vec<&Swap>)> = Vec::new();
+        for swap in &self.swaps {
+            if let Some(&idx) = group_index.get(&swap.token_in) {
+                groups[idx].1.push(swap);
+            } else {
+                group_index.insert(swap.token_in.clone(), groups.len());
+                groups.push((swap.token_in.clone(), vec![swap]));
+            }
+        }
+
+        for (token_in, group) in &groups {
+            if group.len() == 1 {
+                if group[0].split != 0.0 {
+                    return Err(RouteValidationError::InvalidSplit {
+                        reason: format!(
+                            "single swap for token_in {token_in} \
+                             must have split == 0.0, got {}",
+                            group[0].split
+                        ),
+                    });
+                }
+                continue;
+            }
+
+            let mut sum = 0.0_f64;
+            let last_idx = group.len() - 1;
+            for (i, swap) in group.iter().enumerate() {
+                if i < last_idx {
+                    if swap.split <= 0.0 || swap.split >= 1.0 {
+                        return Err(RouteValidationError::InvalidSplit {
+                            reason: format!(
+                                "swap {} for token_in {token_in} \
+                                 must have 0.0 < split < 1.0, got {}",
+                                i, swap.split
+                            ),
+                        });
+                    }
+                    sum += swap.split;
+                } else if swap.split != 0.0 {
+                    return Err(RouteValidationError::InvalidSplit {
+                        reason: format!(
+                            "last swap in group for token_in {token_in} \
+                             must have split == 0.0 (remainder), got {}",
+                            swap.split
+                        ),
+                    });
+                }
+            }
+
+            if sum >= 1.0 {
+                return Err(RouteValidationError::InvalidSplit {
+                    reason: format!(
+                        "split sum for token_in {token_in} must be \
+                         < 1.0, got {sum}"
+                    ),
+                });
+            }
+        }
+
+        // BFS connectivity: starting from the first group's token_in,
+        // expand through swap outputs to verify all group inputs are reachable.
+        let first_token = &groups[0].0;
+        let mut reachable: HashSet<&Address> = HashSet::new();
+        reachable.insert(first_token);
+        let mut queue: VecDeque<&Address> = VecDeque::new();
+        queue.push_back(first_token);
+        while let Some(token) = queue.pop_front() {
+            if let Some(&idx) = group_index.get(token) {
+                for swap in &groups[idx].1 {
+                    if reachable.insert(&swap.token_out) {
+                        queue.push_back(&swap.token_out);
+                    }
+                }
+            }
+        }
+        for (token_in, _) in &groups {
+            if !reachable.contains(token_in) {
+                return Err(RouteValidationError::InvalidSplit {
+                    reason: format!(
+                        "group input {token_in} is not reachable from \
+                         the start token {first_token} (reachable: {reachable:?})",
+                    ),
+                });
+            }
+        }
+
+        let terminal_token = &self.swaps[self.swaps.len() - 1].token_out;
+
+        let non_first_input_tokens: HashSet<&Address> = groups
+            .iter()
+            .skip(1)
+            .map(|(token_in, _)| token_in)
+            .collect();
+
+        // Dead-end detection: every swap output must either feed a later group
+        // or be the terminal output token.
+        for (_, group) in &groups {
+            for swap in group {
+                if !non_first_input_tokens.contains(&swap.token_out) &&
+                    &swap.token_out != terminal_token
+                {
+                    return Err(RouteValidationError::InvalidSplit {
+                        reason: format!(
+                            "swap output {} is a dead end — not consumed by any \
+                             later group and not the terminal token {terminal_token}",
+                            swap.token_out
+                        ),
+                    });
+                }
+            }
+        }
+
+        // Cycle detection: no swap output may match an earlier group's input.
+        // Exception: in a round-trip (first == terminal) exactly one group may
+        // produce back-edges to first_token. Multiple groups doing so means token
+        // is visited more than twice (e.g. A→…→A→…→A).
+        let is_round_trip = first_token == terminal_token;
+        let mut seen_back_edge_group = false;
+        let mut earlier_inputs: HashSet<&Address> = HashSet::new();
+        for (token_in, group) in &groups {
+            earlier_inputs.insert(token_in);
+            let mut group_has_back_edge = false;
+            for swap in group {
+                if !earlier_inputs.contains(&swap.token_out) {
+                    continue;
+                }
+                if is_round_trip && &swap.token_out == first_token {
+                    group_has_back_edge = true;
+                } else {
+                    return Err(RouteValidationError::UnsupportedCycle {
+                        token: swap.token_out.clone(),
+                        first: first_token.clone(),
+                        last: terminal_token.clone(),
+                    });
+                }
+            }
+            if group_has_back_edge {
+                if seen_back_edge_group {
+                    return Err(RouteValidationError::UnsupportedCycle {
+                        token: first_token.clone(),
+                        first: first_token.clone(),
+                        last: terminal_token.clone(),
+                    });
+                }
+                seen_back_edge_group = true;
             }
         }
 
@@ -1211,6 +1380,12 @@ pub enum RouteValidationError {
         first: Address,
         /// Last token in the route.
         last: Address,
+    },
+    /// A split route has invalid split fractions or disconnected groups.
+    #[error("invalid split route: {reason}")]
+    InvalidSplit {
+        /// Human-readable description of the violation.
+        reason: String,
     },
 }
 
@@ -1595,6 +1770,169 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
+    // Split Route Validation Tests
+    // -------------------------------------------------------------------------
+
+    fn make_split_swap(token_in: u8, token_out: u8, split: f64) -> Swap {
+        make_swap(token_in, token_out, 1000, 990).with_split(split)
+    }
+
+    #[test]
+    fn test_validate_interior_split_valid() {
+        // A→B sequential, then B→C parallel with remainder convention
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.0),
+            make_split_swap(0x02, 0x03, 0.5),
+            make_split_swap(0x02, 0x03, 0.0),
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        assert!(route.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_interior_split_no_remainder() {
+        // A→B, then B→C parallel but last swap has nonzero split (no remainder)
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.0),
+            make_split_swap(0x02, 0x03, 0.5),
+            make_split_swap(0x02, 0x03, 0.3),
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::InvalidSplit { .. }));
+    }
+
+    #[test]
+    fn test_validate_interior_split_sum_exceeds_one() {
+        // A→B, then B→C parallel with explicit splits summing >= 1.0
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.0),
+            make_split_swap(0x02, 0x03, 0.6),
+            make_split_swap(0x02, 0x03, 0.5),
+            make_split_swap(0x02, 0x03, 0.0),
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::InvalidSplit { .. }));
+    }
+
+    #[test]
+    fn test_validate_source_split_valid() {
+        // Two parallel legs from A through different intermediates, converging on D
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.5),
+            make_split_swap(0x01, 0x03, 0.0),
+            make_swap(0x02, 0x04, 490, 480),
+            make_swap(0x03, 0x04, 490, 480),
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        assert!(route.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_diamond_split_valid() {
+        // Diamond: A splits to B and D via different intermediates, both converge on C.
+        // A→B (60%), B→C, A→D (remainder), D→C
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.6), // A→B, 60%
+            make_swap(0x02, 0x03, 590, 580),  // B→C
+            make_split_swap(0x01, 0x04, 0.0), // A→D, remainder
+            make_swap(0x04, 0x03, 390, 380),  // D→C
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        assert!(route.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_split_single_swap_nonzero_split() {
+        // A single swap for a given token_in must have split == 0.0
+        let swaps = vec![make_split_swap(0x01, 0x02, 0.5)];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::InvalidSplit { .. }));
+    }
+
+    #[test]
+    fn test_validate_split_dead_end() {
+        // A splits to B and C, but the paths don't converge — B→D diverges
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.5), // A→B
+            make_split_swap(0x01, 0x03, 0.0), // A→C
+            make_swap(0x02, 0x04, 490, 480),  // B→D (dead end)
+            make_swap(0x03, 0x05, 490, 480),  // C→E (terminal)
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::InvalidSplit { .. }));
+    }
+
+    #[test]
+    fn test_validate_split_cycle() {
+        // Both split paths converge back to B, creating a cycle
+        let swaps = vec![
+            make_swap(0x01, 0x02, 1000, 990),                // A→B
+            make_swap(0x02, 0x03, 990, 980).with_split(0.5), // B→C
+            make_swap(0x02, 0x04, 490, 480).with_split(0.0), // B→D remainder
+            make_swap(0x03, 0x02, 980, 970),                 // C→B (cycle)
+            make_swap(0x04, 0x02, 480, 470),                 // D→B (cycle)
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::UnsupportedCycle { .. }));
+    }
+
+    #[test]
+    fn test_validate_split_round_trip_valid() {
+        // A splits to B and C, both converge on D, then D→A (round-trip).
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.5), // A→B
+            make_split_swap(0x01, 0x03, 0.0), // A→C
+            make_swap(0x02, 0x04, 490, 480),  // B→D
+            make_swap(0x03, 0x04, 490, 480),  // C→D
+            make_swap(0x04, 0x01, 960, 950),  // D→A (round-trip)
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        assert!(route.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_split_multi_back_edge_groups() {
+        // A→B→D→A→F→A and A→C→D→E→F→A — two groups (D and F) produce
+        // back-edges to A, which means A is visited more than twice.
+        // A→F merges into group A so splits must account for all three.
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.3),                // A→B
+            make_split_swap(0x01, 0x03, 0.3),                // A→C
+            make_swap(0x02, 0x04, 290, 280),                 // B→D
+            make_swap(0x03, 0x04, 290, 280),                 // C→D
+            make_swap(0x04, 0x01, 560, 550).with_split(0.5), // D→A
+            make_swap(0x04, 0x05, 280, 270).with_split(0.0), // D→E
+            make_split_swap(0x01, 0x06, 0.0),                // A→F (remainder)
+            make_swap(0x05, 0x06, 270, 260),                 // E→F
+            make_swap(0x06, 0x01, 810, 800),                 // F→A
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::UnsupportedCycle { .. }));
+    }
+
+    #[test]
+    fn test_validate_split_terminal_is_group_input() {
+        // A→C→B→C: terminal C is also a group input, creating a cycle.
+        // Not a round-trip (first=A ≠ terminal=C).
+        let swaps = vec![
+            make_swap(0x01, 0x03, 1000, 990),                // A→C
+            make_swap(0x03, 0x02, 990, 980).with_split(0.5), // C→B
+            make_swap(0x03, 0x04, 490, 480).with_split(0.0), // C→D
+            make_swap(0x02, 0x03, 980, 970),                 // B→C (cycle)
+            make_swap(0x04, 0x03, 480, 470),                 // D→C (cycle)
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::UnsupportedCycle { .. }));
+    }
+
+    // -------------------------------------------------------------------------
     // Serialization Tests - BigUint as String
     // -------------------------------------------------------------------------
 
@@ -1807,6 +2145,36 @@ mod tests {
             100
         );
         assert!((deserialized.slippage() - 0.005).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_is_split_detection() {
+        // Single hop, no split
+        let route_single = make_route(vec![(0x01, 0x02)]);
+        assert!(!route_single.is_split());
+
+        // Multi-hop, no split
+        let route_multi = make_route(vec![(0x01, 0x02), (0x02, 0x03)]);
+        assert!(!route_multi.is_split());
+
+        // Interior split: A→B single, B→C through two parallel pools
+        let swaps_interior = vec![
+            make_swap(0x01, 0x02, 1000, 990),                // A→B, no split
+            make_swap(0x02, 0x03, 594, 580).with_split(0.6), // B→C via P2, 60%
+            make_swap(0x02, 0x03, 396, 385),                 // B→C via P3, remainder
+        ];
+        let route_interior = Route::new(swaps_interior, HashMap::new());
+        assert!(route_interior.is_split());
+
+        // Source-level split: two routes with different intermediates
+        let swaps_source = vec![
+            make_swap(0x01, 0x02, 600, 590).with_split(0.6), // A→B, 60%
+            make_swap(0x02, 0x03, 590, 580),                 // B→C
+            make_swap(0x01, 0x04, 400, 390),                 // A→D, remainder
+            make_swap(0x04, 0x03, 390, 380),                 // D→C
+        ];
+        let route_source = Route::new(swaps_source, HashMap::new());
+        assert!(route_source.is_split());
     }
 
     #[test]

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -992,10 +992,12 @@ impl BlockInfo {
 // ROUTE & SWAP TYPES
 // ============================================================================
 
-/// A route consisting of one or more sequential swaps.
+/// A route consisting of one or more swaps, either sequential or split.
 ///
 /// A route describes the path through liquidity pools to execute a swap.
-/// For multi-hop swaps, the output of each swap becomes the input of the next.
+/// For sequential (multi-hop) swaps, the output of each swap becomes the input
+/// of the next. For split swaps, the input is divided across multiple parallel
+/// paths (each swap carries a `split` fraction).
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Route {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1413,17 +1413,18 @@ pub enum RouteValidationError {
         last: Address,
     },
     /// A split route has invalid split fractions.
+    #[non_exhaustive]
     #[error("invalid split route: {reason}")]
     InvalidSplit {
         /// Human-readable description of the violation.
         reason: String,
     },
-    /// A swap output token is a dead end — not consumed by any later branch
-    /// collection and not the terminal token.
+    /// A swap output token is a dead end — not consumed by any later step
+    /// in the route and not the terminal token.
     #[non_exhaustive]
     #[error(
-        "dead-end output: {token_out} is not consumed by any later branch \
-         collection and is not the terminal token {terminal_token}"
+        "dead-end output: {token_out} is not consumed by any later step \
+         in the route and is not the terminal token {terminal_token}"
     )]
     DeadEndOutput {
         /// The output token that leads nowhere.
@@ -1431,15 +1432,14 @@ pub enum RouteValidationError {
         /// The route's terminal token.
         terminal_token: Address,
     },
-    /// A branch collection's input token is not reachable from the route's
-    /// start token.
+    /// A split's input token is not reachable from the route's start token.
     #[non_exhaustive]
     #[error(
-        "disconnected branch collection: input {token_in} is not reachable \
+        "disconnected split: input {token_in} is not reachable \
          from start token {start_token}"
     )]
     DisconnectedBranchCollection {
-        /// Input token of the unreachable branch collection.
+        /// Input token of the unreachable split.
         token_in: Address,
         /// The route's start token.
         start_token: Address,

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -2216,7 +2216,10 @@ mod tests {
             make_swap(0x03, 0x04, 490, 480),  // C→D
         ];
         let route = Route::new(swaps, HashMap::new());
-        assert!(route.validate().is_err());
+        assert!(matches!(
+            route.validate(),
+            Err(RouteValidationError::DisconnectedSwaps { .. })
+        ));
     }
 
     #[test]

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1203,14 +1203,15 @@ impl Route {
 
     /// Validates a split route.
     ///
-    /// Groups swaps by `token_in`, then checks:
-    /// - Single-swap groups: `split` must be `0.0`
-    /// - Multi-swap groups: all but the last must have `0.0 < split < 1.0`, the last must have
-    ///   `split == 0.0` (remainder), and the sum must be strictly less than `1.0`
-    /// - BFS connectivity: outputs of each group connect to inputs of the next
+    /// Collects swaps into branch collections by `token_in`, then checks:
+    /// - Single-swap branch collections: `split` must be `0.0`
+    /// - Multi-swap branch collections: all but the last must have `0.0 < split < 1.0`, the last
+    ///   must have `split == 0.0` (remainder), and the sum must be strictly less than `1.0`
+    /// - BFS connectivity: outputs of each branch collection connect to inputs of the next
     fn validate_split_route(&self) -> Result<(), RouteValidationError> {
-        // Group swaps by their input token. Each group represents a split
-        // (parallel swaps sharing the same token_in), not a sequential path.
+        // Collect swaps into branch collections by their input token. Each
+        // branch collection represents a split (parallel branches sharing the
+        // same token_in), not a sequential path.
         let mut token_in_to_index: HashMap<Address, usize> = HashMap::new();
         let mut swaps_by_token_in: Vec<(Address, Vec<&Swap>)> = Vec::new();
         for swap in &self.swaps {
@@ -1243,14 +1244,14 @@ impl Route {
 fn validate_split_amounts(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
 ) -> Result<(), RouteValidationError> {
-    for (token_in, group) in swaps_by_token_in {
-        if group.len() == 1 {
-            if group[0].split != 0.0 {
+    for (token_in, branch_collection) in swaps_by_token_in {
+        if branch_collection.len() == 1 {
+            if branch_collection[0].split != 0.0 {
                 return Err(RouteValidationError::InvalidSplit {
                     reason: format!(
                         "single swap for token_in {token_in} \
                          must have split == 0.0, got {}",
-                        group[0].split
+                        branch_collection[0].split
                     ),
                 });
             }
@@ -1258,8 +1259,8 @@ fn validate_split_amounts(
         }
 
         let mut sum = 0.0_f64;
-        let last_idx = group.len() - 1;
-        for (i, swap) in group.iter().enumerate() {
+        let last_idx = branch_collection.len() - 1;
+        for (i, swap) in branch_collection.iter().enumerate() {
             if i < last_idx {
                 if swap.split <= 0.0 || swap.split >= 1.0 {
                     return Err(RouteValidationError::InvalidSplit {
@@ -1274,7 +1275,7 @@ fn validate_split_amounts(
             } else if swap.split != 0.0 {
                 return Err(RouteValidationError::InvalidSplit {
                     reason: format!(
-                        "last swap in group for token_in {token_in} \
+                        "last branch in collection for token_in {token_in} \
                          must have split == 0.0 (remainder), got {}",
                         swap.split
                     ),
@@ -1294,8 +1295,9 @@ fn validate_split_amounts(
     Ok(())
 }
 
-/// BFS connectivity: starting from the first group's token_in, expand through
-/// swap outputs to verify all group inputs are reachable.
+/// BFS connectivity: starting from the first branch collection's token_in,
+/// expand through swap outputs to verify all branch collection inputs are
+/// reachable.
 fn validate_bfs_connectivity(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
     token_in_to_index: &HashMap<Address, usize>,
@@ -1316,7 +1318,7 @@ fn validate_bfs_connectivity(
     }
     for (token_in, _) in swaps_by_token_in {
         if !reachable.contains(token_in) {
-            return Err(RouteValidationError::DisconnectedGroup {
+            return Err(RouteValidationError::DisconnectedBranchCollection {
                 token_in: token_in.clone(),
                 start_token: first_token.clone(),
             });
@@ -1325,8 +1327,8 @@ fn validate_bfs_connectivity(
     Ok(())
 }
 
-/// Dead-end detection: every swap output must either feed a later group
-/// or be the terminal output token.
+/// Dead-end detection: every swap output must either feed a later branch
+/// collection or be the terminal output token.
 fn validate_dead_ends(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
     non_first_input_tokens: &HashSet<&Address>,
@@ -1340,7 +1342,8 @@ fn validate_dead_ends(
             return Err(RouteValidationError::InvalidSplit {
                 reason: format!(
                     "swap output {} is a dead end — not consumed by any \
-                     later group and not the terminal token {terminal_token}",
+                     later branch collection and not the terminal token \
+                     {terminal_token}",
                     swap.token_out
                 ),
             });
@@ -1349,10 +1352,10 @@ fn validate_dead_ends(
     Ok(())
 }
 
-/// Cycle detection: no swap output may match an earlier group's input.
-/// Exception: in a round-trip (first == terminal) outputs equal to
-/// `first_token` are allowed, provided the route has more than one
-/// group — a single-group round-trip is always rejected.
+/// Cycle detection: no swap output may match an earlier branch collection's
+/// input. Exception: in a round-trip (first == terminal) outputs equal to
+/// `first_token` are allowed, provided the route has more than one branch
+/// collection — a single-collection round-trip is always rejected.
 fn validate_cycles(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
     first_token: &Address,
@@ -1367,9 +1370,9 @@ fn validate_cycles(
         });
     }
     let mut earlier_inputs: HashSet<&Address> = HashSet::new();
-    for (token_in, group) in swaps_by_token_in {
+    for (token_in, branch_collection) in swaps_by_token_in {
         earlier_inputs.insert(token_in);
-        for swap in group {
+        for swap in branch_collection {
             if !earlier_inputs.contains(&swap.token_out) {
                 continue;
             }
@@ -1421,14 +1424,15 @@ pub enum RouteValidationError {
         /// Human-readable description of the violation.
         reason: String,
     },
-    /// A group's input token is not reachable from the route's start token.
+    /// A branch collection's input token is not reachable from the route's
+    /// start token.
     #[non_exhaustive]
     #[error(
-        "disconnected group: input {token_in} is not reachable from \
-         start token {start_token}"
+        "disconnected branch collection: input {token_in} is not reachable \
+         from start token {start_token}"
     )]
-    DisconnectedGroup {
-        /// Input token of the unreachable group.
+    DisconnectedBranchCollection {
+        /// Input token of the unreachable branch collection.
         token_in: Address,
         /// The route's start token.
         start_token: Address,
@@ -1893,7 +1897,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_split_unreachable_group() {
+    fn test_validate_split_unreachable_branch_collection() {
         //   ┌──[50%]──┐
         // A │          B    C → D   ERROR: C unreachable from A
         //   └──[rem]──┘
@@ -1904,7 +1908,7 @@ mod tests {
         ];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();
-        assert!(matches!(err, RouteValidationError::DisconnectedGroup { .. }));
+        assert!(matches!(err, RouteValidationError::DisconnectedBranchCollection { .. }));
     }
 
     #[test]
@@ -1957,7 +1961,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_split_round_trip_valid_from_multiple_groups() {
+    fn test_validate_split_round_trip_valid_from_multiple_branch_collections() {
         //       ┌──[40%]── C ──┐
         // A → B │               → A   (round-trip back to start)
         //       └──[rem]── D ──┘
@@ -1973,9 +1977,9 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_split_single_group_round_trip() {
+    fn test_validate_split_single_branch_collection_round_trip() {
         //   ┌──[50%]──┐
-        // A │         │ A   ERROR: single group cycling back to start
+        // A │         │ A   ERROR: single branch collection cycling back to start
         //   └──[rem]──┘
         let swaps = vec![
             make_split_swap(0x01, 0x01, 0.5), // A→A
@@ -2216,10 +2220,7 @@ mod tests {
             make_swap(0x03, 0x04, 490, 480),  // C→D
         ];
         let route = Route::new(swaps, HashMap::new());
-        assert!(matches!(
-            route.validate(),
-            Err(RouteValidationError::DisconnectedSwaps { .. })
-        ));
+        assert!(matches!(route.validate(), Err(RouteValidationError::DisconnectedSwaps { .. })));
     }
 
     #[test]

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1158,8 +1158,8 @@ impl Route {
     ///
     /// Checks:
     /// - Consecutive swaps are connected (output token == next input token)
-    /// - No token appears more than once unless it is both the first and last
-    ///   token (simple round-trip cycle)
+    /// - No token appears more than once unless it is both the first and last token (simple
+    ///   round-trip cycle)
     fn validate_sequential_route(&self) -> Result<(), RouteValidationError> {
         for window in self.swaps.windows(2) {
             if window[0].token_out != window[1].token_in {

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1220,144 +1220,174 @@ impl Route {
             }
         }
 
-        for (token_in, group) in &swaps_by_token_in {
-            if group.len() == 1 {
-                if group[0].split != 0.0 {
-                    return Err(RouteValidationError::InvalidSplit {
-                        reason: format!(
-                            "single swap for token_in {token_in} \
-                             must have split == 0.0, got {}",
-                            group[0].split
-                        ),
-                    });
-                }
-                continue;
-            }
+        validate_split_amounts(&swaps_by_token_in)?;
+        validate_bfs_connectivity(&swaps_by_token_in, &token_in_to_index)?;
 
-            let mut sum = 0.0_f64;
-            let last_idx = group.len() - 1;
-            for (i, swap) in group.iter().enumerate() {
-                if i < last_idx {
-                    if swap.split <= 0.0 || swap.split >= 1.0 {
-                        return Err(RouteValidationError::InvalidSplit {
-                            reason: format!(
-                                "swap {} for token_in {token_in} \
-                                 must have 0.0 < split < 1.0, got {}",
-                                i, swap.split
-                            ),
-                        });
-                    }
-                    sum += swap.split;
-                } else if swap.split != 0.0 {
-                    return Err(RouteValidationError::InvalidSplit {
-                        reason: format!(
-                            "last swap in group for token_in {token_in} \
-                             must have split == 0.0 (remainder), got {}",
-                            swap.split
-                        ),
-                    });
-                }
-            }
-
-            if sum >= 1.0 {
-                return Err(RouteValidationError::InvalidSplit {
-                    reason: format!(
-                        "split sum for token_in {token_in} must be \
-                         < 1.0, got {sum}"
-                    ),
-                });
-            }
-        }
-
-        // BFS connectivity: starting from the first group's token_in,
-        // expand through swap outputs to verify all group inputs are reachable.
         let first_token = &swaps_by_token_in[0].0;
-        let mut reachable: HashSet<&Address> = HashSet::new();
-        reachable.insert(first_token);
-        let mut tokens_to_visit: VecDeque<&Address> = VecDeque::new();
-        tokens_to_visit.push_back(first_token);
-        while let Some(token) = tokens_to_visit.pop_front() {
-            if let Some(&idx) = token_in_to_index.get(token) {
-                for swap in &swaps_by_token_in[idx].1 {
-                    if reachable.insert(&swap.token_out) {
-                        tokens_to_visit.push_back(&swap.token_out);
-                    }
-                }
-            }
-        }
-        for (token_in, _) in &swaps_by_token_in {
-            if !reachable.contains(token_in) {
-                return Err(RouteValidationError::DisconnectedGroup {
-                    token_in: token_in.clone(),
-                    start_token: first_token.clone(),
-                });
-            }
-        }
-
         let terminal_token = &self.swaps[self.swaps.len() - 1].token_out;
-
         let non_first_input_tokens: HashSet<&Address> = swaps_by_token_in
             .iter()
             .skip(1)
             .map(|(token_in, _)| token_in)
             .collect();
 
-        // Dead-end detection: every swap output must either feed a later group
-        // or be the terminal output token.
-        for (_, group) in &swaps_by_token_in {
-            for swap in group {
-                if !non_first_input_tokens.contains(&swap.token_out) &&
-                    &swap.token_out != terminal_token
-                {
-                    return Err(RouteValidationError::InvalidSplit {
-                        reason: format!(
-                            "swap output {} is a dead end — not consumed by any \
-                             later group and not the terminal token {terminal_token}",
-                            swap.token_out
-                        ),
-                    });
-                }
-            }
-        }
-
-        // Cycle detection: no swap output may match an earlier group's input.
-        // Exception: in a round-trip (first == terminal) exactly one group may
-        // produce back-edges to first_token. Multiple groups doing so means token
-        // is visited more than twice (e.g. A→…→A→…→A).
-        let is_round_trip = first_token == terminal_token;
-        let mut seen_back_edge_group = false;
-        let mut earlier_inputs: HashSet<&Address> = HashSet::new();
-        for (token_in, group) in &swaps_by_token_in {
-            earlier_inputs.insert(token_in);
-            let mut group_has_back_edge = false;
-            for swap in group {
-                if !earlier_inputs.contains(&swap.token_out) {
-                    continue;
-                }
-                if is_round_trip && &swap.token_out == first_token {
-                    group_has_back_edge = true;
-                } else {
-                    return Err(RouteValidationError::UnsupportedCycle {
-                        token: swap.token_out.clone(),
-                        first: first_token.clone(),
-                        last: terminal_token.clone(),
-                    });
-                }
-            }
-            if group_has_back_edge {
-                if seen_back_edge_group {
-                    return Err(RouteValidationError::UnsupportedCycle {
-                        token: first_token.clone(),
-                        first: first_token.clone(),
-                        last: terminal_token.clone(),
-                    });
-                }
-                seen_back_edge_group = true;
-            }
-        }
+        validate_dead_ends(&swaps_by_token_in, &non_first_input_tokens, terminal_token)?;
+        validate_cycles(&swaps_by_token_in, first_token, terminal_token)?;
 
         Ok(())
     }
+}
+
+fn validate_split_amounts(
+    swaps_by_token_in: &[(Address, Vec<&Swap>)],
+) -> Result<(), RouteValidationError> {
+    for (token_in, group) in swaps_by_token_in {
+        if group.len() == 1 {
+            if group[0].split != 0.0 {
+                return Err(RouteValidationError::InvalidSplit {
+                    reason: format!(
+                        "single swap for token_in {token_in} \
+                         must have split == 0.0, got {}",
+                        group[0].split
+                    ),
+                });
+            }
+            continue;
+        }
+
+        let mut sum = 0.0_f64;
+        let last_idx = group.len() - 1;
+        for (i, swap) in group.iter().enumerate() {
+            if i < last_idx {
+                if swap.split <= 0.0 || swap.split >= 1.0 {
+                    return Err(RouteValidationError::InvalidSplit {
+                        reason: format!(
+                            "swap {} for token_in {token_in} \
+                             must have 0.0 < split < 1.0, got {}",
+                            i, swap.split
+                        ),
+                    });
+                }
+                sum += swap.split;
+            } else if swap.split != 0.0 {
+                return Err(RouteValidationError::InvalidSplit {
+                    reason: format!(
+                        "last swap in group for token_in {token_in} \
+                         must have split == 0.0 (remainder), got {}",
+                        swap.split
+                    ),
+                });
+            }
+        }
+
+        if sum >= 1.0 {
+            return Err(RouteValidationError::InvalidSplit {
+                reason: format!(
+                    "split sum for token_in {token_in} must be \
+                     < 1.0, got {sum}"
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// BFS connectivity: starting from the first group's token_in, expand through
+/// swap outputs to verify all group inputs are reachable.
+fn validate_bfs_connectivity(
+    swaps_by_token_in: &[(Address, Vec<&Swap>)],
+    token_in_to_index: &HashMap<Address, usize>,
+) -> Result<(), RouteValidationError> {
+    let first_token = &swaps_by_token_in[0].0;
+    let mut reachable: HashSet<&Address> = HashSet::new();
+    reachable.insert(first_token);
+    let mut tokens_to_visit: VecDeque<&Address> = VecDeque::new();
+    tokens_to_visit.push_back(first_token);
+    while let Some(token) = tokens_to_visit.pop_front() {
+        if let Some(&idx) = token_in_to_index.get(token) {
+            for swap in &swaps_by_token_in[idx].1 {
+                if reachable.insert(&swap.token_out) {
+                    tokens_to_visit.push_back(&swap.token_out);
+                }
+            }
+        }
+    }
+    for (token_in, _) in swaps_by_token_in {
+        if !reachable.contains(token_in) {
+            return Err(RouteValidationError::DisconnectedGroup {
+                token_in: token_in.clone(),
+                start_token: first_token.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Dead-end detection: every swap output must either feed a later group
+/// or be the terminal output token.
+fn validate_dead_ends(
+    swaps_by_token_in: &[(Address, Vec<&Swap>)],
+    non_first_input_tokens: &HashSet<&Address>,
+    terminal_token: &Address,
+) -> Result<(), RouteValidationError> {
+    for (_, group) in swaps_by_token_in {
+        for swap in group {
+            if !non_first_input_tokens.contains(&swap.token_out) &&
+                &swap.token_out != terminal_token
+            {
+                return Err(RouteValidationError::InvalidSplit {
+                    reason: format!(
+                        "swap output {} is a dead end — not consumed by any \
+                         later group and not the terminal token {terminal_token}",
+                        swap.token_out
+                    ),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Cycle detection: no swap output may match an earlier group's input.
+/// Exception: in a round-trip (first == terminal) exactly one group may
+/// produce back-edges to first_token.
+fn validate_cycles(
+    swaps_by_token_in: &[(Address, Vec<&Swap>)],
+    first_token: &Address,
+    terminal_token: &Address,
+) -> Result<(), RouteValidationError> {
+    let is_round_trip = first_token == terminal_token;
+    let mut seen_back_edge_group = false;
+    let mut earlier_inputs: HashSet<&Address> = HashSet::new();
+    for (token_in, group) in swaps_by_token_in {
+        earlier_inputs.insert(token_in);
+        let mut group_has_back_edge = false;
+        for swap in group {
+            if !earlier_inputs.contains(&swap.token_out) {
+                continue;
+            }
+            if is_round_trip && &swap.token_out == first_token {
+                group_has_back_edge = true;
+            } else {
+                return Err(RouteValidationError::UnsupportedCycle {
+                    token: swap.token_out.clone(),
+                    first: first_token.clone(),
+                    last: terminal_token.clone(),
+                });
+            }
+        }
+        if group_has_back_edge {
+            if seen_back_edge_group {
+                return Err(RouteValidationError::UnsupportedCycle {
+                    token: first_token.clone(),
+                    first: first_token.clone(),
+                    last: terminal_token.clone(),
+                });
+            }
+            seen_back_edge_group = true;
+        }
+    }
+    Ok(())
 }
 
 /// Errors that can occur when validating a [`Route`].

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1350,8 +1350,9 @@ fn validate_dead_ends(
 }
 
 /// Cycle detection: no swap output may match an earlier group's input.
-/// Exception: in a round-trip (first == terminal) exactly one group may
-/// produce back-edges to first_token.
+/// Exception: in a round-trip (first == terminal) outputs equal to
+/// `first_token` are allowed, provided the route has more than one
+/// group — a single-group round-trip is always rejected.
 fn validate_cycles(
     swaps_by_token_in: &[(Address, Vec<&Swap>)],
     first_token: &Address,
@@ -1365,34 +1366,20 @@ fn validate_cycles(
             last: terminal_token.clone(),
         });
     }
-    let mut seen_back_edge_group = false;
     let mut earlier_inputs: HashSet<&Address> = HashSet::new();
     for (token_in, group) in swaps_by_token_in {
         earlier_inputs.insert(token_in);
-        let mut group_has_back_edge = false;
         for swap in group {
             if !earlier_inputs.contains(&swap.token_out) {
                 continue;
             }
-            if is_round_trip && &swap.token_out == first_token {
-                group_has_back_edge = true;
-            } else {
+            if !(is_round_trip && &swap.token_out == first_token) {
                 return Err(RouteValidationError::UnsupportedCycle {
                     token: swap.token_out.clone(),
                     first: first_token.clone(),
                     last: terminal_token.clone(),
                 });
             }
-        }
-        if group_has_back_edge {
-            if seen_back_edge_group {
-                return Err(RouteValidationError::UnsupportedCycle {
-                    token: first_token.clone(),
-                    first: first_token.clone(),
-                    last: terminal_token.clone(),
-                });
-            }
-            seen_back_edge_group = true;
         }
     }
     Ok(())

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1278,11 +1278,9 @@ impl Route {
         }
         for (token_in, _) in &groups {
             if !reachable.contains(token_in) {
-                return Err(RouteValidationError::InvalidSplit {
-                    reason: format!(
-                        "group input {token_in} is not reachable from \
-                         the start token {first_token} (reachable: {reachable:?})",
-                    ),
+                return Err(RouteValidationError::DisconnectedGroup {
+                    token_in: token_in.clone(),
+                    start_token: first_token.clone(),
                 });
             }
         }
@@ -1383,11 +1381,23 @@ pub enum RouteValidationError {
         /// Last token in the route.
         last: Address,
     },
-    /// A split route has invalid split fractions or disconnected groups.
+    /// A split route has invalid split fractions.
     #[error("invalid split route: {reason}")]
     InvalidSplit {
         /// Human-readable description of the violation.
         reason: String,
+    },
+    /// A group's input token is not reachable from the route's start token.
+    #[non_exhaustive]
+    #[error(
+        "disconnected group: input {token_in} is not reachable from \
+         start token {start_token}"
+    )]
+    DisconnectedGroup {
+        /// Input token of the unreachable group.
+        token_in: Address,
+        /// The route's start token.
+        start_token: Address,
     },
 }
 

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1884,27 +1884,27 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_diamond_split_valid() {
-        //   ┌──[60%]── B ──┐
-        // A │               C
-        //   └──[rem]── D ──┘
-        let swaps = vec![
-            make_split_swap(0x01, 0x02, 0.6), // A→B, 60%
-            make_swap(0x02, 0x03, 590, 580),  // B→C
-            make_split_swap(0x01, 0x04, 0.0), // A→D, remainder
-            make_swap(0x04, 0x03, 390, 380),  // D→C
-        ];
-        let route = Route::new(swaps, HashMap::new());
-        assert!(route.validate().is_ok());
-    }
-
-    #[test]
     fn test_validate_split_single_swap_nonzero_split() {
         // A ──[50%]── B   ERROR: single swap must have split=0.0
         let swaps = vec![make_split_swap(0x01, 0x02, 0.5)];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();
         assert!(matches!(err, RouteValidationError::InvalidSplit { .. }));
+    }
+
+    #[test]
+    fn test_validate_split_unreachable_group() {
+        //   ┌──[50%]──┐
+        // A │          B    C → D   ERROR: C unreachable from A
+        //   └──[rem]──┘
+        let swaps = vec![
+            make_split_swap(0x01, 0x02, 0.5), // A→B
+            make_split_swap(0x01, 0x02, 0.0), // A→B (remainder)
+            make_swap(0x03, 0x04, 490, 480),  // C→D (unreachable)
+        ];
+        let route = Route::new(swaps, HashMap::new());
+        let err = route.validate().unwrap_err();
+        assert!(matches!(err, RouteValidationError::DisconnectedGroup { .. }));
     }
 
     #[test]
@@ -1957,27 +1957,19 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_split_multi_back_edge_groups() {
-        //   ┌──[30%]── B ──┐       ┌──[rem]──┐
-        // A ┤               D──→A──┤          F──→A
-        //   └──[30%]── C ──┘       └──── E ──┘
-        //                    ↑                  ↑
-        //              back-edge 1        back-edge 2
-        //         ERROR: two groups cycle back to A
+    fn test_validate_split_round_trip_valid_from_multiple_groups() {
+        //       ┌──[40%]── C ──┐
+        // A → B │               → A   (round-trip back to start)
+        //       └──[rem]── D ──┘
         let swaps = vec![
-            make_split_swap(0x01, 0x02, 0.3),                // A→B
-            make_split_swap(0x01, 0x03, 0.3),                // A→C
-            make_swap(0x02, 0x04, 290, 280),                 // B→D
-            make_swap(0x03, 0x04, 290, 280),                 // C→D
-            make_swap(0x04, 0x01, 560, 550).with_split(0.5), // D→A
-            make_swap(0x04, 0x05, 280, 270).with_split(0.0), // D→E
-            make_split_swap(0x01, 0x06, 0.0),                // A→F (remainder)
-            make_swap(0x05, 0x06, 270, 260),                 // E→F
-            make_swap(0x06, 0x01, 810, 800),                 // F→A
+            make_swap(0x01, 0x02, 960, 950),  // A→B
+            make_split_swap(0x02, 0x03, 0.4), // B→C
+            make_split_swap(0x02, 0x04, 0.0), // B→D
+            make_swap(0x03, 0x01, 960, 950),  // C→A (round-trip)
+            make_swap(0x04, 0x01, 960, 950),  // D→A (round-trip)
         ];
         let route = Route::new(swaps, HashMap::new());
-        let err = route.validate().unwrap_err();
-        assert!(matches!(err, RouteValidationError::UnsupportedCycle { .. }));
+        assert!(route.validate().is_ok());
     }
 
     #[test]
@@ -1988,23 +1980,6 @@ mod tests {
         let swaps = vec![
             make_split_swap(0x01, 0x01, 0.5), // A→A
             make_split_swap(0x01, 0x01, 0.0), // A→A (remainder)
-        ];
-        let route = Route::new(swaps, HashMap::new());
-        let err = route.validate().unwrap_err();
-        assert!(matches!(err, RouteValidationError::UnsupportedCycle { .. }));
-    }
-
-    #[test]
-    fn test_validate_split_terminal_is_group_input() {
-        //     ┌──[50%]── B ──┐
-        // A → C               → C   ERROR: B→C and D→C cycle back
-        //     └──[rem]── D ──┘       (not a round-trip: first=A ≠ terminal=C)
-        let swaps = vec![
-            make_swap(0x01, 0x03, 1000, 990),                // A→C
-            make_swap(0x03, 0x02, 990, 980).with_split(0.5), // C→B
-            make_swap(0x03, 0x04, 490, 480).with_split(0.0), // C→D
-            make_swap(0x02, 0x03, 980, 970),                 // B→C (cycle)
-            make_swap(0x04, 0x03, 480, 470),                 // D→C (cycle)
         ];
         let route = Route::new(swaps, HashMap::new());
         let err = route.validate().unwrap_err();


### PR DESCRIPTION
  - Route::validate() now detects split routes and dispatches to validate_split_route()
  - Adds BFS connectivity, dead-end detection, and cycle detection