### PR TITLE
fix(split routing): PathFrankWolfe bugs

### DIFF
--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -132,14 +132,14 @@ impl PathFrankWolfeAlgorithm {
                 )));
             }
 
-            // marginal_price_product is in human units (from spot_price), so
-            // convert raw amounts to human units before comparing.
-            let amount_in_human =
+            // marginal_price_product is in decimal-normalized units (from
+            // spot_price), so convert raw amounts before comparing.
+            let amount_in_decimal =
                 amount_in / 10f64.powi(first_hop.descriptor.token_in.decimals as i32);
-            let amount_out_human =
+            let amount_out_decimal =
                 amount_out / 10f64.powi(last_hop.descriptor.token_out.decimals as i32);
-            let ideal_out = amount_in_human * path.marginal_price_product;
-            let price_impact = 1.0 - amount_out_human / ideal_out;
+            let ideal_out = amount_in_decimal * path.marginal_price_product;
+            let price_impact = 1.0 - amount_out_decimal / ideal_out;
             weighted_price_impact += path.flow_fraction * price_impact;
         }
         Ok(weighted_price_impact)

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -101,6 +101,15 @@ impl PathFrankWolfeAlgorithm {
     fn compute_average_price_impact(paths: &[PathAllocation]) -> Result<f64, AlgorithmError> {
         let mut weighted_price_impact = 0.0;
         for path in paths {
+            let first_hop = path
+                .hops
+                .first()
+                .ok_or_else(|| AlgorithmError::Other("path has no hops".to_string()))?;
+            let last_hop = path
+                .hops
+                .last()
+                .ok_or_else(|| AlgorithmError::Other("path has no hops".to_string()))?;
+
             let amount_in = path.amount_in.to_f64().ok_or_else(|| {
                 AlgorithmError::Other(format!("amount_in too large for f64: {}", path.amount_in))
             })?;
@@ -123,8 +132,14 @@ impl PathFrankWolfeAlgorithm {
                 )));
             }
 
-            let ideal_out = amount_in * path.marginal_price_product;
-            let price_impact = 1.0 - amount_out / ideal_out;
+            // marginal_price_product is in human units (from spot_price), so
+            // convert raw amounts to human units before comparing.
+            let amount_in_human =
+                amount_in / 10f64.powi(first_hop.descriptor.token_in.decimals as i32);
+            let amount_out_human =
+                amount_out / 10f64.powi(last_hop.descriptor.token_out.decimals as i32);
+            let ideal_out = amount_in_human * path.marginal_price_product;
+            let price_impact = 1.0 - amount_out_human / ideal_out;
             weighted_price_impact += path.flow_fraction * price_impact;
         }
         Ok(weighted_price_impact)
@@ -625,7 +640,8 @@ mod tests {
         algorithm::{
             split_primitives::{build_split_route, MarketOverrides},
             test_utils::{
-                order, setup_market_unweighted, token, ConstantProductSim, MockProtocolSim,
+                order, setup_market_unweighted, token, token_with_decimals, ConstantProductSim,
+                MockProtocolSim,
             },
             AlgorithmConfig,
         },
@@ -633,6 +649,20 @@ mod tests {
         graph::GraphManager,
         types::OrderSide,
     };
+
+    /// Creates a single dummy hop for test PathAllocations that need token
+    /// decimal info but don't care about the actual path.
+    fn dummy_hops(decimals_in: u32, decimals_out: u32) -> Vec<SimulatedHop> {
+        vec![SimulatedHop {
+            descriptor: HopDescriptor::new(
+                "dummy".to_string(),
+                token_with_decimals(0xAA, "IN", decimals_in),
+                token_with_decimals(0xBB, "OUT", decimals_out),
+            ),
+            amount_out: BigUint::ZERO,
+            gas: BigUint::ZERO,
+        }]
+    }
 
     /// Builds a `SharedDerivedDataRef` with token prices for the given tokens.
     ///
@@ -748,8 +778,9 @@ mod tests {
         // Splitting flow across more paths should reduce average price impact.
         // Uses constant-product pool outputs (reserve_in=1M, reserve_out=2M) to construct
         // allocations at 1, 2, and 3 paths.
+        let hops = dummy_hops(18, 18);
         let iter_0 = [PathAllocation {
-            hops: vec![],
+            hops: hops.clone(),
             flow_fraction: 1.0,
             amount_in: BigUint::from(100_000u64),
             amount_out: BigUint::from(181_818u64),
@@ -758,14 +789,14 @@ mod tests {
 
         let iter_1 = [
             PathAllocation {
-                hops: vec![],
+                hops: hops.clone(),
                 flow_fraction: 0.5,
                 amount_in: BigUint::from(50_000u64),
                 amount_out: BigUint::from(95_238u64),
                 marginal_price_product: 2.0,
             },
             PathAllocation {
-                hops: vec![],
+                hops: hops.clone(),
                 flow_fraction: 0.5,
                 amount_in: BigUint::from(50_000u64),
                 amount_out: BigUint::from(95_238u64),
@@ -776,21 +807,21 @@ mod tests {
         let third = 1.0 / 3.0;
         let iter_2 = [
             PathAllocation {
-                hops: vec![],
+                hops: hops.clone(),
                 flow_fraction: third,
                 amount_in: BigUint::from(33_333u64),
                 amount_out: BigUint::from(64_514u64),
                 marginal_price_product: 2.0,
             },
             PathAllocation {
-                hops: vec![],
+                hops: hops.clone(),
                 flow_fraction: third,
                 amount_in: BigUint::from(33_333u64),
                 amount_out: BigUint::from(64_514u64),
                 marginal_price_product: 2.0,
             },
             PathAllocation {
-                hops: vec![],
+                hops: hops.clone(),
                 flow_fraction: third,
                 amount_in: BigUint::from(33_334u64),
                 amount_out: BigUint::from(64_516u64),
@@ -817,16 +848,17 @@ mod tests {
         //   Path 1: flow=0.9, price_impact = 1 − 900/1000 = 0.10
         //   Path 2: flow=0.1, price_impact = 1 − 50/100  = 0.50
         //   Weighted = 0.9 × 0.10 + 0.1 × 0.50 = 0.14
+        let hops = dummy_hops(18, 18);
         let allocations = [
             PathAllocation {
-                hops: vec![],
+                hops: hops.clone(),
                 flow_fraction: 0.9,
                 amount_in: BigUint::from(1000u64),
                 amount_out: BigUint::from(900u64),
                 marginal_price_product: 1.0,
             },
             PathAllocation {
-                hops: vec![],
+                hops: hops.clone(),
                 flow_fraction: 0.1,
                 amount_in: BigUint::from(100u64),
                 amount_out: BigUint::from(50u64),
@@ -836,6 +868,28 @@ mod tests {
 
         let pi = PathFrankWolfeAlgorithm::compute_average_price_impact(&allocations).unwrap();
         assert!((pi - 0.14).abs() < 1e-10, "expected 0.14, got {pi}");
+    }
+
+    #[test]
+    fn test_average_price_impact_mixed_decimals() {
+        // USDC (6 dec) → WETH (18 dec): spot_price = 0.0005 (human units).
+        // Trade: 2000 USDC → ~1 WETH with 10% price impact.
+        //   amount_in  = 2000 * 10^6  = 2_000_000_000 (raw USDC)
+        //   amount_out = 0.9 * 10^18  = 900_000_000_000_000_000 (raw WETH)
+        //   human_in   = 2000, human_out = 0.9
+        //   ideal_out  = 2000 * 0.0005 = 1.0
+        //   PI = 1 - 0.9/1.0 = 0.10
+        let hops = dummy_hops(6, 18);
+        let allocations = [PathAllocation {
+            hops,
+            flow_fraction: 1.0,
+            amount_in: BigUint::from(2_000_000_000u64),
+            amount_out: BigUint::from(900_000_000_000_000_000u64),
+            marginal_price_product: 0.0005,
+        }];
+
+        let pi = PathFrankWolfeAlgorithm::compute_average_price_impact(&allocations).unwrap();
+        assert!((pi - 0.10).abs() < 1e-10, "expected 0.10 for cross-decimal pair, got {pi}");
     }
 
     #[tokio::test]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -384,12 +384,7 @@ pub(crate) fn compute_marginal_price_product(
                 component_id: hop.component_id.clone(),
                 error: e.to_string(),
             })?;
-        // spot_price returns a decimal-normalized price (human units), but
-        // amount_in/amount_out are in raw token units. Scale to raw so that
-        // `amount_in_raw * product ≈ amount_out_raw`.
-        let decimal_correction =
-            10f64.powi(hop.token_out.decimals as i32 - hop.token_in.decimals as i32);
-        product *= price * decimal_correction;
+        product *= price;
     }
     Ok(product)
 }
@@ -801,9 +796,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        algorithm::test_utils::{
-            component, order, token, token_with_decimals, ConstantProductSim, MockProtocolSim,
-        },
+        algorithm::test_utils::{component, order, token, ConstantProductSim, MockProtocolSim},
         types::OrderSide,
     };
 
@@ -1063,72 +1056,6 @@ mod tests {
 
         let product = compute_marginal_price_product(&hops, &market, &overrides).unwrap();
         assert!((product - 7.0).abs() < f64::EPSILON, "expected 7.0, got {product}");
-    }
-
-    #[test]
-    fn test_compute_marginal_price_product_mixed_decimals() {
-        // WETH (18 dec) → USDC (6 dec): spot_price returns ~2000.0 (human units).
-        // The raw conversion rate is 2000 * 10^(6-18) = 2e-9.
-        // For 1 WETH (10^18 raw): ideal_out = 10^18 * 2e-9 = 2e9 = 2000 USDC raw. ✓
-        let weth = token_with_decimals(0x01, "WETH", 18);
-        let usdc = token_with_decimals(0x02, "USDC", 6);
-        let market = make_market(vec![(
-            "pool_weth_usdc",
-            vec![weth.clone(), usdc.clone()],
-            Box::new(MockProtocolSim::new(2000.0)),
-        )]);
-
-        let hops = [HopDescriptor::new("pool_weth_usdc".to_string(), weth, usdc)];
-
-        let product =
-            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
-        // 2000.0 * 10^(6-18) = 2e-9
-        let expected = 2000.0 * 10f64.powi(6 - 18);
-        assert!(
-            (product - expected).abs() / expected < 1e-10,
-            "expected {expected}, got {product}"
-        );
-    }
-
-    #[test]
-    fn test_compute_marginal_price_product_mixed_decimals_multi_hop() {
-        // USDC (6 dec) → WETH (18 dec) → DAI (18 dec)
-        // Hop 1: spot_price(USDC, WETH) = 0.0005, correction = 10^(18-6) = 10^12
-        //   raw rate = 0.0005 * 10^12 = 5e8
-        // Hop 2: spot_price(WETH, DAI) = 2000.0, correction = 10^(18-18) = 1
-        //   raw rate = 2000.0
-        // Product = 5e8 * 2000 = 1e12
-        // Check: 2000 USDC raw (2000e6) * 1e12 = 2e18 → but we expect ~1 DAI = 1e18
-        //   Actually 2000 USDC = 1 WETH = 2000 DAI → 2000e6 * product = 2000e18
-        //   product should be 1e12. ✓
-        let usdc = token_with_decimals(0x01, "USDC", 6);
-        let weth = token_with_decimals(0x02, "WETH", 18);
-        let dai = token_with_decimals(0x03, "DAI", 18);
-        let market = make_market(vec![
-            (
-                "pool_usdc_weth",
-                vec![usdc.clone(), weth.clone()],
-                Box::new(MockProtocolSim::new(0.0005)),
-            ),
-            (
-                "pool_weth_dai",
-                vec![weth.clone(), dai.clone()],
-                Box::new(MockProtocolSim::new(2000.0)),
-            ),
-        ]);
-
-        let hops = [
-            HopDescriptor::new("pool_usdc_weth".to_string(), usdc, weth.clone()),
-            HopDescriptor::new("pool_weth_dai".to_string(), weth, dai),
-        ];
-
-        let product =
-            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
-        let expected = 0.0005 * 10f64.powi(18 - 6) * 2000.0 * 10f64.powi(18 - 18);
-        assert!(
-            (product - expected).abs() / expected < 1e-10,
-            "expected {expected}, got {product}"
-        );
     }
 
     #[test]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -384,7 +384,13 @@ pub(crate) fn compute_marginal_price_product(
                 component_id: hop.component_id.clone(),
                 error: e.to_string(),
             })?;
-        product *= price;
+        // spot_price returns a decimal-normalized price (human units), but
+        // amount_in/amount_out are in raw token units. Scale to raw so that
+        // `amount_in_raw * product ≈ amount_out_raw`.
+        let decimal_correction = 10f64.powi(
+            hop.token_out.decimals as i32 - hop.token_in.decimals as i32,
+        );
+        product *= price * decimal_correction;
     }
     Ok(product)
 }
@@ -796,7 +802,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        algorithm::test_utils::{component, order, token, ConstantProductSim, MockProtocolSim},
+        algorithm::test_utils::{
+            component, order, token, token_with_decimals, ConstantProductSim, MockProtocolSim,
+        },
         types::OrderSide,
     };
 
@@ -1056,6 +1064,76 @@ mod tests {
 
         let product = compute_marginal_price_product(&hops, &market, &overrides).unwrap();
         assert!((product - 7.0).abs() < f64::EPSILON, "expected 7.0, got {product}");
+    }
+
+    #[test]
+    fn test_compute_marginal_price_product_mixed_decimals() {
+        // WETH (18 dec) → USDC (6 dec): spot_price returns ~2000.0 (human units).
+        // The raw conversion rate is 2000 * 10^(6-18) = 2e-9.
+        // For 1 WETH (10^18 raw): ideal_out = 10^18 * 2e-9 = 2e9 = 2000 USDC raw. ✓
+        let weth = token_with_decimals(0x01, "WETH", 18);
+        let usdc = token_with_decimals(0x02, "USDC", 6);
+        let market = make_market(vec![(
+            "pool_weth_usdc",
+            vec![weth.clone(), usdc.clone()],
+            Box::new(MockProtocolSim::new(2000.0)),
+        )]);
+
+        let hops = [HopDescriptor::new(
+            "pool_weth_usdc".to_string(),
+            weth,
+            usdc,
+        )];
+
+        let product =
+            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
+        // 2000.0 * 10^(6-18) = 2e-9
+        let expected = 2000.0 * 10f64.powi(6 - 18);
+        assert!(
+            (product - expected).abs() / expected < 1e-10,
+            "expected {expected}, got {product}"
+        );
+    }
+
+    #[test]
+    fn test_compute_marginal_price_product_mixed_decimals_multi_hop() {
+        // USDC (6 dec) → WETH (18 dec) → DAI (18 dec)
+        // Hop 1: spot_price(USDC, WETH) = 0.0005, correction = 10^(18-6) = 10^12
+        //   raw rate = 0.0005 * 10^12 = 5e8
+        // Hop 2: spot_price(WETH, DAI) = 2000.0, correction = 10^(18-18) = 1
+        //   raw rate = 2000.0
+        // Product = 5e8 * 2000 = 1e12
+        // Check: 2000 USDC raw (2000e6) * 1e12 = 2e18 → but we expect ~1 DAI = 1e18
+        //   Actually 2000 USDC = 1 WETH = 2000 DAI → 2000e6 * product = 2000e18
+        //   product should be 1e12. ✓
+        let usdc = token_with_decimals(0x01, "USDC", 6);
+        let weth = token_with_decimals(0x02, "WETH", 18);
+        let dai = token_with_decimals(0x03, "DAI", 18);
+        let market = make_market(vec![
+            (
+                "pool_usdc_weth",
+                vec![usdc.clone(), weth.clone()],
+                Box::new(MockProtocolSim::new(0.0005)),
+            ),
+            (
+                "pool_weth_dai",
+                vec![weth.clone(), dai.clone()],
+                Box::new(MockProtocolSim::new(2000.0)),
+            ),
+        ]);
+
+        let hops = [
+            HopDescriptor::new("pool_usdc_weth".to_string(), usdc, weth.clone()),
+            HopDescriptor::new("pool_weth_dai".to_string(), weth, dai),
+        ];
+
+        let product =
+            compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
+        let expected = 0.0005 * 10f64.powi(18 - 6) * 2000.0 * 10f64.powi(18 - 18);
+        assert!(
+            (product - expected).abs() / expected < 1e-10,
+            "expected {expected}, got {product}"
+        );
     }
 
     #[test]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -387,9 +387,8 @@ pub(crate) fn compute_marginal_price_product(
         // spot_price returns a decimal-normalized price (human units), but
         // amount_in/amount_out are in raw token units. Scale to raw so that
         // `amount_in_raw * product ≈ amount_out_raw`.
-        let decimal_correction = 10f64.powi(
-            hop.token_out.decimals as i32 - hop.token_in.decimals as i32,
-        );
+        let decimal_correction =
+            10f64.powi(hop.token_out.decimals as i32 - hop.token_in.decimals as i32);
         product *= price * decimal_correction;
     }
     Ok(product)
@@ -1079,11 +1078,7 @@ mod tests {
             Box::new(MockProtocolSim::new(2000.0)),
         )]);
 
-        let hops = [HopDescriptor::new(
-            "pool_weth_usdc".to_string(),
-            weth,
-            usdc,
-        )];
+        let hops = [HopDescriptor::new("pool_weth_usdc".to_string(), weth, usdc)];
 
         let product =
             compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -236,17 +236,19 @@ where
                         })?
                 };
                 let amount_out = if order.is_sell() {
+                    let output_token = route.output_token().ok_or_else(|| {
+                        error!(
+                            order_id = %order.id(),
+                            "route missing swaps for sell order"
+                        );
+                        SolveError::NoRouteFound { order_id: order.id().to_string() }
+                    })?;
                     route
                         .swaps()
-                        .last()
+                        .iter()
+                        .filter(|s| *s.token_out() == output_token)
                         .map(|s| s.amount_out().clone())
-                        .ok_or_else(|| {
-                            error!(
-                                order_id = %order.id(),
-                                "route missing last swap for sell order"
-                            );
-                            SolveError::NoRouteFound { order_id: order.id().to_string() }
-                        })?
+                        .fold(BigUint::ZERO, |acc, x| acc + x)
                 } else {
                     order.amount().clone()
                 };


### PR DESCRIPTION
I'll fix the base branch to be main before merging.

## Bug 1: Price impact was not considering token decimals.                                                                                         

-   `compute_marginal_price_product` used spot_price (which returns decimal-normalized human units, e.g. 2000.0 for WETH/USDC) directly against raw token amounts. For cross-decimal pairs like WETH (18) / USDC (6), this produced price impact values of -10^12 instead of ~0.01, causing the PI gate to skip splitting on virtually every trade. 

The logs I was seeing:
```
2026-06-11T19:36:33.008667Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594367938.8019 gas_cost=6.978733999167245e16
2026-06-11T19:36:33.822045Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594267632.0906 gas_cost=6.978733999167245e16
2026-06-11T19:36:33.822140Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594267638.7703 gas_cost=6.978733999167245e16
2026-06-11T19:36:33.822266Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594366339.0143 gas_cost=6.978733999167245e16
2026-06-11T19:36:33.966675Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594269039.1056 gas_cost=6.978733999167245e16
2026-06-11T19:36:33.967420Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594152364.2762 gas_cost=6.978733999167245e16
2026-06-11T19:36:34.667360Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594152307.2026 gas_cost=6.978733999167245e16
2026-06-11T19:36:34.667364Z DEBUG fynd_core::algorithm::path_frank_wolfe: price impact too low to justify splitting pi=-999594153127.4119 gas_cost=6.978733999167245e16
```                                                                                                                                                             
                                                                  
## Bug 2: Split route results panicked the server                                                                                                                       
                                                   
  When a split route was chosen, `amount_out` was computed from only the last swap (one leg of the split), but `amount_out_net_gas` was correctly summed across all legs. Downstream gas refinement subtracted the larger total from the smaller partial, causing a BigUint underflow panic.