### PR TITLE
docs: document chain selection in quickstart

### DIFF
--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -69,6 +69,35 @@ fynd serve
 {% endtab %}
 {% endtabs %}
 
+### Select a chain
+
+Each Fynd instance serves a single chain. `fynd serve` defaults to **Ethereum**; pass `--chain` to target another one:
+
+```bash
+fynd serve --chain Base
+```
+
+For Docker, append the flag after `serve`:
+
+```bash
+docker run \
+  -e TYCHO_API_KEY=your-api-key \
+  -e RUST_LOG=fynd=info \
+  -p 3000:3000 -p 9898:9898 \
+  ghcr.io/propeller-heads/fynd serve --chain Base
+```
+
+These chains ship with built-in Tycho and RPC endpoints: `Ethereum`, `Base`, `Unichain`, `BSC`, `Arbitrum`, `Polygon`. For any other chain, also pass `--tycho-url` and `--rpc-url` explicitly.
+
+Your client must target the same chain. In the TypeScript example, set `chainId` (and the viem chain) to match the server:
+
+```typescript
+import { base } from 'viem/chains';
+
+const publicClient = createPublicClient({ chain: base, transport: http(rpcUrl) });
+const client = new FyndClient({ baseUrl: FYND_URL, chainId: base.id, /* ... */ });
+```
+
 ## Step 1 — Execute a swap
 
 {% hint style="info" %}

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -87,9 +87,9 @@ docker run \
   ghcr.io/propeller-heads/fynd serve --chain Base
 ```
 
-These chains ship with built-in Tycho and RPC endpoints: `Ethereum`, `Base`, `Unichain`, `BSC`, `Arbitrum`, `Polygon`. For any other chain, also pass `--tycho-url` and `--rpc-url` explicitly.
+These chains ship with built-in Tycho and RPC endpoints (names are case-insensitive): `Ethereum`, `Base`, `Unichain`, `BSC`, `Arbitrum`, `Polygon`. For any other chain, also pass `--tycho-url` and `--rpc-url` explicitly.
 
-Your client must target the same chain. In the TypeScript example, set `chainId` (and the viem chain) to match the server:
+Your client must target the same chain. If you use the TypeScript client (Step 1), set `chainId` and the viem chain to match the server:
 
 ```typescript
 import { base } from 'viem/chains';

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -74,7 +74,7 @@ fynd serve
 Each Fynd instance serves a single chain. `fynd serve` defaults to **Ethereum**; pass `--chain` to target another one:
 
 ```bash
-fynd serve --chain Base
+fynd serve --chain base
 ```
 
 For Docker, append the flag after `serve`:
@@ -84,10 +84,10 @@ docker run \
   -e TYCHO_API_KEY=your-api-key \
   -e RUST_LOG=fynd=info \
   -p 3000:3000 -p 9898:9898 \
-  ghcr.io/propeller-heads/fynd serve --chain Base
+  ghcr.io/propeller-heads/fynd serve --chain base
 ```
 
-These chains ship with built-in Tycho and RPC endpoints (names are case-insensitive): `Ethereum`, `Base`, `Unichain`, `BSC`, `Arbitrum`, `Polygon`. For any other chain, also pass `--tycho-url` and `--rpc-url` explicitly.
+These chains ship with built-in Tycho and RPC endpoints (names are case-insensitive): `ethereum`, `base`, `unichain`, `bsc`, `arbitrum`, `polygon`. For any other chain, also pass `--tycho-url` and `--rpc-url` explicitly.
 
 Your client must target the same chain. If you use the TypeScript client (Step 1), set `chainId` and the viem chain to match the server:
 


### PR DESCRIPTION
The quickstart did not mention how to choose which chain Fynd runs on. Added a **Select a chain** subsection after Step 0.

It covers:
- `fynd serve --chain <Chain>` (default `Ethereum`), with the Docker equivalent
- The chains that ship with built-in Tycho and RPC endpoints: `Ethereum`, `Base`, `Unichain`, `BSC`, `Arbitrum`, `Polygon`; other chains require explicit `--tycho-url` and `--rpc-url`
- Matching the client to the server chain, shown with `chainId` and the viem chain in the TypeScript example

🤖 Generated with [Claude Code](https://claude.com/claude-code)