### PR TITLE
feat(hindsight): re-solve engine + resolve subcommand (ENG-6123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,8 +3821,11 @@ version = "0.82.3"
 dependencies = [
  "alloy",
  "anyhow",
+ "async-trait",
  "clap",
  "futures 0.3.32",
+ "fynd-client",
+ "fynd-tools-common",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3826,6 +3826,7 @@ dependencies = [
  "futures 0.3.32",
  "fynd-client",
  "fynd-tools-common",
+ "num-bigint",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 fynd-client = { workspace = true }
 # Shared tooling (BPS comparison math, FyndAggregator wrapper)
 fynd-tools-common = { workspace = true }
+num-bigint = { workspace = true }
 
 # Async runtime
 tokio = { workspace = true }

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -10,9 +10,15 @@ name = "hindsight"
 path = "src/main.rs"
 
 [dependencies]
+# Fynd integration (re-solve via a running solver)
+fynd-client = { workspace = true }
+# Shared tooling (BPS comparison math, FyndAggregator wrapper)
+fynd-tools-common = { workspace = true }
+
 # Async runtime
 tokio = { workspace = true }
 futures = { workspace = true }
+async-trait = { workspace = true }
 
 # CLI
 clap = { workspace = true }

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -1,4 +1,5 @@
 mod decoder;
+mod resolve;
 
 use std::time::Instant;
 
@@ -21,6 +22,8 @@ enum Command {
     Decode(DecodeArgs),
     /// Decode and compare against Allium's aggregator_trades ground truth.
     Verify(VerifyArgs),
+    /// Decode a block's trades and re-solve each through a running Fynd instance.
+    Resolve(ResolveArgs),
 }
 
 #[derive(Args)]
@@ -83,6 +86,33 @@ struct VerifyArgs {
     json: bool,
 }
 
+#[derive(Args)]
+struct ResolveArgs {
+    /// Ethereum RPC URL (used to decode the block's settled trades)
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: String,
+
+    /// Base URL of a running Fynd solver to re-solve trades through
+    #[arg(long, env = "FYND_URL", default_value = "http://localhost:3000")]
+    fynd_url: String,
+
+    /// Block number to re-solve (latest if omitted)
+    #[arg(long)]
+    block: Option<u64>,
+
+    /// Range of blocks to re-solve (e.g. 21000000-21000010)
+    #[arg(long, conflicts_with = "block")]
+    range: Option<String>,
+
+    /// Per-quote timeout in milliseconds for Fynd
+    #[arg(long, default_value_t = 10_000)]
+    timeout_ms: u64,
+
+    /// Output as JSON instead of human-readable
+    #[arg(long)]
+    json: bool,
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
@@ -95,6 +125,17 @@ async fn main() -> anyhow::Result<()> {
     match Cli::parse().command {
         Command::Decode(args) => run_decode(args).await,
         Command::Verify(args) => run_verify(args).await,
+        Command::Resolve(args) => {
+            resolve::run::run(
+                &args.rpc_url,
+                &args.fynd_url,
+                args.block,
+                args.range.as_deref(),
+                args.timeout_ms,
+                args.json,
+            )
+            .await
+        }
     }
 }
 
@@ -150,14 +191,14 @@ async fn run_verify(args: VerifyArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn provider_from(rpc_url: &str) -> anyhow::Result<impl Provider> {
+pub(crate) fn provider_from(rpc_url: &str) -> anyhow::Result<impl Provider> {
     let url: reqwest::Url = rpc_url
         .parse()
         .with_context(|| format!("invalid RPC URL: {rpc_url}"))?;
     Ok(ProviderBuilder::new().connect_http(url))
 }
 
-async fn resolve_blocks<P: Provider>(
+pub(crate) async fn resolve_blocks<P: Provider>(
     provider: &P,
     block: Option<u64>,
     range: Option<&str>,

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -1,0 +1,113 @@
+//! Pure comparison math between a Fynd re-solve and the on-chain settled amount.
+
+use alloy::primitives::U256;
+use fynd_tools_common::bps::raw_bps_diff;
+use serde::Serialize;
+
+use crate::resolve::Outcome;
+
+/// Basis-point deltas of a Fynd quote against the settled amount (positive = Fynd better).
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub(crate) struct Deltas {
+    /// `fynd amount_out` vs settled, ignoring gas.
+    pub raw_bps: Option<f64>,
+    /// `fynd amount_out_net_gas` vs settled — Fynd's output after its own gas cost.
+    pub net_bps: Option<f64>,
+}
+
+impl Deltas {
+    const NONE: Self = Self { raw_bps: None, net_bps: None };
+}
+
+/// Win/loss/unsolvable classification for a single trade, judged at one block state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Verdict {
+    /// Fynd would have produced strictly more output than settled (net of gas).
+    Win,
+    /// Fynd's output was equal to or worse than settled, or it could not be compared.
+    Loss,
+    /// Fynd could not solve the trade at all.
+    Unsolvable,
+}
+
+/// Compute raw and net-of-gas bps deltas of `outcome` against `settled_amount_out`.
+pub(crate) fn compare(outcome: &Outcome, settled_amount_out: U256) -> Deltas {
+    let Outcome::Solved(solved) = outcome else {
+        return Deltas::NONE;
+    };
+    let settled = settled_amount_out.to_string();
+    Deltas {
+        raw_bps: raw_bps_diff(&solved.amount_out.to_string(), &settled),
+        net_bps: raw_bps_diff(&solved.amount_out_net_gas.to_string(), &settled),
+    }
+}
+
+/// Classify a trade by its net-of-gas delta at the given outcome (top-of-block is the default
+/// reference). Fynd wins only when it delivers strictly more output after gas.
+pub(crate) fn verdict(outcome: &Outcome, settled_amount_out: U256) -> Verdict {
+    match compare(outcome, settled_amount_out).net_bps {
+        Some(d) if d > 0.0 => Verdict::Win,
+        Some(_) => Verdict::Loss,
+        None => Verdict::Unsolvable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolve::SolvedAmount;
+
+    fn solved(amount_out: u64, net: u64) -> Outcome {
+        Outcome::Solved(SolvedAmount {
+            amount_out: U256::from(amount_out),
+            amount_out_net_gas: U256::from(net),
+            gas_estimate: U256::from(21_000),
+        })
+    }
+
+    #[test]
+    fn compare_fynd_better_is_positive() {
+        let d = compare(&solved(10_100, 10_050), U256::from(10_000u64));
+        assert!((d.raw_bps.unwrap() - 100.0).abs() < 0.01);
+        assert!((d.net_bps.unwrap() - 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn compare_fynd_worse_is_negative() {
+        let d = compare(&solved(9_900, 9_800), U256::from(10_000u64));
+        assert!(d.raw_bps.unwrap() < 0.0);
+        assert!(d.net_bps.unwrap() < 0.0);
+    }
+
+    #[test]
+    fn compare_unsolvable_is_none() {
+        let d = compare(&Outcome::Unsolvable("no route".into()), U256::from(10_000u64));
+        assert_eq!(d, Deltas::NONE);
+    }
+
+    #[test]
+    fn compare_zero_settled_is_none() {
+        let d = compare(&solved(10_000, 10_000), U256::ZERO);
+        assert_eq!(d.raw_bps, None);
+    }
+
+    #[test]
+    fn verdict_win_only_when_net_positive() {
+        assert_eq!(verdict(&solved(10_100, 10_050), U256::from(10_000u64)), Verdict::Win);
+    }
+
+    #[test]
+    fn verdict_loss_when_net_not_better() {
+        // Raw is better but net-of-gas is worse → loss (gas ate the edge).
+        assert_eq!(verdict(&solved(10_100, 9_990), U256::from(10_000u64)), Verdict::Loss);
+    }
+
+    #[test]
+    fn verdict_unsolvable_passthrough() {
+        assert_eq!(
+            verdict(&Outcome::Unsolvable("missing token".into()), U256::from(10_000u64)),
+            Verdict::Unsolvable
+        );
+    }
+}

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -26,29 +26,32 @@ impl Deltas {
     const NONE: Self = Self { raw_bps: None, net_bps: None };
 }
 
-/// Win/loss/unsolvable classification for a single trade, judged at one block state.
+/// Win/loss classification for a single trade, judged at one block state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum Verdict {
     /// Fynd would have produced strictly more output than settled (net of gas).
     Win,
     /// Fynd's output was equal to or worse than settled, or it could not be compared.
     Loss,
+    /// Fynd only returned a partial route for the trade's size — a coverage miss, not a fair loss.
+    CoverageMiss,
     /// Fynd could not solve the trade at all.
     Unsolvable,
 }
 
 /// Minimum fraction of the settled output Fynd must produce for the result to count as a real
-/// comparison. Below this, Fynd could not serve the trade's size (it returned a partial route), so
-/// the result is treated as a coverage miss rather than booked as a near-total loss — otherwise a
-/// single un-fillable whale dominates the USD aggregate.
+/// comparison. Below this, Fynd could not serve the trade's size — because liquidity was too thin
+/// it returned a route covering only part of it — so the result is a coverage miss rather than a
+/// near-total loss; otherwise a single un-fillable whale dominates the USD aggregate.
 const MIN_FILL_RATIO: f64 = 0.5;
 
-/// Reclassify a Fynd quote that filled far less than the settled amount as a coverage miss.
+/// Reclassify a Fynd quote that covers far less than the settled amount as a coverage miss.
 ///
-/// Both amounts are in `token_out` units, so their ratio is unit-free. A `Solved` outcome whose raw
-/// output is below [`MIN_FILL_RATIO`] of the settled amount becomes [`Outcome::Unsolvable`]; every
-/// other outcome passes through unchanged.
+/// Fynd does not do price-constrained partial fills, but when liquidity is thin it can return a
+/// route for only part of the requested size. Both amounts are in `token_out` units, so their
+/// ratio is unit-free. A `Solved` outcome whose raw output is below [`MIN_FILL_RATIO`] of the
+/// settled amount becomes [`Outcome::Partial`]; every other outcome passes through unchanged.
 pub(crate) fn served(outcome: Outcome, settled_amount_out: U256) -> Outcome {
     let Outcome::Solved(ref solved) = outcome else {
         return outcome;
@@ -63,8 +66,8 @@ pub(crate) fn served(outcome: Outcome, settled_amount_out: U256) -> Outcome {
         .parse()
         .unwrap_or(0.0);
     if settled > 0.0 && fynd < MIN_FILL_RATIO * settled {
-        return Outcome::Unsolvable(format!(
-            "partial fill: {:.0}% of settled",
+        return Outcome::Partial(format!(
+            "partial route: {:.0}% of settled size",
             fynd / settled * 100.0
         ));
     }
@@ -86,6 +89,9 @@ pub(crate) fn compare(outcome: &Outcome, settled_amount_out: U256) -> Deltas {
 /// Classify a trade by its net-of-gas delta at the given outcome (top-of-block is the default
 /// reference). Fynd wins only when it delivers strictly more output after gas.
 pub(crate) fn verdict(outcome: &Outcome, settled_amount_out: U256) -> Verdict {
+    if let Outcome::Partial(_) = outcome {
+        return Verdict::CoverageMiss;
+    }
     match compare(outcome, settled_amount_out).net_bps {
         Some(d) if d > 0.0 => Verdict::Win,
         Some(_) => Verdict::Loss,
@@ -152,14 +158,16 @@ mod tests {
     }
 
     #[test]
-    fn served_reclassifies_partial_fill_as_unsolvable() {
-        // Fynd produced only 40% of the settled output → coverage miss, not a loss.
-        assert!(matches!(served(solved(400, 390), U256::from(1_000u64)), Outcome::Unsolvable(_)));
+    fn served_reclassifies_partial_route_as_partial() {
+        // Fynd covered only 40% of the settled size → coverage miss, not a loss.
+        let outcome = served(solved(400, 390), U256::from(1_000u64));
+        assert!(matches!(outcome, Outcome::Partial(_)));
+        assert_eq!(verdict(&outcome, U256::from(1_000u64)), Verdict::CoverageMiss);
     }
 
     #[test]
     fn served_keeps_adequate_fill() {
-        // 90% fill is a real (worse) quote, not a coverage miss; the floor is kept.
+        // 90% coverage is a real (worse) quote, not a coverage miss; the floor is kept.
         assert!(matches!(served(solved(900, 880), U256::from(1_000u64)), Outcome::Solved(_)));
         assert!(matches!(served(solved(500, 490), U256::from(1_000u64)), Outcome::Solved(_)));
     }

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -30,7 +30,8 @@ impl Deltas {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Verdict {
-    /// Fynd would have produced strictly more output than settled (net of gas).
+    /// Fynd delivered strictly more output than settled after subtracting only its own gas (see
+    /// [`verdict`] for why this comparison is intentionally conservative).
     Win,
     /// Fynd's output was equal to or worse than settled, or it could not be compared.
     Loss,
@@ -86,8 +87,14 @@ pub(crate) fn compare(outcome: &Outcome, settled_amount_out: U256) -> Deltas {
     }
 }
 
-/// Classify a trade by its net-of-gas delta at the given outcome (top-of-block is the default
-/// reference). Fynd wins only when it delivers strictly more output after gas.
+/// Classify a trade by its net-of-gas delta against the settled amount. Fynd wins only when it
+/// delivers strictly more output after subtracting its own estimated gas cost.
+///
+/// The comparison is deliberately conservative and asymmetric: Fynd's output is net of its own
+/// gas, while the settled `amount_out` is gross — the settled swap's gas was paid separately in ETH
+/// and is not subtracted here. Isolating the on-chain trade's true gas cost is hard (it can sit
+/// deep in a larger transaction alongside unrelated activity), so a `Win` under-counts rather than
+/// over-counts Fynd's edge. Symmetric N-1/N gas accounting is a follow-up.
 pub(crate) fn verdict(outcome: &Outcome, settled_amount_out: U256) -> Verdict {
     if let Outcome::Partial(_) = outcome {
         return Verdict::CoverageMiss;

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -2,9 +2,16 @@
 
 use alloy::primitives::U256;
 use fynd_tools_common::bps::raw_bps_diff;
+use num_bigint::BigUint;
 use serde::Serialize;
 
 use crate::resolve::Outcome;
+
+/// Convert an alloy `U256` token amount to `BigUint` for the bps helpers, big-endian and without a
+/// decimal string round-trip.
+fn to_biguint(amount: U256) -> BigUint {
+    BigUint::from_bytes_be(&amount.to_be_bytes::<32>())
+}
 
 /// Basis-point deltas of a Fynd quote against the settled amount (positive = Fynd better).
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
@@ -69,10 +76,10 @@ pub(crate) fn compare(outcome: &Outcome, settled_amount_out: U256) -> Deltas {
     let Outcome::Solved(solved) = outcome else {
         return Deltas::NONE;
     };
-    let settled = settled_amount_out.to_string();
+    let settled = to_biguint(settled_amount_out);
     Deltas {
-        raw_bps: raw_bps_diff(&solved.amount_out.to_string(), &settled),
-        net_bps: raw_bps_diff(&solved.amount_out_net_gas.to_string(), &settled),
+        raw_bps: raw_bps_diff(&to_biguint(solved.amount_out), &settled),
+        net_bps: raw_bps_diff(&to_biguint(solved.amount_out_net_gas), &settled),
     }
 }
 

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -31,6 +31,39 @@ pub(crate) enum Verdict {
     Unsolvable,
 }
 
+/// Minimum fraction of the settled output Fynd must produce for the result to count as a real
+/// comparison. Below this, Fynd could not serve the trade's size (it returned a partial route), so
+/// the result is treated as a coverage miss rather than booked as a near-total loss — otherwise a
+/// single un-fillable whale dominates the USD aggregate.
+const MIN_FILL_RATIO: f64 = 0.5;
+
+/// Reclassify a Fynd quote that filled far less than the settled amount as a coverage miss.
+///
+/// Both amounts are in `token_out` units, so their ratio is unit-free. A `Solved` outcome whose raw
+/// output is below [`MIN_FILL_RATIO`] of the settled amount becomes [`Outcome::Unsolvable`]; every
+/// other outcome passes through unchanged.
+pub(crate) fn served(outcome: Outcome, settled_amount_out: U256) -> Outcome {
+    let Outcome::Solved(ref solved) = outcome else {
+        return outcome;
+    };
+    let settled: f64 = settled_amount_out
+        .to_string()
+        .parse()
+        .unwrap_or(0.0);
+    let fynd: f64 = solved
+        .amount_out
+        .to_string()
+        .parse()
+        .unwrap_or(0.0);
+    if settled > 0.0 && fynd < MIN_FILL_RATIO * settled {
+        return Outcome::Unsolvable(format!(
+            "partial fill: {:.0}% of settled",
+            fynd / settled * 100.0
+        ));
+    }
+    outcome
+}
+
 /// Compute raw and net-of-gas bps deltas of `outcome` against `settled_amount_out`.
 pub(crate) fn compare(outcome: &Outcome, settled_amount_out: U256) -> Deltas {
     let Outcome::Solved(solved) = outcome else {
@@ -109,5 +142,27 @@ mod tests {
             verdict(&Outcome::Unsolvable("missing token".into()), U256::from(10_000u64)),
             Verdict::Unsolvable
         );
+    }
+
+    #[test]
+    fn served_reclassifies_partial_fill_as_unsolvable() {
+        // Fynd produced only 40% of the settled output → coverage miss, not a loss.
+        assert!(matches!(served(solved(400, 390), U256::from(1_000u64)), Outcome::Unsolvable(_)));
+    }
+
+    #[test]
+    fn served_keeps_adequate_fill() {
+        // 90% fill is a real (worse) quote, not a coverage miss; the floor is kept.
+        assert!(matches!(served(solved(900, 880), U256::from(1_000u64)), Outcome::Solved(_)));
+        assert!(matches!(served(solved(500, 490), U256::from(1_000u64)), Outcome::Solved(_)));
+    }
+
+    #[test]
+    fn served_passes_through_unsolvable_and_zero_settled() {
+        assert!(matches!(
+            served(Outcome::Unsolvable("x".into()), U256::from(1_000u64)),
+            Outcome::Unsolvable(_)
+        ));
+        assert!(matches!(served(solved(1, 1), U256::ZERO), Outcome::Solved(_)));
     }
 }

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -30,9 +30,12 @@ pub(crate) struct SolvedAmount {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(tag = "status", rename_all = "lowercase")]
 pub(crate) enum Outcome {
-    /// Fynd produced a quote.
+    /// Fynd produced a quote for the trade's full size.
     Solved(SolvedAmount),
-    /// Fynd could not solve (missing token in Tycho, insufficient liquidity, timeout).
+    /// Fynd returned a route but for far less than the settled size — a liquidity-limited partial
+    /// route. Tracked apart from [`Outcome::Unsolvable`] so a coverage gap is not read as a loss.
+    Partial(String),
+    /// Fynd could not solve at all (missing token in Tycho, insufficient liquidity, timeout).
     Unsolvable(String),
 }
 
@@ -145,5 +148,14 @@ mod tests {
         // Raw better but net-of-gas worse → loss.
         let cmp = compare_trade(&MockSolver(solved(10_100, 9_980)), &trade(10_000)).await;
         assert_eq!(cmp.verdict, Verdict::Loss);
+    }
+
+    #[tokio::test]
+    async fn compare_trade_partial_route_is_coverage_miss() {
+        // Fynd covers only 30% of the settled size → coverage miss, deltas suppressed.
+        let cmp = compare_trade(&MockSolver(solved(3_000, 2_900)), &trade(10_000)).await;
+        assert_eq!(cmp.verdict, Verdict::CoverageMiss);
+        assert!(matches!(cmp.outcome, Outcome::Partial(_)));
+        assert_eq!(cmp.deltas, Deltas { raw_bps: None, net_bps: None });
     }
 }

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -12,9 +12,8 @@ pub(crate) mod run;
 
 use alloy::primitives::{Address, U256};
 use async_trait::async_trait;
-use serde::Serialize;
-
 pub(crate) use compare::{Deltas, Verdict};
+use serde::Serialize;
 
 use crate::decoder::DecodedTrade;
 
@@ -68,6 +67,7 @@ pub(crate) async fn compare_trade<R: ReSolver + ?Sized>(
     let outcome = resolver
         .solve(trade.token_in, trade.token_out, trade.amount_in)
         .await;
+    let outcome = compare::served(outcome, trade.amount_out);
     let deltas = compare::compare(&outcome, trade.amount_out);
     let verdict = compare::verdict(&outcome, trade.amount_out);
 
@@ -133,8 +133,9 @@ mod tests {
 
     #[tokio::test]
     async fn compare_trade_unsolvable() {
-        let cmp = compare_trade(&MockSolver(Outcome::Unsolvable("no route".into())), &trade(10_000))
-            .await;
+        let cmp =
+            compare_trade(&MockSolver(Outcome::Unsolvable("no route".into())), &trade(10_000))
+                .await;
         assert_eq!(cmp.verdict, Verdict::Unsolvable);
         assert_eq!(cmp.deltas, Deltas { raw_bps: None, net_bps: None });
     }

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -1,0 +1,148 @@
+//! Re-solve engine: run Fynd on a decoded swap's inputs and compare its output against what
+//! actually settled on-chain.
+//!
+//! The [`ReSolver`] trait abstracts the solver so the comparison pipeline is testable without a
+//! live Fynd instance. The production implementation ([`run`]) re-solves through a running Fynd
+//! via the shared `FyndAggregator` (HTTP). This compares at the chain's current state; re-solving
+//! at top-of-block (N-1) and back-of-block (N) as a range is a follow-up that depends on
+//! block-stepping support (`BlockStepController`) being wired into `fynd-core`.
+
+mod compare;
+pub(crate) mod run;
+
+use alloy::primitives::{Address, U256};
+use async_trait::async_trait;
+use serde::Serialize;
+
+pub(crate) use compare::{Deltas, Verdict};
+
+use crate::decoder::DecodedTrade;
+
+/// A Fynd quote for the re-solved order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct SolvedAmount {
+    pub amount_out: U256,
+    /// Output after Fynd's own estimated gas cost.
+    pub amount_out_net_gas: U256,
+    pub gas_estimate: U256,
+}
+
+/// The outcome of re-solving a trade.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub(crate) enum Outcome {
+    /// Fynd produced a quote.
+    Solved(SolvedAmount),
+    /// Fynd could not solve (missing token in Tycho, insufficient liquidity, timeout).
+    Unsolvable(String),
+}
+
+/// Re-solves a sell order. Implementors return [`Outcome::Unsolvable`] (rather than an error)
+/// when Fynd cannot produce a quote, so a single untradeable pair never aborts a whole block.
+#[async_trait]
+pub(crate) trait ReSolver {
+    async fn solve(&self, token_in: Address, token_out: Address, amount_in: U256) -> Outcome;
+}
+
+/// One re-solved trade compared against the settled on-chain amount.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct Comparison {
+    pub tx_hash: String,
+    pub block_number: u64,
+    pub client: String,
+    pub aggregator: String,
+    pub token_in: Address,
+    pub token_out: Address,
+    pub amount_in: U256,
+    pub settled_amount_out: U256,
+    pub outcome: Outcome,
+    pub deltas: Deltas,
+    pub verdict: Verdict,
+}
+
+/// Re-solve one decoded trade and compare it against the settled amount.
+pub(crate) async fn compare_trade<R: ReSolver + ?Sized>(
+    resolver: &R,
+    trade: &DecodedTrade,
+) -> Comparison {
+    let outcome = resolver
+        .solve(trade.token_in, trade.token_out, trade.amount_in)
+        .await;
+    let deltas = compare::compare(&outcome, trade.amount_out);
+    let verdict = compare::verdict(&outcome, trade.amount_out);
+
+    Comparison {
+        tx_hash: trade.tx_hash.to_string(),
+        block_number: trade.block_number,
+        client: trade.client.clone(),
+        aggregator: trade.aggregator.clone(),
+        token_in: trade.token_in,
+        token_out: trade.token_out,
+        amount_in: trade.amount_in,
+        settled_amount_out: trade.amount_out,
+        outcome,
+        deltas,
+        verdict,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mock resolver returning a fixed outcome.
+    struct MockSolver(Outcome);
+
+    #[async_trait]
+    impl ReSolver for MockSolver {
+        async fn solve(&self, _: Address, _: Address, _: U256) -> Outcome {
+            self.0.clone()
+        }
+    }
+
+    fn trade(settled: u64) -> DecodedTrade {
+        DecodedTrade {
+            tx_hash: Default::default(),
+            block_number: 21_000_000,
+            client: "relay".into(),
+            aggregator: "tycho".into(),
+            sender: Address::ZERO,
+            token_in: Address::repeat_byte(0x11),
+            token_out: Address::repeat_byte(0x22),
+            amount_in: U256::from(1_000u64),
+            amount_out: U256::from(settled),
+        }
+    }
+
+    fn solved(amount_out: u64, net: u64) -> Outcome {
+        Outcome::Solved(SolvedAmount {
+            amount_out: U256::from(amount_out),
+            amount_out_net_gas: U256::from(net),
+            gas_estimate: U256::from(21_000),
+        })
+    }
+
+    #[tokio::test]
+    async fn compare_trade_win_carries_identity() {
+        let cmp = compare_trade(&MockSolver(solved(10_200, 10_100)), &trade(10_000)).await;
+        assert_eq!(cmp.verdict, Verdict::Win);
+        assert_eq!(cmp.client, "relay");
+        assert_eq!(cmp.settled_amount_out, U256::from(10_000u64));
+        assert!(cmp.deltas.raw_bps.unwrap() > 0.0);
+    }
+
+    #[tokio::test]
+    async fn compare_trade_unsolvable() {
+        let cmp = compare_trade(&MockSolver(Outcome::Unsolvable("no route".into())), &trade(10_000))
+            .await;
+        assert_eq!(cmp.verdict, Verdict::Unsolvable);
+        assert_eq!(cmp.deltas, Deltas { raw_bps: None, net_bps: None });
+    }
+
+    #[tokio::test]
+    async fn compare_trade_loss_when_gas_eats_edge() {
+        // Raw better but net-of-gas worse → loss.
+        let cmp = compare_trade(&MockSolver(solved(10_100, 9_980)), &trade(10_000)).await;
+        assert_eq!(cmp.verdict, Verdict::Loss);
+    }
+}

--- a/tools/hindsight/src/resolve/run.rs
+++ b/tools/hindsight/src/resolve/run.rs
@@ -129,6 +129,9 @@ pub(crate) struct Summary {
     pub total: usize,
     pub wins: usize,
     pub losses: usize,
+    /// Trades where Fynd only returned a partial route for the settled size (a coverage gap,
+    /// tracked apart from `unsolvable`).
+    pub coverage_miss: usize,
     pub unsolvable: usize,
     /// Median raw bps delta over solvable trades (positive = Fynd better).
     pub median_raw_bps: Option<f64>,
@@ -145,6 +148,7 @@ pub(crate) fn summarize(comparisons: &[Comparison]) -> Summary {
         match cmp.verdict {
             Verdict::Win => summary.wins += 1,
             Verdict::Loss => summary.losses += 1,
+            Verdict::CoverageMiss => summary.coverage_miss += 1,
             Verdict::Unsolvable => summary.unsolvable += 1,
         }
         if let Some(d) = cmp.deltas.raw_bps {
@@ -179,8 +183,9 @@ fn print_summary(summary: &Summary) {
     let win_pct =
         if comparable > 0 { summary.wins as f64 / comparable as f64 * 100.0 } else { 0.0 };
     println!("  Fynd wins:  {}/{} ({win_pct:.1}%)", summary.wins, comparable);
-    println!("  losses:     {}", summary.losses);
-    println!("  unsolvable: {}", summary.unsolvable);
+    println!("  losses:        {}", summary.losses);
+    println!("  coverage miss: {}", summary.coverage_miss);
+    println!("  unsolvable:    {}", summary.unsolvable);
     match summary.median_raw_bps {
         Some(d) => println!("  median raw:     {d:+.2} bps"),
         None => println!("  median raw:     n/a"),
@@ -315,12 +320,14 @@ mod tests {
             comparison(Verdict::Win, Some(100.0), Some(80.0)),
             comparison(Verdict::Win, Some(50.0), Some(40.0)),
             comparison(Verdict::Loss, Some(-30.0), Some(-50.0)),
+            comparison(Verdict::CoverageMiss, None, None),
             comparison(Verdict::Unsolvable, None, None),
         ];
         let s = summarize(&comparisons);
-        assert_eq!(s.total, 4);
+        assert_eq!(s.total, 5);
         assert_eq!(s.wins, 2);
         assert_eq!(s.losses, 1);
+        assert_eq!(s.coverage_miss, 1);
         assert_eq!(s.unsolvable, 1);
         // Median of [-30, 50, 100] = 50.
         assert_eq!(s.median_raw_bps, Some(50.0));

--- a/tools/hindsight/src/resolve/run.rs
+++ b/tools/hindsight/src/resolve/run.rs
@@ -6,7 +6,10 @@
 
 use std::{sync::Arc, time::Duration};
 
-use alloy::primitives::{Address, U256};
+use alloy::{
+    primitives::{Address, U256},
+    providers::Provider,
+};
 use async_trait::async_trait;
 use fynd_client::{FyndClientBuilder, RetryConfig};
 use fynd_tools_common::{
@@ -81,6 +84,43 @@ fn quote_to_outcome(quote: AggregatorQuote) -> Outcome {
 
 fn parse_u256(s: &str) -> Option<U256> {
     s.parse().ok()
+}
+
+/// Blocks farther behind chain head than this make a re-solve misleading: Fynd solves against the
+/// chain's *current* state, so comparing that quote to a much older settled amount mixes present
+/// liquidity with a historical baseline. ~100 blocks is roughly 20 minutes on Ethereum.
+const STALE_BLOCK_THRESHOLD: u64 = 100;
+
+/// Whether the newest requested block trails chain head by more than `threshold` blocks.
+fn is_stale(head: u64, newest_requested: u64, threshold: u64) -> bool {
+    head.saturating_sub(newest_requested) > threshold
+}
+
+/// Warn if `blocks` are far enough behind chain head that a current-state re-solve is misleading.
+///
+/// This is the guardrail against accidentally re-solving a historical block against the live Fynd
+/// state, which yields nonsensical deltas. A fetch failure is itself only a warning — it must not
+/// abort the run.
+async fn warn_if_stale<P: Provider>(provider: &P, blocks: &[u64]) {
+    let Some(&newest) = blocks.iter().max() else {
+        return;
+    };
+    let head = match provider.get_block_number().await {
+        Ok(head) => head,
+        Err(error) => {
+            warn!(%error, "could not fetch chain head to check block staleness");
+            return;
+        }
+    };
+    if is_stale(head, newest, STALE_BLOCK_THRESHOLD) {
+        warn!(
+            head,
+            newest_requested = newest,
+            blocks_behind = head.saturating_sub(newest),
+            "re-solving blocks far behind chain head; Fynd solves at current state, so these \
+             comparisons pit present liquidity against a historical settled amount"
+        );
+    }
 }
 
 /// Aggregate win/loss statistics over a set of comparisons.
@@ -163,6 +203,7 @@ pub(crate) async fn run(
 ) -> anyhow::Result<()> {
     let provider = crate::provider_from(rpc_url)?;
     let blocks = crate::resolve_blocks(&provider, block, range).await?;
+    warn_if_stale(&provider, &blocks).await;
 
     let client = FyndClientBuilder::new(fynd_url)
         .with_timeout(Duration::from_millis(timeout_ms))
@@ -288,5 +329,14 @@ mod tests {
     #[test]
     fn summarize_empty() {
         assert_eq!(summarize(&[]), Summary::default());
+    }
+
+    #[test]
+    fn is_stale_flags_only_far_behind_blocks() {
+        assert!(is_stale(1_000, 800, 100));
+        assert!(!is_stale(1_000, 950, 100));
+        assert!(!is_stale(1_000, 1_000, 100));
+        // Requested block ahead of head (e.g. head moved back on a reorg) is not stale.
+        assert!(!is_stale(1_000, 1_050, 100));
     }
 }

--- a/tools/hindsight/src/resolve/run.rs
+++ b/tools/hindsight/src/resolve/run.rs
@@ -57,11 +57,21 @@ fn quote_to_outcome(quote: AggregatorQuote) -> Outcome {
     else {
         return Outcome::Unsolvable("missing amount_out".to_string());
     };
-    let amount_out_net_gas = quote
+    let amount_out_net_gas = match quote
         .amount_out_net_gas
         .as_deref()
         .and_then(parse_u256)
-        .unwrap_or(amount_out);
+    {
+        Some(net) => net,
+        None => {
+            warn!(
+                %amount_out,
+                "quote missing amount_out_net_gas; using raw amount_out (net-of-gas delta is \
+                 biased in Fynd's favour for this trade)"
+            );
+            amount_out
+        }
+    };
     let gas_estimate = quote
         .gas_units
         .map(U256::from)

--- a/tools/hindsight/src/resolve/run.rs
+++ b/tools/hindsight/src/resolve/run.rs
@@ -31,7 +31,12 @@ impl super::ReSolver for FyndReSolver {
     async fn solve(&self, token_in: Address, token_out: Address, amount_in: U256) -> Outcome {
         match self
             .aggregator
-            .quote(&format!("{token_in:#x}"), &format!("{token_out:#x}"), &amount_in.to_string(), None)
+            .quote(
+                &format!("{token_in:#x}"),
+                &format!("{token_out:#x}"),
+                &amount_in.to_string(),
+                None,
+            )
             .await
         {
             Ok(quote) => quote_to_outcome(quote),
@@ -121,11 +126,8 @@ fn print_summary(summary: &Summary) {
     println!("  HINDSIGHT RE-SOLVE  ({} trades)", summary.total);
     println!("{}", "=".repeat(60));
     let comparable = summary.wins + summary.losses;
-    let win_pct = if comparable > 0 {
-        summary.wins as f64 / comparable as f64 * 100.0
-    } else {
-        0.0
-    };
+    let win_pct =
+        if comparable > 0 { summary.wins as f64 / comparable as f64 * 100.0 } else { 0.0 };
     println!("  Fynd wins:  {}/{} ({win_pct:.1}%)", summary.wins, comparable);
     println!("  losses:     {}", summary.losses);
     println!("  unsolvable: {}", summary.unsolvable);
@@ -157,7 +159,8 @@ pub(crate) async fn run(
         .with_retry(RetryConfig::new(1, Duration::from_millis(0), Duration::from_millis(0)))
         .build_quote_only()
         .map_err(|e| anyhow::anyhow!("failed to build Fynd client: {e}"))?;
-    let resolver = FyndReSolver { aggregator: FyndAggregator::new(Arc::new(client), timeout_ms, 0.0) };
+    let resolver =
+        FyndReSolver { aggregator: FyndAggregator::new(Arc::new(client), timeout_ms, 0.0) };
 
     let mut comparisons = Vec::new();
     for block_number in &blocks {
@@ -175,7 +178,10 @@ pub(crate) async fn run(
             summary: &'a Summary,
             comparisons: &'a [Comparison],
         }
-        println!("{}", serde_json::to_string_pretty(&Report { summary: &summary, comparisons: &comparisons })?);
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&Report { summary: &summary, comparisons: &comparisons })?
+        );
     } else {
         print_summary(&summary);
     }
@@ -222,18 +228,12 @@ mod tests {
 
     #[test]
     fn quote_to_outcome_unsuccessful_is_unsolvable() {
-        assert!(matches!(
-            quote_to_outcome(quote(None, None, false)),
-            Outcome::Unsolvable(_)
-        ));
+        assert!(matches!(quote_to_outcome(quote(None, None, false)), Outcome::Unsolvable(_)));
     }
 
     #[test]
     fn quote_to_outcome_missing_amount_is_unsolvable() {
-        assert!(matches!(
-            quote_to_outcome(quote(None, None, true)),
-            Outcome::Unsolvable(_)
-        ));
+        assert!(matches!(quote_to_outcome(quote(None, None, true)), Outcome::Unsolvable(_)));
     }
 
     fn comparison(verdict: Verdict, raw: Option<f64>, net: Option<f64>) -> Comparison {

--- a/tools/hindsight/src/resolve/run.rs
+++ b/tools/hindsight/src/resolve/run.rs
@@ -1,0 +1,276 @@
+//! Live `resolve` driver: decode a block's aggregator trades, re-solve each through a running
+//! Fynd, and report how Fynd compares to what settled on-chain.
+//!
+//! This compares at the chain's current state. Re-solving at top-of-block (N-1) and back-of-block
+//! (N) as a range is a follow-up gated on `BlockStepController` support in `fynd-core`.
+
+use std::{sync::Arc, time::Duration};
+
+use alloy::primitives::{Address, U256};
+use async_trait::async_trait;
+use fynd_client::{FyndClientBuilder, RetryConfig};
+use fynd_tools_common::{
+    aggregator::{AggregatorClient, AggregatorQuote},
+    fynd::FyndAggregator,
+};
+use serde::Serialize;
+use tracing::info;
+
+use crate::{
+    decoder::decode_block,
+    resolve::{compare_trade, Comparison, Outcome, SolvedAmount, Verdict},
+};
+
+/// Re-solves through a running Fynd instance over HTTP via the shared `FyndAggregator`.
+struct FyndReSolver {
+    aggregator: FyndAggregator,
+}
+
+#[async_trait]
+impl super::ReSolver for FyndReSolver {
+    async fn solve(&self, token_in: Address, token_out: Address, amount_in: U256) -> Outcome {
+        match self
+            .aggregator
+            .quote(&format!("{token_in:#x}"), &format!("{token_out:#x}"), &amount_in.to_string(), None)
+            .await
+        {
+            Ok(quote) => quote_to_outcome(quote),
+            Err(e) => Outcome::Unsolvable(format!("request failed: {e}")),
+        }
+    }
+}
+
+/// Map a Fynd [`AggregatorQuote`] onto a re-solve [`Outcome`].
+fn quote_to_outcome(quote: AggregatorQuote) -> Outcome {
+    if !quote.is_success() {
+        return Outcome::Unsolvable(quote.status.to_string());
+    }
+    let Some(amount_out) = quote
+        .amount_out
+        .as_deref()
+        .and_then(parse_u256)
+    else {
+        return Outcome::Unsolvable("missing amount_out".to_string());
+    };
+    let amount_out_net_gas = quote
+        .amount_out_net_gas
+        .as_deref()
+        .and_then(parse_u256)
+        .unwrap_or(amount_out);
+    let gas_estimate = quote
+        .gas_units
+        .map(U256::from)
+        .unwrap_or(U256::ZERO);
+    Outcome::Solved(SolvedAmount { amount_out, amount_out_net_gas, gas_estimate })
+}
+
+fn parse_u256(s: &str) -> Option<U256> {
+    s.parse().ok()
+}
+
+/// Aggregate win/loss statistics over a set of comparisons.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub(crate) struct Summary {
+    pub total: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub unsolvable: usize,
+    /// Median raw bps delta over solvable trades (positive = Fynd better).
+    pub median_raw_bps: Option<f64>,
+    /// Median net-of-gas bps delta over solvable trades.
+    pub median_net_bps: Option<f64>,
+}
+
+pub(crate) fn summarize(comparisons: &[Comparison]) -> Summary {
+    let mut raw: Vec<f64> = Vec::new();
+    let mut net: Vec<f64> = Vec::new();
+    let mut summary = Summary { total: comparisons.len(), ..Default::default() };
+
+    for cmp in comparisons {
+        match cmp.verdict {
+            Verdict::Win => summary.wins += 1,
+            Verdict::Loss => summary.losses += 1,
+            Verdict::Unsolvable => summary.unsolvable += 1,
+        }
+        if let Some(d) = cmp.deltas.raw_bps {
+            raw.push(d);
+        }
+        if let Some(d) = cmp.deltas.net_bps {
+            net.push(d);
+        }
+    }
+
+    summary.median_raw_bps = median(&mut raw);
+    summary.median_net_bps = median(&mut net);
+    summary
+}
+
+fn median(values: &mut [f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(|a, b| {
+        a.partial_cmp(b)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    Some(values[values.len() / 2])
+}
+
+fn print_summary(summary: &Summary) {
+    println!("\n{}", "=".repeat(60));
+    println!("  HINDSIGHT RE-SOLVE  ({} trades)", summary.total);
+    println!("{}", "=".repeat(60));
+    let comparable = summary.wins + summary.losses;
+    let win_pct = if comparable > 0 {
+        summary.wins as f64 / comparable as f64 * 100.0
+    } else {
+        0.0
+    };
+    println!("  Fynd wins:  {}/{} ({win_pct:.1}%)", summary.wins, comparable);
+    println!("  losses:     {}", summary.losses);
+    println!("  unsolvable: {}", summary.unsolvable);
+    match summary.median_raw_bps {
+        Some(d) => println!("  median raw:     {d:+.2} bps"),
+        None => println!("  median raw:     n/a"),
+    }
+    match summary.median_net_bps {
+        Some(d) => println!("  median net-gas: {d:+.2} bps"),
+        None => println!("  median net-gas: n/a"),
+    }
+    println!("{}", "=".repeat(60));
+}
+
+/// Decode `blocks`, re-solve every trade through the Fynd instance at `fynd_url`, and report.
+pub(crate) async fn run(
+    rpc_url: &str,
+    fynd_url: &str,
+    block: Option<u64>,
+    range: Option<&str>,
+    timeout_ms: u64,
+    json: bool,
+) -> anyhow::Result<()> {
+    let provider = crate::provider_from(rpc_url)?;
+    let blocks = crate::resolve_blocks(&provider, block, range).await?;
+
+    let client = FyndClientBuilder::new(fynd_url)
+        .with_timeout(Duration::from_millis(timeout_ms))
+        .with_retry(RetryConfig::new(1, Duration::from_millis(0), Duration::from_millis(0)))
+        .build_quote_only()
+        .map_err(|e| anyhow::anyhow!("failed to build Fynd client: {e}"))?;
+    let resolver = FyndReSolver { aggregator: FyndAggregator::new(Arc::new(client), timeout_ms, 0.0) };
+
+    let mut comparisons = Vec::new();
+    for block_number in &blocks {
+        let trades = decode_block(&provider, *block_number).await?;
+        info!(block = block_number, count = trades.len(), "re-solving decoded trades");
+        for trade in &trades {
+            comparisons.push(compare_trade(&resolver, trade).await);
+        }
+    }
+
+    let summary = summarize(&comparisons);
+    if json {
+        #[derive(Serialize)]
+        struct Report<'a> {
+            summary: &'a Summary,
+            comparisons: &'a [Comparison],
+        }
+        println!("{}", serde_json::to_string_pretty(&Report { summary: &summary, comparisons: &comparisons })?);
+    } else {
+        print_summary(&summary);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resolve::Deltas;
+
+    fn quote(amount_out: Option<&str>, net: Option<&str>, success: bool) -> AggregatorQuote {
+        use fynd_tools_common::aggregator::AggregatorStatus;
+        AggregatorQuote {
+            status: if success { AggregatorStatus::Success } else { AggregatorStatus::NoRoute },
+            amount_out: amount_out.map(str::to_string),
+            amount_out_net_gas: net.map(str::to_string),
+            gas_units: Some(120_000),
+            protocols: vec![],
+            num_splits: None,
+            response_time_ms: 5,
+            calldata: None,
+            route: None,
+        }
+    }
+
+    #[test]
+    fn quote_to_outcome_solved() {
+        let Outcome::Solved(s) = quote_to_outcome(quote(Some("10000"), Some("9900"), true)) else {
+            panic!("expected solved");
+        };
+        assert_eq!(s.amount_out, U256::from(10_000u64));
+        assert_eq!(s.amount_out_net_gas, U256::from(9_900u64));
+        assert_eq!(s.gas_estimate, U256::from(120_000u64));
+    }
+
+    #[test]
+    fn quote_to_outcome_net_falls_back_to_raw() {
+        let Outcome::Solved(s) = quote_to_outcome(quote(Some("10000"), None, true)) else {
+            panic!("expected solved");
+        };
+        assert_eq!(s.amount_out_net_gas, U256::from(10_000u64));
+    }
+
+    #[test]
+    fn quote_to_outcome_unsuccessful_is_unsolvable() {
+        assert!(matches!(
+            quote_to_outcome(quote(None, None, false)),
+            Outcome::Unsolvable(_)
+        ));
+    }
+
+    #[test]
+    fn quote_to_outcome_missing_amount_is_unsolvable() {
+        assert!(matches!(
+            quote_to_outcome(quote(None, None, true)),
+            Outcome::Unsolvable(_)
+        ));
+    }
+
+    fn comparison(verdict: Verdict, raw: Option<f64>, net: Option<f64>) -> Comparison {
+        Comparison {
+            tx_hash: "0x".into(),
+            block_number: 1,
+            client: "c".into(),
+            aggregator: "a".into(),
+            token_in: Address::ZERO,
+            token_out: Address::ZERO,
+            amount_in: U256::ZERO,
+            settled_amount_out: U256::ZERO,
+            outcome: Outcome::Unsolvable("x".into()),
+            deltas: Deltas { raw_bps: raw, net_bps: net },
+            verdict,
+        }
+    }
+
+    #[test]
+    fn summarize_counts_and_medians() {
+        let comparisons = vec![
+            comparison(Verdict::Win, Some(100.0), Some(80.0)),
+            comparison(Verdict::Win, Some(50.0), Some(40.0)),
+            comparison(Verdict::Loss, Some(-30.0), Some(-50.0)),
+            comparison(Verdict::Unsolvable, None, None),
+        ];
+        let s = summarize(&comparisons);
+        assert_eq!(s.total, 4);
+        assert_eq!(s.wins, 2);
+        assert_eq!(s.losses, 1);
+        assert_eq!(s.unsolvable, 1);
+        // Median of [-30, 50, 100] = 50.
+        assert_eq!(s.median_raw_bps, Some(50.0));
+    }
+
+    #[test]
+    fn summarize_empty() {
+        assert_eq!(summarize(&[]), Summary::default());
+    }
+}

--- a/tools/hindsight/src/resolve/run.rs
+++ b/tools/hindsight/src/resolve/run.rs
@@ -14,7 +14,7 @@ use fynd_tools_common::{
     fynd::FyndAggregator,
 };
 use serde::Serialize;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     decoder::decode_block,
@@ -164,7 +164,13 @@ pub(crate) async fn run(
 
     let mut comparisons = Vec::new();
     for block_number in &blocks {
-        let trades = decode_block(&provider, *block_number).await?;
+        let trades = match decode_block(&provider, *block_number).await {
+            Ok(trades) => trades,
+            Err(error) => {
+                warn!(block = block_number, %error, "failed to decode block; skipping");
+                continue;
+            }
+        };
         info!(block = block_number, count = trades.len(), "re-solving decoded trades");
         for trade in &trades {
             comparisons.push(compare_trade(&resolver, trade).await);


### PR DESCRIPTION
Re-solve decoded trades through a running Fynd over HTTP and compare against the settled amount (bps verdict). Includes the partial-fill→coverage-miss reclassification (`served`). Stacked PR #3/6; base `eng-6122`.