### PR TITLE
fix(worker): Call Route.validate() in the SolverWorker

### DIFF
--- a/docs/guides/custom-algorithm.md
+++ b/docs/guides/custom-algorithm.md
@@ -11,7 +11,7 @@ Fynd exposes an `Algorithm` trait that lets you plug in custom routing logic wit
 The trait has four methods:
 
 * `name()` — a string identifier used in config and logs
-* `find_best_route()` — given a routing graph and an order, return the best route
+* `find_best_route()` — given a routing graph and an order, return the best route. Call `Route::validate()` on each candidate and skip invalid ones (disconnected swaps, repeated tokens, malformed splits): the solver worker rejects an invalid route, which drops the whole solution for that worker pool, so prefer the next-best valid route instead
 * `computation_requirements()` — declares which derived data the algorithm needs (spot prices, depths, etc.)
 * `timeout()` — per-order solve deadline
 
@@ -119,6 +119,18 @@ impl Algorithm for DirectPoolAlgorithm {
             );
 
             let route = Route::new(vec![swap], HashMap::new())?;
+
+            // Validate every candidate route before returning it. The solver worker rejects
+            // invalid routes (disconnected swaps, repeated tokens, malformed splits) and that
+            // failure drops the whole solution for this worker pool. Skipping invalid candidates
+            // here lets a later pool be chosen instead. Any custom algorithm should validate the
+            // routes it might return, and — when it ranks multiple candidates — fall through to
+            // the next-best valid one rather than returning the invalid route.
+            if let Err(e) = route.validate() {
+                eprintln!("skipping invalid route: {e}");
+                continue;
+            }
+
             let net_amount_out = BigInt::from(result.amount);
 
             return Ok(RouteResult::new(route, net_amount_out, gas_price));

--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -133,6 +133,18 @@ impl Algorithm for DirectPoolAlgorithm {
             );
 
             let route = Route::new(vec![swap], HashMap::new())?;
+
+            // Validate every candidate route before returning it. The solver worker rejects
+            // invalid routes (disconnected swaps, repeated tokens, malformed splits) and that
+            // failure drops the whole solution for this worker pool. Skipping invalid candidates
+            // here lets a later pool be chosen instead. Any custom algorithm should validate the
+            // routes it might return, and — when it ranks multiple candidates — fall through to
+            // the next-best valid one rather than returning the invalid route.
+            if let Err(e) = route.validate() {
+                eprintln!("skipping invalid route: {e}");
+                continue;
+            }
+
             let net_amount_out = BigInt::from(result.amount);
 
             return Ok(RouteResult::new(route, net_amount_out, gas_price));

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -588,6 +588,7 @@ impl Algorithm for MostLiquidAlgorithm {
 
         let mut paths_simulated = 0usize;
         let mut simulation_failures = 0usize;
+        let mut validation_failures = 0usize;
 
         // Step 5: Simulate all paths in score order using the local market subset
         let mut best: Option<RouteResult> = None;
@@ -613,6 +614,13 @@ impl Algorithm for MostLiquidAlgorithm {
                     continue;
                 }
             };
+
+            // Skip routes that fail validation so the next-best candidate can win.
+            if let Err(e) = result.route().validate() {
+                trace!(error = %e, "skipping invalid route");
+                validation_failures += 1;
+                continue;
+            }
 
             // Check if this is the best result so far
             if best
@@ -641,6 +649,7 @@ impl Algorithm for MostLiquidAlgorithm {
         // Record metrics
         counter!("algorithm.scoring_failures").increment(scoring_failures as u64);
         counter!("algorithm.simulation_failures").increment(simulation_failures as u64);
+        counter!("algorithm.validation_failures").increment(validation_failures as u64);
         histogram!("algorithm.simulation_coverage_pct").record(coverage_pct);
 
         match &best {
@@ -672,6 +681,7 @@ impl Algorithm for MostLiquidAlgorithm {
                     paths_to_simulate,
                     paths_simulated,
                     simulation_failures,
+                    validation_failures,
                     simulation_coverage_pct = coverage_pct,
                     components_considered = component_ids.len(),
                     tokens_considered = market.token_registry_ref().len(),
@@ -692,6 +702,7 @@ impl Algorithm for MostLiquidAlgorithm {
                     paths_to_simulate,
                     paths_simulated,
                     simulation_failures,
+                    validation_failures,
                     simulation_coverage_pct = coverage_pct,
                     components_considered = component_ids.len(),
                     tokens_considered = market.token_registry_ref().len(),

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -598,6 +598,14 @@ impl Algorithm for PathFrankWolfeAlgorithm {
 
         // Build the split route and compare with the initial single-path result.
         let split_route = build_split_route(&allocations, &ctx.market_data, order)?;
+
+        // Fall back to the single-path result if the split route is invalid, so a malformed split
+        // doesn't fail the whole solve when a valid route is available.
+        if let Err(e) = split_route.validate() {
+            debug!(error = %e, "split route failed validation, falling back to single path");
+            return Ok(single_path_result);
+        }
+
         let gas_price = ctx
             .gas_price_wei
             .clone()

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -217,6 +217,19 @@ where
                 let gas_price = result.gas_price().clone();
                 let route = result.into_route();
 
+                if let Err(err) = route.validate() {
+                    error!(
+                        order_id = %order.id(),
+                        algorithm = self.algorithm.name(),
+                        error = %err,
+                        "algorithm produced an invalid route"
+                    );
+                    return Err(SolveError::AlgorithmError(format!(
+                        "{} produced an invalid route: {err}",
+                        self.algorithm.name()
+                    )));
+                }
+
                 // This is a first naive approach to getting the total gas of this quote
                 // A finer estimation is done during encoding
                 let gas_estimate = route.total_gas();
@@ -525,17 +538,22 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{collections::HashMap, time::Duration};
 
     use super::*;
     use crate::{
-        algorithm::{most_liquid::DepthAndPrice, test_utils::setup_market_weighted},
+        algorithm::{
+            most_liquid::DepthAndPrice,
+            test_utils::{component, order, setup_market_weighted, token, MockProtocolSim},
+        },
         derived::{
             computation::DerivedComputation,
             computations::{SpotPriceComputation, TokenGasPriceComputation},
             DerivedData,
         },
         graph::petgraph::{PetgraphStableDiGraphManager, StableDiGraph},
+        types::{OrderSide, Route, RouteResult, Swap},
+        AlgorithmError,
     };
 
     /// A minimal mock algorithm for testing the worker.
@@ -581,6 +599,91 @@ mod tests {
 
         fn timeout(&self) -> Duration {
             self.timeout
+        }
+    }
+
+    /// Mock algorithm that returns a structurally invalid route (two disconnected swaps).
+    /// Used to verify the worker rejects invalid routes regardless of which algorithm produced
+    /// them.
+    struct InvalidRouteAlgorithm;
+
+    impl Algorithm for InvalidRouteAlgorithm {
+        type GraphType = StableDiGraph<DepthAndPrice>;
+        type GraphManager = PetgraphStableDiGraphManager<DepthAndPrice>;
+
+        fn name(&self) -> &str {
+            "invalid_route_mock"
+        }
+
+        async fn find_best_route(
+            &self,
+            _graph: &Self::GraphType,
+            _market: MarketData,
+            _label: Option<crate::feed::market_data::StateLabel>,
+            _derived: Option<SharedDerivedDataRef>,
+            _order: &Order,
+        ) -> Result<RouteResult, AlgorithmError> {
+            let token_a = token(0x01, "A");
+            let token_b = token(0x02, "B");
+            let token_c = token(0x03, "C");
+            let token_d = token(0x04, "D");
+            // A→B then C→D: the first swap's output (B) does not feed the second's input (C),
+            // so `validate` must reject this as `DisconnectedSwaps`.
+            let swap_ab = Swap::new(
+                "p1".to_string(),
+                "mock".to_string(),
+                token_a.address.clone(),
+                token_b.address.clone(),
+                BigUint::from(100u64),
+                BigUint::from(90u64),
+                BigUint::from(1u64),
+                component("p1", &[token_a.clone(), token_b.clone()]),
+                Box::new(MockProtocolSim::new(2.0)),
+            );
+            let swap_cd = Swap::new(
+                "p2".to_string(),
+                "mock".to_string(),
+                token_c.address.clone(),
+                token_d.address.clone(),
+                BigUint::from(90u64),
+                BigUint::from(80u64),
+                BigUint::from(1u64),
+                component("p2", &[token_c.clone(), token_d.clone()]),
+                Box::new(MockProtocolSim::new(2.0)),
+            );
+            let route =
+                Route::new(vec![swap_ab, swap_cd], HashMap::new()).expect("non-empty route");
+            Ok(RouteResult::new(route, num_bigint::BigInt::from(0), BigUint::from(1u64)))
+        }
+
+        fn computation_requirements(&self) -> ComputationRequirements {
+            ComputationRequirements::none()
+        }
+
+        fn timeout(&self) -> Duration {
+            Duration::from_secs(1)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_quote_rejects_invalid_route() {
+        let (market, _) = setup_market_weighted(vec![]);
+        let derived = DerivedData::new_shared();
+        let mut worker = SolverWorker::new(market, derived, InvalidRouteAlgorithm, 0);
+
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let ord = order(&token_a, &token_b, 100, OrderSide::Sell);
+
+        let result = worker
+            .quote(&ord, SolveParams::default())
+            .await;
+
+        match result {
+            Err(SolveError::AlgorithmError(msg)) => {
+                assert!(msg.contains("invalid route"), "unexpected message: {msg}");
+            }
+            other => panic!("expected AlgorithmError for invalid route, got {other:?}"),
         }
     }
 


### PR DESCRIPTION
This way we make sure that the Route returned by whatever algorithm is compatible with what tycho-execution expects