### PR TITLE
feat(PFW): implement find_candidate_path and is_duplicate_path 

### DIFF
--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -12,7 +12,9 @@ use num_traits::ToPrimitive;
 
 use super::{
     bellman_ford::{BellmanFordContext, FindRouteOptions},
-    split_primitives::{build_post_swap_overrides, split_amount, HopDescriptor, PathAllocation},
+    split_primitives::{
+        build_post_swap_overrides, split_amount, HopDescriptor, PathAllocation, SimulatedHop,
+    },
     Algorithm, AlgorithmConfig, AlgorithmError, BellmanFordAlgorithm,
 };
 use crate::{
@@ -138,7 +140,7 @@ impl PathFrankWolfeAlgorithm {
     /// Pools already present in `current_allocations` are promoted to zero-gas so their
     /// committed gas cost is not counted again as marginal cost for the new path.
     ///
-    /// Returns an ordered sequence of [`HopDescriptor`]s representing the discovered path,
+    /// Returns an ordered sequence of [`SimulatedHop`]s representing the discovered path,
     /// or an error if no route exists.
     #[allow(dead_code)]
     pub(crate) fn find_candidate_path(
@@ -146,7 +148,7 @@ impl PathFrankWolfeAlgorithm {
         ctx: &BellmanFordContext,
         current_allocations: &[PathAllocation],
         probe_amount: &BigUint,
-    ) -> Result<Vec<HopDescriptor>, AlgorithmError> {
+    ) -> Result<Vec<SimulatedHop>, AlgorithmError> {
         let mut overrides = build_post_swap_overrides(current_allocations, &ctx.market_data);
 
         // Pools committed in the current solution are executed once on-chain — their gas is
@@ -157,9 +159,9 @@ impl PathFrankWolfeAlgorithm {
         for alloc in current_allocations {
             for hop in &alloc.hops {
                 overrides = overrides.with_zero_gas(
-                    hop.component_id.clone(),
-                    hop.token_in.address.clone(),
-                    hop.token_out.address.clone(),
+                    hop.descriptor.component_id.clone(),
+                    hop.descriptor.token_in.address.clone(),
+                    hop.descriptor.token_out.address.clone(),
                 );
             }
         }
@@ -212,8 +214,15 @@ impl PathFrankWolfeAlgorithm {
                         kind: "token",
                         id: Some(format!("{:?}", swap.token_out())),
                     })?;
-                Ok(HopDescriptor::new(swap.component_id().to_string(), token_in, token_out)
-                    .with_amounts(swap.amount_out().clone(), swap.gas_estimate().clone()))
+                Ok(SimulatedHop {
+                    descriptor: HopDescriptor::new(
+                        swap.component_id().to_string(),
+                        token_in,
+                        token_out,
+                    ),
+                    amount_out: swap.amount_out().clone(),
+                    gas: swap.gas_estimate().clone(),
+                })
             })
             .collect()
     }
@@ -229,7 +238,7 @@ impl PathFrankWolfeAlgorithm {
     /// the common segment.
     #[allow(dead_code)]
     pub(crate) fn is_duplicate_path(
-        candidate: &[HopDescriptor],
+        candidate: &[SimulatedHop],
         existing: &[PathAllocation],
     ) -> bool {
         existing.iter().any(|alloc| {
@@ -239,9 +248,9 @@ impl PathFrankWolfeAlgorithm {
                     .iter()
                     .zip(candidate.iter())
                     .all(|(a, b)| {
-                        a.component_id == b.component_id &&
-                            a.token_in.address == b.token_in.address &&
-                            a.token_out.address == b.token_out.address
+                        a.descriptor.component_id == b.descriptor.component_id &&
+                            a.descriptor.token_in.address == b.descriptor.token_in.address &&
+                            a.descriptor.token_out.address == b.descriptor.token_out.address
                     })
         })
     }
@@ -498,7 +507,6 @@ mod tests {
             AlgorithmConfig::new(1, max_hops, StdDuration::from_millis(1000), None).unwrap(),
             PathFrankWolfeConfig::default(),
         )
-        .unwrap()
     }
 
     #[test]
@@ -506,9 +514,11 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let candidate =
-            vec![HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())];
+            vec![HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())
+                .with_amounts(BigUint::from(200u64), BigUint::from(50_000u64))];
         let alloc = PathAllocation {
-            hops: vec![HopDescriptor::new("P1".to_string(), token_a, token_b)],
+            hops: vec![HopDescriptor::new("P1".to_string(), token_a, token_b)
+                .with_amounts(BigUint::from(200u64), BigUint::from(50_000u64))],
             flow_fraction: 1.0,
             amount_in: BigUint::from(100u64),
             amount_out: BigUint::from(200u64),
@@ -523,10 +533,13 @@ mod tests {
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
 
+        let zero = BigUint::from(0u64);
         let alloc = PathAllocation {
             hops: vec![
-                HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone()),
-                HopDescriptor::new("P2".to_string(), token_b.clone(), token_c.clone()),
+                HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())
+                    .with_amounts(zero.clone(), zero.clone()),
+                HopDescriptor::new("P2".to_string(), token_b.clone(), token_c.clone())
+                    .with_amounts(zero.clone(), zero.clone()),
             ],
             flow_fraction: 1.0,
             amount_in: BigUint::from(100u64),
@@ -536,8 +549,10 @@ mod tests {
 
         // [P1, P3] shares first hop with [P1, P2] but diverges at hop 2
         let candidate = vec![
-            HopDescriptor::new("P1".to_string(), token_a, token_b.clone()),
-            HopDescriptor::new("P3".to_string(), token_b, token_c),
+            HopDescriptor::new("P1".to_string(), token_a, token_b.clone())
+                .with_amounts(zero.clone(), zero.clone()),
+            HopDescriptor::new("P3".to_string(), token_b, token_c)
+                .with_amounts(zero.clone(), zero.clone()),
         ];
         assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(&candidate, &[alloc]));
     }
@@ -549,14 +564,17 @@ mod tests {
         let token_c = token(0x03, "C");
 
         // Same pool "P1" but with different token pairs — not a duplicate.
+        let zero = BigUint::from(0u64);
         let alloc = PathAllocation {
-            hops: vec![HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())],
+            hops: vec![HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())
+                .with_amounts(zero.clone(), zero.clone())],
             flow_fraction: 1.0,
             amount_in: BigUint::from(100u64),
             amount_out: BigUint::from(200u64),
             marginal_price_product: 2.0,
         };
-        let candidate = vec![HopDescriptor::new("P1".to_string(), token_a, token_c)];
+        let candidate = vec![HopDescriptor::new("P1".to_string(), token_a, token_c)
+            .with_amounts(zero.clone(), zero.clone())];
         assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(&candidate, &[alloc]));
     }
 
@@ -618,13 +636,10 @@ mod tests {
         let first_path = algo
             .find_candidate_path(&ctx, &[], &probe_amount)
             .unwrap();
-        assert_eq!(first_path[0].component_id, "P1");
-        assert_eq!(first_path[1].component_id, "P2");
+        assert_eq!(first_path[0].descriptor.component_id, "P1");
+        assert_eq!(first_path[1].descriptor.component_id, "P2");
 
-        let first_amount_out = first_path[1]
-            .amount_out
-            .clone()
-            .expect("amount_out populated");
+        let first_amount_out = first_path[1].amount_out.clone();
         let first_alloc = PathAllocation {
             hops: first_path,
             flow_fraction: 0.5,
@@ -637,8 +652,8 @@ mod tests {
         let second_path = algo
             .find_candidate_path(&ctx, std::slice::from_ref(&first_alloc), &probe_amount)
             .unwrap();
-        assert_eq!(second_path[0].component_id, "P1");
-        assert_eq!(second_path[1].component_id, "P3");
+        assert_eq!(second_path[0].descriptor.component_id, "P1");
+        assert_eq!(second_path[1].descriptor.component_id, "P3");
 
         // Shared prefix [P1] does not make these duplicates.
         assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(
@@ -646,10 +661,7 @@ mod tests {
             std::slice::from_ref(&first_alloc)
         ));
 
-        let second_amount_out = second_path[1]
-            .amount_out
-            .clone()
-            .expect("amount_out populated");
+        let second_amount_out = second_path[1].amount_out.clone();
         let second_alloc = PathAllocation {
             hops: second_path,
             flow_fraction: 0.5,
@@ -707,7 +719,7 @@ mod tests {
         let first_path = algo
             .find_candidate_path(&ctx, &[], &probe_amount)
             .unwrap();
-        assert_eq!(first_path[0].component_id, "P1");
+        assert_eq!(first_path[0].descriptor.component_id, "P1");
 
         let first_alloc = PathAllocation {
             hops: first_path,

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -170,7 +170,7 @@ impl PathFrankWolfeAlgorithm {
             .get(&ctx.token_in_node)
             .cloned()
             .ok_or_else(|| AlgorithmError::DataNotFound {
-                kind: "token_in address",
+                kind: "token_in node address",
                 id: Some(format!("{:?}", ctx.token_in_node)),
             })?;
         let token_out = ctx
@@ -178,7 +178,7 @@ impl PathFrankWolfeAlgorithm {
             .get(&ctx.token_out_node)
             .cloned()
             .ok_or_else(|| AlgorithmError::DataNotFound {
-                kind: "token_out address",
+                kind: "token_out node address",
                 id: Some(format!("{:?}", ctx.token_out_node)),
             })?;
         let probe_order = Order::new(

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -5,7 +5,7 @@
 //! single-path discovery; this module layers on the Frank-Wolfe optimisation
 //! loop to determine the best split fractions.
 
-use std::{collections::HashSet, time::Duration};
+use std::time::Duration;
 
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
@@ -151,17 +151,17 @@ impl PathFrankWolfeAlgorithm {
 
         // Pools committed in the current solution are executed once on-chain — their gas is
         // already priced into the combined transaction. Zero out marginal gas so BF doesn't
-        // double-charge them when evaluating extensions.
-        let committed: HashSet<String> = current_allocations
-            .iter()
-            .flat_map(|a| {
-                a.hops
-                    .iter()
-                    .map(|h| h.component_id.clone())
-            })
-            .collect();
-        for pool_id in committed {
-            overrides = overrides.with_zero_gas(pool_id);
+        // double-charge them when evaluating extensions. We track by (component_id, token_in,
+        // token_out) because different token pairs through the same pool are separate on-chain
+        // swaps with independent gas costs.
+        for alloc in current_allocations {
+            for hop in &alloc.hops {
+                overrides = overrides.with_zero_gas(
+                    hop.component_id.clone(),
+                    hop.token_in.address.clone(),
+                    hop.token_out.address.clone(),
+                );
+            }
         }
 
         let token_in = ctx
@@ -735,7 +735,7 @@ mod tests {
 
         let overrides = MarketOverrides::empty()
             .with_override("P1".to_string(), Box::new(sim.clone()))
-            .with_zero_gas("P1".to_string());
+            .with_zero_gas("P1".to_string(), token_a.address.clone(), token_b.address.clone());
 
         let result = overrides
             .get(&"P1".to_string())

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -150,7 +150,7 @@ impl PathFrankWolfeAlgorithm {
         let mut overrides = build_post_swap_overrides(current_allocations, &ctx.market_data);
 
         // Pools committed in the current solution are executed once on-chain — their gas is
-        // already priced into the combined transaction. Zero out marginal gas so BF doesn't
+        // already priced into the combined transaction. Zero out protocol gas so BF doesn't
         // double-charge them when evaluating extensions. We track by (component_id, token_in,
         // token_out) because different token pairs through the same pool are separate on-chain
         // swaps with independent gas costs.
@@ -169,7 +169,7 @@ impl PathFrankWolfeAlgorithm {
             .get(&ctx.token_in_node)
             .cloned()
             .ok_or_else(|| AlgorithmError::DataNotFound {
-                kind: "token_in node address",
+                kind: "token_in node index",
                 id: Some(format!("{:?}", ctx.token_in_node)),
             })?;
         let token_out = ctx
@@ -177,7 +177,7 @@ impl PathFrankWolfeAlgorithm {
             .get(&ctx.token_out_node)
             .cloned()
             .ok_or_else(|| AlgorithmError::DataNotFound {
-                kind: "token_out node address",
+                kind: "token_out node index",
                 id: Some(format!("{:?}", ctx.token_out_node)),
             })?;
         let probe_order = Order::new(

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -5,20 +5,21 @@
 //! single-path discovery; this module layers on the Frank-Wolfe optimisation
 //! loop to determine the best split fractions.
 
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use num_bigint::BigUint;
 use num_traits::ToPrimitive;
 
 use super::{
-    split_primitives::{split_amount, PathAllocation},
+    bellman_ford::{BellmanFordContext, FindRouteOptions},
+    split_primitives::{build_post_swap_overrides, split_amount, HopDescriptor, PathAllocation},
     Algorithm, AlgorithmConfig, AlgorithmError, BellmanFordAlgorithm,
 };
 use crate::{
     derived::{computation::ComputationRequirements, SharedDerivedDataRef},
     feed::market_data::{MarketData, StateLabel},
     graph::{petgraph::StableDiGraph, PetgraphStableDiGraphManager},
-    types::{quote::Order, RouteResult},
+    types::{quote::Order, OrderSide, RouteResult},
 };
 
 /// Tuning parameters for the path-based Frank-Wolfe split-routing loop.
@@ -127,6 +128,121 @@ impl PathFrankWolfeAlgorithm {
         }
         Ok(weighted_price_impact)
     }
+
+    /// Finds the next candidate routing path for the Frank-Wolfe algorithm.
+    ///
+    /// Builds a post-swap market state that reflects `current_allocations` (applying each
+    /// allocation's simulated pool outputs as overrides), then runs Bellman-Ford at
+    /// `probe_amount` to discover the best remaining route.
+    ///
+    /// Pools already present in `current_allocations` are promoted to zero-gas so their
+    /// committed gas cost is not counted again as marginal cost for the new path.
+    ///
+    /// Returns an ordered sequence of [`HopDescriptor`]s representing the discovered path,
+    /// or an error if no route exists.
+    #[allow(dead_code)]
+    pub(crate) fn find_candidate_path(
+        &self,
+        ctx: &BellmanFordContext,
+        current_allocations: &[PathAllocation],
+        probe_amount: &BigUint,
+    ) -> Result<Vec<HopDescriptor>, AlgorithmError> {
+        let paths: Vec<&PathAllocation> = current_allocations.iter().collect();
+        let mut overrides = build_post_swap_overrides(&paths, &ctx.market_data);
+
+        // Pools committed in the current solution are executed once on-chain — their gas is
+        // already priced into the combined transaction. Zero out marginal gas so BF doesn't
+        // double-charge them when evaluating extensions.
+        let committed: HashSet<String> = current_allocations
+            .iter()
+            .flat_map(|a| {
+                a.hops
+                    .iter()
+                    .map(|h| h.component_id.clone())
+            })
+            .collect();
+        for pool_id in committed {
+            overrides = overrides.with_zero_gas(pool_id);
+        }
+
+        let token_in = ctx
+            .node_address
+            .get(&ctx.token_in_node)
+            .cloned()
+            .ok_or_else(|| AlgorithmError::DataNotFound {
+                kind: "token_in address",
+                id: Some(format!("{:?}", ctx.token_in_node)),
+            })?;
+        let token_out = ctx
+            .node_address
+            .get(&ctx.token_out_node)
+            .cloned()
+            .ok_or_else(|| AlgorithmError::DataNotFound {
+                kind: "token_out address",
+                id: Some(format!("{:?}", ctx.token_out_node)),
+            })?;
+        let probe_order = Order::new(
+            token_in,
+            token_out,
+            probe_amount.clone(),
+            OrderSide::Sell,
+            Default::default(),
+        );
+
+        let result =
+            self.inner
+                .find_single_route(ctx, &probe_order, FindRouteOptions { overrides })?;
+
+        let route = result.route();
+        let tokens = route.tokens();
+        route
+            .swaps()
+            .iter()
+            .map(|swap| {
+                let token_in = tokens
+                    .get(swap.token_in())
+                    .cloned()
+                    .ok_or_else(|| AlgorithmError::DataNotFound {
+                        kind: "token",
+                        id: Some(format!("{:?}", swap.token_in())),
+                    })?;
+                let token_out = tokens
+                    .get(swap.token_out())
+                    .cloned()
+                    .ok_or_else(|| AlgorithmError::DataNotFound {
+                        kind: "token",
+                        id: Some(format!("{:?}", swap.token_out())),
+                    })?;
+                Ok(HopDescriptor::new(swap.component_id().to_string(), token_in, token_out)
+                    .with_amounts(swap.amount_out().clone(), swap.gas_estimate().clone()))
+            })
+            .collect()
+    }
+
+    /// Returns `true` if `candidate` has the same ordered sequence of pool component IDs as any
+    /// existing allocation.
+    ///
+    /// Paths that share only a prefix but diverge at a later hop are **not** duplicates — the
+    /// shared hops are handled by `build_split_route`, which emits a single combined swap for
+    /// the common segment.
+    #[allow(dead_code)]
+    pub(crate) fn is_duplicate_path(
+        candidate: &[HopDescriptor],
+        existing: &[PathAllocation],
+    ) -> bool {
+        let candidate_ids: Vec<&str> = candidate
+            .iter()
+            .map(|h| h.component_id.as_str())
+            .collect();
+        existing.iter().any(|alloc| {
+            let existing_ids: Vec<&str> = alloc
+                .hops
+                .iter()
+                .map(|h| h.component_id.as_str())
+                .collect();
+            existing_ids == candidate_ids
+        })
+    }
 }
 
 impl Algorithm for PathFrankWolfeAlgorithm {
@@ -166,8 +282,22 @@ impl Algorithm for PathFrankWolfeAlgorithm {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration as StdDuration;
+
+    use tycho_simulation::tycho_common::simulation::protocol_sim::ProtocolSim;
+
     use super::*;
-    use crate::algorithm::AlgorithmConfig;
+    use crate::{
+        algorithm::{
+            split_primitives::{build_split_route, MarketOverrides},
+            test_utils::{
+                order, setup_market_unweighted, token, ConstantProductSim, MockProtocolSim,
+            },
+            AlgorithmConfig,
+        },
+        graph::GraphManager,
+        types::OrderSide,
+    };
 
     impl PathFrankWolfeAlgorithm {
         /// Returns a reference to the PFW-specific tuning config.
@@ -358,4 +488,242 @@ mod tests {
     #[test]
     #[ignore]
     fn test_pi_exit_criterion_stops_loop_early() {}
+
+    // ==================== find_candidate_path / is_duplicate_path ====================
+
+    fn pfw_algo(max_hops: usize) -> PathFrankWolfeAlgorithm {
+        PathFrankWolfeAlgorithm::new(
+            AlgorithmConfig::new(1, max_hops, StdDuration::from_millis(1000), None).unwrap(),
+            PathFrankWolfeConfig::default(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_is_duplicate_path_exact_match() {
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let candidate =
+            vec![HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())];
+        let alloc = PathAllocation {
+            hops: vec![HopDescriptor::new("P1".to_string(), token_a, token_b)],
+            flow_fraction: 1.0,
+            amount_in: BigUint::from(100u64),
+            amount_out: BigUint::from(200u64),
+            marginal_price_product: 2.0,
+        };
+        assert!(PathFrankWolfeAlgorithm::is_duplicate_path(&candidate, &[alloc]));
+    }
+
+    #[test]
+    fn test_is_duplicate_path_shared_prefix() {
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let token_c = token(0x03, "C");
+
+        let alloc = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone()),
+                HopDescriptor::new("P2".to_string(), token_b.clone(), token_c.clone()),
+            ],
+            flow_fraction: 1.0,
+            amount_in: BigUint::from(100u64),
+            amount_out: BigUint::from(200u64),
+            marginal_price_product: 1.0,
+        };
+
+        // [P1, P3] shares first hop with [P1, P2] but diverges at hop 2
+        let candidate = vec![
+            HopDescriptor::new("P1".to_string(), token_a, token_b.clone()),
+            HopDescriptor::new("P3".to_string(), token_b, token_c),
+        ];
+        assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(&candidate, &[alloc]));
+    }
+
+    #[tokio::test]
+    async fn test_shared_first_pool_two_outputs() {
+        // Two paths share pool P1 (A→B) and diverge at B→C via P2 vs P3.
+        //
+        // P2 has higher initial rate but degrades after one allocation; BF then discovers P3.
+        // Verifies: `is_duplicate_path` returns false, `build_split_route` emits 3 swaps,
+        // P1 gas counted once.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let token_c = token(0x03, "C");
+
+        let (market, graph_manager) = setup_market_unweighted(vec![
+            (
+                "P1",
+                &token_a,
+                &token_b,
+                Box::new(ConstantProductSim {
+                    reserve_0: BigUint::from(10_000u64),
+                    reserve_1: BigUint::from(10_000u64),
+                    gas: 50_000,
+                }) as Box<dyn ProtocolSim>,
+            ),
+            (
+                "P2",
+                &token_b,
+                &token_c,
+                Box::new(ConstantProductSim {
+                    reserve_0: BigUint::from(1_000u64),
+                    reserve_1: BigUint::from(1_500u64),
+                    gas: 50_000,
+                }) as Box<dyn ProtocolSim>,
+            ),
+            (
+                "P3",
+                &token_b,
+                &token_c,
+                Box::new(ConstantProductSim {
+                    reserve_0: BigUint::from(1_000u64),
+                    reserve_1: BigUint::from(1_000u64),
+                    gas: 50_000,
+                }) as Box<dyn ProtocolSim>,
+            ),
+        ]);
+
+        let algo = pfw_algo(3);
+        let probe_amount = BigUint::from(1_000u64);
+        let ord = order(&token_a, &token_c, 1_000, OrderSide::Sell);
+
+        let ctx = algo
+            .inner
+            .build_context(graph_manager.graph(), market, None, None, &ord)
+            .await
+            .unwrap();
+
+        // First candidate: P2 has 1.5x rate vs P3's 1.0x → finds [P1, P2].
+        let first_path = algo
+            .find_candidate_path(&ctx, &[], &probe_amount)
+            .unwrap();
+        assert_eq!(first_path[0].component_id, "P1");
+        assert_eq!(first_path[1].component_id, "P2");
+
+        let first_amount_out = first_path[1]
+            .amount_out
+            .clone()
+            .expect("amount_out populated");
+        let first_alloc = PathAllocation {
+            hops: first_path,
+            flow_fraction: 0.5,
+            amount_in: probe_amount.clone(),
+            amount_out: first_amount_out,
+            marginal_price_product: 1.5,
+        };
+
+        // After allocating 1000 A on [P1, P2], P2 degrades enough that BF finds [P1, P3].
+        let second_path = algo
+            .find_candidate_path(&ctx, std::slice::from_ref(&first_alloc), &probe_amount)
+            .unwrap();
+        assert_eq!(second_path[0].component_id, "P1");
+        assert_eq!(second_path[1].component_id, "P3");
+
+        // Shared prefix [P1] does not make these duplicates.
+        assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(
+            &second_path,
+            std::slice::from_ref(&first_alloc)
+        ));
+
+        let second_amount_out = second_path[1]
+            .amount_out
+            .clone()
+            .expect("amount_out populated");
+        let second_alloc = PathAllocation {
+            hops: second_path,
+            flow_fraction: 0.5,
+            amount_in: probe_amount.clone(),
+            amount_out: second_amount_out,
+            marginal_price_product: 1.0,
+        };
+
+        // build_split_route must emit 3 swaps: one combined A→B (P1), two B→C (P2, P3).
+        let all_allocs = [first_alloc, second_alloc];
+        let route = build_split_route(&all_allocs, &ctx.market_data, &ord).unwrap();
+        let swaps = route.swaps();
+        assert_eq!(swaps.len(), 3, "expected P1 + P2 + P3 = 3 swaps");
+        let ids: Vec<&str> = swaps
+            .iter()
+            .map(|s| s.component_id())
+            .collect();
+        assert_eq!(
+            ids.iter()
+                .filter(|&&id| id == "P1")
+                .count(),
+            1,
+            "P1 deduplicated"
+        );
+        assert!(ids.contains(&"P2"));
+        assert!(ids.contains(&"P3"));
+        // P1 gas counted once: P1(50k) + P2(50k) + P3(50k) = 150k.
+        assert_eq!(route.total_gas(), BigUint::from(150_000u64));
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_path_stops_iteration() {
+        // When BF repeatedly returns the same path, `is_duplicate_path` detects it so the
+        // Frank-Wolfe loop can stop.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+
+        let (market, graph_manager) = setup_market_unweighted(vec![(
+            "P1",
+            &token_a,
+            &token_b,
+            Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+        )]);
+
+        let algo = pfw_algo(2);
+        let probe_amount = BigUint::from(100u64);
+        let ord = order(&token_a, &token_b, 100, OrderSide::Sell);
+
+        let ctx = algo
+            .inner
+            .build_context(graph_manager.graph(), market, None, None, &ord)
+            .await
+            .unwrap();
+
+        let first_path = algo
+            .find_candidate_path(&ctx, &[], &probe_amount)
+            .unwrap();
+        assert_eq!(first_path[0].component_id, "P1");
+
+        let first_alloc = PathAllocation {
+            hops: first_path,
+            flow_fraction: 1.0,
+            amount_in: probe_amount.clone(),
+            amount_out: BigUint::from(200u64),
+            marginal_price_product: 2.0,
+        };
+
+        // P1 is the only pool — BF returns it again.
+        let second_path = algo
+            .find_candidate_path(&ctx, std::slice::from_ref(&first_alloc), &probe_amount)
+            .unwrap();
+        assert!(PathFrankWolfeAlgorithm::is_duplicate_path(
+            &second_path,
+            std::slice::from_ref(&first_alloc)
+        ));
+    }
+
+    #[test]
+    fn test_with_zero_gas_zeroes_gas_keeps_amounts() {
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let sim = MockProtocolSim::new(2.0).with_gas(50_000);
+
+        let overrides = MarketOverrides::empty()
+            .with_override("P1".to_string(), Box::new(sim.clone()))
+            .with_zero_gas("P1".to_string());
+
+        let result = overrides
+            .get(&"P1".to_string())
+            .unwrap()
+            .get_amount_out(BigUint::from(100u64), &token_a, &token_b)
+            .unwrap();
+
+        assert_eq!(result.amount, BigUint::from(200u64), "amount unaffected");
+        assert_eq!(result.gas, BigUint::ZERO, "gas zeroed by with_zero_gas");
+    }
 }

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -233,12 +233,16 @@ impl PathFrankWolfeAlgorithm {
         existing: &[PathAllocation],
     ) -> bool {
         existing.iter().any(|alloc| {
-            alloc.hops.len() == candidate.len()
-                && alloc.hops.iter().zip(candidate.iter()).all(|(a, b)| {
-                    a.component_id == b.component_id
-                        && a.token_in.address == b.token_in.address
-                        && a.token_out.address == b.token_out.address
-                })
+            alloc.hops.len() == candidate.len() &&
+                alloc
+                    .hops
+                    .iter()
+                    .zip(candidate.iter())
+                    .all(|(a, b)| {
+                        a.component_id == b.component_id &&
+                            a.token_in.address == b.token_in.address &&
+                            a.token_out.address == b.token_out.address
+                    })
         })
     }
 }
@@ -552,8 +556,7 @@ mod tests {
             amount_out: BigUint::from(200u64),
             marginal_price_product: 2.0,
         };
-        let candidate =
-            vec![HopDescriptor::new("P1".to_string(), token_a, token_c)];
+        let candidate = vec![HopDescriptor::new("P1".to_string(), token_a, token_c)];
         assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(&candidate, &[alloc]));
     }
 

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -219,8 +219,11 @@ impl PathFrankWolfeAlgorithm {
             .collect()
     }
 
-    /// Returns `true` if `candidate` has the same ordered sequence of pool component IDs as any
-    /// existing allocation.
+    /// Returns `true` if `candidate` has the same ordered sequence of
+    /// `(component_id, token_in, token_out)` as any existing allocation.
+    ///
+    /// Both the pool and the token pair must match at every hop — the same pool used with
+    /// different tokens (e.g. in a multi-token pool) is a distinct path.
     ///
     /// Paths that share only a prefix but diverge at a later hop are **not** duplicates — the
     /// shared hops are handled by `build_split_route`, which emits a single combined swap for
@@ -230,17 +233,13 @@ impl PathFrankWolfeAlgorithm {
         candidate: &[HopDescriptor],
         existing: &[PathAllocation],
     ) -> bool {
-        let candidate_ids: Vec<&str> = candidate
-            .iter()
-            .map(|h| h.component_id.as_str())
-            .collect();
         existing.iter().any(|alloc| {
-            let existing_ids: Vec<&str> = alloc
-                .hops
-                .iter()
-                .map(|h| h.component_id.as_str())
-                .collect();
-            existing_ids == candidate_ids
+            alloc.hops.len() == candidate.len()
+                && alloc.hops.iter().zip(candidate.iter()).all(|(a, b)| {
+                    a.component_id == b.component_id
+                        && a.token_in.address == b.token_in.address
+                        && a.token_out.address == b.token_out.address
+                })
         })
     }
 }
@@ -537,6 +536,25 @@ mod tests {
             HopDescriptor::new("P1".to_string(), token_a, token_b.clone()),
             HopDescriptor::new("P3".to_string(), token_b, token_c),
         ];
+        assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(&candidate, &[alloc]));
+    }
+
+    #[test]
+    fn test_is_duplicate_path_same_pool_different_tokens() {
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let token_c = token(0x03, "C");
+
+        // Same pool "P1" but with different token pairs — not a duplicate.
+        let alloc = PathAllocation {
+            hops: vec![HopDescriptor::new("P1".to_string(), token_a.clone(), token_b.clone())],
+            flow_fraction: 1.0,
+            amount_in: BigUint::from(100u64),
+            amount_out: BigUint::from(200u64),
+            marginal_price_product: 2.0,
+        };
+        let candidate =
+            vec![HopDescriptor::new("P1".to_string(), token_a, token_c)];
         assert!(!PathFrankWolfeAlgorithm::is_duplicate_path(&candidate, &[alloc]));
     }
 

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -147,8 +147,7 @@ impl PathFrankWolfeAlgorithm {
         current_allocations: &[PathAllocation],
         probe_amount: &BigUint,
     ) -> Result<Vec<HopDescriptor>, AlgorithmError> {
-        let paths: Vec<&PathAllocation> = current_allocations.iter().collect();
-        let mut overrides = build_post_swap_overrides(&paths, &ctx.market_data);
+        let mut overrides = build_post_swap_overrides(current_allocations, &ctx.market_data);
 
         // Pools committed in the current solution are executed once on-chain — their gas is
         // already priced into the combined transaction. Zero out marginal gas so BF doesn't

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -133,7 +133,9 @@ impl MarketOverrides {
     ) -> Self {
         if let Some(sim) = self.0.remove(&id) {
             // If already wrapped, add the new pair to the existing set.
-            let wrapped = if let Some(selective) = sim.as_any().downcast_ref::<SelectiveZeroGasSim>()
+            let wrapped = if let Some(selective) = sim
+                .as_any()
+                .downcast_ref::<SelectiveZeroGasSim>()
             {
                 let mut pairs = selective.zero_gas_pairs.clone();
                 pairs.insert((token_in, token_out));
@@ -202,7 +204,8 @@ impl ProtocolSim for SelectiveZeroGasSim {
         sell_token: Bytes,
         buy_token: Bytes,
     ) -> Result<(BigUint, BigUint), SimulationError> {
-        self.inner.get_limits(sell_token, buy_token)
+        self.inner
+            .get_limits(sell_token, buy_token)
     }
 
     fn delta_transition(

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -115,15 +115,38 @@ impl MarketOverrides {
         self
     }
 
-    /// Wraps an existing override entry so that `get_amount_out().gas` is always zero.
+    /// Wraps an existing override entry so that `get_amount_out().gas` is zero for
+    /// the specified `(token_in, token_out)` pair, but unchanged for other pairs
+    /// through the same pool.
     ///
-    /// The underlying pool still produces correct amounts; only the gas is zeroed. Use for
-    /// pools already present in `current_allocations` — their gas is paid once in the combined
-    /// transaction and must not be counted again as a marginal cost. If the ID has no override
-    /// entry (e.g., simulation failed during degradation), this is a no-op.
-    pub(crate) fn with_zero_gas(mut self, id: ComponentId) -> Self {
+    /// Different token pairs through the same pool are separate on-chain swaps with
+    /// independent gas costs, so only committed pairs should be zeroed. Call this
+    /// once per committed `(component_id, token_in, token_out)` triple.
+    ///
+    /// Multiple calls for the same component accumulate pairs. If the ID has no
+    /// override entry, this is a no-op.
+    pub(crate) fn with_zero_gas(
+        mut self,
+        id: ComponentId,
+        token_in: Bytes,
+        token_out: Bytes,
+    ) -> Self {
         if let Some(sim) = self.0.remove(&id) {
-            self.0.insert(id, wrap_zero_gas(sim));
+            // If already wrapped, add the new pair to the existing set.
+            let wrapped = if let Some(selective) = sim.as_any().downcast_ref::<SelectiveZeroGasSim>()
+            {
+                let mut pairs = selective.zero_gas_pairs.clone();
+                pairs.insert((token_in, token_out));
+                Box::new(SelectiveZeroGasSim {
+                    inner: selective.inner.clone_box(),
+                    zero_gas_pairs: pairs,
+                }) as Box<dyn ProtocolSim>
+            } else {
+                let mut pairs = HashSet::new();
+                pairs.insert((token_in, token_out));
+                Box::new(SelectiveZeroGasSim { inner: sim, zero_gas_pairs: pairs })
+            };
+            self.0.insert(id, wrapped);
         }
         self
     }
@@ -133,25 +156,23 @@ impl MarketOverrides {
     }
 }
 
-/// Wraps a sim so that `get_amount_out().gas` is always zero while amounts
-/// remain correct. Use for pools whose gas is already accounted for elsewhere.
-pub(crate) fn wrap_zero_gas(sim: Box<dyn ProtocolSim>) -> Box<dyn ProtocolSim> {
-    Box::new(ZeroGasSim(sim))
+/// Wrapper that delegates all [`ProtocolSim`] calls unchanged except
+/// [`get_amount_out`](ProtocolSim::get_amount_out), where it zeroes the returned gas
+/// only for token pairs in `zero_gas_pairs`. Other pairs pass through unchanged.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct SelectiveZeroGasSim {
+    inner: Box<dyn ProtocolSim>,
+    zero_gas_pairs: HashSet<(Bytes, Bytes)>,
 }
 
-/// Wrapper that delegates all [`ProtocolSim`] calls unchanged except
-/// [`get_amount_out`](ProtocolSim::get_amount_out), where it zeroes the returned gas.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct ZeroGasSim(Box<dyn ProtocolSim>);
-
 #[typetag::serde]
-impl ProtocolSim for ZeroGasSim {
+impl ProtocolSim for SelectiveZeroGasSim {
     fn fee(&self) -> f64 {
-        self.0.fee()
+        self.inner.fee()
     }
 
     fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
-        self.0.spot_price(base, quote)
+        self.inner.spot_price(base, quote)
     }
 
     fn get_amount_out(
@@ -161,10 +182,18 @@ impl ProtocolSim for ZeroGasSim {
         token_out: &Token,
     ) -> Result<GetAmountOutResult, SimulationError> {
         let mut result = self
-            .0
+            .inner
             .get_amount_out(amount_in, token_in, token_out)?;
-        result.gas = BigUint::ZERO;
-        result.new_state = Box::new(ZeroGasSim(result.new_state));
+        if self
+            .zero_gas_pairs
+            .contains(&(token_in.address.clone(), token_out.address.clone()))
+        {
+            result.gas = BigUint::ZERO;
+        }
+        result.new_state = Box::new(SelectiveZeroGasSim {
+            inner: result.new_state,
+            zero_gas_pairs: self.zero_gas_pairs.clone(),
+        });
         Ok(result)
     }
 
@@ -173,7 +202,7 @@ impl ProtocolSim for ZeroGasSim {
         sell_token: Bytes,
         buy_token: Bytes,
     ) -> Result<(BigUint, BigUint), SimulationError> {
-        self.0.get_limits(sell_token, buy_token)
+        self.inner.get_limits(sell_token, buy_token)
     }
 
     fn delta_transition(
@@ -182,12 +211,15 @@ impl ProtocolSim for ZeroGasSim {
         tokens: &HashMap<Bytes, Token>,
         balances: &Balances,
     ) -> Result<(), TransitionError> {
-        self.0
+        self.inner
             .delta_transition(delta, tokens, balances)
     }
 
     fn clone_box(&self) -> Box<dyn ProtocolSim> {
-        Box::new(ZeroGasSim(self.0.clone_box()))
+        Box::new(SelectiveZeroGasSim {
+            inner: self.inner.clone_box(),
+            zero_gas_pairs: self.zero_gas_pairs.clone(),
+        })
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -202,7 +234,7 @@ impl ProtocolSim for ZeroGasSim {
         other
             .as_any()
             .downcast_ref::<Self>()
-            .map(|o| self.0.eq(&*o.0))
+            .map(|o| self.inner.eq(&*o.inner) && self.zero_gas_pairs == o.zero_gas_pairs)
             .unwrap_or(false)
     }
 }
@@ -1077,7 +1109,7 @@ mod tests {
         // Zero gas on pool_ab, leave pool_bc as a normal override.
         let overrides = MarketOverrides::empty()
             .with_override("pool_ab".to_string(), Box::new(sim_ab))
-            .with_zero_gas("pool_ab".to_string())
+            .with_zero_gas("pool_ab".to_string(), token_a.address.clone(), token_b.address.clone())
             .with_override("pool_bc".to_string(), Box::new(sim_bc));
 
         let hops_ab = [HopDescriptor::new("pool_ab".to_string(), token_a.clone(), token_b.clone())];

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -115,13 +115,16 @@ impl MarketOverrides {
         self
     }
 
-    /// Insert a zero-gas wrapper around an existing sim. The underlying pool still
-    /// produces correct amounts; only `get_amount_out().gas` is zeroed. Use for pools
-    /// already present in `current_allocations` — their gas is paid once in the
-    /// combined transaction.
-    pub(crate) fn with_zero_gas(mut self, id: ComponentId, sim: Box<dyn ProtocolSim>) -> Self {
-        self.0
-            .insert(id, Box::new(ZeroGasSim(sim)));
+    /// Wraps an existing override entry so that `get_amount_out().gas` is always zero.
+    ///
+    /// The underlying pool still produces correct amounts; only the gas is zeroed. Use for
+    /// pools already present in `current_allocations` — their gas is paid once in the combined
+    /// transaction and must not be counted again as a marginal cost. If the ID has no override
+    /// entry (e.g., simulation failed during degradation), this is a no-op.
+    pub(crate) fn with_zero_gas(mut self, id: ComponentId) -> Self {
+        if let Some(sim) = self.0.remove(&id) {
+            self.0.insert(id, wrap_zero_gas(sim));
+        }
         self
     }
 
@@ -1073,7 +1076,8 @@ mod tests {
 
         // Zero gas on pool_ab, leave pool_bc as a normal override.
         let overrides = MarketOverrides::empty()
-            .with_zero_gas("pool_ab".to_string(), Box::new(sim_ab))
+            .with_override("pool_ab".to_string(), Box::new(sim_ab))
+            .with_zero_gas("pool_ab".to_string())
             .with_override("pool_bc".to_string(), Box::new(sim_bc));
 
         let hops_ab = [HopDescriptor::new("pool_ab".to_string(), token_a.clone(), token_b.clone())];

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -468,7 +468,7 @@ pub(crate) fn evaluate_total_output(
 /// Paths are processed in order so shared pools accumulate the effects of
 /// all prior paths.
 pub(crate) fn build_post_swap_overrides(
-    paths: &[&PathAllocation],
+    paths: &[PathAllocation],
     market: &MarketState,
 ) -> MarketOverrides {
     let mut overrides = MarketOverrides::empty();
@@ -1256,7 +1256,7 @@ mod tests {
             marginal_price_product: 2.0,
         };
 
-        let degraded = build_post_swap_overrides(&[&allocation], &market);
+        let degraded = build_post_swap_overrides(&[allocation], &market);
 
         // xy=k: amount_out = amount_in * reserve_out / (reserve_in + amount_in)
         // Fresh pool (10000/20000): 100 * 20000 / (10000 + 100) = 198


### PR DESCRIPTION
Done:
- Adds two Frank-Wolfe path-discovery primitives to PathFrankWolfeAlgorithm: find_candidate_path and is_duplicate_path
- Also replaces MarketOverrides::with_zero_gas(id, sim) with with_zero_gas(id): the old form required cloning the degraded sim out of the map to pass it back in; the new form removes the entry, wraps it, and reinserts — no clone, same intent.