### PR TITLE
feat(fynd-core): expose BlockStepController for gated block ingestion

### DIFF
--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -536,7 +536,7 @@ impl TychoFeed {
         let mut protocol_stream = match stream_builder.build().await {
             Ok(stream) => {
                 let _ = controller_tx.send(Ok(controller));
-                stream
+                Box::pin(stream)
             }
             Err(e) => {
                 let msg = e.to_string();

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -442,6 +442,210 @@ impl TychoFeed {
         Ok(())
     }
 
+    /// Like [`run_with_pending`](Self::run_with_pending) but also gates each block behind a
+    /// [`BlockStepController`].
+    ///
+    /// Both the [`PendingBlockProcessor`] and the [`BlockStepController`] are delivered before
+    /// the first block is processed. Only valid when at least one non-RFQ protocol is configured.
+    pub(crate) async fn run_with_pending_and_step_controller(
+        self,
+        pending_tx: oneshot::Sender<Result<PendingBlockProcessor, String>>,
+        controller_tx: oneshot::Sender<Result<BlockStepController, String>>,
+        pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
+    ) -> Result<(), DataFeedError> {
+        info!(
+            tycho_url = %self.config.tycho_url,
+            protocols = ?self.config.protocols,
+            "Starting Data Feed (with pending + step controller)..."
+        );
+
+        if self
+            .config
+            .protocols
+            .iter()
+            .all(|p| p.starts_with("rfq:"))
+        {
+            let msg = "step controller requires at least one non-RFQ protocol".to_string();
+            let _ = pending_tx.send(Err(msg.clone()));
+            let _ = controller_tx.send(Err(msg.clone()));
+            return Err(DataFeedError::Config(msg));
+        }
+
+        let tycho_api_key = self
+            .config
+            .tycho_api_key
+            .clone()
+            .or_else(|| std::env::var("TYCHO_API_KEY").ok());
+
+        let all_tokens = match load_all_tokens(
+            self.config.tycho_url.as_str(),
+            !self.config.use_tls,
+            tycho_api_key.as_deref(),
+            true,
+            self.config.chain,
+            Some(self.config.min_token_quality),
+            self.config.traded_n_days_ago,
+        )
+        .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                let e = DataFeedError::StreamError(e.to_string());
+                let _ = pending_tx.send(Err(e.to_string()));
+                let _ = controller_tx.send(Err(e.to_string()));
+                return Err(e);
+            }
+        };
+
+        debug!("Loaded {} tokens from Tycho", all_tokens.len());
+
+        let mut stream_builder = match register_exchanges(
+            ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
+                .skip_state_decode_failures(true),
+            ComponentFilter::with_tvl_range(
+                self.config.min_tvl / self.config.tvl_buffer_ratio,
+                self.config.min_tvl,
+            )
+            .blocklist(
+                self.config
+                    .blocklisted_components
+                    .clone(),
+            ),
+            &self.config.protocols,
+        ) {
+            Ok(sb) => sb,
+            Err(e) => {
+                let _ = pending_tx.send(Err(e.to_string()));
+                let _ = controller_tx.send(Err(e.to_string()));
+                return Err(e);
+            }
+        }
+        .auth_key(self.config.tycho_api_key.clone())
+        .skip_state_decode_failures(true)
+        .min_token_quality(self.config.min_token_quality as u32)
+        .set_tokens(all_tokens.clone())
+        .await;
+
+        for (extractor, indexer) in pending_indexers {
+            stream_builder = match stream_builder.with_pending_indexer(&extractor, indexer) {
+                Ok(sb) => sb,
+                Err(e) => {
+                    let e = DataFeedError::StreamError(e.to_string());
+                    let _ = pending_tx.send(Err(e.to_string()));
+                    let _ = controller_tx.send(Err(e.to_string()));
+                    return Err(e);
+                }
+            };
+        }
+
+        let (stream_builder, controller) = stream_builder.with_step_controller();
+
+        let mut protocol_stream = match stream_builder
+            .build_with_pending()
+            .await
+        {
+            Ok((stream, pending)) => {
+                if pending_tx.send(Ok(pending)).is_err() {
+                    tracing::warn!(
+                        "PendingBlockProcessor receiver dropped before send; continuing without \
+                         pending updates"
+                    );
+                }
+                let _ = controller_tx.send(Ok(controller));
+                Box::pin(stream)
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                let _ = pending_tx.send(Err(msg.clone()));
+                let _ = controller_tx.send(Err(msg.clone()));
+                return Err(DataFeedError::StreamError(msg));
+            }
+        };
+
+        // Spawn RFQ stream (same as run_with_pending()).
+        let (mut rfq_rx, mut rfq_handle) = if self
+            .config
+            .protocols
+            .iter()
+            .any(|p| p.starts_with("rfq:"))
+        {
+            let rfq_tokens: HashSet<Bytes> = all_tokens.keys().cloned().collect();
+            let rfq_stream_builder = register_rfq(
+                RFQStreamBuilder::new()
+                    .set_tokens(all_tokens)
+                    .await,
+                self.config.chain,
+                self.config.min_tvl,
+                &self.config.protocols,
+                rfq_tokens,
+            )?;
+            let (rfq_tx, rfq_rx) = tokio::sync::mpsc::channel(64);
+            let rfq_handle: JoinHandle<Result<(), DataFeedError>> = tokio::spawn(async move {
+                rfq_stream_builder
+                    .build(rfq_tx)
+                    .await
+                    .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+                Ok(())
+            });
+            (Some(rfq_rx), Some(rfq_handle))
+        } else {
+            (None, None)
+        };
+
+        loop {
+            tokio::select! {
+                msg = protocol_stream.next() => {
+                    match msg {
+                        Some(msg) => {
+                            trace!("Received message from protocol stream: {:?}", msg);
+                            let msg = msg.map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+                            self.handle_tycho_message(msg).await?;
+                        }
+                        None => {
+                            info!("Protocol stream ended");
+                            break;
+                        }
+                    }
+                }
+                msg = async {
+                    if let Some(rx) = &mut rfq_rx { rx.recv().await }
+                    else { std::future::pending().await }
+                } => {
+                    match msg {
+                        Some(msg) => {
+                            trace!("Received message from RFQ stream: {:?}", msg);
+                            self.handle_tycho_message(msg).await?;
+                        }
+                        None => {
+                            info!("RFQ stream ended");
+                            break;
+                        }
+                    }
+                }
+                rfq_result = async {
+                    if let Some(handle) = &mut rfq_handle { handle.await }
+                    else { std::future::pending().await }
+                } => {
+                    match rfq_result {
+                        Ok(Ok(())) => {
+                            return Err(DataFeedError::StreamError(
+                                "RFQ stream task ended unexpectedly".to_string(),
+                            ));
+                        }
+                        Ok(Err(e)) => {
+                            return Err(DataFeedError::StreamError(format!("RFQ stream error: {e}")));
+                        }
+                        Err(e) => {
+                            return Err(DataFeedError::StreamError(format!("RFQ task panicked: {e}")));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Like [`run`](Self::run) but gates each block behind a [`BlockStepController`].
     ///
     /// Delivers the controller (or an error string) via `controller_tx` once the stream is

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -14,7 +14,10 @@ use tokio::{
 use tokio_stream::StreamExt;
 use tracing::{debug, info, instrument, span, trace, Instrument, Level};
 use tycho_simulation::{
-    evm::{pending::PendingBlockProcessor, stream::ProtocolStreamBuilder},
+    evm::{
+        pending::PendingBlockProcessor,
+        stream::{BlockStepController, ProtocolStreamBuilder},
+    },
     protocol::models::Update,
     rfq::stream::RFQStreamBuilder,
     tycho_client::feed::{component_tracker::ComponentFilter, SynchronizerState},
@@ -356,6 +359,193 @@ impl TychoFeed {
         }
 
         // Spawn RFQ stream (same as run()) — runs alongside the EVM pending stream.
+        let (mut rfq_rx, mut rfq_handle) = if self
+            .config
+            .protocols
+            .iter()
+            .any(|p| p.starts_with("rfq:"))
+        {
+            let rfq_tokens: HashSet<Bytes> = all_tokens.keys().cloned().collect();
+            let rfq_stream_builder = register_rfq(
+                RFQStreamBuilder::new()
+                    .set_tokens(all_tokens)
+                    .await,
+                self.config.chain,
+                self.config.min_tvl,
+                &self.config.protocols,
+                rfq_tokens,
+            )?;
+            let (rfq_tx, rfq_rx) = tokio::sync::mpsc::channel(64);
+            let rfq_handle: JoinHandle<Result<(), DataFeedError>> = tokio::spawn(async move {
+                rfq_stream_builder
+                    .build(rfq_tx)
+                    .await
+                    .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+                Ok(())
+            });
+            (Some(rfq_rx), Some(rfq_handle))
+        } else {
+            (None, None)
+        };
+
+        loop {
+            tokio::select! {
+                msg = protocol_stream.next() => {
+                    match msg {
+                        Some(msg) => {
+                            trace!("Received message from protocol stream: {:?}", msg);
+                            let msg = msg.map_err(|e| DataFeedError::StreamError(e.to_string()))?;
+                            self.handle_tycho_message(msg).await?;
+                        }
+                        None => {
+                            info!("Protocol stream ended");
+                            break;
+                        }
+                    }
+                }
+                msg = async {
+                    if let Some(rx) = &mut rfq_rx { rx.recv().await }
+                    else { std::future::pending().await }
+                } => {
+                    match msg {
+                        Some(msg) => {
+                            trace!("Received message from RFQ stream: {:?}", msg);
+                            self.handle_tycho_message(msg).await?;
+                        }
+                        None => {
+                            info!("RFQ stream ended");
+                            break;
+                        }
+                    }
+                }
+                rfq_result = async {
+                    if let Some(handle) = &mut rfq_handle { handle.await }
+                    else { std::future::pending().await }
+                } => {
+                    match rfq_result {
+                        Ok(Ok(())) => {
+                            return Err(DataFeedError::StreamError(
+                                "RFQ stream task ended unexpectedly".to_string(),
+                            ));
+                        }
+                        Ok(Err(e)) => {
+                            return Err(DataFeedError::StreamError(format!("RFQ stream error: {e}")));
+                        }
+                        Err(e) => {
+                            return Err(DataFeedError::StreamError(format!("RFQ task panicked: {e}")));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Like [`run`](Self::run) but gates each block behind a [`BlockStepController`].
+    ///
+    /// Delivers the controller (or an error string) via `controller_tx` once the stream is
+    /// built and before the first block is processed. The caller must call
+    /// [`BlockStepController::trigger_next_block`] for each block to be processed.
+    ///
+    /// Only valid when at least one non-RFQ protocol is configured. Returns
+    /// [`DataFeedError::Config`] if all protocols are RFQ.
+    pub(crate) async fn run_with_step_controller(
+        self,
+        controller_tx: oneshot::Sender<Result<BlockStepController, String>>,
+    ) -> Result<(), DataFeedError> {
+        info!(
+            tycho_url = %self.config.tycho_url,
+            protocols = ?self.config.protocols,
+            "Starting Data Feed (with step controller)..."
+        );
+
+        if self
+            .config
+            .protocols
+            .iter()
+            .all(|p| p.starts_with("rfq:"))
+        {
+            let msg = "step controller requires at least one non-RFQ protocol".to_string();
+            let _ = controller_tx.send(Err(msg.clone()));
+            return Err(DataFeedError::Config(msg));
+        }
+
+        let tycho_api_key = self
+            .config
+            .tycho_api_key
+            .clone()
+            .or_else(|| std::env::var("TYCHO_API_KEY").ok());
+
+        let all_tokens = match load_all_tokens(
+            self.config.tycho_url.as_str(),
+            !self.config.use_tls,
+            tycho_api_key.as_deref(),
+            true,
+            self.config.chain,
+            Some(self.config.min_token_quality),
+            self.config.traded_n_days_ago,
+        )
+        .await
+        {
+            Ok(t) => t,
+            Err(e) => {
+                let e = DataFeedError::StreamError(e.to_string());
+                let _ = controller_tx.send(Err(e.to_string()));
+                return Err(e);
+            }
+        };
+
+        debug!("Loaded {} tokens from Tycho", all_tokens.len());
+
+        let tvl_filter = ComponentFilter::with_tvl_range(
+            self.config.min_tvl / self.config.tvl_buffer_ratio,
+            self.config.min_tvl,
+        )
+        .blocklist(
+            self.config
+                .blocklisted_components
+                .clone(),
+        );
+
+        let mut stream_builder = match register_exchanges(
+            ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
+                .skip_state_decode_failures(true),
+            tvl_filter,
+            &self.config.protocols,
+        ) {
+            Ok(sb) => sb,
+            Err(e) => {
+                let _ = controller_tx.send(Err(e.to_string()));
+                return Err(e);
+            }
+        }
+        .auth_key(self.config.tycho_api_key.clone())
+        .skip_state_decode_failures(true)
+        .min_token_quality(self.config.min_token_quality as u32);
+
+        if self.config.partial_blocks {
+            stream_builder = stream_builder.enable_partial_blocks();
+        }
+
+        let stream_builder = stream_builder
+            .set_tokens(all_tokens.clone())
+            .await;
+        let (stream_builder, controller) = stream_builder.with_step_controller();
+
+        let mut protocol_stream = match stream_builder.build().await {
+            Ok(stream) => {
+                let _ = controller_tx.send(Ok(controller));
+                stream
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                let _ = controller_tx.send(Err(msg.clone()));
+                return Err(DataFeedError::StreamError(msg));
+            }
+        };
+
+        // Spawn rfq stream (same as run()).
         let (mut rfq_rx, mut rfq_handle) = if self
             .config
             .protocols

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -65,6 +65,9 @@ pub use tycho_simulation::evm::pending::PendingBlockProcessor;
 pub use tycho_simulation::evm::pending::PendingError;
 /// A pending transaction bundle passed to [`PendingBlockProcessor`] for simulation.
 pub use tycho_simulation::evm::pending::PendingUpdate;
+/// Handle returned by [`FyndBuilder::build_with_step_controller`] that controls when each
+/// buffered block is released for decoding. See [`tycho_simulation`] for the full API.
+pub use tycho_simulation::evm::stream::BlockStepController;
 /// Implement this trait and register it via
 /// [`FyndBuilder::with_pending_indexer`](solver::FyndBuilder::with_pending_indexer)
 /// to receive raw transaction deltas during pending-block simulation.

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -65,8 +65,9 @@ pub use tycho_simulation::evm::pending::PendingBlockProcessor;
 pub use tycho_simulation::evm::pending::PendingError;
 /// A pending transaction bundle passed to [`PendingBlockProcessor`] for simulation.
 pub use tycho_simulation::evm::pending::PendingUpdate;
-/// Handle returned by [`FyndBuilder::build_with_step_controller`] that controls when each
-/// buffered block is released for decoding. See [`tycho_simulation`] for the full API.
+/// Handle returned by [`FyndBuilder::build_with_step_controller`] or
+/// [`FyndBuilder::build_with_pending_and_step_controller`] that controls when each buffered
+/// block is released for decoding. See [`tycho_simulation`] for the full API.
 pub use tycho_simulation::evm::stream::BlockStepController;
 /// Implement this trait and register it via
 /// [`FyndBuilder::with_pending_indexer`](solver::FyndBuilder::with_pending_indexer)

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -952,6 +952,9 @@ impl FyndBuilder {
         let gas_price_handle = tokio::spawn(async move {
             c.gas_price_fetcher.run().await;
         });
+        let router_fee_handle = tokio::spawn(async move {
+            c.router_fee_fetcher.run().await;
+        });
         let computation_handle = tokio::spawn(async move {
             c.computation_manager
                 .run(c.computation_event_rx, c.computation_shutdown_rx)
@@ -969,14 +972,89 @@ impl FyndBuilder {
                 worker_pools: c.worker_pools,
                 market_data: c.market_data,
                 derived_data: c.derived_data,
+                router_fees: c.router_fees,
                 feed_handle,
                 gas_price_handle,
+                router_fee_handle,
                 computation_handle,
                 computation_shutdown_tx: c.computation_shutdown_tx,
                 chain: c.chain,
                 router_address: c.router_address,
                 market_event_tx: c.market_event_tx,
             },
+            controller,
+        ))
+    }
+
+    /// Assembles and starts all solver components, returning both a [`PendingBlockProcessor`]
+    /// and a [`BlockStepController`].
+    ///
+    /// Combines the capabilities of [`build_with_pending`](Self::build_with_pending) and
+    /// [`build_with_step_controller`](Self::build_with_step_controller). Only valid when at
+    /// least one non-RFQ protocol is configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SolverBuildError`] if any component fails to initialize, all protocols are RFQ,
+    /// or either delivery channel closes before its value is received.
+    pub async fn build_with_pending_and_step_controller(
+        self,
+    ) -> Result<(Solver, PendingBlockProcessor, BlockStepController), SolverBuildError> {
+        let mut c = self.assemble_components()?;
+
+        let (pending_tx, pending_rx) =
+            tokio::sync::oneshot::channel::<Result<PendingBlockProcessor, String>>();
+        let (controller_tx, controller_rx) =
+            tokio::sync::oneshot::channel::<Result<BlockStepController, String>>();
+
+        let pending_indexers = c.pending_indexers;
+        let feed_handle = tokio::spawn(async move {
+            if let Err(e) = c
+                .tycho_feed
+                .run_with_pending_and_step_controller(pending_tx, controller_tx, pending_indexers)
+                .await
+            {
+                tracing::error!(error = %e, "tycho feed error");
+            }
+        });
+        let gas_price_handle = tokio::spawn(async move {
+            c.gas_price_fetcher.run().await;
+        });
+        let router_fee_handle = tokio::spawn(async move {
+            c.router_fee_fetcher.run().await;
+        });
+        let computation_handle = tokio::spawn(async move {
+            c.computation_manager
+                .run(c.computation_event_rx, c.computation_shutdown_rx)
+                .await;
+        });
+
+        let pending = pending_rx
+            .await
+            .map_err(|_| SolverBuildError::PendingChannelClosed)?
+            .map_err(SolverBuildError::FeedSetup)?;
+        let controller = controller_rx
+            .await
+            .map_err(|_| SolverBuildError::StepControllerChannelClosed)?
+            .map_err(SolverBuildError::FeedSetup)?;
+
+        Ok((
+            Solver {
+                router: c.router,
+                worker_pools: c.worker_pools,
+                market_data: c.market_data,
+                derived_data: c.derived_data,
+                router_fees: c.router_fees,
+                feed_handle,
+                gas_price_handle,
+                router_fee_handle,
+                computation_handle,
+                computation_shutdown_tx: c.computation_shutdown_tx,
+                chain: c.chain,
+                router_address: c.router_address,
+                market_event_tx: c.market_event_tx,
+            },
+            pending,
             controller,
         ))
     }

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -19,7 +19,7 @@ use tycho_execution::encoding::evm::swap_encoder::swap_encoder_registry::SwapEnc
 #[cfg(feature = "test-utils")]
 use tycho_simulation::tycho_ethereum::gas::{BlockGasPrice, GasPrice};
 use tycho_simulation::{
-    evm::pending::PendingBlockProcessor,
+    evm::{pending::PendingBlockProcessor, stream::BlockStepController},
     tycho_common::{models::Chain, traits::TxDeltaIndexer, Bytes},
     tycho_core::models::Address,
     tycho_ethereum::rpc::EthereumRpcClient,
@@ -301,6 +301,10 @@ pub enum SolverBuildError {
     /// panicked rather than returning an error through the channel.
     #[error("pending processor channel closed before processor was delivered")]
     PendingChannelClosed,
+    /// The step-controller oneshot closed without delivering a value, meaning the feed task
+    /// panicked rather than returning an error through the channel.
+    #[error("step controller channel closed before controller was delivered")]
+    StepControllerChannelClosed,
 }
 
 /// Internal pool entry — either a built-in algorithm (by name) or a custom one.
@@ -913,7 +917,70 @@ impl FyndBuilder {
             pending,
         ))
     }
-}
+
+    /// Assembles and starts all solver components, also returning a [`BlockStepController`]
+    /// that lets the caller control when each buffered block is released for processing.
+    ///
+    /// Intended for deterministic testing: call [`BlockStepController::trigger_next_block`] to
+    /// step through blocks one at a time, and [`BlockStepController::peek_next_block`] to inspect
+    /// a block before it is decoded. Dropping the controller ungates the stream so it runs to its
+    /// natural end.
+    ///
+    /// Only valid when at least one non-RFQ protocol is configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SolverBuildError`] if any component fails to initialize, all protocols are RFQ,
+    /// or the step-controller channel closes before the controller is delivered.
+    pub async fn build_with_step_controller(
+        self,
+    ) -> Result<(Solver, BlockStepController), SolverBuildError> {
+        let mut c = self.assemble_components()?;
+
+        let (controller_tx, controller_rx) =
+            tokio::sync::oneshot::channel::<Result<BlockStepController, String>>();
+
+        let feed_handle = tokio::spawn(async move {
+            if let Err(e) = c
+                .tycho_feed
+                .run_with_step_controller(controller_tx)
+                .await
+            {
+                tracing::error!(error = %e, "tycho feed error");
+            }
+        });
+        let gas_price_handle = tokio::spawn(async move {
+            c.gas_price_fetcher.run().await;
+        });
+        let computation_handle = tokio::spawn(async move {
+            c.computation_manager
+                .run(c.computation_event_rx, c.computation_shutdown_rx)
+                .await;
+        });
+
+        let controller = controller_rx
+            .await
+            .map_err(|_| SolverBuildError::StepControllerChannelClosed)?
+            .map_err(SolverBuildError::FeedSetup)?;
+
+        Ok((
+            Solver {
+                router: c.router,
+                worker_pools: c.worker_pools,
+                market_data: c.market_data,
+                derived_data: c.derived_data,
+                feed_handle,
+                gas_price_handle,
+                computation_handle,
+                computation_shutdown_tx: c.computation_shutdown_tx,
+                chain: c.chain,
+                router_address: c.router_address,
+                market_event_tx: c.market_event_tx,
+            },
+            controller,
+        ))
+    }
+} // impl FyndBuilder
 
 /// A running solver assembled by [`FyndBuilder`].
 pub struct Solver {


### PR DESCRIPTION
## Summary

- Adds `FyndBuilder::build_with_step_controller()` — an async builder method that returns `(Solver, BlockStepController)`. The Tycho feed runs in step-controlled mode: each incoming block is buffered and held until the caller calls `controller.trigger_next_block()`.
- Re-exports `BlockStepController` from `fynd_core` (alongside `PendingBlockProcessor`) so consumers don't need to import from `tycho_simulation` directly.
- Adds `SolverBuildError::StepControllerChannelClosed` for the case where the feed task panics before delivering the controller.

The implementation follows the same pattern as `build_with_pending`: a `oneshot` channel delivers the `BlockStepController` from `TychoFeed::run_with_step_controller` back to the builder before the event loop starts.

Upstream: propeller-heads/tycho#1067 (merged).

## Usage

```rust
let (solver, controller) = FyndBuilder::new(...)
    .algorithm("most_liquid")
    .build_with_step_controller()
    .await?;

// Peek at the next block before processing it
let block = controller.peek_next_block().await;

// Release it for the solvers
controller.trigger_next_block()?;
```

## Dependency

**Blocked on the next `tycho-simulation` release after `0.302.0`** that includes `BlockStepController`. Once published:
1. Update `tycho-simulation = ">=<NEW_VERSION>"` in `Cargo.toml` (workspace dependencies).
2. Run `cargo check --workspace` to update `Cargo.lock`.
3. CI will pass.

## Test plan

- [ ] Wait for next `tycho-simulation` crates.io release with `BlockStepController`
- [ ] Update version constraint and verify `cargo check --workspace` passes
- [ ] Run `./check.sh` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)