### PR TITLE
fix(release): exclude fynd-core integration tests from published crate

### DIFF
--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2021"
 description = "Core solving logic for Fynd DEX router"
 license = "MIT"
 readme = "README.md"
+# Integration tests and their Git LFS fixtures are dev-only; excluding them keeps
+# the published crate lean and stops `cargo publish` from dirty-checking the
+# LFS fixture (whose smudge state differs on the release runner).
+exclude = ["tests/"]
 
 [dependencies]
 tycho-simulation.workspace = true


### PR DESCRIPTION
## Problem

The crates.io release for 0.81.0 failed at the **Publish fynd-core** step ([run](https://github.com/propeller-heads/fynd/actions/runs/27715657056/job/81987787642)):

```
error: 1 files in the working directory contain changes that were not yet committed into git:
    fynd-core/tests/fixtures/market_recording.json.zst
```

The integration tests added in #127 live inside the published `fynd-core` crate (`fynd-core/tests/`), and their fixture `market_recording.json.zst` is tracked with Git LFS. The release workflow's checkout does not fetch LFS, so on the runner the fixture's smudge state differs from its committed pointer and git reports it as modified. `cargo publish` aborts on any dirty file in the package, so nothing was published (the remaining crate publishes skipped).

## Fix

Add `exclude = ["tests/"]` to `fynd-core`'s `[package]`. The integration tests and their LFS fixtures are dev-only and have no place on crates.io. Excluding `tests/` removes them from the package, so cargo no longer dirty-checks the LFS fixture, and it keeps the published crate lean.

## Verification

- On a clean `origin/main` worktree, reproduced the failure: with the LFS fixture made dirty, `cargo package -p fynd-core` failed naming `market_recording.json.zst`. After adding `exclude = ["tests/"]`, the same command succeeds ("Packaged 62 files") with the fixture still dirty.
- `cargo package --list -p fynd-core` no longer includes any `tests/` files.
- Integration tests still pass from the repo (`cargo nextest run -p fynd-core --features test-utils --test integration` → 8 passed); exclude only affects packaging.

After this merges the release needs re-running to publish 0.81.0 (nothing reached crates.io, since the publish failed before the first upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)