### PR TITLE
feat(hindsight): metrics, USD valuation & /metrics exporter (ENG-6124)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,13 +3819,18 @@ dependencies = [
 name = "hindsight"
 version = "0.82.3"
 dependencies = [
+ "actix-web",
  "alloy",
  "anyhow",
  "async-trait",
  "clap",
  "futures 0.3.32",
  "fynd-client",
+ "fynd-core",
+ "fynd-rpc",
  "fynd-tools-common",
+ "metrics",
+ "metrics-exporter-prometheus",
  "num-bigint",
  "reqwest 0.12.28",
  "serde",
@@ -3833,6 +3838,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber 0.3.23",
+ "tycho-simulation",
 ]
 
 [[package]]

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -10,8 +10,11 @@ name = "hindsight"
 path = "src/main.rs"
 
 [dependencies]
-# Fynd integration (re-solve via a running solver)
+# Fynd integration: re-solve via a running solver (HTTP) or an in-process stepped solver
 fynd-client = { workspace = true }
+fynd-core = { workspace = true }
+fynd-rpc = { workspace = true }
+tycho-simulation = { workspace = true }
 # Shared tooling (BPS comparison math, FyndAggregator wrapper)
 fynd-tools-common = { workspace = true }
 num-bigint = { workspace = true }
@@ -33,8 +36,13 @@ alloy = { workspace = true, features = [
     "rpc-types-trace",
 ] }
 
-# HTTP (for RPC URL parsing)
+# HTTP (for RPC URL parsing) + metrics server
 reqwest = { workspace = true }
+actix-web = { workspace = true }
+
+# Prometheus metrics
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 
 # Error handling & logging
 anyhow = { workspace = true }

--- a/tools/hindsight/grafana/hindsight.json
+++ b/tools/hindsight/grafana/hindsight.json
@@ -1,0 +1,132 @@
+{
+  "title": "Hindsight — Fynd vs settled aggregator swaps",
+  "uid": "hindsight",
+  "schemaVersion": 39,
+  "timezone": "browser",
+  "refresh": "30s",
+  "tags": ["hindsight", "fynd"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {}
+      },
+      {
+        "name": "chain",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(hindsight_trades_total, chain)",
+        "includeAll": true,
+        "multi": true
+      },
+      {
+        "name": "aggregator",
+        "type": "query",
+        "datasource": "${datasource}",
+        "query": "label_values(hindsight_trades_total, aggregator)",
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "Win rate (Fynd better, net of gas)",
+      "type": "stat",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(hindsight_trades_total{outcome=\"win\", chain=~\"$chain\", aggregator=~\"$aggregator\"}) / clamp_min(sum(hindsight_trades_total{outcome=~\"win|loss\", chain=~\"$chain\", aggregator=~\"$aggregator\"}), 1)"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Coverage ratio (re-solvable)",
+      "type": "gauge",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "min": 0, "max": 1 } },
+      "targets": [{ "refId": "A", "expr": "hindsight_coverage_ratio" }]
+    },
+    {
+      "id": 3,
+      "title": "Trades by outcome",
+      "type": "piechart",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (outcome) (hindsight_trades_total{chain=~\"$chain\", aggregator=~\"$aggregator\"})",
+          "legendFormat": "{{outcome}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Median net-of-gas savings (bps)",
+      "type": "timeseries",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "none" } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le, aggregator) (rate(hindsight_savings_bps_bucket{chain=~\"$chain\", aggregator=~\"$aggregator\"}[$__rate_interval])))",
+          "legendFormat": "{{aggregator}} p50"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Trades by aggregator",
+      "type": "timeseries",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (aggregator) (rate(hindsight_trades_total{chain=~\"$chain\"}[$__rate_interval]))",
+          "legendFormat": "{{aggregator}}"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Block processing time (p95)",
+      "type": "timeseries",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(hindsight_block_processing_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Median USD savings (stablecoin-out)",
+      "type": "timeseries",
+      "datasource": "${datasource}",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 22 },
+      "fieldConfig": { "defaults": { "unit": "currencyUSD" } },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.5, sum by (le, aggregator) (rate(hindsight_savings_usd_bucket{chain=~\"$chain\", aggregator=~\"$aggregator\"}[$__rate_interval])))",
+          "legendFormat": "{{aggregator}} p50"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -1,5 +1,7 @@
 mod decoder;
 mod resolve;
+mod telemetry;
+mod usd;
 
 use std::time::Instant;
 
@@ -96,6 +98,10 @@ struct ResolveArgs {
     #[arg(long, env = "FYND_URL", default_value = "http://localhost:3000")]
     fynd_url: String,
 
+    /// Chain label applied to metrics (the decoder is Ethereum-only for now)
+    #[arg(long, default_value = "ethereum")]
+    chain: String,
+
     /// Block number to re-solve (latest if omitted)
     #[arg(long)]
     block: Option<u64>,
@@ -107,6 +113,10 @@ struct ResolveArgs {
     /// Per-quote timeout in milliseconds for Fynd
     #[arg(long, default_value_t = 10_000)]
     timeout_ms: u64,
+
+    /// Serve Prometheus metrics on this port; keeps running after the pass so it can be scraped
+    #[arg(long)]
+    metrics_port: Option<u16>,
 
     /// Output as JSON instead of human-readable
     #[arg(long)]
@@ -126,14 +136,16 @@ async fn main() -> anyhow::Result<()> {
         Command::Decode(args) => run_decode(args).await,
         Command::Verify(args) => run_verify(args).await,
         Command::Resolve(args) => {
-            resolve::run::run(
-                &args.rpc_url,
-                &args.fynd_url,
-                args.block,
-                args.range.as_deref(),
-                args.timeout_ms,
-                args.json,
-            )
+            resolve::run::run(resolve::run::ResolveConfig {
+                rpc_url: &args.rpc_url,
+                fynd_url: &args.fynd_url,
+                chain: &args.chain,
+                block: args.block,
+                range: args.range.as_deref(),
+                timeout_ms: args.timeout_ms,
+                metrics_port: args.metrics_port,
+                json: args.json,
+            })
             .await
         }
     }

--- a/tools/hindsight/src/resolve/run.rs
+++ b/tools/hindsight/src/resolve/run.rs
@@ -4,7 +4,10 @@
 //! This compares at the chain's current state. Re-solving at top-of-block (N-1) and back-of-block
 //! (N) as a range is a follow-up gated on `BlockStepController` support in `fynd-core`.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use alloy::{
     primitives::{Address, U256},
@@ -197,29 +200,46 @@ fn print_summary(summary: &Summary) {
     println!("{}", "=".repeat(60));
 }
 
-/// Decode `blocks`, re-solve every trade through the Fynd instance at `fynd_url`, and report.
-pub(crate) async fn run(
-    rpc_url: &str,
-    fynd_url: &str,
-    block: Option<u64>,
-    range: Option<&str>,
-    timeout_ms: u64,
-    json: bool,
-) -> anyhow::Result<()> {
-    let provider = crate::provider_from(rpc_url)?;
-    let blocks = crate::resolve_blocks(&provider, block, range).await?;
+/// Inputs for the `resolve` driver.
+pub(crate) struct ResolveConfig<'a> {
+    pub rpc_url: &'a str,
+    pub fynd_url: &'a str,
+    /// Chain label applied to metrics (the decoder is Ethereum-only for now).
+    pub chain: &'a str,
+    pub block: Option<u64>,
+    pub range: Option<&'a str>,
+    pub timeout_ms: u64,
+    /// When set, install the Prometheus exporter on this port and keep serving after the run.
+    pub metrics_port: Option<u16>,
+    pub json: bool,
+}
+
+/// Decode the requested blocks, re-solve every trade through the Fynd instance, record metrics,
+/// and report.
+pub(crate) async fn run(cfg: ResolveConfig<'_>) -> anyhow::Result<()> {
+    let provider = crate::provider_from(cfg.rpc_url)?;
+    let blocks = crate::resolve_blocks(&provider, cfg.block, cfg.range).await?;
     warn_if_stale(&provider, &blocks).await;
 
-    let client = FyndClientBuilder::new(fynd_url)
-        .with_timeout(Duration::from_millis(timeout_ms))
+    if let Some(port) = cfg.metrics_port {
+        crate::telemetry::install_exporter(port)?;
+        info!(port, "serving Prometheus metrics at /metrics");
+    }
+
+    let client = FyndClientBuilder::new(cfg.fynd_url)
+        .with_timeout(Duration::from_millis(cfg.timeout_ms))
         .with_retry(RetryConfig::new(1, Duration::from_millis(0), Duration::from_millis(0)))
         .build_quote_only()
         .map_err(|e| anyhow::anyhow!("failed to build Fynd client: {e}"))?;
     let resolver =
-        FyndReSolver { aggregator: FyndAggregator::new(Arc::new(client), timeout_ms, 0.0) };
+        FyndReSolver { aggregator: FyndAggregator::new(Arc::new(client), cfg.timeout_ms, 0.0) };
 
+    // The HTTP resolve path has no in-process solver, so no token prices are available; USD savings
+    // is recorded only by the in-process `monitor`.
+    let prices = crate::usd::PriceMap::new();
     let mut comparisons = Vec::new();
     for block_number in &blocks {
+        let start = Instant::now();
         let trades = match decode_block(&provider, *block_number).await {
             Ok(trades) => trades,
             Err(error) => {
@@ -227,25 +247,36 @@ pub(crate) async fn run(
                 continue;
             }
         };
-        info!(block = block_number, count = trades.len(), "re-solving decoded trades");
+        let mut block_comparisons = Vec::with_capacity(trades.len());
         for trade in &trades {
-            comparisons.push(compare_trade(&resolver, trade).await);
+            let comparison = compare_trade(&resolver, trade).await;
+            crate::telemetry::record(&comparison, cfg.chain, &prices);
+            block_comparisons.push(comparison);
         }
+        let elapsed_s = start.elapsed().as_secs_f64();
+        crate::telemetry::record_block_seconds(elapsed_s);
+        info!(block = block_number, count = block_comparisons.len(), elapsed_s, "re-solved block");
+        comparisons.extend(block_comparisons);
     }
 
     let summary = summarize(&comparisons);
-    if json {
+    crate::telemetry::record_coverage(summary.total, summary.wins + summary.losses);
+
+    if cfg.json {
         #[derive(Serialize)]
         struct Report<'a> {
             summary: &'a Summary,
             comparisons: &'a [Comparison],
         }
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&Report { summary: &summary, comparisons: &comparisons })?
-        );
+        let report = Report { summary: &summary, comparisons: &comparisons };
+        println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         print_summary(&summary);
+    }
+
+    if cfg.metrics_port.is_some() {
+        info!("metrics server still running — press ctrl-c to exit");
+        tokio::signal::ctrl_c().await.ok();
     }
     Ok(())
 }

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -4,7 +4,6 @@
 //! and serve its rendered output on a dedicated port via Actix.
 
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
-use alloy::primitives::Address;
 use metrics::{
     counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram, Unit,
 };
@@ -34,12 +33,6 @@ pub(crate) fn outcome_label(verdict: Verdict) -> &'static str {
     }
 }
 
-/// Pair label as lowercase `token_in->token_out` addresses. Symbol resolution is a future
-/// enhancement; raw addresses keep label cardinality deterministic.
-pub(crate) fn pair_label(token_in: Address, token_out: Address) -> String {
-    format!("{token_in:#x}->{token_out:#x}")
-}
-
 /// Fraction of trades that were comparable (solvable) out of the total seen.
 pub(crate) fn coverage_ratio(total: usize, comparable: usize) -> f64 {
     if total == 0 {
@@ -53,7 +46,9 @@ pub(crate) fn coverage_ratio(total: usize, comparable: usize) -> f64 {
 pub(crate) fn describe() {
     describe_counter!(
         TRADES_TOTAL,
-        "Re-solved trades, labeled by client / aggregator / pair / chain / outcome"
+        "Re-solved trades, labeled by client / aggregator / chain / outcome. Per-pair detail lives \
+         in the JSONL comparison output; a token-pair label here is unbounded on mainnet and would \
+         explode Prometheus series cardinality over a long run."
     );
     describe_histogram!(
         SAVINGS_BPS,
@@ -84,7 +79,6 @@ pub(crate) fn record(cmp: &Comparison, chain: &str, prices: &usd::PriceMap) {
         TRADES_TOTAL,
         "client" => cmp.client.clone(),
         "aggregator" => cmp.aggregator.clone(),
-        "pair" => pair_label(cmp.token_in, cmp.token_out),
         "chain" => chain.to_string(),
         "outcome" => outcome_label(cmp.verdict).to_string(),
     )
@@ -195,7 +189,7 @@ pub(crate) fn install_exporter(port: u16) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, U256};
+    use alloy::primitives::{address, Address, U256};
     use metrics_exporter_prometheus::PrometheusBuilder;
 
     use super::*;
@@ -223,15 +217,6 @@ mod tests {
         assert_eq!(outcome_label(Verdict::Loss), "loss");
         assert_eq!(outcome_label(Verdict::CoverageMiss), "coverage_miss");
         assert_eq!(outcome_label(Verdict::Unsolvable), "unsolvable");
-    }
-
-    #[test]
-    fn pair_label_is_directional_hex() {
-        let label = pair_label(Address::repeat_byte(0x11), Address::repeat_byte(0x22));
-        assert!(label.starts_with("0x"));
-        assert!(label.contains("->"));
-        // Direction matters: in->out differs from out->in.
-        assert_ne!(label, pair_label(Address::repeat_byte(0x22), Address::repeat_byte(0x11)));
     }
 
     #[test]

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -1,0 +1,320 @@
+//! Prometheus metrics for re-solve comparisons, plus the `/metrics` HTTP exporter.
+//!
+//! Mirrors the exporter pattern used by the `fynd` binary: install a global Prometheus recorder
+//! and serve its rendered output on a dedicated port via Actix.
+
+use actix_web::{web, App, HttpResponse, HttpServer, Responder};
+use alloy::primitives::Address;
+use metrics::{
+    counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram, Unit,
+};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use tracing::error;
+
+use crate::{
+    resolve::{Comparison, Outcome, Verdict},
+    usd,
+};
+
+const TRADES_TOTAL: &str = "hindsight_trades_total";
+const SAVINGS_BPS: &str = "hindsight_savings_bps";
+const SAVINGS_USD: &str = "hindsight_savings_usd";
+const IMPROVEMENT_USD: &str = "hindsight_improvement_usd";
+const VOLUME_USD: &str = "hindsight_volume_usd";
+const COVERAGE_RATIO: &str = "hindsight_coverage_ratio";
+const BLOCK_SECONDS: &str = "hindsight_block_processing_seconds";
+
+/// Metric label for a trade's headline verdict.
+pub(crate) fn outcome_label(verdict: Verdict) -> &'static str {
+    match verdict {
+        Verdict::Win => "win",
+        Verdict::Loss => "loss",
+        Verdict::CoverageMiss => "coverage_miss",
+        Verdict::Unsolvable => "unsolvable",
+    }
+}
+
+/// Pair label as lowercase `token_in->token_out` addresses. Symbol resolution is a future
+/// enhancement; raw addresses keep label cardinality deterministic.
+pub(crate) fn pair_label(token_in: Address, token_out: Address) -> String {
+    format!("{token_in:#x}->{token_out:#x}")
+}
+
+/// Fraction of trades that were comparable (solvable) out of the total seen.
+pub(crate) fn coverage_ratio(total: usize, comparable: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        comparable as f64 / total as f64
+    }
+}
+
+/// Register metric descriptions with the active recorder.
+pub(crate) fn describe() {
+    describe_counter!(
+        TRADES_TOTAL,
+        "Re-solved trades, labeled by client / aggregator / pair / chain / outcome"
+    );
+    describe_histogram!(
+        SAVINGS_BPS,
+        Unit::Count,
+        "Net-of-gas bps delta of Fynd vs settled (positive = Fynd better)"
+    );
+    describe_histogram!(
+        SAVINGS_USD,
+        "Signed USD savings of Fynd vs settled (positive = Fynd better), for Fynd-priced trades"
+    );
+    describe_histogram!(
+        IMPROVEMENT_USD,
+        "Net-of-gas USD uplift on trades Fynd would improve (losses excluded — a client routes \
+         elsewhere when Fynd is worse). Sum = value of adding Fynd; count = improving trades"
+    );
+    describe_histogram!(
+        VOLUME_USD,
+        "Observed settled trade volume in USD, labeled by client / aggregator (Fynd-priced trades)"
+    );
+    describe_gauge!(COVERAGE_RATIO, "Fraction of trades Fynd could re-solve");
+    describe_histogram!(BLOCK_SECONDS, Unit::Seconds, "Wall-clock time to process one block");
+}
+
+/// Record a single re-solve comparison. `prices` is the solver's token-price snapshot used to value
+/// savings in USD; an empty map disables USD recording.
+pub(crate) fn record(cmp: &Comparison, chain: &str, prices: &usd::PriceMap) {
+    counter!(
+        TRADES_TOTAL,
+        "client" => cmp.client.clone(),
+        "aggregator" => cmp.aggregator.clone(),
+        "pair" => pair_label(cmp.token_in, cmp.token_out),
+        "chain" => chain.to_string(),
+        "outcome" => outcome_label(cmp.verdict).to_string(),
+    )
+    .increment(1);
+
+    // Observed volume covers every trade (including unsolvable) so per-client coverage is accurate.
+    if let Some(volume) = usd::value_usd(cmp.token_out, cmp.settled_amount_out, prices) {
+        histogram!(
+            VOLUME_USD,
+            "client" => cmp.client.clone(),
+            "aggregator" => cmp.aggregator.clone(),
+            "chain" => chain.to_string(),
+        )
+        .record(volume);
+    }
+
+    if let Some(bps) = cmp.deltas.net_bps {
+        histogram!(
+            SAVINGS_BPS,
+            "client" => cmp.client.clone(),
+            "aggregator" => cmp.aggregator.clone(),
+            "chain" => chain.to_string(),
+        )
+        .record(bps);
+    }
+
+    if let Outcome::Solved(solved) = &cmp.outcome {
+        if let Some(usd) =
+            usd::savings_usd(cmp.token_out, solved.amount_out, cmp.settled_amount_out, prices)
+        {
+            histogram!(
+                SAVINGS_USD,
+                "client" => cmp.client.clone(),
+                "aggregator" => cmp.aggregator.clone(),
+                "chain" => chain.to_string(),
+            )
+            .record(usd);
+        }
+
+        // Client-benefit uplift: net-of-gas improvement, recorded only when Fynd beats settled.
+        if let Some(uplift) = usd::savings_usd(
+            cmp.token_out,
+            solved.amount_out_net_gas,
+            cmp.settled_amount_out,
+            prices,
+        ) {
+            if uplift > 0.0 {
+                histogram!(
+                    IMPROVEMENT_USD,
+                    "client" => cmp.client.clone(),
+                    "aggregator" => cmp.aggregator.clone(),
+                    "chain" => chain.to_string(),
+                )
+                .record(uplift);
+            }
+        }
+    }
+}
+
+pub(crate) fn record_coverage(total: usize, comparable: usize) {
+    gauge!(COVERAGE_RATIO).set(coverage_ratio(total, comparable));
+}
+
+pub(crate) fn record_block_seconds(seconds: f64) {
+    histogram!(BLOCK_SECONDS).record(seconds);
+}
+
+async fn metrics_handler(handle: PrometheusHandle) -> impl Responder {
+    HttpResponse::Ok()
+        .content_type("text/plain; version=0.0.4; charset=utf-8")
+        .body(handle.render())
+}
+
+/// Install the global Prometheus recorder and serve `/metrics` on `port`.
+///
+/// The Actix server runs on its own thread with a dedicated Actix runtime; its server future is
+/// `!Send`, so it can't be `tokio::spawn`ed onto the main multi-threaded runtime.
+pub(crate) fn install_exporter(port: u16) -> anyhow::Result<()> {
+    let handle = PrometheusBuilder::new()
+        .install_recorder()
+        .map_err(|e| anyhow::anyhow!("failed to install Prometheus recorder: {e}"))?;
+    describe();
+
+    std::thread::Builder::new()
+        .name("hindsight-metrics".to_string())
+        .spawn(move || {
+            let result = actix_web::rt::System::new().block_on(async move {
+                HttpServer::new(move || {
+                    App::new().route(
+                        "/metrics",
+                        web::get().to({
+                            let handle = handle.clone();
+                            move || metrics_handler(handle.clone())
+                        }),
+                    )
+                })
+                .bind(("0.0.0.0", port))?
+                .run()
+                .await
+            });
+            if let Err(e) = result {
+                error!("metrics server failed: {e}");
+            }
+        })
+        .map_err(|e| anyhow::anyhow!("failed to spawn metrics thread: {e}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{address, U256};
+    use metrics_exporter_prometheus::PrometheusBuilder;
+
+    use super::*;
+    use crate::resolve::{Deltas, SolvedAmount};
+
+    fn comparison(verdict: Verdict, net_bps: Option<f64>) -> Comparison {
+        Comparison {
+            tx_hash: "0xabc".into(),
+            block_number: 21_000_000,
+            client: "relay".into(),
+            aggregator: "tycho".into(),
+            token_in: Address::repeat_byte(0x11),
+            token_out: Address::repeat_byte(0x22),
+            amount_in: U256::ZERO,
+            settled_amount_out: U256::ZERO,
+            outcome: Outcome::Unsolvable("x".into()),
+            deltas: Deltas { raw_bps: None, net_bps },
+            verdict,
+        }
+    }
+
+    #[test]
+    fn outcome_labels() {
+        assert_eq!(outcome_label(Verdict::Win), "win");
+        assert_eq!(outcome_label(Verdict::Loss), "loss");
+        assert_eq!(outcome_label(Verdict::CoverageMiss), "coverage_miss");
+        assert_eq!(outcome_label(Verdict::Unsolvable), "unsolvable");
+    }
+
+    #[test]
+    fn pair_label_is_directional_hex() {
+        let label = pair_label(Address::repeat_byte(0x11), Address::repeat_byte(0x22));
+        assert!(label.starts_with("0x"));
+        assert!(label.contains("->"));
+        // Direction matters: in->out differs from out->in.
+        assert_ne!(label, pair_label(Address::repeat_byte(0x22), Address::repeat_byte(0x11)));
+    }
+
+    #[test]
+    fn coverage_ratio_math() {
+        assert_eq!(coverage_ratio(0, 0), 0.0);
+        assert_eq!(coverage_ratio(10, 4), 0.4);
+        assert_eq!(coverage_ratio(5, 5), 1.0);
+    }
+
+    #[test]
+    fn record_emits_labeled_metrics() {
+        // Isolated recorder (not global) so the test is deterministic and re-runnable.
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record(&comparison(Verdict::Win, Some(42.0)), "ethereum", &usd::PriceMap::new());
+            record_coverage(2, 1);
+        });
+        let rendered = handle.render();
+
+        assert!(rendered.contains("hindsight_trades_total"), "rendered: {rendered}");
+        assert!(rendered.contains("outcome=\"win\""));
+        assert!(rendered.contains("client=\"relay\""));
+        assert!(rendered.contains("hindsight_savings_bps"));
+        assert!(rendered.contains("hindsight_coverage_ratio"));
+    }
+
+    #[test]
+    fn record_emits_usd_for_stablecoin_out() {
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        let mut cmp = comparison(Verdict::Win, Some(10.0));
+        cmp.token_out = usdc;
+        cmp.settled_amount_out = U256::from(1_000_000_000u64); // 1000 USDC
+        cmp.outcome = Outcome::Solved(SolvedAmount {
+            amount_out: U256::from(1_010_000_000u64), // 1010 USDC
+            amount_out_net_gas: U256::from(1_005_000_000u64),
+            gas_estimate: U256::from(120_000u64),
+        });
+        // USDC priced at 2e-9 native-units per ETH-wei (ETH = $2000) anchors ETH→USD.
+        let prices = usd::PriceMap::from([(usdc, 2e-9)]);
+
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || record(&cmp, "ethereum", &prices));
+        let rendered = handle.render();
+        assert!(rendered.contains("hindsight_savings_usd"), "rendered: {rendered}");
+        // Volume is valued from the same price snapshot and labeled by client.
+        assert!(rendered.contains("hindsight_volume_usd"), "rendered: {rendered}");
+        // Fynd's net-of-gas output (1005 USDC) beats settled (1000) → uplift recorded.
+        assert!(rendered.contains("hindsight_improvement_usd"), "rendered: {rendered}");
+    }
+
+    #[test]
+    fn record_skips_improvement_when_fynd_worse() {
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        let mut cmp = comparison(Verdict::Loss, Some(-10.0));
+        cmp.token_out = usdc;
+        cmp.settled_amount_out = U256::from(1_000_000_000u64); // 1000 USDC
+        cmp.outcome = Outcome::Solved(SolvedAmount {
+            amount_out: U256::from(995_000_000u64),
+            amount_out_net_gas: U256::from(990_000_000u64), // worse than settled
+            gas_estimate: U256::from(120_000u64),
+        });
+        let prices = usd::PriceMap::from([(usdc, 2e-9)]);
+
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || record(&cmp, "ethereum", &prices));
+        let rendered = handle.render();
+        // Fynd is worse → no uplift (client would route elsewhere).
+        assert!(!rendered.contains("hindsight_improvement_usd"), "rendered: {rendered}");
+    }
+
+    #[test]
+    fn record_skips_savings_when_unsolvable() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record(&comparison(Verdict::Unsolvable, None), "ethereum", &usd::PriceMap::new());
+        });
+        let rendered = handle.render();
+        assert!(rendered.contains("outcome=\"unsolvable\""));
+        // No net bps → no savings sample recorded.
+        assert!(!rendered.contains("hindsight_savings_bps"));
+    }
+}

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -1,0 +1,192 @@
+//! USD valuation from Fynd's own token prices.
+//!
+//! The in-process solver exposes, via its derived data, each token's mid-price relative to the gas
+//! token (ETH): `price[token]` is the token's native-unit amount per 1 ETH-wei (tycho's
+//! best-spread mid-price). Those prices are ETH-denominated, not USD, so to report USD we anchor
+//! ETH→USD using the stablecoins' own entries in the same price map (a stablecoin is worth ~$1 per
+//! `10^decimals` native units). This values any trade whose output token Fynd has priced — far
+//! broader than the previous stablecoin-leg-only valuation — using the solver's self-consistent
+//! price view. The prices are f64 approximations suitable for a USD estimate, not execution.
+
+use std::collections::HashMap;
+
+use alloy::primitives::{address, Address, U256};
+
+/// Token prices snapshot from the solver's derived data: `price[token]` = token native-unit amount
+/// per 1 ETH-wei. Native ETH is the zero address.
+pub(crate) type PriceMap = HashMap<Address, f64>;
+
+/// Wrapped ETH. Interchangeable with native ETH (the zero address) for pricing, since only one of
+/// the two may carry a derived price depending on the solver's gas-token configuration.
+const WETH: Address = address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+
+/// `(stablecoin address, decimals)` on Ethereum mainnet, used only to anchor ETH→USD.
+const STABLECOINS: &[(Address, u32)] = &[
+    (address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 6), // USDC
+    (address!("0xdac17f958d2ee523a2206206994597c13d831ec7"), 6), // USDT
+    (address!("0x6b175474e89094c44da98b954eedeac495271d0f"), 18), // DAI
+    (address!("0x4c9edd5852cd905f086c759e8383e09bff1e68b3"), 18), // USDe
+    (address!("0xdc035d45d973e3ec169d2276ddab16f1e407384f"), 18), // USDS
+];
+
+/// Positive, finite price of `token`, treating native ETH and WETH as interchangeable.
+fn price_of(prices: &PriceMap, token: Address) -> Option<f64> {
+    let direct = prices.get(&token).copied();
+    let fallback = match token {
+        t if t == Address::ZERO => prices.get(&WETH).copied(),
+        t if t == WETH => prices.get(&Address::ZERO).copied(),
+        _ => None,
+    };
+    direct
+        .or(fallback)
+        .filter(|p| *p > 0.0 && p.is_finite())
+}
+
+/// USD value of one ETH-wei, averaged over whichever anchor stablecoins are priced.
+///
+/// For a stablecoin with `d` decimals, `price[stable]` is its native-unit amount per ETH-wei, so
+/// `price[stable] / 10^d` is USD per ETH-wei (one native unit ≈ `1/10^d` USD). Returns `None` when
+/// no anchor stablecoin is priced.
+fn usd_per_eth_wei(prices: &PriceMap) -> Option<f64> {
+    let mut sum = 0.0;
+    let mut count = 0u32;
+    for &(stable, decimals) in STABLECOINS {
+        if let Some(price) = price_of(prices, stable) {
+            sum += price / 10f64.powi(decimals as i32);
+            count += 1;
+        }
+    }
+    (count > 0).then(|| sum / f64::from(count))
+}
+
+/// USD value of `amount` native units of `token`: `amount / price[token] * usd_per_eth_wei`.
+///
+/// Returns `None` when `token` is not priced, no anchor stablecoin is available, or the result is
+/// not finite (e.g. an amount that overflows f64).
+pub(crate) fn value_usd(token: Address, amount: U256, prices: &PriceMap) -> Option<f64> {
+    let usd_per_eth_wei = usd_per_eth_wei(prices)?;
+    let price = price_of(prices, token)?;
+    let amount: f64 = amount.to_string().parse().ok()?;
+    let usd = amount * usd_per_eth_wei / price;
+    usd.is_finite().then_some(usd)
+}
+
+/// Signed USD savings of Fynd's output vs the settled amount (positive = Fynd better).
+///
+/// Both amounts are `token_out` native units, valued in USD via [`value_usd`]; the savings is their
+/// difference. Returns `None` when `token_out` is not priced or no anchor stablecoin is available.
+pub(crate) fn savings_usd(
+    token_out: Address,
+    fynd_amount_out: U256,
+    settled_amount_out: U256,
+    prices: &PriceMap,
+) -> Option<f64> {
+    let fynd_usd = value_usd(token_out, fynd_amount_out, prices)?;
+    let settled_usd = value_usd(token_out, settled_amount_out, prices)?;
+    Some(fynd_usd - settled_usd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const USDC: Address = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+
+    /// ETH = $2000. price[token] = token native-units per ETH-wei.
+    /// USDC (6 dp): 2000 USDC per ETH = 2000 * 1e6 native units / 1e18 wei = 2e-9.
+    const USDC_PRICE: f64 = 2e-9;
+    /// WETH (18 dp): ~1:1 with ETH → 1e18 native units / 1e18 wei = 1.0.
+    const WETH_PRICE: f64 = 1.0;
+
+    fn prices() -> PriceMap {
+        PriceMap::from([(USDC, USDC_PRICE), (WETH, WETH_PRICE)])
+    }
+
+    #[test]
+    fn output_leg_stable_positive_when_fynd_better() {
+        // WETH→USDC: Fynd 1010 USDC vs settled 1000 USDC → +$10.
+        let s = savings_usd(
+            USDC,
+            U256::from(1_010_000_000u64),
+            U256::from(1_000_000_000u64),
+            &prices(),
+        )
+        .unwrap();
+        assert!((s - 10.0).abs() < 1e-6, "expected +10, got {s}");
+    }
+
+    #[test]
+    fn output_leg_negative_when_fynd_worse() {
+        let s =
+            savings_usd(USDC, U256::from(990_000_000u64), U256::from(1_000_000_000u64), &prices())
+                .unwrap();
+        assert!((s + 10.0).abs() < 1e-6, "expected -10, got {s}");
+    }
+
+    #[test]
+    fn output_leg_non_stable_token_priced_via_eth() {
+        // USDC→WETH: Fynd 1.01 WETH vs settled 1.00 WETH → +0.01 ETH = +$20 (ETH = $2000).
+        let one_weth = U256::from(10u64).pow(U256::from(18u64));
+        let fynd_weth = one_weth * U256::from(101u64) / U256::from(100u64);
+        let s = savings_usd(WETH, fynd_weth, one_weth, &prices()).unwrap();
+        assert!((s - 20.0).abs() < 1e-3, "expected ~+20, got {s}");
+    }
+
+    #[test]
+    fn native_eth_falls_back_to_weth_price() {
+        // token_out is native ETH (zero address); only WETH is priced → use WETH's price.
+        let one_eth = U256::from(10u64).pow(U256::from(18u64));
+        let fynd_eth = one_eth * U256::from(101u64) / U256::from(100u64);
+        let s = savings_usd(Address::ZERO, fynd_eth, one_eth, &prices()).unwrap();
+        assert!((s - 20.0).abs() < 1e-3, "expected ~+20, got {s}");
+    }
+
+    #[test]
+    fn large_gain_not_capped() {
+        // Fynd 1500 USDC vs settled 1000 USDC → +$500, no plausibility cap.
+        let s = savings_usd(
+            USDC,
+            U256::from(1_500_000_000u64),
+            U256::from(1_000_000_000u64),
+            &prices(),
+        )
+        .unwrap();
+        assert!((s - 500.0).abs() < 1e-6, "expected +500, got {s}");
+    }
+
+    #[test]
+    fn value_usd_scales_amount_by_price_and_anchor() {
+        // 1000 USDC (6 dp) → $1000.
+        let v = value_usd(USDC, U256::from(1_000_000_000u64), &prices()).unwrap();
+        assert!((v - 1_000.0).abs() < 1e-6, "expected $1000, got {v}");
+        // 1 WETH → $2000 (ETH = $2000).
+        let one_weth = U256::from(10u64).pow(U256::from(18u64));
+        let v = value_usd(WETH, one_weth, &prices()).unwrap();
+        assert!((v - 2_000.0).abs() < 1e-3, "expected $2000, got {v}");
+    }
+
+    #[test]
+    fn value_usd_unpriced_or_no_anchor_is_none() {
+        assert_eq!(value_usd(Address::repeat_byte(0x42), U256::from(1u64), &prices()), None);
+        assert_eq!(value_usd(USDC, U256::from(1u64), &PriceMap::new()), None);
+    }
+
+    #[test]
+    fn unpriced_output_token_is_none() {
+        let unknown = Address::repeat_byte(0x42);
+        assert_eq!(savings_usd(unknown, U256::from(2u64), U256::from(1u64), &prices()), None);
+    }
+
+    #[test]
+    fn no_anchor_stablecoin_is_none() {
+        // WETH priced but no stablecoin → cannot anchor ETH→USD.
+        let prices = PriceMap::from([(WETH, WETH_PRICE)]);
+        let one_weth = U256::from(10u64).pow(U256::from(18u64));
+        assert_eq!(savings_usd(WETH, one_weth, one_weth, &prices), None);
+    }
+
+    #[test]
+    fn empty_prices_is_none() {
+        assert_eq!(savings_usd(USDC, U256::from(2u64), U256::from(1u64), &PriceMap::new()), None);
+    }
+}


### PR DESCRIPTION
Prometheus metrics (trades, net-of-gas bps) with a dedicated /metrics exporter and Grafana dashboard. USD valuation via Fynd token prices anchored to USD through stablecoins, plus per-client observed volume and client-uplift (losses floored at zero). Supersedes the earlier stablecoin-leg/±band USD approach. Stacked PR #4/6; base `eng-6123`.