### PR TITLE
fix: quiet expected solve failures in logs

### DIFF
--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -272,7 +272,7 @@ where
             Err(err) => {
                 let solve_error = match err {
                     crate::AlgorithmError::NoPath { .. } => {
-                        error!(
+                        debug!(
                             order_id = %order.id(),
                             error = %err,
                             "no route found"
@@ -280,7 +280,7 @@ where
                         SolveError::NoRouteFound { order_id: order.id().to_string() }
                     }
                     crate::AlgorithmError::Timeout { elapsed_ms } => {
-                        error!(
+                        warn!(
                             order_id = %order.id(),
                             elapsed_ms,
                             "solve timeout"
@@ -507,16 +507,8 @@ where
                                 self.quote(order, params).await
                             };
 
-                            if let Err(ref e) = result {
-                                warn!(
-                                    self.worker_id,
-                                    task_id = %task_id,
-                                    error = %e,
-                                    "solve failed"
-                                );
-                            }
-
-                            // Send response
+                            // Send response. The specific failure cause is already logged in
+                            // `quote()` and returned to the caller, so we don't re-log here.
                             task.respond(result);
                         }
                         None => {

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -297,7 +297,7 @@ impl WorkerPoolRouter {
                         }
                         Some((pool_name, Err(e))) => {
                             remaining_pools.remove(&pool_name);
-                            warn!(
+                            debug!(
                                 pool = %pool_name,
                                 order_id = %order_id,
                                 error = %e,


### PR DESCRIPTION
A single order with no route currently produces three log lines (one ERROR, two WARN), plus an aggregated WARN. No-route and timeout outcomes are routine when orders arrive for tokens we don't index or under load — they are not application faults.

## Changes

- `worker.rs` `quote()`: no-route (`NoPath`) `error!` → `debug!`; timeout `error!` → `warn!`. Genuine algorithm errors stay at `error!`.
- `worker.rs` worker loop: removed the `warn!("solve failed")` block. It re-logged every error already logged in `quote()` and returned to the caller.
- `worker_pool_router/mod.rs`: per-pool `warn!("solver pool failed")` → `debug!`. The aggregated `warn!("some solver pools failed")` and per-error metrics already cover the router level.

The failure reason is still returned to the caller as `QuoteStatus::NoRouteFound` and recorded in `worker_router_solver_failures_total{error_type}`. A no-route order now produces no ERROR/WARN lines by default; the detail returns at `RUST_LOG=debug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)