### PR TITLE
fix: include native/wrapped tokens in derive-connector-tokens

### DIFF
--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -128,11 +128,24 @@ pub async fn run(args: DeriveConnectorTokensArgs) -> Result<()> {
     ranked.sort_by_key(|(_, s)| std::cmp::Reverse(s.pool_count));
     let total = ranked.len();
 
-    let candidates: Vec<&(Address, TokenScore)> = ranked
+    let mut candidates: Vec<&(Address, TokenScore)> = ranked
         .iter()
         .filter(|(_, s)| s.pool_count >= args.min_pool_count)
         .take(args.top_n)
         .collect();
+
+    // Always include the chain's native and wrapped native tokens so that
+    // wrap/unwrap hops are never accidentally blocked by connector_tokens.
+    for addr in [chain.native_token().address, chain.wrapped_native_token().address] {
+        let already_present = candidates
+            .iter()
+            .any(|(a, _)| *a == addr);
+        if !already_present {
+            if let Some(entry) = ranked.iter().find(|(a, _)| *a == addr) {
+                candidates.push(entry);
+            }
+        }
+    }
 
     solver.shutdown();
 


### PR DESCRIPTION
The derive-connector-tokens command now always includes the chain's native and wrapped native tokens in the output, even if they fall outside the top-N or min-pool-count filters. This prevents users from accidentally blocking zero-cost wrap/unwrap hops when using the generated connector_tokens list.