### PR TITLE
feat: scaffold permissioned surplus pools

### DIFF
--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -58,11 +58,11 @@ impl TryFrom<&OrderQuote> for Solution {
             SolveError::FailedEncoding("successful quote must have a route".to_string())
         })?;
 
-        // TODO: when this quote routes through a permissioned pool, read
-        // `quote.committed_amount_out()` and `quote.eg_amount()` here and carry them into the
-        // encoded `Solution` so the on-chain fair-flow hook can be parameterised. The user is
-        // committed to `committed_amount_out` while the executed route yields the surplus. Hook
-        // calldata/signature encoding is a separate later extension and is out of scope here.
+        // TODO: when a swap in this route is permissioned, read its `Swap::committed_amount_out`
+        // and carry it into the encoded `Solution` so the on-chain permissioned hook can be
+        // parameterised — the user is committed to that amount while the executed route yields the
+        // surplus. Hook calldata/signature encoding is a separate later extension, out of scope
+        // here.
 
         let token_in = route
             .input_token()

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -58,6 +58,12 @@ impl TryFrom<&OrderQuote> for Solution {
             SolveError::FailedEncoding("successful quote must have a route".to_string())
         })?;
 
+        // TODO: when this quote routes through a permissioned pool, read
+        // `quote.committed_amount_out()` and `quote.eg_amount()` here and carry them into the
+        // encoded `Solution` so the on-chain fair-flow hook can be parameterised. The user is
+        // committed to `committed_amount_out` while the executed route yields the surplus. Hook
+        // calldata/signature encoding is a separate later extension and is out of scope here.
+
         let token_in = route
             .input_token()
             .ok_or_else(|| SolveError::FailedEncoding("route has no input token".to_string()))?;

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -7,7 +7,7 @@ pub mod events;
 pub(crate) mod gas;
 /// Shared market data store (`MarketState`, `MarketData`).
 pub mod market_data;
-/// Per-worker permission scoping for permissioned (Fynd-exclusive) pools.
+/// Per-worker permission scoping for permissioned components.
 pub mod permission;
 /// Protocol system registry: maps protocol names to their Tycho identifiers.
 pub mod protocol_registry;

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -7,6 +7,8 @@ pub mod events;
 pub(crate) mod gas;
 /// Shared market data store (`MarketState`, `MarketData`).
 pub mod market_data;
+/// Per-worker permission scoping for permissioned (Fynd-exclusive) pools.
+pub mod permission;
 /// Protocol system registry: maps protocol names to their Tycho identifiers.
 pub mod protocol_registry;
 /// Tycho WebSocket feed: connects to the Tycho data stream and populates `MarketState`.

--- a/fynd-core/src/feed/permission.rs
+++ b/fynd-core/src/feed/permission.rs
@@ -6,11 +6,17 @@
 //! each worker's local graph topology/events through a `PermissionPolicy` according to its
 //! `ComponentScope` — the shared `MarketState` is never duplicated.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use tycho_simulation::tycho_common::models::{protocol::ProtocolComponent, Address};
 
-use crate::{feed::market_data::MarketState, types::ComponentId};
+use crate::{
+    feed::{events::MarketEvent, market_data::MarketState},
+    types::ComponentId,
+};
 
 /// Classifies a [`ProtocolComponent`] as permissioned (Fynd-exclusive) or public.
 ///
@@ -58,38 +64,98 @@ pub enum ComponentScope {
     IncludeAll,
 }
 
-/// Filters a full topology map to the components visible under `scope`.
+/// Per-worker permission scoping: which components a worker may ingest into its local graph.
 ///
-/// Returned by public workers as a strict subset of the input; surplus workers receive the input
-/// unchanged.
-pub fn filter_topology(
+/// Bundles a [`ComponentScope`] with an optional [`PermissionPolicy`]. All graph filtering for a
+/// worker flows through this type, so the worker never reasons about permissioned-ness itself — it
+/// just hands its topology and incoming events here.
+#[derive(Clone, Debug)]
+pub(crate) struct PermissionContext {
+    /// Scope governing whether permissioned components are filtered out.
     scope: ComponentScope,
-    policy: &PermissionPolicy,
-    market: &MarketState,
-    topology: HashMap<ComponentId, Vec<Address>>,
-) -> HashMap<ComponentId, Vec<Address>> {
-    // TODO: when scope == ExcludePermissioned, drop entries whose ComponentId resolves (via
-    // market.get_component(id)) to a ProtocolComponent for which policy.is_permissioned is true.
-    // When scope == IncludeAll, return `topology` unchanged.
-    let _ = (scope, policy, market, topology);
-    todo!("filter permissioned components from the worker's initial topology")
+    /// Predicate classifying components as permissioned. `None` ⇒ no filtering is ever applied.
+    policy: Option<PermissionPolicy>,
 }
 
-/// Filters a list of changed component ids to those visible under `scope`.
-///
-/// Used on the incremental-event path (added/updated/removed component ids) so that a public
-/// worker never ingests a permissioned component mid-stream.
-pub fn filter_component_ids(
-    scope: ComponentScope,
-    policy: &PermissionPolicy,
-    market: &MarketState,
-    ids: &[ComponentId],
-) -> Vec<ComponentId> {
-    // TODO: when scope == ExcludePermissioned, keep only ids whose ProtocolComponent (via
-    // market.get_component(id)) is NOT permissioned per policy.is_permissioned. When scope ==
-    // IncludeAll, return all ids unchanged.
-    let _ = (scope, policy, market, ids);
-    todo!("filter permissioned component ids from an incremental market event")
+impl PermissionContext {
+    /// Default context: see every component, apply no permission filtering.
+    pub(crate) fn include_all() -> Self {
+        Self { scope: ComponentScope::IncludeAll, policy: None }
+    }
+
+    /// Context derived from a pool's role: a scope plus the (optional) classifying policy.
+    pub(crate) fn new(scope: ComponentScope, policy: Option<PermissionPolicy>) -> Self {
+        Self { scope, policy }
+    }
+
+    /// Returns the policy to enforce, or `None` when this worker filters nothing (scope is
+    /// `IncludeAll`, or no policy was configured).
+    fn active_policy(&self) -> Option<&PermissionPolicy> {
+        match (self.scope, &self.policy) {
+            (ComponentScope::ExcludePermissioned, Some(policy)) => Some(policy),
+            _ => None,
+        }
+    }
+
+    /// Filters a full topology map to the components this worker may see.
+    ///
+    /// Public workers drop permissioned components; surplus workers (and workers with no policy)
+    /// receive the map unchanged.
+    pub(crate) fn filter_topology(
+        &self,
+        market: &MarketState,
+        topology: HashMap<ComponentId, Vec<Address>>,
+    ) -> HashMap<ComponentId, Vec<Address>> {
+        let Some(policy) = self.active_policy() else {
+            return topology;
+        };
+        // TODO: drop entries whose ComponentId resolves (via market.get_component(id)) to a
+        // ProtocolComponent for which policy.is_permissioned is true.
+        let _ = (policy, market);
+        todo!("filter permissioned components from the worker's initial topology")
+    }
+
+    /// Restricts a market event to the components this worker may see.
+    ///
+    /// Public workers drop permissioned component ids from the added/updated/removed lists so a
+    /// permissioned component is never ingested mid-stream; other workers see the event unchanged.
+    pub(crate) fn scope_event(&self, market: &MarketState, event: MarketEvent) -> MarketEvent {
+        let Some(policy) = self.active_policy() else {
+            return event;
+        };
+        let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
+            event;
+
+        let added_ids: Vec<ComponentId> = added_components
+            .keys()
+            .cloned()
+            .collect();
+        let permitted_added: HashSet<ComponentId> = self
+            .filter_component_ids(policy, market, &added_ids)
+            .into_iter()
+            .collect();
+        let added_components = added_components
+            .into_iter()
+            .filter(|(id, _)| permitted_added.contains(id))
+            .collect();
+        let removed_components = self.filter_component_ids(policy, market, &removed_components);
+        let updated_components = self.filter_component_ids(policy, market, &updated_components);
+
+        MarketEvent::MarketUpdated { added_components, removed_components, updated_components }
+    }
+
+    /// Keeps only the component ids that are NOT permissioned under `policy`.
+    fn filter_component_ids(
+        &self,
+        policy: &PermissionPolicy,
+        market: &MarketState,
+        ids: &[ComponentId],
+    ) -> Vec<ComponentId> {
+        // TODO: keep only ids whose ProtocolComponent (via market.get_component(id)) is NOT
+        // permissioned per policy.is_permissioned.
+        let _ = (policy, market, ids);
+        todo!("filter permissioned component ids from an incremental market event")
+    }
 }
 
 #[cfg(test)]
@@ -97,7 +163,7 @@ mod tests {
     use super::*;
     use crate::{
         algorithm::test_utils::{component, token},
-        feed::market_data::MarketState,
+        feed::{events::MarketEvent, market_data::MarketState},
     };
 
     /// A predicate that treats the `vm:permissioned` protocol system as Fynd-exclusive.
@@ -136,32 +202,36 @@ mod tests {
         let market = market_with(vec![public_component("pub-1"), permissioned_component("perm-1")]);
         let topology = market.component_topology();
 
-        let public_view = filter_topology(
-            ComponentScope::ExcludePermissioned,
-            &policy,
-            &market,
-            topology.clone(),
-        );
+        let public = PermissionContext::new(ComponentScope::ExcludePermissioned, Some(policy));
+        let public_view = public.filter_topology(&market, topology.clone());
         assert!(public_view.contains_key("pub-1"));
         assert!(!public_view.contains_key("perm-1"));
 
         let surplus_view =
-            filter_topology(ComponentScope::IncludeAll, &policy, &market, topology.clone());
+            PermissionContext::include_all().filter_topology(&market, topology.clone());
         assert_eq!(surplus_view.len(), topology.len());
     }
 
     #[test]
     #[ignore = "scaffold: filter helpers are todo!()"]
-    fn filter_component_ids_excludes_permissioned() {
+    fn scope_event_excludes_permissioned() {
         let policy = permissioned_protocol_policy();
         let market = market_with(vec![public_component("pub-1"), permissioned_component("perm-1")]);
-        let ids = vec!["pub-1".to_string(), "perm-1".to_string()];
+        let event = MarketEvent::MarketUpdated {
+            added_components: HashMap::from([
+                ("pub-1".to_string(), vec![]),
+                ("perm-1".to_string(), vec![]),
+            ]),
+            removed_components: vec!["pub-1".to_string(), "perm-1".to_string()],
+            updated_components: vec!["pub-1".to_string(), "perm-1".to_string()],
+        };
 
-        let public_ids =
-            filter_component_ids(ComponentScope::ExcludePermissioned, &policy, &market, &ids);
-        assert_eq!(public_ids, vec!["pub-1".to_string()]);
-
-        let surplus_ids = filter_component_ids(ComponentScope::IncludeAll, &policy, &market, &ids);
-        assert_eq!(surplus_ids, ids);
+        let public = PermissionContext::new(ComponentScope::ExcludePermissioned, Some(policy));
+        let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
+            public.scope_event(&market, event);
+        assert!(added_components.contains_key("pub-1"));
+        assert!(!added_components.contains_key("perm-1"));
+        assert_eq!(removed_components, vec!["pub-1".to_string()]);
+        assert_eq!(updated_components, vec!["pub-1".to_string()]);
     }
 }

--- a/fynd-core/src/feed/permission.rs
+++ b/fynd-core/src/feed/permission.rs
@@ -1,10 +1,11 @@
 //! Per-worker permission scoping for permissioned components.
 //!
-//! "Permissioned" means accessible only to Fynd: such components must never appear in a normal
-//! public quote, yet a dedicated worker is allowed to route through them to capture the surplus
-//! they offer above the best public-market rate. Isolation is achieved by filtering each worker's
-//! local graph topology/events through its `PermissionContext` — the shared `MarketState` is
-//! never duplicated.
+//! "Permissioned" means accessible only to Fynd: such components must never enter the route a
+//! public pool returns, yet the surplus pool is allowed to route through them to capture the
+//! surplus they offer above the best public-market rate. Both pool kinds serve the same request;
+//! they differ only in which liquidity their workers may route through. Isolation is achieved by
+//! filtering each worker's local graph topology/events through its `PermissionContext` — the
+//! shared `MarketState` is never duplicated.
 
 use std::{
     collections::{HashMap, HashSet},

--- a/fynd-core/src/feed/permission.rs
+++ b/fynd-core/src/feed/permission.rs
@@ -1,10 +1,10 @@
-//! Per-worker permission scoping for permissioned ("fair-flow hook") pools.
+//! Per-worker permission scoping for permissioned components.
 //!
-//! Some pools are exclusive to Fynd: they must never appear in a normal public quote, yet a
-//! dedicated "surplus" worker is allowed to route through them to capture the surplus
-//! (`egAmount`) they offer above the best public-market rate. Isolation is achieved by filtering
-//! each worker's local graph topology/events through a `PermissionPolicy` according to its
-//! `ComponentScope` — the shared `MarketState` is never duplicated.
+//! "Permissioned" means accessible only to Fynd: such components must never appear in a normal
+//! public quote, yet a dedicated worker is allowed to route through them to capture the surplus
+//! they offer above the best public-market rate. Isolation is achieved by filtering each worker's
+//! local graph topology/events through a `PermissionPolicy` according to its `ComponentScope` — the
+//! shared `MarketState` is never duplicated.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -18,7 +18,7 @@ use crate::{
     types::ComponentId,
 };
 
-/// Classifies a [`ProtocolComponent`] as permissioned (Fynd-exclusive) or public.
+/// Classifies a [`ProtocolComponent`] as permissioned or public.
 ///
 /// The predicate is supplied by the caller rather than hard-coded against an id or protocol name,
 /// so the notion of "permissioned" can evolve (e.g. a hook address allowlist) without touching the
@@ -39,7 +39,7 @@ impl PermissionPolicy {
         Self { is_permissioned: Arc::new(predicate) }
     }
 
-    /// Returns `true` if the component is permissioned (Fynd-exclusive).
+    /// Returns `true` if the component is permissioned.
     pub fn is_permissioned(&self, component: &ProtocolComponent) -> bool {
         (self.is_permissioned)(component)
     }
@@ -166,7 +166,7 @@ mod tests {
         feed::{events::MarketEvent, market_data::MarketState},
     };
 
-    /// A predicate that treats the `vm:permissioned` protocol system as Fynd-exclusive.
+    /// A predicate that treats the `vm:permissioned` protocol system as permissioned.
     fn permissioned_protocol_policy() -> PermissionPolicy {
         PermissionPolicy::new(|c: &ProtocolComponent| c.protocol_system == "vm:permissioned")
     }

--- a/fynd-core/src/feed/permission.rs
+++ b/fynd-core/src/feed/permission.rs
@@ -1,0 +1,167 @@
+//! Per-worker permission scoping for permissioned ("fair-flow hook") pools.
+//!
+//! Some pools are exclusive to Fynd: they must never appear in a normal public quote, yet a
+//! dedicated "surplus" worker is allowed to route through them to capture the surplus
+//! (`egAmount`) they offer above the best public-market rate. Isolation is achieved by filtering
+//! each worker's local graph topology/events through a `PermissionPolicy` according to its
+//! `ComponentScope` — the shared `MarketState` is never duplicated.
+
+use std::{collections::HashMap, sync::Arc};
+
+use tycho_simulation::tycho_common::models::{protocol::ProtocolComponent, Address};
+
+use crate::{feed::market_data::MarketState, types::ComponentId};
+
+/// Classifies a [`ProtocolComponent`] as permissioned (Fynd-exclusive) or public.
+///
+/// The predicate is supplied by the caller rather than hard-coded against an id or protocol name,
+/// so the notion of "permissioned" can evolve (e.g. a hook address allowlist) without touching the
+/// routing core.
+#[derive(Clone)]
+pub struct PermissionPolicy {
+    /// Returns `true` when the component is permissioned and therefore excluded from public
+    /// quotes.
+    is_permissioned: Arc<dyn Fn(&ProtocolComponent) -> bool + Send + Sync>,
+}
+
+impl PermissionPolicy {
+    /// Creates a policy from a predicate identifying permissioned components.
+    pub fn new<F>(predicate: F) -> Self
+    where
+        F: Fn(&ProtocolComponent) -> bool + Send + Sync + 'static,
+    {
+        Self { is_permissioned: Arc::new(predicate) }
+    }
+
+    /// Returns `true` if the component is permissioned (Fynd-exclusive).
+    pub fn is_permissioned(&self, component: &ProtocolComponent) -> bool {
+        (self.is_permissioned)(component)
+    }
+}
+
+impl std::fmt::Debug for PermissionPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PermissionPolicy")
+            .finish_non_exhaustive()
+    }
+}
+
+/// The set of components a worker is allowed to see in its local graph.
+///
+/// Determines whether permissioned components are filtered out before the worker builds or updates
+/// its graph. Each worker gets exactly one scope for its lifetime, derived from its pool's role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComponentScope {
+    /// Public workers: permissioned components are dropped so they can never appear in a quote.
+    ExcludePermissioned,
+    /// Surplus workers: every component is visible, including permissioned ones.
+    IncludeAll,
+}
+
+/// Filters a full topology map to the components visible under `scope`.
+///
+/// Returned by public workers as a strict subset of the input; surplus workers receive the input
+/// unchanged.
+pub fn filter_topology(
+    scope: ComponentScope,
+    policy: &PermissionPolicy,
+    market: &MarketState,
+    topology: HashMap<ComponentId, Vec<Address>>,
+) -> HashMap<ComponentId, Vec<Address>> {
+    // TODO: when scope == ExcludePermissioned, drop entries whose ComponentId resolves (via
+    // market.get_component(id)) to a ProtocolComponent for which policy.is_permissioned is true.
+    // When scope == IncludeAll, return `topology` unchanged.
+    let _ = (scope, policy, market, topology);
+    todo!("filter permissioned components from the worker's initial topology")
+}
+
+/// Filters a list of changed component ids to those visible under `scope`.
+///
+/// Used on the incremental-event path (added/updated/removed component ids) so that a public
+/// worker never ingests a permissioned component mid-stream.
+pub fn filter_component_ids(
+    scope: ComponentScope,
+    policy: &PermissionPolicy,
+    market: &MarketState,
+    ids: &[ComponentId],
+) -> Vec<ComponentId> {
+    // TODO: when scope == ExcludePermissioned, keep only ids whose ProtocolComponent (via
+    // market.get_component(id)) is NOT permissioned per policy.is_permissioned. When scope ==
+    // IncludeAll, return all ids unchanged.
+    let _ = (scope, policy, market, ids);
+    todo!("filter permissioned component ids from an incremental market event")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        algorithm::test_utils::{component, token},
+        feed::market_data::MarketState,
+    };
+
+    /// A predicate that treats the `vm:permissioned` protocol system as Fynd-exclusive.
+    fn permissioned_protocol_policy() -> PermissionPolicy {
+        PermissionPolicy::new(|c: &ProtocolComponent| c.protocol_system == "vm:permissioned")
+    }
+
+    fn permissioned_component(id: &str) -> ProtocolComponent {
+        let mut c = component(id, &[token(0x01, "A"), token(0x02, "B")]);
+        c.protocol_system = "vm:permissioned".to_string();
+        c
+    }
+
+    fn public_component(id: &str) -> ProtocolComponent {
+        component(id, &[token(0x01, "A"), token(0x02, "B")])
+    }
+
+    fn market_with(components: Vec<ProtocolComponent>) -> MarketState {
+        let mut market = MarketState::new();
+        market.upsert_components(components);
+        market
+    }
+
+    #[test]
+    #[ignore = "scaffold: filter helpers are todo!()"]
+    fn is_permissioned_reflects_predicate() {
+        let policy = permissioned_protocol_policy();
+        assert!(policy.is_permissioned(&permissioned_component("perm-1")));
+        assert!(!policy.is_permissioned(&public_component("pub-1")));
+    }
+
+    #[test]
+    #[ignore = "scaffold: filter helpers are todo!()"]
+    fn filter_topology_excludes_permissioned() {
+        let policy = permissioned_protocol_policy();
+        let market = market_with(vec![public_component("pub-1"), permissioned_component("perm-1")]);
+        let topology = market.component_topology();
+
+        let public_view = filter_topology(
+            ComponentScope::ExcludePermissioned,
+            &policy,
+            &market,
+            topology.clone(),
+        );
+        assert!(public_view.contains_key("pub-1"));
+        assert!(!public_view.contains_key("perm-1"));
+
+        let surplus_view =
+            filter_topology(ComponentScope::IncludeAll, &policy, &market, topology.clone());
+        assert_eq!(surplus_view.len(), topology.len());
+    }
+
+    #[test]
+    #[ignore = "scaffold: filter helpers are todo!()"]
+    fn filter_component_ids_excludes_permissioned() {
+        let policy = permissioned_protocol_policy();
+        let market = market_with(vec![public_component("pub-1"), permissioned_component("perm-1")]);
+        let ids = vec!["pub-1".to_string(), "perm-1".to_string()];
+
+        let public_ids =
+            filter_component_ids(ComponentScope::ExcludePermissioned, &policy, &market, &ids);
+        assert_eq!(public_ids, vec!["pub-1".to_string()]);
+
+        let surplus_ids = filter_component_ids(ComponentScope::IncludeAll, &policy, &market, &ids);
+        assert_eq!(surplus_ids, ids);
+    }
+}

--- a/fynd-core/src/feed/permission.rs
+++ b/fynd-core/src/feed/permission.rs
@@ -3,8 +3,8 @@
 //! "Permissioned" means accessible only to Fynd: such components must never appear in a normal
 //! public quote, yet a dedicated worker is allowed to route through them to capture the surplus
 //! they offer above the best public-market rate. Isolation is achieved by filtering each worker's
-//! local graph topology/events through a `PermissionPolicy` according to its `ComponentScope` — the
-//! shared `MarketState` is never duplicated.
+//! local graph topology/events through its `PermissionContext` — the shared `MarketState` is
+//! never duplicated.
 
 use std::{
     collections::{HashMap, HashSet},
@@ -52,48 +52,25 @@ impl std::fmt::Debug for PermissionPolicy {
     }
 }
 
-/// The set of components a worker is allowed to see in its local graph.
-///
-/// Determines whether permissioned components are filtered out before the worker builds or updates
-/// its graph. Each worker gets exactly one scope for its lifetime, derived from its pool's role.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ComponentScope {
-    /// Public workers: permissioned components are dropped so they can never appear in a quote.
-    ExcludePermissioned,
-    /// Surplus workers: every component is visible, including permissioned ones.
-    IncludeAll,
-}
-
 /// Per-worker permission scoping: which components a worker may ingest into its local graph.
 ///
-/// Bundles a [`ComponentScope`] with an optional [`PermissionPolicy`]. All graph filtering for a
-/// worker flows through this type, so the worker never reasons about permissioned-ness itself — it
-/// just hands its topology and incoming events here.
+/// Each worker gets exactly one context for its lifetime, derived from its pool's role. All graph
+/// filtering for a worker flows through this type, so the worker never reasons about
+/// permissioned-ness itself — it just hands its topology and incoming events here.
 #[derive(Clone, Debug)]
-pub(crate) struct PermissionContext {
-    /// Scope governing whether permissioned components are filtered out.
-    scope: ComponentScope,
-    /// Predicate classifying components as permissioned. `None` ⇒ no filtering is ever applied.
-    policy: Option<PermissionPolicy>,
+pub enum PermissionContext {
+    /// See every component — the default. No filtering is applied.
+    IncludeAll,
+    /// Drop components classified as permissioned by this policy, so they never enter the graph.
+    ExcludePermissioned(PermissionPolicy),
 }
 
 impl PermissionContext {
-    /// Default context: see every component, apply no permission filtering.
-    pub(crate) fn include_all() -> Self {
-        Self { scope: ComponentScope::IncludeAll, policy: None }
-    }
-
-    /// Context derived from a pool's role: a scope plus the (optional) classifying policy.
-    pub(crate) fn new(scope: ComponentScope, policy: Option<PermissionPolicy>) -> Self {
-        Self { scope, policy }
-    }
-
-    /// Returns the policy to enforce, or `None` when this worker filters nothing (scope is
-    /// `IncludeAll`, or no policy was configured).
+    /// Returns the policy to enforce, or `None` when this worker filters nothing.
     fn active_policy(&self) -> Option<&PermissionPolicy> {
-        match (self.scope, &self.policy) {
-            (ComponentScope::ExcludePermissioned, Some(policy)) => Some(policy),
-            _ => None,
+        match self {
+            Self::ExcludePermissioned(policy) => Some(policy),
+            Self::IncludeAll => None,
         }
     }
 
@@ -202,13 +179,12 @@ mod tests {
         let market = market_with(vec![public_component("pub-1"), permissioned_component("perm-1")]);
         let topology = market.component_topology();
 
-        let public = PermissionContext::new(ComponentScope::ExcludePermissioned, Some(policy));
+        let public = PermissionContext::ExcludePermissioned(policy);
         let public_view = public.filter_topology(&market, topology.clone());
         assert!(public_view.contains_key("pub-1"));
         assert!(!public_view.contains_key("perm-1"));
 
-        let surplus_view =
-            PermissionContext::include_all().filter_topology(&market, topology.clone());
+        let surplus_view = PermissionContext::IncludeAll.filter_topology(&market, topology.clone());
         assert_eq!(surplus_view.len(), topology.len());
     }
 
@@ -226,7 +202,7 @@ mod tests {
             updated_components: vec!["pub-1".to_string(), "perm-1".to_string()],
         };
 
-        let public = PermissionContext::new(ComponentScope::ExcludePermissioned, Some(policy));
+        let public = PermissionContext::ExcludePermissioned(policy);
         let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
             public.scope_event(&market, event);
         assert!(added_components.contains_key("pub-1"));

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -57,9 +57,7 @@ pub use price_guard::{
     config::PriceGuardConfig,
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
-pub use solver::{
-    FyndBuilder, PoolConfig, PoolRoleConfig, Solver, SolverBuildError, SolverParts, WaitReadyError,
-};
+pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
 /// Processes ephemeral pending bundles against live Tycho market state. Obtained by calling
 /// [`FyndBuilder::build_with_pending`](solver::FyndBuilder::build_with_pending).
 pub use tycho_simulation::evm::pending::PendingBlockProcessor;

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -57,7 +57,9 @@ pub use price_guard::{
     config::PriceGuardConfig,
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
-pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
+pub use solver::{
+    FyndBuilder, PoolConfig, PoolRoleConfig, Solver, SolverBuildError, SolverParts, WaitReadyError,
+};
 /// Processes ephemeral pending bundles against live Tycho market state. Obtained by calling
 /// [`FyndBuilder::build_with_pending`](solver::FyndBuilder::build_with_pending).
 pub use tycho_simulation::evm::pending::PendingBlockProcessor;
@@ -73,11 +75,13 @@ pub use types::{
     BlockInfo, ClientFeeParams, ComponentId, EncodingOptions, FeeBreakdown, Order, OrderQuote,
     OrderSide, OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions,
     QuoteRequest, QuoteStatus, Route, RouteValidationError, SingleOrderQuote, SolveError,
-    SolveParams, SolveResult, Swap, TaskId, Transaction, UserTransferType,
+    SolveParams, SolveResult, SurplusInfo, Swap, TaskId, Transaction, UserTransferType,
 };
 pub use worker_pool::{
     pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig},
     registry::UnknownAlgorithmError,
     TaskQueueHandle,
 };
-pub use worker_pool_router::{config::WorkerPoolRouterConfig, SolverPoolHandle, WorkerPoolRouter};
+pub use worker_pool_router::{
+    config::WorkerPoolRouterConfig, PoolRole, SolverPoolHandle, WorkerPoolRouter,
+};

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -126,18 +126,19 @@ fn parse_connector_tokens(
     Ok(Some(set))
 }
 
-/// Role a configured pool plays in routing: public-only or permissioned-inclusive (surplus).
+/// Role a configured pool plays in routing: public-only or permissioned-inclusive.
 ///
-/// Serialized in lowercase (`"public"` / `"surplus"`) in `worker_pools.toml`. Maps to the
-/// router's `PoolRole` and the worker's `ComponentScope`: public pools exclude permissioned
-/// components, the surplus pool includes everything.
+/// Serialized in lowercase (`"public"` / `"surplus"`) in `worker_pools.toml`. Maps to the router's
+/// `PoolRole` and the worker's `ComponentScope`: a public pool excludes permissioned components; a
+/// surplus pool routes through all liquidity to capture surplus above the public rate.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PoolRoleConfig {
     /// Public pool: routes through public liquidity only (the committed reference). Default.
     #[default]
     Public,
-    /// Surplus pool: routes through permissioned pools to capture surplus above the public rate.
+    /// Surplus pool: routes through all liquidity, including permissioned components, to capture
+    /// surplus above the public rate.
     Surplus,
 }
 
@@ -146,7 +147,7 @@ impl PoolRoleConfig {
     fn pool_role(self) -> PoolRole {
         match self {
             Self::Public => PoolRole::Public,
-            Self::Surplus => PoolRole::Surplus,
+            Self::Surplus => PoolRole::All,
         }
     }
 
@@ -667,7 +668,7 @@ impl FyndBuilder {
         self
     }
 
-    /// Sets the predicate that classifies components as permissioned (Fynd-exclusive).
+    /// Sets the predicate that classifies components as permissioned.
     ///
     /// Public pools exclude matching components from their graphs; the surplus pool includes them.
     /// Without a policy, no pool performs any permission filtering.

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -33,6 +33,7 @@ use crate::{
         events::{MarketEvent, MarketEventHandler},
         gas::GasPriceFetcher,
         market_data::MarketData,
+        permission::{ComponentScope, PermissionPolicy},
         tycho_feed::TychoFeed,
         TychoFeedConfig,
     },
@@ -45,7 +46,9 @@ use crate::{
         pool::{WorkerPool, WorkerPoolBuilder},
         registry::UnknownAlgorithmError,
     },
-    worker_pool_router::{config::WorkerPoolRouterConfig, SolverPoolHandle, WorkerPoolRouter},
+    worker_pool_router::{
+        config::WorkerPoolRouterConfig, PoolRole, SolverPoolHandle, WorkerPoolRouter,
+    },
     Algorithm, Quote, QuoteRequest, SolveError,
 };
 
@@ -123,6 +126,39 @@ fn parse_connector_tokens(
     Ok(Some(set))
 }
 
+/// Role a configured pool plays in routing: public-only or permissioned-inclusive (surplus).
+///
+/// Serialized in lowercase (`"public"` / `"surplus"`) in `worker_pools.toml`. Maps to the
+/// router's `PoolRole` and the worker's `ComponentScope`: public pools exclude permissioned
+/// components, the surplus pool includes everything.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolRoleConfig {
+    /// Public pool: routes through public liquidity only (the committed reference). Default.
+    #[default]
+    Public,
+    /// Surplus pool: routes through permissioned pools to capture surplus above the public rate.
+    Surplus,
+}
+
+impl PoolRoleConfig {
+    /// The router role this config maps to.
+    fn pool_role(self) -> PoolRole {
+        match self {
+            Self::Public => PoolRole::Public,
+            Self::Surplus => PoolRole::Surplus,
+        }
+    }
+
+    /// The per-worker component scope this config maps to.
+    fn component_scope(self) -> ComponentScope {
+        match self {
+            Self::Public => ComponentScope::ExcludePermissioned,
+            Self::Surplus => ComponentScope::IncludeAll,
+        }
+    }
+}
+
 /// Per-pool configuration for [`FyndBuilder::add_pool`].
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -151,6 +187,9 @@ pub struct PoolConfig {
     /// Absent = no restriction. Typically 3–10 entries (e.g. WETH, USDC, USDT, DAI).
     #[serde(default)]
     connector_tokens: Option<Vec<String>>,
+    /// Pool role: `public` (default) or `surplus` (permissioned-inclusive).
+    #[serde(default)]
+    role: PoolRoleConfig,
 }
 
 impl PoolConfig {
@@ -165,12 +204,24 @@ impl PoolConfig {
             timeout_ms: defaults::POOL_TIMEOUT_MS,
             max_routes: None,
             connector_tokens: None,
+            role: PoolRoleConfig::Public,
         }
     }
 
     /// Returns the algorithm name.
     pub fn algorithm(&self) -> &str {
         &self.algorithm
+    }
+
+    /// Returns the pool role.
+    pub fn role(&self) -> PoolRoleConfig {
+        self.role
+    }
+
+    /// Sets the pool role (public or surplus).
+    pub fn with_role(mut self, role: PoolRoleConfig) -> Self {
+        self.role = role;
+        self
     }
 
     /// Returns the number of worker threads.
@@ -315,8 +366,19 @@ enum PoolEntry {
         timeout_ms: u64,
         max_routes: Option<usize>,
         connector_tokens: Option<HashSet<Address>>,
+        role: PoolRoleConfig,
     },
     Custom(CustomPoolEntry),
+}
+
+impl PoolEntry {
+    /// Returns the configured role for this pool.
+    fn role(&self) -> PoolRoleConfig {
+        match self {
+            PoolEntry::BuiltIn { role, .. } => *role,
+            PoolEntry::Custom(custom) => custom.role,
+        }
+    }
 }
 
 /// Pool entry backed by a custom [`Algorithm`] implementation.
@@ -328,6 +390,8 @@ struct CustomPoolEntry {
     max_hops: usize,
     timeout_ms: u64,
     max_routes: Option<usize>,
+    /// Pool role: public (default) or surplus.
+    role: PoolRoleConfig,
     /// Applies the custom algorithm to a `WorkerPoolBuilder`.
     configure: Box<dyn FnOnce(WorkerPoolBuilder) -> WorkerPoolBuilder + Send>,
 }
@@ -380,6 +444,9 @@ pub struct FyndBuilder {
     price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
     pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
+    /// Predicate identifying permissioned components. Shared by all pools: public pools exclude
+    /// matching components, the surplus pool includes them. `None` ⇒ no pool filters anything.
+    permission_policy: Option<PermissionPolicy>,
 }
 
 impl FyndBuilder {
@@ -413,6 +480,7 @@ impl FyndBuilder {
             price_guard_enabled: false,
             price_providers: Vec::new(),
             pending_indexers: Vec::new(),
+            permission_policy: None,
         }
     }
 
@@ -516,6 +584,7 @@ impl FyndBuilder {
             timeout_ms: defaults::POOL_TIMEOUT_MS,
             max_routes: None,
             connector_tokens: None,
+            role: PoolRoleConfig::Public,
         });
         self
     }
@@ -542,6 +611,7 @@ impl FyndBuilder {
                 max_hops: defaults::POOL_MAX_HOPS,
                 timeout_ms: defaults::POOL_TIMEOUT_MS,
                 max_routes: None,
+                role: PoolRoleConfig::Public,
                 configure,
             }));
         self
@@ -597,6 +667,21 @@ impl FyndBuilder {
         self
     }
 
+    /// Sets the predicate that classifies components as permissioned (Fynd-exclusive).
+    ///
+    /// Public pools exclude matching components from their graphs; the surplus pool includes them.
+    /// Without a policy, no pool performs any permission filtering.
+    pub fn permission_policy<F>(mut self, predicate: F) -> Self
+    where
+        F: Fn(&tycho_simulation::tycho_common::models::protocol::ProtocolComponent) -> bool
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.permission_policy = Some(PermissionPolicy::new(predicate));
+        self
+    }
+
     /// Adds a named pool using the given [`PoolConfig`].
     ///
     /// # Errors
@@ -619,6 +704,7 @@ impl FyndBuilder {
             timeout_ms: config.timeout_ms(),
             max_routes: config.max_routes(),
             connector_tokens,
+            role: config.role(),
         });
         Ok(self)
     }
@@ -681,9 +767,20 @@ impl FyndBuilder {
         let mut solver_pool_handles: Vec<SolverPoolHandle> = Vec::new();
         let mut worker_pools: Vec<WorkerPool> = Vec::new();
 
-        for pool_entry in self.pools {
+        // Shared across all pools: public pools exclude permissioned components, the surplus pool
+        // includes them. `None` ⇒ no pool filters anything (original behaviour).
+        let permission_policy = self.permission_policy.take();
+        let pools = std::mem::take(&mut self.pools);
+
+        for pool_entry in pools {
             let pool_event_rx = tycho_feed.subscribe();
             let derived_rx = derived_event_tx.subscribe();
+
+            // Derive the per-worker component scope and the router-facing pool role from the
+            // configured role, then thread the shared permission policy through the builder.
+            let role_config = pool_entry.role();
+            let pool_role = role_config.pool_role();
+            let component_scope = role_config.component_scope();
 
             let (worker_pool, task_handle) = match pool_entry {
                 PoolEntry::BuiltIn {
@@ -696,6 +793,7 @@ impl FyndBuilder {
                     timeout_ms,
                     max_routes,
                     connector_tokens,
+                    role: _,
                 } => {
                     let mut algo_cfg = AlgorithmConfig::new(
                         min_hops,
@@ -706,18 +804,22 @@ impl FyndBuilder {
                     if let Some(tokens) = connector_tokens {
                         algo_cfg = algo_cfg.with_connector_tokens(tokens);
                     }
-                    WorkerPoolBuilder::new()
+                    let mut builder = WorkerPoolBuilder::new()
                         .name(name)
                         .algorithm(algorithm)
                         .algorithm_config(algo_cfg)
                         .num_workers(num_workers)
                         .task_queue_capacity(task_queue_capacity)
-                        .build(
-                            market_data.clone(),
-                            Arc::clone(&derived_data),
-                            pool_event_rx,
-                            derived_rx,
-                        )?
+                        .component_scope(component_scope);
+                    if let Some(policy) = permission_policy.clone() {
+                        builder = builder.permission_policy(policy);
+                    }
+                    builder.build(
+                        market_data.clone(),
+                        Arc::clone(&derived_data),
+                        pool_event_rx,
+                        derived_rx,
+                    )?
                 }
                 PoolEntry::Custom(custom) => {
                     let algo_cfg = AlgorithmConfig::new(
@@ -726,11 +828,15 @@ impl FyndBuilder {
                         Duration::from_millis(custom.timeout_ms),
                         custom.max_routes,
                     )?;
-                    let builder = WorkerPoolBuilder::new()
+                    let mut builder = WorkerPoolBuilder::new()
                         .name(custom.name)
                         .algorithm_config(algo_cfg)
                         .num_workers(custom.num_workers)
-                        .task_queue_capacity(custom.task_queue_capacity);
+                        .task_queue_capacity(custom.task_queue_capacity)
+                        .component_scope(component_scope);
+                    if let Some(policy) = permission_policy.clone() {
+                        builder = builder.permission_policy(policy);
+                    }
                     let builder = (custom.configure)(builder);
                     builder.build(
                         market_data.clone(),
@@ -741,7 +847,8 @@ impl FyndBuilder {
                 }
             };
 
-            solver_pool_handles.push(SolverPoolHandle::new(worker_pool.name(), task_handle));
+            solver_pool_handles
+                .push(SolverPoolHandle::new(worker_pool.name(), task_handle).with_role(pool_role));
             worker_pools.push(worker_pool);
         }
 

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -33,7 +33,7 @@ use crate::{
         events::{MarketEvent, MarketEventHandler},
         gas::GasPriceFetcher,
         market_data::MarketData,
-        permission::{ComponentScope, PermissionPolicy},
+        permission::{PermissionContext, PermissionPolicy},
         tycho_feed::TychoFeed,
         TychoFeedConfig,
     },
@@ -126,40 +126,6 @@ fn parse_connector_tokens(
     Ok(Some(set))
 }
 
-/// Role a configured pool plays in routing: public-only or permissioned-inclusive.
-///
-/// Serialized in lowercase (`"public"` / `"surplus"`) in `worker_pools.toml`. Maps to the router's
-/// `PoolRole` and the worker's `ComponentScope`: a public pool excludes permissioned components; a
-/// surplus pool routes through all liquidity to capture surplus above the public rate.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PoolRoleConfig {
-    /// Public pool: routes through public liquidity only (the committed reference). Default.
-    #[default]
-    Public,
-    /// Surplus pool: routes through all liquidity, including permissioned components, to capture
-    /// surplus above the public rate.
-    Surplus,
-}
-
-impl PoolRoleConfig {
-    /// The router role this config maps to.
-    fn pool_role(self) -> PoolRole {
-        match self {
-            Self::Public => PoolRole::Public,
-            Self::Surplus => PoolRole::All,
-        }
-    }
-
-    /// The per-worker component scope this config maps to.
-    fn component_scope(self) -> ComponentScope {
-        match self {
-            Self::Public => ComponentScope::ExcludePermissioned,
-            Self::Surplus => ComponentScope::IncludeAll,
-        }
-    }
-}
-
 /// Per-pool configuration for [`FyndBuilder::add_pool`].
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -188,9 +154,9 @@ pub struct PoolConfig {
     /// Absent = no restriction. Typically 3–10 entries (e.g. WETH, USDC, USDT, DAI).
     #[serde(default)]
     connector_tokens: Option<Vec<String>>,
-    /// Pool role: `public` (default) or `surplus` (permissioned-inclusive).
+    /// Pool role: `public` (default) or `all` (permissioned-inclusive).
     #[serde(default)]
-    role: PoolRoleConfig,
+    role: PoolRole,
 }
 
 impl PoolConfig {
@@ -205,7 +171,7 @@ impl PoolConfig {
             timeout_ms: defaults::POOL_TIMEOUT_MS,
             max_routes: None,
             connector_tokens: None,
-            role: PoolRoleConfig::Public,
+            role: PoolRole::Public,
         }
     }
 
@@ -215,12 +181,12 @@ impl PoolConfig {
     }
 
     /// Returns the pool role.
-    pub fn role(&self) -> PoolRoleConfig {
+    pub fn role(&self) -> PoolRole {
         self.role
     }
 
-    /// Sets the pool role (public or surplus).
-    pub fn with_role(mut self, role: PoolRoleConfig) -> Self {
+    /// Sets the pool role (public or all).
+    pub fn with_role(mut self, role: PoolRole) -> Self {
         self.role = role;
         self
     }
@@ -367,14 +333,14 @@ enum PoolEntry {
         timeout_ms: u64,
         max_routes: Option<usize>,
         connector_tokens: Option<HashSet<Address>>,
-        role: PoolRoleConfig,
+        role: PoolRole,
     },
     Custom(CustomPoolEntry),
 }
 
 impl PoolEntry {
     /// Returns the configured role for this pool.
-    fn role(&self) -> PoolRoleConfig {
+    fn role(&self) -> PoolRole {
         match self {
             PoolEntry::BuiltIn { role, .. } => *role,
             PoolEntry::Custom(custom) => custom.role,
@@ -391,8 +357,8 @@ struct CustomPoolEntry {
     max_hops: usize,
     timeout_ms: u64,
     max_routes: Option<usize>,
-    /// Pool role: public (default) or surplus.
-    role: PoolRoleConfig,
+    /// Pool role: public (default) or all.
+    role: PoolRole,
     /// Applies the custom algorithm to a `WorkerPoolBuilder`.
     configure: Box<dyn FnOnce(WorkerPoolBuilder) -> WorkerPoolBuilder + Send>,
 }
@@ -585,7 +551,7 @@ impl FyndBuilder {
             timeout_ms: defaults::POOL_TIMEOUT_MS,
             max_routes: None,
             connector_tokens: None,
-            role: PoolRoleConfig::Public,
+            role: PoolRole::Public,
         });
         self
     }
@@ -612,7 +578,7 @@ impl FyndBuilder {
                 max_hops: defaults::POOL_MAX_HOPS,
                 timeout_ms: defaults::POOL_TIMEOUT_MS,
                 max_routes: None,
-                role: PoolRoleConfig::Public,
+                role: PoolRole::Public,
                 configure,
             }));
         self
@@ -777,11 +743,13 @@ impl FyndBuilder {
             let pool_event_rx = tycho_feed.subscribe();
             let derived_rx = derived_event_tx.subscribe();
 
-            // Derive the per-worker component scope and the router-facing pool role from the
-            // configured role, then thread the shared permission policy through the builder.
-            let role_config = pool_entry.role();
-            let pool_role = role_config.pool_role();
-            let component_scope = role_config.component_scope();
+            // The router-facing role doubles as the per-worker scope: only a public pool with a
+            // policy filters; the surplus pool (and any pool without a policy) includes everything.
+            let pool_role = pool_entry.role();
+            let permission = match (pool_role, permission_policy.clone()) {
+                (PoolRole::Public, Some(policy)) => PermissionContext::ExcludePermissioned(policy),
+                _ => PermissionContext::IncludeAll,
+            };
 
             let (worker_pool, task_handle) = match pool_entry {
                 PoolEntry::BuiltIn {
@@ -805,16 +773,13 @@ impl FyndBuilder {
                     if let Some(tokens) = connector_tokens {
                         algo_cfg = algo_cfg.with_connector_tokens(tokens);
                     }
-                    let mut builder = WorkerPoolBuilder::new()
+                    let builder = WorkerPoolBuilder::new()
                         .name(name)
                         .algorithm(algorithm)
                         .algorithm_config(algo_cfg)
                         .num_workers(num_workers)
                         .task_queue_capacity(task_queue_capacity)
-                        .component_scope(component_scope);
-                    if let Some(policy) = permission_policy.clone() {
-                        builder = builder.permission_policy(policy);
-                    }
+                        .permission(permission);
                     builder.build(
                         market_data.clone(),
                         Arc::clone(&derived_data),
@@ -829,15 +794,12 @@ impl FyndBuilder {
                         Duration::from_millis(custom.timeout_ms),
                         custom.max_routes,
                     )?;
-                    let mut builder = WorkerPoolBuilder::new()
+                    let builder = WorkerPoolBuilder::new()
                         .name(custom.name)
                         .algorithm_config(algo_cfg)
                         .num_workers(custom.num_workers)
                         .task_queue_capacity(custom.task_queue_capacity)
-                        .component_scope(component_scope);
-                    if let Some(policy) = permission_policy.clone() {
-                        builder = builder.permission_policy(policy);
-                    }
+                        .permission(permission);
                     let builder = (custom.configure)(builder);
                     builder.build(
                         market_data.clone(),

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -25,6 +25,6 @@ pub use primitives::*;
 pub use quote::{
     BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown, Order, OrderQuote, OrderSide,
     OrderValidationError, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteRequest,
-    QuoteStatus, Route, RouteResult, RouteValidationError, SingleOrderQuote, SolveParams, Swap,
-    Transaction, UserTransferType,
+    QuoteStatus, Route, RouteResult, RouteValidationError, SingleOrderQuote, SolveParams,
+    SurplusInfo, Swap, Transaction, UserTransferType,
 };

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -701,9 +701,9 @@ impl SingleOrderQuote {
     }
 }
 
-/// Order-level surplus summary for a quote routed through a permissioned component: `eg_amount` is
-/// the surplus the protocol captures (realized output minus the committed public-market output the
-/// user is quoted), in the order's `token_out`.
+/// Order-level surplus summary for a quote routed through a permissioned component:
+/// `surplus_amount` is what the protocol captures (realized output minus the committed
+/// public-market output the user is quoted), in the order's `token_out`.
 ///
 /// Informational only (observability). The value the encoder acts on is the per-leg
 /// [`Swap::committed_amount_out`], since the on-chain hook captures surplus per component.
@@ -713,7 +713,7 @@ pub struct SurplusInfo {
     /// Surplus captured by the protocol: realized surplus-route output minus the committed
     /// (public-reference) output.
     #[serde_as(as = "DisplayFromStr")]
-    eg_amount: BigUint,
+    surplus_amount: BigUint,
     /// The best public-market output the user is committed to (the quoted `amount_out`).
     #[serde_as(as = "DisplayFromStr")]
     committed_amount_out: BigUint,
@@ -721,13 +721,13 @@ pub struct SurplusInfo {
 
 impl SurplusInfo {
     /// Creates surplus info from the captured surplus and the committed public output.
-    pub fn new(eg_amount: BigUint, committed_amount_out: BigUint) -> Self {
-        Self { eg_amount, committed_amount_out }
+    pub fn new(surplus_amount: BigUint, committed_amount_out: BigUint) -> Self {
+        Self { surplus_amount, committed_amount_out }
     }
 
     /// Returns the surplus amount captured by the protocol.
-    pub fn eg_amount(&self) -> &BigUint {
-        &self.eg_amount
+    pub fn surplus_amount(&self) -> &BigUint {
+        &self.surplus_amount
     }
 
     /// Returns the committed public-market output the user is quoted.
@@ -846,10 +846,10 @@ impl OrderQuote {
     }
 
     /// Returns the captured surplus amount, if this quote routes through a permissioned component.
-    pub fn eg_amount(&self) -> Option<&BigUint> {
+    pub fn surplus_amount(&self) -> Option<&BigUint> {
         self.surplus
             .as_ref()
-            .map(SurplusInfo::eg_amount)
+            .map(SurplusInfo::surplus_amount)
     }
 
     /// Returns the committed public-market output, if this quote routes through a permissioned
@@ -1853,10 +1853,11 @@ mod tests {
     #[ignore = "scaffold: surplus wiring not yet exercised end-to-end"]
     fn surplus_round_trips_through_getters() {
         let committed = BigUint::from(990u64);
-        let eg = BigUint::from(15u64);
-        let quote = make_quote(990).with_surplus(SurplusInfo::new(eg.clone(), committed.clone()));
+        let surplus = BigUint::from(15u64);
+        let quote =
+            make_quote(990).with_surplus(SurplusInfo::new(surplus.clone(), committed.clone()));
 
-        assert_eq!(quote.eg_amount(), Some(&eg));
+        assert_eq!(quote.surplus_amount(), Some(&surplus));
         assert_eq!(quote.committed_amount_out(), Some(&committed));
     }
 
@@ -1864,7 +1865,7 @@ mod tests {
     #[ignore = "scaffold: surplus wiring not yet exercised end-to-end"]
     fn public_quote_has_no_surplus() {
         let quote = make_quote(990);
-        assert_eq!(quote.eg_amount(), None);
+        assert_eq!(quote.surplus_amount(), None);
         assert_eq!(quote.committed_amount_out(), None);
     }
 

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -701,18 +701,12 @@ impl SingleOrderQuote {
     }
 }
 
-/// Order-level surplus summary for a quote routed through a permissioned ("fair-flow hook") pool.
+/// Order-level surplus summary for a quote routed through a permissioned component: `eg_amount` is
+/// the surplus the protocol captures (realized output minus the committed public-market output the
+/// user is quoted), in the order's `token_out`.
 ///
-/// The user is quoted and committed to the best *public*-market output
-/// (`committed_amount_out`), while the trade actually executes through a permissioned pool that
-/// yields more. The protocol captures the difference (`eg_amount = realized_surplus_output −
-/// committed_amount_out`, in the order's `token_out`). Present only on quotes selected from the
-/// surplus pool; absent for pure public quotes.
-///
-/// This is the *reporting aggregate* (observability only). The *actionable* per-pool commitment
-/// the encoder signs lives on the permissioned [`Swap::committed_amount_out`] leg, because the
-/// on-chain hook captures surplus per pool (in that pool's `token_out`), which only equals the
-/// order-level `eg_amount` when the permissioned pool is the route's terminal leg.
+/// Informational only (observability). The value the encoder acts on is the per-leg
+/// [`Swap::committed_amount_out`], since the on-chain hook captures surplus per component.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SurplusInfo {
@@ -839,20 +833,19 @@ impl OrderQuote {
         }
     }
 
-    /// Attaches the order-level surplus summary (committed output + captured `egAmount`).
+    /// Attaches the order-level surplus summary (committed output + captured surplus).
     ///
     /// Set by the router when a surplus route is selected, for observability. The per-leg
     /// [`Swap::committed_amount_out`] (not this) is what the encoder acts on.
-    // Wired into `combine_with_surplus`, whose body is still scaffolded (`todo!()`); the only
-    // current callers are `#[cfg(test)]`, so the prod build sees it as unused.
+    // Called by the surplus overlay in `combine_with_surplus` (still scaffolded); no prod caller
+    // yet.
     #[allow(dead_code)]
     pub(crate) fn with_surplus(mut self, surplus: SurplusInfo) -> Self {
         self.surplus = Some(surplus);
         self
     }
 
-    /// Returns the captured surplus amount (`egAmount`), if this quote routes through a
-    /// permissioned pool.
+    /// Returns the captured surplus amount, if this quote routes through a permissioned component.
     pub fn eg_amount(&self) -> Option<&BigUint> {
         self.surplus
             .as_ref()
@@ -860,7 +853,7 @@ impl OrderQuote {
     }
 
     /// Returns the committed public-market output, if this quote routes through a permissioned
-    /// pool.
+    /// component.
     pub fn committed_amount_out(&self) -> Option<&BigUint> {
         self.surplus
             .as_ref()
@@ -1570,11 +1563,11 @@ pub struct Swap {
     /// Decimal of the amount to be swapped in this operation (for example, 0.5 means 50%)
     #[serde_as(as = "DisplayFromStr")]
     split: f64,
-    /// Per-leg committed output for a permissioned ("fair-flow hook") swap.
+    /// Per-leg committed output for a permissioned swap.
     ///
     /// Set only on the single permissioned leg of a surplus route. The on-chain hook signs a
     /// `maxExchangeRate` derived from this value (`committed_amount_out * denom / amount_in`); the
-    /// pool then captures `amount_out - committed_amount_out` as `egAmount`, denominated in this
+    /// component then captures `amount_out - committed_amount_out` as surplus, denominated in this
     /// swap's `token_out`. `None` for ordinary public swaps. In-process only — consumed by the
     /// encoder; `#[serde(skip)]` so it never enters the wire format.
     #[serde(skip)]

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -709,13 +709,10 @@ impl SingleOrderQuote {
 /// committed_amount_out`, in the order's `token_out`). Present only on quotes selected from the
 /// surplus pool; absent for pure public quotes.
 ///
-/// This struct is the *reporting aggregate*. The *actionable* per-pool commitment the encoder
-/// signs lives on the permissioned [`Swap::committed_amount_out`] leg, because the on-chain hook
-/// captures surplus per pool (in that pool's `token_out`), which only equals the order-level
-/// `eg_amount` when the permissioned pool is the route's terminal leg.
-///
-/// These values must survive into the encoding path so the on-chain hook can be parameterised, but
-/// are intentionally never exposed on the public `/v1/quote` HTTP response.
+/// This is the *reporting aggregate* (observability only). The *actionable* per-pool commitment
+/// the encoder signs lives on the permissioned [`Swap::committed_amount_out`] leg, because the
+/// on-chain hook captures surplus per pool (in that pool's `token_out`), which only equals the
+/// order-level `eg_amount` when the permissioned pool is the route's terminal leg.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SurplusInfo {
@@ -796,10 +793,12 @@ pub struct OrderQuote {
     /// The state overlay this quote was computed against.
     /// When no overlay was requested this is the block number of the base state at solve time.
     solved_against: StateLabel,
-    /// Surplus captured when this quote executes through a permissioned pool.
+    /// Order-level surplus summary, populated when this quote executes through a permissioned
+    /// pool.
     ///
-    /// `None` for pure public quotes. Skipped during (de)serialization: it must reach the
-    /// in-process encoder but is deliberately not part of the public HTTP response DTO.
+    /// Informational only (observability); the value the encoder acts on is the per-leg
+    /// [`Swap::committed_amount_out`]. `None` for pure public quotes. `#[serde(skip)]` — internal
+    /// reporting data, not part of the wire format.
     #[serde(skip)]
     surplus: Option<SurplusInfo>,
 }
@@ -840,9 +839,10 @@ impl OrderQuote {
         }
     }
 
-    /// Attaches permissioned-pool surplus info (committed output + captured `egAmount`).
+    /// Attaches the order-level surplus summary (committed output + captured `egAmount`).
     ///
-    /// Set by the router when a surplus route is selected so the values reach the encoder.
+    /// Set by the router when a surplus route is selected, for observability. The per-leg
+    /// [`Swap::committed_amount_out`] (not this) is what the encoder acts on.
     // Wired into `combine_with_surplus`, whose body is still scaffolded (`todo!()`); the only
     // current callers are `#[cfg(test)]`, so the prod build sees it as unused.
     #[allow(dead_code)]
@@ -1576,7 +1576,7 @@ pub struct Swap {
     /// `maxExchangeRate` derived from this value (`committed_amount_out * denom / amount_in`); the
     /// pool then captures `amount_out - committed_amount_out` as `egAmount`, denominated in this
     /// swap's `token_out`. `None` for ordinary public swaps. In-process only — consumed by the
-    /// encoder, never serialized into the public response.
+    /// encoder; `#[serde(skip)]` so it never enters the wire format.
     #[serde(skip)]
     committed_amount_out: Option<BigUint>,
 }

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -701,6 +701,50 @@ impl SingleOrderQuote {
     }
 }
 
+/// Order-level surplus summary for a quote routed through a permissioned ("fair-flow hook") pool.
+///
+/// The user is quoted and committed to the best *public*-market output
+/// (`committed_amount_out`), while the trade actually executes through a permissioned pool that
+/// yields more. The protocol captures the difference (`eg_amount = realized_surplus_output −
+/// committed_amount_out`, in the order's `token_out`). Present only on quotes selected from the
+/// surplus pool; absent for pure public quotes.
+///
+/// This struct is the *reporting aggregate*. The *actionable* per-pool commitment the encoder
+/// signs lives on the permissioned [`Swap::committed_amount_out`] leg, because the on-chain hook
+/// captures surplus per pool (in that pool's `token_out`), which only equals the order-level
+/// `eg_amount` when the permissioned pool is the route's terminal leg.
+///
+/// These values must survive into the encoding path so the on-chain hook can be parameterised, but
+/// are intentionally never exposed on the public `/v1/quote` HTTP response.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SurplusInfo {
+    /// Surplus captured by the protocol: realized surplus-route output minus the committed
+    /// (public-reference) output.
+    #[serde_as(as = "DisplayFromStr")]
+    eg_amount: BigUint,
+    /// The best public-market output the user is committed to (the quoted `amount_out`).
+    #[serde_as(as = "DisplayFromStr")]
+    committed_amount_out: BigUint,
+}
+
+impl SurplusInfo {
+    /// Creates surplus info from the captured surplus and the committed public output.
+    pub fn new(eg_amount: BigUint, committed_amount_out: BigUint) -> Self {
+        Self { eg_amount, committed_amount_out }
+    }
+
+    /// Returns the surplus amount captured by the protocol.
+    pub fn eg_amount(&self) -> &BigUint {
+        &self.eg_amount
+    }
+
+    /// Returns the committed public-market output the user is quoted.
+    pub fn committed_amount_out(&self) -> &BigUint {
+        &self.committed_amount_out
+    }
+}
+
 /// Quote for a single [`Order`].
 ///
 /// Contains the route to execute (if found), along with expected amounts,
@@ -752,6 +796,12 @@ pub struct OrderQuote {
     /// The state overlay this quote was computed against.
     /// When no overlay was requested this is the block number of the base state at solve time.
     solved_against: StateLabel,
+    /// Surplus captured when this quote executes through a permissioned pool.
+    ///
+    /// `None` for pure public quotes. Skipped during (de)serialization: it must reach the
+    /// in-process encoder but is deliberately not part of the public HTTP response DTO.
+    #[serde(skip)]
+    surplus: Option<SurplusInfo>,
 }
 
 impl OrderQuote {
@@ -786,7 +836,35 @@ impl OrderQuote {
             sender,
             receiver,
             solved_against,
+            surplus: None,
         }
+    }
+
+    /// Attaches permissioned-pool surplus info (committed output + captured `egAmount`).
+    ///
+    /// Set by the router when a surplus route is selected so the values reach the encoder.
+    // Wired into `combine_with_surplus`, whose body is still scaffolded (`todo!()`); the only
+    // current callers are `#[cfg(test)]`, so the prod build sees it as unused.
+    #[allow(dead_code)]
+    pub(crate) fn with_surplus(mut self, surplus: SurplusInfo) -> Self {
+        self.surplus = Some(surplus);
+        self
+    }
+
+    /// Returns the captured surplus amount (`egAmount`), if this quote routes through a
+    /// permissioned pool.
+    pub fn eg_amount(&self) -> Option<&BigUint> {
+        self.surplus
+            .as_ref()
+            .map(SurplusInfo::eg_amount)
+    }
+
+    /// Returns the committed public-market output, if this quote routes through a permissioned
+    /// pool.
+    pub fn committed_amount_out(&self) -> Option<&BigUint> {
+        self.surplus
+            .as_ref()
+            .map(SurplusInfo::committed_amount_out)
     }
 
     /// Sets the status of this quote.
@@ -1492,6 +1570,15 @@ pub struct Swap {
     /// Decimal of the amount to be swapped in this operation (for example, 0.5 means 50%)
     #[serde_as(as = "DisplayFromStr")]
     split: f64,
+    /// Per-leg committed output for a permissioned ("fair-flow hook") swap.
+    ///
+    /// Set only on the single permissioned leg of a surplus route. The on-chain hook signs a
+    /// `maxExchangeRate` derived from this value (`committed_amount_out * denom / amount_in`); the
+    /// pool then captures `amount_out - committed_amount_out` as `egAmount`, denominated in this
+    /// swap's `token_out`. `None` for ordinary public swaps. In-process only — consumed by the
+    /// encoder, never serialized into the public response.
+    #[serde(skip)]
+    committed_amount_out: Option<BigUint>,
 }
 
 impl Swap {
@@ -1519,11 +1606,24 @@ impl Swap {
             protocol_component,
             protocol_state,
             split: 0.0,
+            committed_amount_out: None,
         }
     }
     /// Sets the split fraction for this swap (e.g. 0.5 means 50% of a split route).
     pub fn with_split(mut self, split: f64) -> Self {
         self.split = split;
+        self
+    }
+
+    /// Sets the per-leg committed output for a permissioned swap.
+    ///
+    /// The router stamps this onto the single permissioned leg of a surplus route so the encoder
+    /// can derive the hook's `maxExchangeRate`. See [`Swap::committed_amount_out`].
+    // Stamped by `combine_with_surplus`, whose body is still scaffolded (`todo!()`); no prod caller
+    // yet, mirroring the `OrderQuote::with_surplus` precedent.
+    #[allow(dead_code)]
+    pub(crate) fn with_committed_amount_out(mut self, committed_amount_out: BigUint) -> Self {
+        self.committed_amount_out = Some(committed_amount_out);
         self
     }
 
@@ -1575,6 +1675,14 @@ impl Swap {
     /// Returns the split of this swap.
     pub fn split(&self) -> &f64 {
         &self.split
+    }
+
+    /// Returns the per-leg committed output, if this is the permissioned leg of a surplus route.
+    ///
+    /// `None` for ordinary public swaps. When `Some`, the encoder derives the hook's
+    /// `maxExchangeRate` as `committed_amount_out * denom / amount_in`.
+    pub fn committed_amount_out(&self) -> Option<&BigUint> {
+        self.committed_amount_out.as_ref()
     }
 }
 
@@ -1730,6 +1838,41 @@ mod tests {
         let id = generate_order_id();
         assert!(!id.is_empty());
         assert!(id.contains('-')); // UUIDs contain dashes
+    }
+
+    fn make_quote(amount_out: u64) -> OrderQuote {
+        OrderQuote::new(
+            "order-1".to_string(),
+            QuoteStatus::Success,
+            BigUint::from(1_000u64),
+            BigUint::from(amount_out),
+            BigUint::from(100_000u64),
+            BigUint::from(amount_out),
+            BlockInfo::new(1, "0x1".to_string(), 1),
+            "test".to_string(),
+            Bytes::from(make_address(0xAA).as_ref()),
+            Bytes::from(make_address(0xAA).as_ref()),
+            "1".to_string(),
+        )
+    }
+
+    #[test]
+    #[ignore = "scaffold: surplus wiring not yet exercised end-to-end"]
+    fn surplus_round_trips_through_getters() {
+        let committed = BigUint::from(990u64);
+        let eg = BigUint::from(15u64);
+        let quote = make_quote(990).with_surplus(SurplusInfo::new(eg.clone(), committed.clone()));
+
+        assert_eq!(quote.eg_amount(), Some(&eg));
+        assert_eq!(quote.committed_amount_out(), Some(&committed));
+    }
+
+    #[test]
+    #[ignore = "scaffold: surplus wiring not yet exercised end-to-end"]
+    fn public_quote_has_no_surplus() {
+        let quote = make_quote(990);
+        assert_eq!(quote.eg_amount(), None);
+        assert_eq!(quote.committed_amount_out(), None);
     }
 
     // -------------------------------------------------------------------------

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -19,6 +19,7 @@ use crate::{
     feed::{
         events::{MarketEvent, MarketEventHandler},
         market_data::MarketData,
+        permission::{ComponentScope, PermissionPolicy},
     },
     graph::EdgeWeightUpdaterWithDerived,
     types::internal::SolveTask,
@@ -28,6 +29,7 @@ use crate::{
             DEFAULT_ALGORITHM,
         },
         task_queue::{TaskQueue, TaskQueueConfig, TaskQueueHandle},
+        worker::PermissionContext,
     },
 };
 
@@ -45,6 +47,10 @@ pub struct WorkerPoolConfig {
     algorithm_config: AlgorithmConfig,
     /// Task queue capacity (maximum number of pending tasks).
     task_queue_capacity: usize,
+    /// Permission scope for this pool's workers (default: include all, no filtering).
+    component_scope: ComponentScope,
+    /// Permission predicate. `None` ⇒ no filtering regardless of scope.
+    permission_policy: Option<PermissionPolicy>,
 }
 
 impl WorkerPoolConfig {
@@ -62,6 +68,8 @@ impl Default for WorkerPoolConfig {
             num_workers: num_cpus::get(),
             algorithm_config: AlgorithmConfig::default(),
             task_queue_capacity: 1000,
+            component_scope: ComponentScope::IncludeAll,
+            permission_policy: None,
         }
     }
 }
@@ -112,6 +120,8 @@ impl WorkerPool {
             .to_string();
 
         // Spawn workers
+        let permission =
+            PermissionContext::new(config.component_scope, config.permission_policy.clone());
         let params = SpawnWorkersParams {
             algorithm: algorithm.clone(),
             num_workers: config.num_workers,
@@ -122,6 +132,7 @@ impl WorkerPool {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
+            permission,
         };
         let workers = config.spawner.spawn(params)?;
 
@@ -249,6 +260,21 @@ impl WorkerPoolBuilder {
     /// Sets the task queue capacity.
     pub fn task_queue_capacity(mut self, capacity: usize) -> Self {
         self.config.task_queue_capacity = capacity;
+        self
+    }
+
+    /// Sets the permission scope for this pool's workers.
+    ///
+    /// `ExcludePermissioned` (public pools) drops permissioned components from each worker's graph;
+    /// `IncludeAll` (surplus pools) keeps them. Only has effect when a policy is also set.
+    pub fn component_scope(mut self, scope: ComponentScope) -> Self {
+        self.config.component_scope = scope;
+        self
+    }
+
+    /// Sets the permission policy used to classify components as permissioned.
+    pub fn permission_policy(mut self, policy: PermissionPolicy) -> Self {
+        self.config.permission_policy = Some(policy);
         self
     }
 

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -19,7 +19,7 @@ use crate::{
     feed::{
         events::{MarketEvent, MarketEventHandler},
         market_data::MarketData,
-        permission::{ComponentScope, PermissionContext, PermissionPolicy},
+        permission::PermissionContext,
     },
     graph::EdgeWeightUpdaterWithDerived,
     types::internal::SolveTask,
@@ -46,10 +46,8 @@ pub struct WorkerPoolConfig {
     algorithm_config: AlgorithmConfig,
     /// Task queue capacity (maximum number of pending tasks).
     task_queue_capacity: usize,
-    /// Permission scope for this pool's workers (default: include all, no filtering).
-    component_scope: ComponentScope,
-    /// Permission predicate. `None` ⇒ no filtering regardless of scope.
-    permission_policy: Option<PermissionPolicy>,
+    /// Permission scoping for this pool's workers (default: include all, no filtering).
+    permission: PermissionContext,
 }
 
 impl WorkerPoolConfig {
@@ -67,8 +65,7 @@ impl Default for WorkerPoolConfig {
             num_workers: num_cpus::get(),
             algorithm_config: AlgorithmConfig::default(),
             task_queue_capacity: 1000,
-            component_scope: ComponentScope::IncludeAll,
-            permission_policy: None,
+            permission: PermissionContext::IncludeAll,
         }
     }
 }
@@ -119,8 +116,7 @@ impl WorkerPool {
             .to_string();
 
         // Spawn workers
-        let permission =
-            PermissionContext::new(config.component_scope, config.permission_policy.clone());
+        let permission = config.permission.clone();
         let params = SpawnWorkersParams {
             algorithm: algorithm.clone(),
             num_workers: config.num_workers,
@@ -262,18 +258,12 @@ impl WorkerPoolBuilder {
         self
     }
 
-    /// Sets the permission scope for this pool's workers.
+    /// Sets the permission scoping for this pool's workers.
     ///
-    /// `ExcludePermissioned` (public pools) drops permissioned components from each worker's graph;
-    /// `IncludeAll` (surplus pools) keeps them. Only has effect when a policy is also set.
-    pub fn component_scope(mut self, scope: ComponentScope) -> Self {
-        self.config.component_scope = scope;
-        self
-    }
-
-    /// Sets the permission policy used to classify components as permissioned.
-    pub fn permission_policy(mut self, policy: PermissionPolicy) -> Self {
-        self.config.permission_policy = Some(policy);
+    /// `ExcludePermissioned(policy)` (public pools) drops permissioned components from each
+    /// worker's graph; `IncludeAll` (surplus pools, the default) keeps every component.
+    pub fn permission(mut self, permission: PermissionContext) -> Self {
+        self.config.permission = permission;
         self
     }
 

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -19,7 +19,7 @@ use crate::{
     feed::{
         events::{MarketEvent, MarketEventHandler},
         market_data::MarketData,
-        permission::{ComponentScope, PermissionPolicy},
+        permission::{ComponentScope, PermissionContext, PermissionPolicy},
     },
     graph::EdgeWeightUpdaterWithDerived,
     types::internal::SolveTask,
@@ -29,7 +29,6 @@ use crate::{
             DEFAULT_ALGORITHM,
         },
         task_queue::{TaskQueue, TaskQueueConfig, TaskQueueHandle},
-        worker::PermissionContext,
     },
 };
 

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -249,7 +249,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx,
-            permission: PermissionContext::include_all(),
+            permission: PermissionContext::IncludeAll,
         }
     }
 
@@ -287,7 +287,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
-            permission: PermissionContext::include_all(),
+            permission: PermissionContext::IncludeAll,
         };
 
         let workers =
@@ -328,7 +328,7 @@ mod tests {
                 event_rx: event_tx.subscribe(),
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
-                permission: PermissionContext::include_all(),
+                permission: PermissionContext::IncludeAll,
             });
         assert!(registry_err.is_err());
 
@@ -355,7 +355,7 @@ mod tests {
                 event_rx: event_tx.subscribe(),
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
-                permission: PermissionContext::include_all(),
+                permission: PermissionContext::IncludeAll,
             });
 
         assert!(workers.is_ok());

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -25,9 +25,9 @@ use crate::{
         MostLiquidAlgorithm, PathFrankWolfeAlgorithm,
     },
     derived::{events::DerivedDataEvent, SharedDerivedDataRef},
-    feed::{events::MarketEvent, market_data::MarketData},
+    feed::{events::MarketEvent, market_data::MarketData, permission::PermissionContext},
     types::internal::SolveTask,
-    worker_pool::worker::{PermissionContext, SolverWorker},
+    worker_pool::worker::SolverWorker,
 };
 
 /// List of available built-in algorithm names (for registry-based dispatch).

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -27,7 +27,7 @@ use crate::{
     derived::{events::DerivedDataEvent, SharedDerivedDataRef},
     feed::{events::MarketEvent, market_data::MarketData},
     types::internal::SolveTask,
-    worker_pool::worker::SolverWorker,
+    worker_pool::worker::{PermissionContext, SolverWorker},
 };
 
 /// List of available built-in algorithm names (for registry-based dispatch).
@@ -57,6 +57,11 @@ pub(crate) struct SpawnWorkersParams {
     pub derived_event_rx: broadcast::Receiver<DerivedDataEvent>,
     /// Sender for shutdown signals.
     pub shutdown_tx: broadcast::Sender<()>,
+    /// Permission scoping applied to every worker in this pool.
+    ///
+    /// Cloned per worker so each gets its own [`PermissionContext`]. Defaults to "include all"
+    /// (no filtering) for public pools without permission configuration.
+    pub permission: PermissionContext,
 }
 
 /// Error returned when algorithm registration fails.
@@ -160,6 +165,7 @@ where
         let shutdown_rx = params.shutdown_tx.subscribe();
         let algorithm_name = params.algorithm.clone();
         let factory = factory.clone();
+        let permission = params.permission.clone();
 
         let handle = thread::Builder::new()
             .name(format!("{}-worker-{}", algorithm_name, worker_id))
@@ -173,7 +179,8 @@ where
                     let algorithm = factory(algorithm_config);
 
                     let mut worker =
-                        SolverWorker::new(market_data, derived_data, algorithm, worker_id);
+                        SolverWorker::new(market_data, derived_data, algorithm, worker_id)
+                            .with_permission(permission);
 
                     worker.initialize_graph().await;
                     worker
@@ -242,6 +249,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx,
+            permission: PermissionContext::include_all(),
         }
     }
 
@@ -279,6 +287,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
+            permission: PermissionContext::include_all(),
         };
 
         let workers =
@@ -319,6 +328,7 @@ mod tests {
                 event_rx: event_tx.subscribe(),
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
+                permission: PermissionContext::include_all(),
             });
         assert!(registry_err.is_err());
 
@@ -345,6 +355,7 @@ mod tests {
                 event_rx: event_tx.subscribe(),
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
+                permission: PermissionContext::include_all(),
             });
 
         assert!(workers.is_ok());

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -383,6 +383,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
+            permission: PermissionContext::IncludeAll,
         };
 
         let workers =

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -8,6 +8,7 @@
 //! - Coordinates market event and solve task processing
 
 use std::{
+    collections::HashSet,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -26,6 +27,7 @@ use crate::{
     feed::{
         events::{MarketEvent, MarketEventHandler},
         market_data::MarketData,
+        permission::{ComponentScope, PermissionPolicy},
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
     types::internal::SolveTask,
@@ -57,6 +59,34 @@ where
     /// Worker identifier (for logging).
     // TODO: make this a string to include pool name
     worker_id: usize,
+    /// Permission scoping for this worker's local graph.
+    ///
+    /// `IncludeAll` with no policy (the default) preserves the original non-filtered behaviour.
+    /// A public worker is configured with `ExcludePermissioned` + a `PermissionPolicy` so
+    /// permissioned components never enter its graph; a surplus worker uses `IncludeAll`.
+    permission: PermissionContext,
+}
+
+/// Per-worker permission scoping: which components the worker may ingest into its local graph.
+#[derive(Clone, Debug)]
+pub(crate) struct PermissionContext {
+    /// Scope governing whether permissioned components are filtered out.
+    scope: ComponentScope,
+    /// Predicate classifying components as permissioned. `None` ⇒ no filtering is ever applied
+    /// (equivalent to `IncludeAll`).
+    policy: Option<PermissionPolicy>,
+}
+
+impl PermissionContext {
+    /// Default context: see every component, apply no permission filtering.
+    pub(crate) fn include_all() -> Self {
+        Self { scope: ComponentScope::IncludeAll, policy: None }
+    }
+
+    /// Context for a public worker that must exclude permissioned components.
+    pub(crate) fn new(scope: ComponentScope, policy: Option<PermissionPolicy>) -> Self {
+        Self { scope, policy }
+    }
 }
 
 impl<A> SolverWorker<A>
@@ -91,7 +121,16 @@ where
             ready_notify: Arc::new(Notify::new()),
             initialized: false,
             worker_id,
+            permission: PermissionContext::include_all(),
         }
+    }
+
+    /// Configures this worker's permission scoping.
+    ///
+    /// Public workers pass `ExcludePermissioned` + a policy; surplus workers pass `IncludeAll`.
+    pub(crate) fn with_permission(mut self, permission: PermissionContext) -> Self {
+        self.permission = permission;
+        self
     }
 
     /// Initializes the graph from MarketState.
@@ -102,7 +141,21 @@ where
         let topology = {
             // read lock on market data
             let market = self.market_data.read().await;
-            market.component_topology().clone() // clone to avoid holding the lock
+            let topology = market.component_topology().clone(); // clone to avoid holding the lock
+            match (self.permission.scope, &self.permission.policy) {
+                (ComponentScope::ExcludePermissioned, Some(policy)) => {
+                    // TODO: a public worker must drop permissioned components from its initial
+                    // topology so they can never surface in a public quote.
+                    crate::feed::permission::filter_topology(
+                        self.permission.scope,
+                        policy,
+                        market.base_market_state(),
+                        topology,
+                    )
+                }
+                // IncludeAll (surplus worker) or no policy ⇒ original unfiltered behaviour.
+                _ => topology,
+            }
         };
 
         self.graph_manager
@@ -112,6 +165,7 @@ where
 
     /// Processes a single market event.
     pub async fn process_event(&mut self, event: MarketEvent) {
+        let event = self.scope_event(event).await;
         match event {
             MarketEvent::MarketUpdated { .. } => {
                 if let Err(e) = self
@@ -125,6 +179,58 @@ where
                 }
             }
         }
+    }
+
+    /// Restricts an incoming market event to the components this worker is permitted to see.
+    ///
+    /// Surplus workers (or any worker with no policy) see the event unchanged; public workers
+    /// drop permissioned component ids before the event reaches the graph manager.
+    async fn scope_event(&self, event: MarketEvent) -> MarketEvent {
+        let (ComponentScope::ExcludePermissioned, Some(policy)) =
+            (self.permission.scope, &self.permission.policy)
+        else {
+            // IncludeAll (surplus worker) or no policy ⇒ original unfiltered behaviour.
+            return event;
+        };
+
+        let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
+            event;
+
+        // TODO: apply policy.is_permissioned (via filter_component_ids) to the added, updated, and
+        // removed id lists so a permissioned component is never ingested mid-stream by a public
+        // worker. `added_components` is keyed by id; filter its keys to the permitted subset.
+        let market = self.market_data.read().await;
+        let market_state = market.base_market_state();
+        let added_ids: Vec<_> = added_components
+            .keys()
+            .cloned()
+            .collect();
+        let permitted_added: HashSet<_> = crate::feed::permission::filter_component_ids(
+            self.permission.scope,
+            policy,
+            market_state,
+            &added_ids,
+        )
+        .into_iter()
+        .collect();
+        let added_components = added_components
+            .into_iter()
+            .filter(|(id, _)| permitted_added.contains(id))
+            .collect();
+        let removed_components = crate::feed::permission::filter_component_ids(
+            self.permission.scope,
+            policy,
+            market_state,
+            &removed_components,
+        );
+        let updated_components = crate::feed::permission::filter_component_ids(
+            self.permission.scope,
+            policy,
+            market_state,
+            &updated_components,
+        );
+
+        MarketEvent::MarketUpdated { added_components, removed_components, updated_components }
     }
 
     /// Returns a quote for an order, optionally solved against a named state overlay.

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -8,7 +8,6 @@
 //! - Coordinates market event and solve task processing
 
 use std::{
-    collections::HashSet,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -27,7 +26,7 @@ use crate::{
     feed::{
         events::{MarketEvent, MarketEventHandler},
         market_data::MarketData,
-        permission::{ComponentScope, PermissionPolicy},
+        permission::PermissionContext,
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
     types::internal::SolveTask,
@@ -65,28 +64,6 @@ where
     /// A public worker is configured with `ExcludePermissioned` + a `PermissionPolicy` so
     /// permissioned components never enter its graph; a surplus worker uses `IncludeAll`.
     permission: PermissionContext,
-}
-
-/// Per-worker permission scoping: which components the worker may ingest into its local graph.
-#[derive(Clone, Debug)]
-pub(crate) struct PermissionContext {
-    /// Scope governing whether permissioned components are filtered out.
-    scope: ComponentScope,
-    /// Predicate classifying components as permissioned. `None` ⇒ no filtering is ever applied
-    /// (equivalent to `IncludeAll`).
-    policy: Option<PermissionPolicy>,
-}
-
-impl PermissionContext {
-    /// Default context: see every component, apply no permission filtering.
-    pub(crate) fn include_all() -> Self {
-        Self { scope: ComponentScope::IncludeAll, policy: None }
-    }
-
-    /// Context for a public worker that must exclude permissioned components.
-    pub(crate) fn new(scope: ComponentScope, policy: Option<PermissionPolicy>) -> Self {
-        Self { scope, policy }
-    }
 }
 
 impl<A> SolverWorker<A>
@@ -142,20 +119,8 @@ where
             // read lock on market data
             let market = self.market_data.read().await;
             let topology = market.component_topology().clone(); // clone to avoid holding the lock
-            match (self.permission.scope, &self.permission.policy) {
-                (ComponentScope::ExcludePermissioned, Some(policy)) => {
-                    // TODO: a public worker must drop permissioned components from its initial
-                    // topology so they can never surface in a public quote.
-                    crate::feed::permission::filter_topology(
-                        self.permission.scope,
-                        policy,
-                        market.base_market_state(),
-                        topology,
-                    )
-                }
-                // IncludeAll (surplus worker) or no policy ⇒ original unfiltered behaviour.
-                _ => topology,
-            }
+            self.permission
+                .filter_topology(market.base_market_state(), topology)
         };
 
         self.graph_manager
@@ -165,7 +130,11 @@ where
 
     /// Processes a single market event.
     pub async fn process_event(&mut self, event: MarketEvent) {
-        let event = self.scope_event(event).await;
+        let event = {
+            let market = self.market_data.read().await;
+            self.permission
+                .scope_event(market.base_market_state(), event)
+        };
         match event {
             MarketEvent::MarketUpdated { .. } => {
                 if let Err(e) = self
@@ -179,58 +148,6 @@ where
                 }
             }
         }
-    }
-
-    /// Restricts an incoming market event to the components this worker is permitted to see.
-    ///
-    /// Surplus workers (or any worker with no policy) see the event unchanged; public workers
-    /// drop permissioned component ids before the event reaches the graph manager.
-    async fn scope_event(&self, event: MarketEvent) -> MarketEvent {
-        let (ComponentScope::ExcludePermissioned, Some(policy)) =
-            (self.permission.scope, &self.permission.policy)
-        else {
-            // IncludeAll (surplus worker) or no policy ⇒ original unfiltered behaviour.
-            return event;
-        };
-
-        let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
-            event;
-
-        // TODO: apply policy.is_permissioned (via filter_component_ids) to the added, updated, and
-        // removed id lists so a permissioned component is never ingested mid-stream by a public
-        // worker. `added_components` is keyed by id; filter its keys to the permitted subset.
-        let market = self.market_data.read().await;
-        let market_state = market.base_market_state();
-        let added_ids: Vec<_> = added_components
-            .keys()
-            .cloned()
-            .collect();
-        let permitted_added: HashSet<_> = crate::feed::permission::filter_component_ids(
-            self.permission.scope,
-            policy,
-            market_state,
-            &added_ids,
-        )
-        .into_iter()
-        .collect();
-        let added_components = added_components
-            .into_iter()
-            .filter(|(id, _)| permitted_added.contains(id))
-            .collect();
-        let removed_components = crate::feed::permission::filter_component_ids(
-            self.permission.scope,
-            policy,
-            market_state,
-            &removed_components,
-        );
-        let updated_components = crate::feed::permission::filter_component_ids(
-            self.permission.scope,
-            policy,
-            market_state,
-            &updated_components,
-        );
-
-        MarketEvent::MarketUpdated { added_components, removed_components, updated_components }
     }
 
     /// Returns a quote for an order, optionally solved against a named state overlay.

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -60,9 +60,9 @@ where
     worker_id: usize,
     /// Permission scoping for this worker's local graph.
     ///
-    /// `IncludeAll` with no policy (the default) preserves the original non-filtered behaviour.
-    /// A public worker is configured with `ExcludePermissioned` + a `PermissionPolicy` so
-    /// permissioned components never enter its graph; a surplus worker uses `IncludeAll`.
+    /// `IncludeAll` (the default) preserves the original non-filtered behaviour. A public worker
+    /// is configured with `ExcludePermissioned(policy)` so permissioned components never enter
+    /// its graph; a surplus worker uses `IncludeAll`.
     permission: PermissionContext,
 }
 
@@ -98,13 +98,13 @@ where
             ready_notify: Arc::new(Notify::new()),
             initialized: false,
             worker_id,
-            permission: PermissionContext::include_all(),
+            permission: PermissionContext::IncludeAll,
         }
     }
 
     /// Configures this worker's permission scoping.
     ///
-    /// Public workers pass `ExcludePermissioned` + a policy; surplus workers pass `IncludeAll`.
+    /// Public workers pass `ExcludePermissioned(policy)`; surplus workers pass `IncludeAll`.
     pub(crate) fn with_permission(mut self, permission: PermissionContext) -> Self {
         self.permission = permission;
         self

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -45,17 +45,17 @@ use crate::{
     QuoteOptions, QuoteRequest, QuoteStatus, SolveError, SolveParams,
 };
 
-/// The role a solver pool plays in a quote.
+/// The role a solver pool (a group of workers) plays in a quote.
 ///
-/// Public pools route only through public liquidity and provide the committed (quoted) reference
-/// output. The single surplus pool additionally routes through permissioned pools and may beat the
-/// public reference, in which case the protocol captures the surplus (`egAmount`).
+/// A `Public` pool routes only through public liquidity and provides the committed (quoted)
+/// reference output. The single `All` pool also routes through permissioned components and may beat
+/// that reference, in which case the protocol captures the surplus.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PoolRole {
     /// Routes through public liquidity only. Establishes the committed reference output.
     Public,
-    /// Routes through all liquidity including permissioned pools; source of surplus quotes.
-    Surplus,
+    /// Routes through all liquidity, including permissioned components; source of surplus quotes.
+    All,
 }
 
 /// Handle to a solver pool for dispatching orders.
@@ -65,7 +65,7 @@ pub struct SolverPoolHandle {
     name: String,
     /// Queue handle for this pool.
     queue: TaskQueueHandle,
-    /// Whether this pool provides public or surplus candidates.
+    /// Whether this pool routes public-only or all liquidity.
     role: PoolRole,
 }
 
@@ -75,7 +75,7 @@ impl SolverPoolHandle {
         Self { name: name.into(), queue, role: PoolRole::Public }
     }
 
-    /// Sets the pool's role (e.g. [`PoolRole::Surplus`] for the permissioned-inclusive pool).
+    /// Sets the pool's role (e.g. [`PoolRole::All`] for the permissioned-inclusive pool).
     pub fn with_role(mut self, role: PoolRole) -> Self {
         self.role = role;
         self
@@ -220,18 +220,19 @@ impl WorkerPoolRouter {
             .iter()
             .map(|p| (p.name().to_string(), p.role()))
             .collect();
-        let has_surplus_pool = pool_roles
+        let has_all_pool = pool_roles
             .values()
-            .any(|r| *r == PoolRole::Surplus);
+            .any(|r| *r == PoolRole::All);
 
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
         // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
-        // fallback chain. When a surplus pool is configured, the surplus winner is overlaid onto
-        // that ranked list (prepended) by `combine_with_surplus`, so the fallbacks are preserved.
+        // fallback chain. When an `All`-role pool is configured, the surplus winner is overlaid
+        // onto that ranked list (prepended) by `combine_with_surplus`, so the fallbacks are
+        // preserved.
         let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
             .map(|responses| {
-                if has_surplus_pool {
+                if has_all_pool {
                     let public_ranked =
                         self.rank_quotes(&responses.public_only(&pool_roles), request.options());
                     combine_with_surplus(&responses, &pool_roles, request.options(), public_ranked)
@@ -553,41 +554,16 @@ impl WorkerPoolRouter {
 ///
 /// `public_ranked` is the public-only ranking from `rank_quotes` — both the committed reference and
 /// the price-guard fallback chain. If the best surplus candidate beats the committed reference
-/// net-of-gas, the executed surplus quote (user `amount_out` pinned to the committed reference,
-/// order-level `SurplusInfo` attached, per-leg `Swap::committed_amount_out` stamped) is returned at
-/// the *head* of the list, preserving the public candidates as fallbacks. Otherwise `public_ranked`
-/// is returned unchanged. The user is never quoted worse than the public market.
+/// net-of-gas, the executed surplus quote is returned at the head of the list (its `amount_out`
+/// pinned to the committed reference, an order-level `SurplusInfo` attached, and each permissioned
+/// leg's `Swap::committed_amount_out` set), preserving the public candidates as fallbacks.
+/// Otherwise `public_ranked` is returned unchanged, so the user is never quoted worse than the
+/// public market.
 ///
-/// # Per-leg attribution
-///
-/// The on-chain hook captures surplus *per pool*, in that pool's `token_out`, from a signed
-/// `maxExchangeRate`. The order-level surplus (`eg_route = realized_route_out −
-/// committed_route_out`, both in the order's `token_out`) must therefore be pushed down to each
-/// permissioned leg. We use a linear (no-inverse-simulation) approximation that is provably
-/// conservative for concave AMMs:
-///
-/// ```text
-/// committed_amount_out_leg = leg.amount_out * committed_route_out / realized_route_out   (ceil)
-/// eg_amount_leg            = leg.amount_out − committed_amount_out_leg                    (floor)
-/// ```
-///
-/// Equivalently, the leg's realized output is scaled down by the same ratio as the whole-route
-/// haircut — i.e. `eg_route` is converted from the order's `token_out` into the leg's `token_out`
-/// by dividing through the realized downstream price `realized_route_out / leg.amount_out`.
-///
-/// ## Why this never shorts the user
-///
-/// Let `f` map the downstream segment's input (the leg's `token_out`) to the order's final
-/// `token_out`. For standard AMMs `f` is concave and increasing, and a composition of such legs
-/// stays concave. Capturing `Δ = eg_route / p_down` (with `p_down = f(x₀)/x₀`) drops the user's
-/// final output by `f(x₀) − f(x₀−Δ)`. Define `h(eg) = eg − [f(x₀) − f(x₀ − eg/p_down)]`. Then
-/// `h(0) = 0`, `h(f(x₀)) = f(0) = 0`, and `h'' = f''/p_down² < 0`, so `h` is concave with both
-/// endpoints zero ⟹ `h ≥ 0` throughout. Hence the true drop never exceeds `eg_route`, so the user
-/// always receives ≥ `committed_route_out`. We capture slightly *less* than the theoretical maximum
-/// (the safe direction). `ceil` on the committed leg and `floor` on `eg_amount_leg` preserve this.
-///
-/// SAFETY: the guarantee assumes downstream legs are concave. If a non-concave downstream protocol
-/// is ever permitted, add a haircut or exclude it.
+/// Each permissioned leg's `committed_amount_out` is its realized output reduced by the same
+/// proportion as the order-level reduction; the protocol captures the difference. The per-leg
+/// attribution formula and the bound that keeps the user at or above the committed reference are
+/// derived in the design plan.
 fn combine_with_surplus(
     responses: &OrderResponses,
     pool_roles: &HashMap<String, PoolRole>,
@@ -595,30 +571,19 @@ fn combine_with_surplus(
     public_ranked: Vec<OrderQuote>,
 ) -> Vec<OrderQuote> {
     // The committed reference and fallback chain are already computed (`public_ranked`); this
-    // function only overlays the surplus winner. TODO: implement the overlay:
+    // function only overlays the surplus winner. TODO: implement the overlay (see the design plan
+    // for the per-leg attribution formula and the user-never-short-changed bound):
     //
-    // 1. best_surplus = best SURPLUS candidate (surplus-role pools per `pool_roles`) by
-    //    `amount_out_net_gas` whose route has exactly one permissioned leg per path
-    //    (`is_permissioned(&swap.protocol_component)`), positioned as that path's terminal leg.
-    //    Reject multi-permissioned-per-path routes (out of scope for v1). Respect
-    //    `options.max_gas`.
-    // 2. committed reference = `public_ranked.first()`. If absent (no public route) there is no
-    //    reference to commit against — return `public_ranked` unchanged.
-    // 3. If best_surplus does not beat the committed reference net-of-gas, return `public_ranked`
-    //    unchanged (eg_amount == None).
-    // 4. Otherwise build the executed quote FROM the surplus route and, for each permissioned leg,
-    //    stamp `Swap::with_committed_amount_out(committed_leg)` where (BigUint, integer math):
-    //    committed_leg = ceil(leg.amount_out * committed_route_out / realized_route_out) clamped to
-    //    [0, leg.amount_out] using `realized_route_out` = the surplus route's gross output and
-    //    `committed_route_out` = the committed reference's amount_out. (Terminal-leg single path:
-    //    reduces to committed_leg == committed_route_out. Split with one permissioned branch: scale
-    //    by that BRANCH's realized/committed and cap at the branch's leg output.)
-    // 5. Pin the executed quote's user-facing `amount_out` to `committed_route_out`, attach
-    //    `SurplusInfo::new(eg_route, committed_route_out)` via `OrderQuote::with_surplus`
-    //    (`eg_route = realized_route_out − committed_route_out`), and PREPEND it to `public_ranked`
-    //    so the price guard keeps the public candidates as fallbacks.
-    // 6. debug_assert! the invariant: simulated user output (after per-leg capture) ≥
-    //    committed_route_out.
+    // 1. best_surplus = best candidate from surplus-role pools (per `pool_roles`) by
+    //    `amount_out_net_gas`, whose route has exactly one permissioned leg per path positioned as
+    //    that path's terminal leg (`is_permissioned(&swap.protocol_component)`); reject
+    //    multi-permissioned-per-path routes (out of scope for v1); respect `options.max_gas`.
+    // 2. committed reference = `public_ranked.first()`. If there is none, or best_surplus does not
+    //    beat it net-of-gas, return `public_ranked` unchanged (no surplus).
+    // 3. Otherwise build the executed quote from the surplus route, set each permissioned leg's
+    //    `Swap::with_committed_amount_out(...)`, pin the user `amount_out` to the committed
+    //    reference, attach `SurplusInfo` via `OrderQuote::with_surplus`, and PREPEND it to
+    //    `public_ranked`. debug_assert! that the user output is ≥ the committed reference.
     let _ = (responses, pool_roles, options);
     public_ranked
 }
@@ -1130,7 +1095,7 @@ mod tests {
     fn surplus_pool_roles() -> HashMap<String, PoolRole> {
         HashMap::from([
             ("public_pool".to_string(), PoolRole::Public),
-            ("surplus_pool".to_string(), PoolRole::Surplus),
+            ("surplus_pool".to_string(), PoolRole::All),
         ])
     }
 

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -48,9 +48,9 @@ use crate::{
 
 /// The role a solver pool (a group of workers) plays in a quote.
 ///
-/// A `Public` pool routes only through public liquidity and provides the committed (quoted)
-/// reference output. The single `All` pool also routes through permissioned components and may beat
-/// that reference, in which case the protocol captures the surplus.
+/// A `Public` worker routes only through public liquidity and provides the committed (quoted)
+/// reference output. An `All` worker also routes through permissioned components and may beat that
+/// reference, in which case the protocol captures the surplus.
 ///
 /// Serialized in lowercase (`"public"` / `"all"`) in `worker_pools.toml` via [`PoolConfig`].
 ///

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -32,6 +32,7 @@ use config::WorkerPoolRouterConfig;
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, histogram};
 use num_bigint::BigUint;
+use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
 use tycho_execution::encoding::{
     evm::gas_estimator::estimate_gas_usage,
@@ -50,9 +51,15 @@ use crate::{
 /// A `Public` pool routes only through public liquidity and provides the committed (quoted)
 /// reference output. The single `All` pool also routes through permissioned components and may beat
 /// that reference, in which case the protocol captures the surplus.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// Serialized in lowercase (`"public"` / `"all"`) in `worker_pools.toml` via [`PoolConfig`].
+///
+/// [`PoolConfig`]: crate::PoolConfig
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum PoolRole {
-    /// Routes through public liquidity only. Establishes the committed reference output.
+    /// Routes through public liquidity only. Establishes the committed reference output. Default.
+    #[default]
     Public,
     /// Routes through all liquidity, including permissioned components; source of surplus quotes.
     All,

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -109,6 +109,34 @@ pub(crate) struct OrderResponses {
     failed_solvers: Vec<(String, SolveError)>,
 }
 
+impl OrderResponses {
+    /// Returns a copy keeping only candidates from public-role pools.
+    ///
+    /// These form the committed reference and the ranked fallback chain (ranked by `rank_quotes`,
+    /// consumed by the price guard); surplus-pool candidates are overlaid separately by
+    /// `combine_with_surplus`. `failed_solvers` is retained so placeholder construction is
+    /// unchanged.
+    fn public_only(&self, pool_roles: &HashMap<String, PoolRole>) -> OrderResponses {
+        let quotes = self
+            .quotes
+            .iter()
+            .filter(|(pool, _)| {
+                pool_roles
+                    .get(pool)
+                    .copied()
+                    .unwrap_or(PoolRole::Public) ==
+                    PoolRole::Public
+            })
+            .cloned()
+            .collect();
+        OrderResponses {
+            order_id: self.order_id.clone(),
+            quotes,
+            failed_solvers: self.failed_solvers.clone(),
+        }
+    }
+}
+
 /// Orchestrates multiple solver pools to find the best quote.
 pub struct WorkerPoolRouter {
     /// All registered solver pools.
@@ -197,13 +225,16 @@ impl WorkerPoolRouter {
             .any(|r| *r == PoolRole::Surplus);
 
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
-        // When a surplus pool is configured, fold the surplus candidate into the public reference
-        // via `combine_with_surplus`; otherwise keep the plain public-only ranking.
+        // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
+        // fallback chain. When a surplus pool is configured, the surplus winner is overlaid onto
+        // that ranked list (prepended) by `combine_with_surplus`, so the fallbacks are preserved.
         let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
             .map(|responses| {
                 if has_surplus_pool {
-                    vec![combine_with_surplus(&responses, &pool_roles, request.options())]
+                    let public_ranked =
+                        self.rank_quotes(&responses.public_only(&pool_roles), request.options());
+                    combine_with_surplus(&responses, &pool_roles, request.options(), public_ranked)
                 } else {
                     self.rank_quotes(&responses, request.options())
                 }
@@ -518,12 +549,14 @@ impl WorkerPoolRouter {
     }
 }
 
-/// Selects the winning quote for an order when a surplus (permissioned-inclusive) pool is present.
+/// Overlays the surplus winner onto the ranked public fallback list for one order.
 ///
-/// Returns either the surplus route — with the user's `amount_out` pinned to the committed public
-/// reference, an order-level `SurplusInfo` attached, and the per-leg `Swap::committed_amount_out`
-/// stamped onto each permissioned leg — or the pure public route as a fallback. The user is never
-/// quoted worse than the public market.
+/// `public_ranked` is the public-only ranking from `rank_quotes` — both the committed reference and
+/// the price-guard fallback chain. If the best surplus candidate beats the committed reference
+/// net-of-gas, the executed surplus quote (user `amount_out` pinned to the committed reference,
+/// order-level `SurplusInfo` attached, per-leg `Swap::committed_amount_out` stamped) is returned at
+/// the *head* of the list, preserving the public candidates as fallbacks. Otherwise `public_ranked`
+/// is returned unchanged. The user is never quoted worse than the public market.
 ///
 /// # Per-leg attribution
 ///
@@ -559,33 +592,35 @@ fn combine_with_surplus(
     responses: &OrderResponses,
     pool_roles: &HashMap<String, PoolRole>,
     options: &QuoteOptions,
-) -> OrderQuote {
-    // TODO: implement surplus-capture selection.
+    public_ranked: Vec<OrderQuote>,
+) -> Vec<OrderQuote> {
+    // The committed reference and fallback chain are already computed (`public_ranked`); this
+    // function only overlays the surplus winner. TODO: implement the overlay:
     //
-    // 1. Split `responses.quotes` into public vs surplus candidates via `pool_roles`.
-    // 2. committed = best PUBLIC candidate by `amount_out_net_gas` (respect `options.max_gas`). If
-    //    there are no public candidates, return the `rank_quotes` placeholder (no surplus).
-    // 3. best_surplus = best SURPLUS candidate by `amount_out_net_gas` whose route contains exactly
-    //    one permissioned leg per path (`is_permissioned(&swap.protocol_component)`), positioned as
-    //    that path's terminal leg. Reject multi-permissioned-per-path routes (out of scope for v1).
-    // 4. Fallback: if best_surplus is absent or does not beat `committed` net-of-gas, return the
-    //    committed public quote unchanged (eg_amount == None).
-    // 5. Otherwise build the executed quote FROM the surplus route and, for each permissioned leg,
+    // 1. best_surplus = best SURPLUS candidate (surplus-role pools per `pool_roles`) by
+    //    `amount_out_net_gas` whose route has exactly one permissioned leg per path
+    //    (`is_permissioned(&swap.protocol_component)`), positioned as that path's terminal leg.
+    //    Reject multi-permissioned-per-path routes (out of scope for v1). Respect
+    //    `options.max_gas`.
+    // 2. committed reference = `public_ranked.first()`. If absent (no public route) there is no
+    //    reference to commit against — return `public_ranked` unchanged.
+    // 3. If best_surplus does not beat the committed reference net-of-gas, return `public_ranked`
+    //    unchanged (eg_amount == None).
+    // 4. Otherwise build the executed quote FROM the surplus route and, for each permissioned leg,
     //    stamp `Swap::with_committed_amount_out(committed_leg)` where (BigUint, integer math):
     //    committed_leg = ceil(leg.amount_out * committed_route_out / realized_route_out) clamped to
     //    [0, leg.amount_out] using `realized_route_out` = the surplus route's gross output and
-    //    `committed_route_out` = committed.amount_out. (Terminal-leg single path: this reduces to
-    //    committed_leg == committed_route_out. Split with one permissioned branch: scale by that
-    //    BRANCH's realized/committed and cap at the branch's leg output; attribute the order
-    //    surplus there.)
-    // 6. Pin the executed quote's user-facing `amount_out` to `committed_route_out` and attach
-    //    `SurplusInfo::new(eg_route, committed_route_out)` via `OrderQuote::with_surplus`, where
-    //    `eg_route = realized_route_out − committed_route_out` (== Σ over legs of `leg.amount_out −
-    //    committed_leg`, normalized to token_out).
-    // 7. debug_assert! the invariant: simulated user output (after per-leg capture) ≥
+    //    `committed_route_out` = the committed reference's amount_out. (Terminal-leg single path:
+    //    reduces to committed_leg == committed_route_out. Split with one permissioned branch: scale
+    //    by that BRANCH's realized/committed and cap at the branch's leg output.)
+    // 5. Pin the executed quote's user-facing `amount_out` to `committed_route_out`, attach
+    //    `SurplusInfo::new(eg_route, committed_route_out)` via `OrderQuote::with_surplus`
+    //    (`eg_route = realized_route_out − committed_route_out`), and PREPEND it to `public_ranked`
+    //    so the price guard keeps the public candidates as fallbacks.
+    // 6. debug_assert! the invariant: simulated user output (after per-leg capture) ≥
     //    committed_route_out.
     let _ = (responses, pool_roles, options);
-    todo!("select surplus-vs-public quote, stamp per-leg committed amounts, attach SurplusInfo")
+    public_ranked
 }
 
 fn refine_gas_estimates(
@@ -1100,26 +1135,37 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "scaffold: combine_with_surplus is todo!()"]
+    #[ignore = "scaffold: surplus overlay in combine_with_surplus is todo"]
     fn combine_prefers_surplus_when_it_beats_public() {
         let responses = surplus_responses(900, 950);
-        let combined =
-            combine_with_surplus(&responses, &surplus_pool_roles(), &QuoteOptions::default());
+        let public_ranked = vec![make_single_quote(900).order().clone()];
+        let combined = combine_with_surplus(
+            &responses,
+            &surplus_pool_roles(),
+            &QuoteOptions::default(),
+            public_ranked,
+        );
 
-        // User is quoted the committed public output, protocol captures the surplus.
-        assert_eq!(*combined.amount_out(), BigUint::from(900u64));
-        assert_eq!(combined.committed_amount_out(), Some(&BigUint::from(900u64)));
-        assert_eq!(combined.eg_amount(), Some(&BigUint::from(50u64)));
+        // The surplus winner is at the head: user is quoted the committed public output, protocol
+        // captures the surplus. The public candidate remains as a fallback.
+        assert_eq!(*combined[0].amount_out(), BigUint::from(900u64));
+        assert_eq!(combined[0].committed_amount_out(), Some(&BigUint::from(900u64)));
+        assert_eq!(combined[0].eg_amount(), Some(&BigUint::from(50u64)));
     }
 
     #[test]
-    #[ignore = "scaffold: combine_with_surplus is todo!()"]
+    #[ignore = "scaffold: surplus overlay in combine_with_surplus is todo"]
     fn combine_falls_back_to_public_when_surplus_does_not_beat_it() {
         let responses = surplus_responses(950, 900);
-        let combined =
-            combine_with_surplus(&responses, &surplus_pool_roles(), &QuoteOptions::default());
+        let public_ranked = vec![make_single_quote(950).order().clone()];
+        let combined = combine_with_surplus(
+            &responses,
+            &surplus_pool_roles(),
+            &QuoteOptions::default(),
+            public_ranked,
+        );
 
-        assert_eq!(*combined.amount_out(), BigUint::from(950u64));
-        assert_eq!(combined.eg_amount(), None);
+        assert_eq!(*combined[0].amount_out(), BigUint::from(950u64));
+        assert_eq!(combined[0].eg_amount(), None);
     }
 }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -24,7 +24,7 @@
 pub mod config;
 
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     time::{Duration, Instant},
 };
 
@@ -45,6 +45,19 @@ use crate::{
     QuoteOptions, QuoteRequest, QuoteStatus, SolveError, SolveParams,
 };
 
+/// The role a solver pool plays in a quote.
+///
+/// Public pools route only through public liquidity and provide the committed (quoted) reference
+/// output. The single surplus pool additionally routes through permissioned pools and may beat the
+/// public reference, in which case the protocol captures the surplus (`egAmount`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PoolRole {
+    /// Routes through public liquidity only. Establishes the committed reference output.
+    Public,
+    /// Routes through all liquidity including permissioned pools; source of surplus quotes.
+    Surplus,
+}
+
 /// Handle to a solver pool for dispatching orders.
 #[derive(Clone)]
 pub struct SolverPoolHandle {
@@ -52,12 +65,20 @@ pub struct SolverPoolHandle {
     name: String,
     /// Queue handle for this pool.
     queue: TaskQueueHandle,
+    /// Whether this pool provides public or surplus candidates.
+    role: PoolRole,
 }
 
 impl SolverPoolHandle {
-    /// Creates a new solver pool handle.
+    /// Creates a new solver pool handle with the default [`PoolRole::Public`] role.
     pub fn new(name: impl Into<String>, queue: TaskQueueHandle) -> Self {
-        Self { name: name.into(), queue }
+        Self { name: name.into(), queue, role: PoolRole::Public }
+    }
+
+    /// Sets the pool's role (e.g. [`PoolRole::Surplus`] for the permissioned-inclusive pool).
+    pub fn with_role(mut self, role: PoolRole) -> Self {
+        self.role = role;
+        self
     }
 
     /// Returns the pool name.
@@ -68,6 +89,11 @@ impl SolverPoolHandle {
     /// Returns the task queue handle.
     pub fn queue(&self) -> &TaskQueueHandle {
         &self.queue
+    }
+
+    /// Returns the pool's role.
+    pub fn role(&self) -> PoolRole {
+        self.role
     }
 }
 
@@ -160,10 +186,28 @@ impl WorkerPoolRouter {
             refine_gas_estimates(&mut order_responses, encoding_options)?;
         }
 
-        // Rank quotes for each order (sorted by refined amount_out_net_gas descending)
+        // Map each pool name to its role so candidate quotes can be split into public vs surplus.
+        let pool_roles: HashMap<String, PoolRole> = self
+            .solver_pools
+            .iter()
+            .map(|p| (p.name().to_string(), p.role()))
+            .collect();
+        let has_surplus_pool = pool_roles
+            .values()
+            .any(|r| *r == PoolRole::Surplus);
+
+        // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
+        // When a surplus pool is configured, fold the surplus candidate into the public reference
+        // via `combine_with_surplus`; otherwise keep the plain public-only ranking.
         let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
-            .map(|responses| self.rank_quotes(&responses, request.options()))
+            .map(|responses| {
+                if has_surplus_pool {
+                    vec![combine_with_surplus(&responses, &pool_roles, request.options())]
+                } else {
+                    self.rank_quotes(&responses, request.options())
+                }
+            })
             .collect();
 
         // Validate against external prices when the client explicitly enables it.
@@ -283,6 +327,11 @@ impl WorkerPoolRouter {
                             // Extract the OrderQuote from SingleOrderQuote
                             quotes.push((pool_name.clone(), single_quote.order().clone()));
 
+                            // TODO: make this gating role-aware for surplus quotes. The surplus
+                            // route can only be priced once BOTH at least one public candidate
+                            // (the committed reference) AND the surplus pool have responded (or the
+                            // deadline elapses). A plain count-based early return may fire before
+                            // the surplus pool reports, silently dropping the surplus opportunity.
                             // Early return if min_responses reached
                             if min_responses > 0 && quotes.len() >= min_responses {
                                 debug!(
@@ -467,6 +516,76 @@ impl WorkerPoolRouter {
             .map(Duration::from_millis)
             .unwrap_or(self.config.default_timeout())
     }
+}
+
+/// Selects the winning quote for an order when a surplus (permissioned-inclusive) pool is present.
+///
+/// Returns either the surplus route — with the user's `amount_out` pinned to the committed public
+/// reference, an order-level `SurplusInfo` attached, and the per-leg `Swap::committed_amount_out`
+/// stamped onto each permissioned leg — or the pure public route as a fallback. The user is never
+/// quoted worse than the public market.
+///
+/// # Per-leg attribution
+///
+/// The on-chain hook captures surplus *per pool*, in that pool's `token_out`, from a signed
+/// `maxExchangeRate`. The order-level surplus (`eg_route = realized_route_out −
+/// committed_route_out`, both in the order's `token_out`) must therefore be pushed down to each
+/// permissioned leg. We use a linear (no-inverse-simulation) approximation that is provably
+/// conservative for concave AMMs:
+///
+/// ```text
+/// committed_amount_out_leg = leg.amount_out * committed_route_out / realized_route_out   (ceil)
+/// eg_amount_leg            = leg.amount_out − committed_amount_out_leg                    (floor)
+/// ```
+///
+/// Equivalently, the leg's realized output is scaled down by the same ratio as the whole-route
+/// haircut — i.e. `eg_route` is converted from the order's `token_out` into the leg's `token_out`
+/// by dividing through the realized downstream price `realized_route_out / leg.amount_out`.
+///
+/// ## Why this never shorts the user
+///
+/// Let `f` map the downstream segment's input (the leg's `token_out`) to the order's final
+/// `token_out`. For standard AMMs `f` is concave and increasing, and a composition of such legs
+/// stays concave. Capturing `Δ = eg_route / p_down` (with `p_down = f(x₀)/x₀`) drops the user's
+/// final output by `f(x₀) − f(x₀−Δ)`. Define `h(eg) = eg − [f(x₀) − f(x₀ − eg/p_down)]`. Then
+/// `h(0) = 0`, `h(f(x₀)) = f(0) = 0`, and `h'' = f''/p_down² < 0`, so `h` is concave with both
+/// endpoints zero ⟹ `h ≥ 0` throughout. Hence the true drop never exceeds `eg_route`, so the user
+/// always receives ≥ `committed_route_out`. We capture slightly *less* than the theoretical maximum
+/// (the safe direction). `ceil` on the committed leg and `floor` on `eg_amount_leg` preserve this.
+///
+/// SAFETY: the guarantee assumes downstream legs are concave. If a non-concave downstream protocol
+/// is ever permitted, add a haircut or exclude it.
+fn combine_with_surplus(
+    responses: &OrderResponses,
+    pool_roles: &HashMap<String, PoolRole>,
+    options: &QuoteOptions,
+) -> OrderQuote {
+    // TODO: implement surplus-capture selection.
+    //
+    // 1. Split `responses.quotes` into public vs surplus candidates via `pool_roles`.
+    // 2. committed = best PUBLIC candidate by `amount_out_net_gas` (respect `options.max_gas`). If
+    //    there are no public candidates, return the `rank_quotes` placeholder (no surplus).
+    // 3. best_surplus = best SURPLUS candidate by `amount_out_net_gas` whose route contains exactly
+    //    one permissioned leg per path (`is_permissioned(&swap.protocol_component)`), positioned as
+    //    that path's terminal leg. Reject multi-permissioned-per-path routes (out of scope for v1).
+    // 4. Fallback: if best_surplus is absent or does not beat `committed` net-of-gas, return the
+    //    committed public quote unchanged (eg_amount == None).
+    // 5. Otherwise build the executed quote FROM the surplus route and, for each permissioned leg,
+    //    stamp `Swap::with_committed_amount_out(committed_leg)` where (BigUint, integer math):
+    //    committed_leg = ceil(leg.amount_out * committed_route_out / realized_route_out) clamped to
+    //    [0, leg.amount_out] using `realized_route_out` = the surplus route's gross output and
+    //    `committed_route_out` = committed.amount_out. (Terminal-leg single path: this reduces to
+    //    committed_leg == committed_route_out. Split with one permissioned branch: scale by that
+    //    BRANCH's realized/committed and cap at the branch's leg output; attribute the order
+    //    surplus there.)
+    // 6. Pin the executed quote's user-facing `amount_out` to `committed_route_out` and attach
+    //    `SurplusInfo::new(eg_route, committed_route_out)` via `OrderQuote::with_surplus`, where
+    //    `eg_route = realized_route_out − committed_route_out` (== Σ over legs of `leg.amount_out −
+    //    committed_leg`, normalized to token_out).
+    // 7. debug_assert! the invariant: simulated user output (after per-leg capture) ≥
+    //    committed_route_out.
+    let _ = (responses, pool_roles, options);
+    todo!("select surplus-vs-public quote, stamp per-leg committed amounts, attach SurplusInfo")
 }
 
 fn refine_gas_estimates(
@@ -951,5 +1070,56 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(*result[0].amount_out_net_gas(), BigUint::from(950u64));
         assert_eq!(*result[1].amount_out_net_gas(), BigUint::from(800u64));
+    }
+
+    /// Builds an `OrderResponses` with a public quote and a surplus quote.
+    ///
+    /// `amount_out` doubles as `amount_out_net_gas` here for simplicity.
+    fn surplus_responses(public_out: u64, surplus_out: u64) -> OrderResponses {
+        let public = make_single_quote(public_out)
+            .order()
+            .clone();
+        let surplus = make_single_quote(surplus_out)
+            .order()
+            .clone();
+        OrderResponses {
+            order_id: "test-order".to_string(),
+            quotes: vec![
+                ("public_pool".to_string(), public),
+                ("surplus_pool".to_string(), surplus),
+            ],
+            failed_solvers: vec![],
+        }
+    }
+
+    fn surplus_pool_roles() -> HashMap<String, PoolRole> {
+        HashMap::from([
+            ("public_pool".to_string(), PoolRole::Public),
+            ("surplus_pool".to_string(), PoolRole::Surplus),
+        ])
+    }
+
+    #[test]
+    #[ignore = "scaffold: combine_with_surplus is todo!()"]
+    fn combine_prefers_surplus_when_it_beats_public() {
+        let responses = surplus_responses(900, 950);
+        let combined =
+            combine_with_surplus(&responses, &surplus_pool_roles(), &QuoteOptions::default());
+
+        // User is quoted the committed public output, protocol captures the surplus.
+        assert_eq!(*combined.amount_out(), BigUint::from(900u64));
+        assert_eq!(combined.committed_amount_out(), Some(&BigUint::from(900u64)));
+        assert_eq!(combined.eg_amount(), Some(&BigUint::from(50u64)));
+    }
+
+    #[test]
+    #[ignore = "scaffold: combine_with_surplus is todo!()"]
+    fn combine_falls_back_to_public_when_surplus_does_not_beat_it() {
+        let responses = surplus_responses(950, 900);
+        let combined =
+            combine_with_surplus(&responses, &surplus_pool_roles(), &QuoteOptions::default());
+
+        assert_eq!(*combined.amount_out(), BigUint::from(950u64));
+        assert_eq!(combined.eg_amount(), None);
     }
 }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -1115,7 +1115,7 @@ mod tests {
         // captures the surplus. The public candidate remains as a fallback.
         assert_eq!(*combined[0].amount_out(), BigUint::from(900u64));
         assert_eq!(combined[0].committed_amount_out(), Some(&BigUint::from(900u64)));
-        assert_eq!(combined[0].eg_amount(), Some(&BigUint::from(50u64)));
+        assert_eq!(combined[0].surplus_amount(), Some(&BigUint::from(50u64)));
     }
 
     #[test]
@@ -1131,6 +1131,6 @@ mod tests {
         );
 
         assert_eq!(*combined[0].amount_out(), BigUint::from(950u64));
-        assert_eq!(combined[0].eg_amount(), None);
+        assert_eq!(combined[0].surplus_amount(), None);
     }
 }

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1700,6 +1700,9 @@ mod conversions {
     }
 
     impl From<fynd_core::OrderQuote> for OrderQuote {
+        // NOTE: `eg_amount` and `committed_amount_out` (permissioned-pool surplus) are
+        // intentionally NOT mapped onto this public response DTO. They are internal values that
+        // reach only the encoder; exposing them would leak Fynd-exclusive surplus to clients.
         fn from(core: fynd_core::OrderQuote) -> Self {
             let order_id = core.order_id().to_string();
             let status = core.status().into();

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1700,7 +1700,7 @@ mod conversions {
     }
 
     impl From<fynd_core::OrderQuote> for OrderQuote {
-        // NOTE: `eg_amount` and `committed_amount_out` (permissioned-component surplus) are
+        // NOTE: `surplus_amount` and `committed_amount_out` (permissioned-component surplus) are
         // intentionally NOT mapped onto this public response DTO — they are internal (the per-leg
         // committed amount reaches the encoder; the order-level surplus is for observability).
         // Exposing them would leak the captured surplus to clients.

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1700,9 +1700,10 @@ mod conversions {
     }
 
     impl From<fynd_core::OrderQuote> for OrderQuote {
-        // NOTE: `eg_amount` and `committed_amount_out` (permissioned-pool surplus) are
-        // intentionally NOT mapped onto this public response DTO. They are internal values that
-        // reach only the encoder; exposing them would leak Fynd-exclusive surplus to clients.
+        // NOTE: `eg_amount` and `committed_amount_out` (permissioned-component surplus) are
+        // intentionally NOT mapped onto this public response DTO — they are internal (the per-leg
+        // committed amount reaches the encoder; the order-level surplus is for observability).
+        // Exposing them would leak the captured surplus to clients.
         fn from(core: fynd_core::OrderQuote) -> Self {
             let order_id = core.order_id().to_string();
             let status = core.status().into();

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -31,7 +31,7 @@ timeout_ms = 500
 # num_workers = 3
 # max_hops = 2
 # timeout_ms = 500
-# role = "surplus"
+# role = "all"
 "#;
 
 /// Worker pools configuration loaded from TOML file.
@@ -113,6 +113,8 @@ impl BlocklistConfig {
 
 #[cfg(test)]
 mod tests {
+    use fynd_core::PoolRole;
+
     use super::*;
 
     #[test]
@@ -150,6 +152,7 @@ mod tests {
             max_hops = 4
             timeout_ms = 200
             max_routes = 50
+            role = "all"
         "#;
         let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
         let pool = &config.pools()["custom"];
@@ -160,6 +163,7 @@ mod tests {
         assert_eq!(pool.max_hops(), 4);
         assert_eq!(pool.timeout_ms(), 200);
         assert_eq!(pool.max_routes(), Some(50));
+        assert_eq!(pool.role(), PoolRole::All);
     }
 }
 

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -23,6 +23,15 @@ num_workers = 3
 task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
+
+# Example: a permissioned-inclusive "surplus" pool (see repo-root worker_pools.toml).
+# Public pools (role omitted; defaults to "public") never see permissioned components.
+# [pools.surplus]
+# algorithm = "bellman_ford"
+# num_workers = 3
+# max_hops = 2
+# timeout_ms = 500
+# role = "surplus"
 "#;
 
 /// Worker pools configuration loaded from TOML file.

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -12,7 +12,7 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
-# Example: a permissioned-inclusive "surplus" pool. `role = "surplus"` lets this pool route
+# Example: a permissioned-inclusive "surplus" pool. `role = "all"` lets this pool route
 # through permissioned components to capture surplus above the best public rate.
 # Public pools (role omitted; defaults to "public") never see permissioned components.
 # [pools.surplus]
@@ -20,7 +20,7 @@ timeout_ms = 500
 # num_workers = 3
 # max_hops = 2
 # timeout_ms = 500
-# role = "surplus"
+# role = "all"
 
 # Example: connector_tokens restricts intermediate hops to trusted, liquid tokens,
 # reducing on-chain reversion risk. Absent = all tokens reachable (default behaviour).

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -13,7 +13,7 @@ max_hops = 2
 timeout_ms = 500
 
 # Example: a permissioned-inclusive "surplus" pool. `role = "surplus"` lets this pool route
-# through permissioned (Fynd-exclusive) pools to capture surplus above the best public rate.
+# through permissioned components to capture surplus above the best public rate.
 # Public pools (role omitted; defaults to "public") never see permissioned components.
 # [pools.surplus]
 # algorithm = "bellman_ford"

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -12,6 +12,16 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
+# Example: a permissioned-inclusive "surplus" pool. `role = "surplus"` lets this pool route
+# through permissioned (Fynd-exclusive) pools to capture surplus above the best public rate.
+# Public pools (role omitted; defaults to "public") never see permissioned components.
+# [pools.surplus]
+# algorithm = "bellman_ford"
+# num_workers = 3
+# max_hops = 2
+# timeout_ms = 500
+# role = "surplus"
+
 # Example: connector_tokens restricts intermediate hops to trusted, liquid tokens,
 # reducing on-chain reversion risk. Absent = all tokens reachable (default behaviour).
 # Run `fynd derive-connector-tokens --top-n 10` to generate a fresh list for your chain.


### PR DESCRIPTION
## What this is

A **scaffold** (structure only, `todo!()` bodies) for routing through permissioned "fair-flow hook" pools that only Fynd can access. The trade executes through the permissioned pool, the user is quoted the best public-market rate, and the protocol captures the surplus (`egAmount`) above that rate. On-chain hook contracts and permissioned-pool ingestion are out of scope; this is the off-chain solving side.

Open it to review the structure and the design encoded in the doc comments — no logic is implemented yet.

## What's in the diff

- **`fynd-core/src/feed/permission.rs`** (new) — `PermissionPolicy` (an `is_permissioned(&ProtocolComponent) -> bool` predicate), `ComponentScope { ExcludePermissioned, IncludeAll }`, and `filter_topology` / `filter_component_ids` helpers (`todo!()`).
- **`worker.rs` / `pool.rs` / `registry.rs`** — thread a per-worker permission context so public pools filter permissioned components out of their local graph in `initialize_graph` and `process_event`. The shared `MarketState` is not duplicated.
- **`worker_pool_router/mod.rs`** — `PoolRole { Public, Surplus }` on `SolverPoolHandle`; a role-aware `combine_with_surplus` wired into `quote()`. Its doc comment carries the full per-leg attribution math (pro-rata haircut, the concavity proof that the user is never quoted worse than the public route, rounding/clamp rules).
- **`types/quote.rs`** — `SurplusInfo` (order-level reporting aggregate) on `OrderQuote`, and a per-leg `committed_amount_out` on `Swap` that the encoder reads to derive the hook's `maxExchangeRate`. Both are `#[serde(skip)]` and never reach the public `/v1/quote` DTO.
- **`solver.rs`** — `PoolConfig.role` (serde) + `FyndBuilder::permission_policy(...)`; `assemble_components` tags each pool with its role and scope.
- **`encoder.rs`**, **`fynd-rpc-types`**, **`worker_pools.toml`** — a TODO to read the committed amount into the encode path, a NOTE that surplus fields stay out of the DTO, and a commented `[pools.surplus]` example.

## Not implemented (next, on top of this scaffold)

- `combine_with_surplus` body (surplus-vs-public selection + per-leg stamping).
- Role-aware response gating in `solve_order` (wait for a public **and** the surplus candidate, not just the first response).
- `filter_topology` / `filter_component_ids` bodies.
- Encoder hook calldata / signature.
