### PR TITLE
fix(split routing): topological order for cross-depth hops 

### DIFF
--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -621,8 +621,8 @@ fn assign_splits_and_amounts(
 /// intermediate token:
 ///
 /// ```text
-/// Path 1 (2 hops): WETH -> USDC -> DAI          (via Pool A)
-/// Path 2 (3 hops): WETH -> USDT -> USDC -> DAI  (via Pool A)
+/// Path 1 (2 hops): WETH -> USDC -(pool A)-> DAI
+/// Path 2 (3 hops): WETH -> USDT -> USDC -(pool A)-> DAI
 /// ```
 ///
 /// Pool A (USDC→DAI) is merged into one swap. If USDC were visited before

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -18,6 +18,7 @@ use crate::{
     types::{ComponentId, Order, Route, Swap},
 };
 
+#[derive(Clone)]
 pub(crate) struct HopDescriptor {
     pub(crate) component_id: ComponentId,
     pub(crate) token_in: Token,
@@ -44,6 +45,7 @@ impl HopDescriptor {
 ///
 /// One path in the current split solution, with the fraction of total `amount_in`
 /// currently allocated to it. All fractions across allocations sum to 1.0.
+#[derive(Clone)]
 pub(crate) struct PathAllocation {
     pub(crate) hops: Vec<HopDescriptor>,
     /// Fraction of total input on this path (0 < f <= 1).
@@ -732,6 +734,26 @@ pub(crate) fn build_split_route(
                 }
             }
         }
+    }
+
+    // If any hops were never reached, the token graph has a cycle and the
+    // topological sort deadlocked. This happens when two paths use the same
+    // pools in opposite order, e.g.:
+    //
+    //   WETH ─┬─ USDC ─ (Pool A) ─ DAI ─ PEPE ─ (Pool B) ─ UNI ─ WBTC
+    //         └─ PEPE ─ (Pool B) ─ UNI ─ USDC ─ (Pool A) ─ DAI ─ WBTC
+    //
+    // merge_shared_hops collapses Pool A (USDC→DAI) and Pool B (PEPE→UNI)
+    // into single swaps, creating the cycle USDC → DAI → PEPE → UNI → USDC.
+    if !hops_by_token.is_empty() {
+        let stuck: Vec<_> = hops_by_token
+            .keys()
+            .map(|k| format!("{k}"))
+            .collect();
+        return Err(AlgorithmError::Other(format!(
+            "dependency cycle — unprocessed tokens: [{}]",
+            stuck.join(", "),
+        )));
     }
 
     Ok(Route::new(swaps, route_tokens))
@@ -1923,6 +1945,101 @@ mod tests {
             route.total_gas(),
             BigUint::from(300_000u64),
             "gas must be counted once per pool, not once per path"
+        );
+    }
+
+    #[test]
+    fn test_build_split_route_rejects_reverse_order_shared_pools() {
+        // Two paths use Pool A and Pool B in opposite order:
+        //
+        //         ┌── USDC ── pool_a ──▶ DAI ── PEPE ── pool_b ──▶ UNI ── WBTC
+        //  WETH ──┤
+        //         └── PEPE ── pool_b ──▶ UNI ── USDC ── pool_a ──▶ DAI ── WBTC
+        //
+        // merge_shared_hops collapses Pool A and Pool B into single swaps,
+        // creating the cycle: USDC → DAI → PEPE → UNI → USDC.
+        let weth = token(0x01, "WETH");
+        let usdc = token(0x02, "USDC");
+        let dai = token(0x03, "DAI");
+        let pepe = token(0x04, "PEPE");
+        let uni = token(0x05, "UNI");
+        let wbtc = token(0x06, "WBTC");
+        let market = make_market(vec![
+            ("pool_wu", vec![weth.clone(), usdc.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("pool_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("pool_dp", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(5.0))),
+            ("pool_b", vec![pepe.clone(), uni.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("pool_uw", vec![uni.clone(), wbtc.clone()], Box::new(MockProtocolSim::new(3.0))),
+            ("pool_wp", vec![weth.clone(), pepe.clone()], Box::new(MockProtocolSim::new(4.0))),
+            ("pool_us", vec![uni.clone(), usdc.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("pool_dw", vec![dai.clone(), wbtc.clone()], Box::new(MockProtocolSim::new(2.0))),
+        ]);
+        let ord = order(&weth, &wbtc, 1000, OrderSide::Sell);
+        let gas = BigUint::from(50_000u64);
+
+        let path1 = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("pool_wu".to_string(), weth.clone(), usdc.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_dp".to_string(), dai.clone(), pepe.clone())
+                    .with_amounts(BigUint::from(6000u64), gas.clone()),
+                HopDescriptor::new("pool_b".to_string(), pepe.clone(), uni.clone())
+                    .with_amounts(BigUint::from(6000u64), gas.clone()),
+                HopDescriptor::new("pool_uw".to_string(), uni.clone(), wbtc.clone())
+                    .with_amounts(BigUint::from(18000u64), gas.clone()),
+            ],
+            flow_fraction: 0.6,
+            amount_in: BigUint::from(600u64),
+            amount_out: BigUint::from(18000u64),
+            marginal_price_product: 30.0,
+        };
+
+        let path2 = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("pool_wp".to_string(), weth.clone(), pepe.clone())
+                    .with_amounts(BigUint::from(1600u64), gas.clone()),
+                HopDescriptor::new("pool_b".to_string(), pepe.clone(), uni.clone())
+                    .with_amounts(BigUint::from(1600u64), gas.clone()),
+                HopDescriptor::new("pool_us".to_string(), uni.clone(), usdc.clone())
+                    .with_amounts(BigUint::from(1600u64), gas.clone()),
+                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                    .with_amounts(BigUint::from(1600u64), gas.clone()),
+                HopDescriptor::new("pool_dw".to_string(), dai.clone(), wbtc.clone())
+                    .with_amounts(BigUint::from(3200u64), gas),
+            ],
+            flow_fraction: 0.4,
+            amount_in: BigUint::from(400u64),
+            amount_out: BigUint::from(3200u64),
+            marginal_price_product: 8.0,
+        };
+
+        // merge_shared_hops collapses Pool A and Pool B into single entries.
+        let merged = merge_shared_hops(&[path1.clone(), path2.clone()]).unwrap();
+        assert_eq!(
+            merged[&usdc.address]
+                .iter()
+                .filter(|s| s.hop.component_id == "pool_a")
+                .count(),
+            1,
+            "merge_shared_hops merges pool_a into one"
+        );
+        assert_eq!(
+            merged[&pepe.address]
+                .iter()
+                .filter(|s| s.hop.component_id == "pool_b")
+                .count(),
+            1,
+            "merge_shared_hops merges pool_b into one"
+        );
+
+        // build_split_route rejects the combination.
+        let err = build_split_route(&[path1, path2], &market, &ord)
+            .expect_err("must reject cyclic path combination");
+        assert!(
+            matches!(&err, AlgorithmError::Other(msg) if msg.contains("dependency cycle")),
+            "expected AlgorithmError::Other with dependency cycle, got: {err}"
         );
     }
 }

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -596,6 +596,46 @@ fn assign_splits_and_amounts(
 /// remainder convention is applied: sorted by fraction descending, all but the
 /// last receive their explicit split fraction, while the last gets
 /// `split = 0.0` (meaning "use all remaining balance").
+///
+/// # Swap ordering
+///
+/// Swaps are emitted in topological order (Kahn's algorithm): a token's
+/// outgoing swaps are only emitted once every upstream swap producing it
+/// has been emitted.
+///
+/// Why this matters:
+/// - `merge_shared_hops` collapses a shared pool hop into one swap (not one per path), saving gas
+///   by calling the pool once with combined input.
+/// - That single swap's split fraction is computed against the full token balance, so all inflows
+///   must be complete before it is emitted.
+/// - The in-degree of each token tracks how many upstream swaps produce it; the token is processed
+///   once all of them are done.
+///
+/// Note: the TychoRouter contract *could* support interleaved splits
+/// (partial consume, more inflows, consume rest), but that would require
+/// an extra swap on the same pool, spending more gas.
+///
+/// For example, given paths of different lengths that converge on the same
+/// intermediate token:
+///
+/// ```text
+/// Path 1 (2 hops): WETH -> USDC -> DAI          (via Pool A)
+/// Path 2 (3 hops): WETH -> USDT -> USDC -> DAI  (via Pool A)
+/// ```
+///
+/// Pool A (USDC→DAI) is merged into one swap. If USDC were visited before
+/// the USDT→USDC hop completes, Pool A would see only Path 1's USDC. The
+/// topological sort prevents this by waiting for all inflows to USDC
+/// before emitting Pool A's swap. This extends to downstream splits too:
+///
+/// ```text
+/// Path 1: WETH -> USDC -> DAI (Pool A) -> PEPE (Pool B)  (0.5)
+/// Path 2: WETH -> USDC -> DAI (Pool A) -> PEPE (Pool C)  (0.5)
+/// Path 3: WETH -> USDT -> USDC -> DAI (Pool A) -> PEPE (Pool B or C)
+/// ```
+///
+/// The DAI→PEPE split between Pool B and Pool C must wait until all DAI
+/// has been produced (from both paths through the merged Pool A swap).
 pub(crate) fn build_split_route(
     paths: &[PathAllocation],
     market: &MarketState,
@@ -606,24 +646,35 @@ pub(crate) fn build_split_route(
     }
     let mut hops_by_token = merge_shared_hops(paths)?;
 
-    let mut pending_tokens = VecDeque::new();
-    pending_tokens.push_back(order.token_in().clone());
+    // Build in-degree map (Kahn's algorithm): a token is ready to process
+    // only when every upstream token that feeds into it has been processed.
+    // This handles paths of different lengths that converge on the same
+    // intermediate token (e.g. WETH→USDC→DAI and WETH→USDT→USDC→DAI both
+    // feeding Pool A at USDC→DAI).
+    let mut in_degree: HashMap<Bytes, usize> = HashMap::new();
+    for (token_in_addr, branch_collection) in &hops_by_token {
+        in_degree
+            .entry(token_in_addr.clone())
+            .or_insert(0);
+        for swap in branch_collection {
+            *in_degree
+                .entry(swap.hop.token_out.address.clone())
+                .or_insert(0) += 1;
+        }
+    }
+
+    let mut ready = VecDeque::new();
+    ready.push_back(order.token_in().clone());
 
     let mut available: HashMap<Bytes, BigUint> = HashMap::new();
     available.insert(order.token_in().clone(), order.amount().clone());
 
     let mut swaps = Vec::new();
     let mut route_tokens: HashMap<Bytes, Token> = HashMap::new();
-    let mut visited: HashSet<Bytes> = HashSet::new();
 
-    // BFS from the source token: at each token, assemble Swap objects from
-    // pre-computed hop amounts (populated by the solving algorithm).
-    while let Some(token_addr) = pending_tokens.pop_front() {
-        // Converging paths (e.g. B→D and C→D) add D to the queue twice — skip duplicates.
-        if !visited.insert(token_addr.clone()) {
-            continue;
-        }
-        // Terminal tokens (e.g. the final output) have no outgoing swaps.
+    // Topological traversal: process each token only after all its inflows
+    // have been accumulated.
+    while let Some(token_addr) = ready.pop_front() {
         let Some(branch_collection) = hops_by_token.remove(&token_addr) else {
             continue;
         };
@@ -672,8 +723,13 @@ pub(crate) fn build_split_route(
             route_tokens
                 .entry(out_addr.clone())
                 .or_insert(split_swap.hop.token_out);
-            if !visited.contains(&out_addr) {
-                pending_tokens.push_back(out_addr);
+
+            // Decrement in-degree; enqueue when all inflows are ready.
+            if let Some(deg) = in_degree.get_mut(&out_addr) {
+                *deg = deg.saturating_sub(1);
+                if *deg == 0 {
+                    ready.push_back(out_addr);
+                }
             }
         }
     }
@@ -1602,5 +1658,271 @@ mod tests {
         assert_eq!(*swaps[3].split(), 0.0);
         assert_eq!(*swaps[3].amount_in(), BigUint::from(1200u64));
         assert_eq!(*swaps[3].amount_out(), BigUint::from(6000u64));
+    }
+
+    #[test]
+    fn test_build_split_route_cross_depth_shared_pool() {
+        // Two paths of different lengths share Pool A (USDC→DAI).
+        // The BFS must process all USDC inflows before visiting USDC's
+        // outgoing swaps.
+        //
+        //  WETH ──┬────────────────────▶ USDC ─── pool_a ──▶ DAI
+        //         │                      ▲
+        //         └──────────▶ USDT ─────┘
+        //
+        // Path 1 (2 hops): WETH → USDC → DAI      (0.6 fraction)
+        // Path 2 (3 hops): WETH → USDT → USDC → DAI (0.4 fraction)
+        //
+        // Pool A appears in both paths with (USDC, DAI). After merging,
+        // Pool A's amount_in must reflect USDC from *both* paths.
+        let weth = token(0x01, "WETH");
+        let usdc = token(0x02, "USDC");
+        let usdt = token(0x03, "USDT");
+        let dai = token(0x04, "DAI");
+        let market = make_market(vec![
+            (
+                "pool_weth_usdc",
+                vec![weth.clone(), usdc.clone()],
+                Box::new(MockProtocolSim::new(2.0)),
+            ),
+            (
+                "pool_weth_usdt",
+                vec![weth.clone(), usdt.clone()],
+                Box::new(MockProtocolSim::new(3.0)),
+            ),
+            (
+                "pool_usdt_usdc",
+                vec![usdt.clone(), usdc.clone()],
+                Box::new(MockProtocolSim::new(1.0)),
+            ),
+            ("pool_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
+        ]);
+        let ord = order(&weth, &dai, 1000, OrderSide::Sell);
+
+        let gas = BigUint::from(50_000u64);
+
+        // Path 1: WETH --(pool_weth_usdc)--> USDC --(pool_a)--> DAI
+        // 600 WETH in, 1200 USDC out from first hop, 1200 DAI out from pool_a
+        let path1 = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("pool_weth_usdc".to_string(), weth.clone(), usdc.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+            ],
+            flow_fraction: 0.6,
+            amount_in: BigUint::from(600u64),
+            amount_out: BigUint::from(1200u64),
+            marginal_price_product: 2.0,
+        };
+
+        // Path 2: WETH --(pool_weth_usdt)--> USDT --(pool_usdt_usdc)--> USDC
+        //         --(pool_a)--> DAI
+        // 400 WETH in, 1200 USDT out, 1200 USDC out, 1200 DAI out from pool_a
+        let path2 = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("pool_weth_usdt".to_string(), weth.clone(), usdt.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_usdt_usdc".to_string(), usdt.clone(), usdc.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                    .with_amounts(BigUint::from(1200u64), gas),
+            ],
+            flow_fraction: 0.4,
+            amount_in: BigUint::from(400u64),
+            amount_out: BigUint::from(1200u64),
+            marginal_price_product: 3.0,
+        };
+
+        let route = build_split_route(&[path1, path2], &market, &ord).unwrap();
+        let swaps = route.swaps();
+
+        // Pool A is shared and merged: it should receive the total USDC
+        // from both paths (1200 + 1200 = 2400).
+        let pool_a_swap = swaps
+            .iter()
+            .find(|s| s.component_id() == "pool_a")
+            .expect("pool_a swap must exist");
+        assert_eq!(
+            *pool_a_swap.amount_in(),
+            BigUint::from(2400u64),
+            "pool_a must receive USDC from both paths (1200 + 1200)"
+        );
+        assert_eq!(
+            *pool_a_swap.amount_out(),
+            BigUint::from(2400u64),
+            "pool_a amount_out should be the merged total"
+        );
+
+        // Pool A is merged into one swap, so its gas is counted once.
+        // Total = 4 distinct pools × 50k gas = 200k (not 5 × 50k).
+        assert_eq!(swaps.len(), 4, "pool_a must appear once, not once per path");
+        assert_eq!(
+            route.total_gas(),
+            BigUint::from(200_000u64),
+            "gas must be counted once per pool, not once per path"
+        );
+    }
+
+    #[test]
+    fn test_build_split_route_cross_depth_convergence_with_downstream_split() {
+        // Cross-depth convergence on Pool A (USDC→DAI) followed by a
+        // downstream split at DAI (Pool B and Pool C → PEPE).
+        //
+        //  WETH ──┬──────────────▶ USDC ── pool_a ──▶ DAI ──┬── pool_b ──▶ PEPE
+        //         │                  ▲                      │
+        //         └──────▶ USDT ─────┘                      └── pool_c ──▶ PEPE
+        //
+        // Path 1: WETH → USDC → DAI → PEPE (Pool B)    fraction 0.3
+        // Path 2: WETH → USDC → DAI → PEPE (Pool C)    fraction 0.3
+        // Path 3: WETH → USDT → USDC → DAI → PEPE (Pool B) fraction 0.4
+        //
+        // Pool A is shared across all 3 paths. The DAI split between Pool B
+        // and Pool C must wait until all DAI has been produced (from both
+        // the direct and USDT-detour paths through the merged Pool A swap).
+        let weth = token(0x01, "WETH");
+        let usdc = token(0x02, "USDC");
+        let usdt = token(0x03, "USDT");
+        let dai = token(0x04, "DAI");
+        let pepe = token(0x05, "PEPE");
+        let market = make_market(vec![
+            ("pool_wu", vec![weth.clone(), usdc.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("pool_wt", vec![weth.clone(), usdt.clone()], Box::new(MockProtocolSim::new(3.0))),
+            ("pool_tu", vec![usdt.clone(), usdc.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("pool_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("pool_b", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(5.0))),
+            ("pool_c", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(4.0))),
+        ]);
+        let ord = order(&weth, &pepe, 1000, OrderSide::Sell);
+        let gas = BigUint::from(50_000u64);
+
+        // Path 1: WETH → USDC → DAI → PEPE (Pool B)
+        let path1 = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("pool_wu".to_string(), weth.clone(), usdc.clone())
+                    .with_amounts(BigUint::from(600u64), gas.clone()),
+                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                    .with_amounts(BigUint::from(600u64), gas.clone()),
+                HopDescriptor::new("pool_b".to_string(), dai.clone(), pepe.clone())
+                    .with_amounts(BigUint::from(3000u64), gas.clone()),
+            ],
+            flow_fraction: 0.3,
+            amount_in: BigUint::from(300u64),
+            amount_out: BigUint::from(3000u64),
+            marginal_price_product: 10.0,
+        };
+
+        // Path 2: WETH → USDC → DAI → PEPE (Pool C)
+        let path2 = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("pool_wu".to_string(), weth.clone(), usdc.clone())
+                    .with_amounts(BigUint::from(600u64), gas.clone()),
+                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                    .with_amounts(BigUint::from(600u64), gas.clone()),
+                HopDescriptor::new("pool_c".to_string(), dai.clone(), pepe.clone())
+                    .with_amounts(BigUint::from(2400u64), gas.clone()),
+            ],
+            flow_fraction: 0.3,
+            amount_in: BigUint::from(300u64),
+            amount_out: BigUint::from(2400u64),
+            marginal_price_product: 8.0,
+        };
+
+        // Path 3: WETH → USDT → USDC → DAI → PEPE (Pool B)
+        let path3 = PathAllocation {
+            hops: vec![
+                HopDescriptor::new("pool_wt".to_string(), weth.clone(), usdt.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_tu".to_string(), usdt.clone(), usdc.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                    .with_amounts(BigUint::from(1200u64), gas.clone()),
+                HopDescriptor::new("pool_b".to_string(), dai.clone(), pepe.clone())
+                    .with_amounts(BigUint::from(6000u64), gas),
+            ],
+            flow_fraction: 0.4,
+            amount_in: BigUint::from(400u64),
+            amount_out: BigUint::from(6000u64),
+            marginal_price_product: 15.0,
+        };
+
+        let route = build_split_route(&[path1, path2, path3], &market, &ord).unwrap();
+        let swaps = route.swaps();
+
+        // Pool A is merged: total USDC in = 600+600+1200 = 2400,
+        // total DAI out = 600+600+1200 = 2400.
+        let pool_a_swap = swaps
+            .iter()
+            .find(|s| s.component_id() == "pool_a")
+            .expect("pool_a swap must exist");
+        assert_eq!(
+            *pool_a_swap.amount_in(),
+            BigUint::from(2400u64),
+            "pool_a must receive all USDC from both direct and USDT-detour paths"
+        );
+
+        // Pool B is merged (paths 1+3): DAI in from both = fraction 0.7
+        // Pool C has only path 2: DAI in = fraction 0.3
+        let pool_b_swap = swaps
+            .iter()
+            .find(|s| s.component_id() == "pool_b")
+            .expect("pool_b swap must exist");
+        let pool_c_swap = swaps
+            .iter()
+            .find(|s| s.component_id() == "pool_c")
+            .expect("pool_c swap must exist");
+
+        // Total DAI = 2400. Pool B gets 0.7 fraction, Pool C gets 0.3.
+        // Pool B amount_out = 3000 + 6000 = 9000 (merged from paths 1+3)
+        // Pool C amount_out = 2400 (path 2 only)
+        assert_eq!(
+            *pool_b_swap.amount_out(),
+            BigUint::from(9000u64),
+            "pool_b amount_out should be merged total from paths 1+3"
+        );
+        assert_eq!(
+            *pool_c_swap.amount_out(),
+            BigUint::from(2400u64),
+            "pool_c amount_out should be path 2 only"
+        );
+
+        // Verify ordering: pool_a must appear before pool_b and pool_c
+        // (DAI must be fully produced before splitting).
+        let pool_a_idx = swaps
+            .iter()
+            .position(|s| s.component_id() == "pool_a")
+            .unwrap();
+        let pool_b_idx = swaps
+            .iter()
+            .position(|s| s.component_id() == "pool_b")
+            .unwrap();
+        let pool_c_idx = swaps
+            .iter()
+            .position(|s| s.component_id() == "pool_c")
+            .unwrap();
+        assert!(
+            pool_a_idx < pool_b_idx && pool_a_idx < pool_c_idx,
+            "pool_a (idx {pool_a_idx}) must appear before pool_b (idx {pool_b_idx}) \
+             and pool_c (idx {pool_c_idx})"
+        );
+
+        // Also verify USDT→USDC appears before pool_a (USDC→DAI).
+        let pool_tu_idx = swaps
+            .iter()
+            .position(|s| s.component_id() == "pool_tu")
+            .unwrap();
+        assert!(
+            pool_tu_idx < pool_a_idx,
+            "pool_tu (idx {pool_tu_idx}) must appear before pool_a (idx {pool_a_idx})"
+        );
+
+        // Pool A is merged into one swap, so its gas is counted once.
+        // Total = 6 distinct pools × 50k gas = 300k (not 8 × 50k).
+        assert_eq!(swaps.len(), 6, "pool_a must appear once, not once per path");
+        assert_eq!(
+            route.total_gas(),
+            BigUint::from(300_000u64),
+            "gas must be counted once per pool, not once per path"
+        );
     }
 }


### PR DESCRIPTION
## Problem, summarized:
The original two paths:
```
WETH ───▶ USDC ─── pool_a ──▶ DAI                    (shorter path)
WETH ───▶ USDT ────────▶ USDC ── pool_a ──▶ DAI      (longer path)
```

The merged paths:
```
WETH ──┬────────────▶ USDC ─── pool_a ──▶ DAI
       │                ▲
       └────▶ USDT ─────┘
                                       
```
Our merging algo was emitting the USDC  ─ pool_a ─▶ DAI before emitting the  USDT ─▶ USDC swap. This would cause unintended consequences on our router side, since only the amount for WETH ─▶ USDC would be inputted into the final USDC ─▶ DAI swap, ignoring the USDT ─▶ USDC amount.

Related addition to the Tycho docs: https://github.com/propeller-heads/tycho/pull/1068

## Solution
Replace naive BFS in build_split_route with [Kahn's topological sort.](https://www.geeksforgeeks.org/dsa/topological-sorting-indegree-based-solution/)

## Summary of Kahn's topological sort:
1. Count incoming edges for every node (the "in-degree")                                                                           
2. Enqueue all nodes with in-degree 0 — they have no dependencies                
3. Loop: pop a node from the queue, "emit" it, and decrement the in-degree of each of its neighbors. Whenever a neighbor's in-degree reaches 0, enqueue it                                                                                                    
4. Done when the queue is empty. If any nodes were never enqueued, the graph has a dependency cycle (A → B → A → C) — distinct from a valid trade cycle (A → B → A) where the trade starts and ends at the same token     

## Consequence
The USDC ─── pool_a ──▶ DAI will now be **one swap** meaning we should **only count gas once**. The swap will be emitted only after the inflow swaps are emitted. Our router is happy.

## Important Note: Unsupported edge case
The following case is still not supported, because Pool A and Pool B cause a deadlock from being swapped in opposite orders in different branches:
```
WETH ─┬─ USDC ─ (Pool A) ─ DAI ─ PEPE ─ (Pool B) ─ UNI ─ WBTC
      └─ PEPE ─ (Pool B) ─ UNI ─ USDC ─ (Pool A) ─ DAI ─ WBTC
```
This is a pretty rare case and any solutions I found resulted in a massive refactor. For now, I've added a test that ensures this results in an error. Let me know if you agree or if you think this is worth spending time to support.