### PR TITLE
fix: apply curve_pool_filter to vm:curve exchange

### DIFF
--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -9,7 +9,10 @@ use tycho_simulation::{
             ekubo::state::EkuboState,
             ekubo_v3::{self, state::EkuboV3State},
             erc4626::state::ERC4626State,
-            filters::{balancer_v2_pool_filter, erc4626_filter, fluid_v1_paused_pools_filter},
+            filters::{
+                balancer_v2_pool_filter, curve_pool_filter, erc4626_filter,
+                fluid_v1_paused_pools_filter,
+            },
             fluid::FluidV1,
             pancakeswap_v2::state::PancakeswapV2State,
             uniswap_v2::state::UniswapV2State,
@@ -81,7 +84,7 @@ pub(crate) fn register_exchanges(
                 builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
                     "vm:curve",
                     tvl_filter.clone(),
-                    None,
+                    Some(curve_pool_filter),
                 );
             }
             "uniswap_v4_hooks" => {


### PR DESCRIPTION
`vm:curve` was registered with no pool filter (`None`), unlike other VM-based exchanges such as `vm:balancer_v2`. This applies `curve_pool_filter`, which excludes Curve pools whose token types the simulation does not support (non-zero `asset_types` / `asset_type`).