### PR TITLE
feat: add optional cache marker to quote responses (ENG-6238)

### DIFF
--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -158,6 +158,28 @@
           }
         }
       },
+      "CacheInfo": {
+        "type": "object",
+        "description": "Cache provenance for a quote served from Fynd's in-memory quote cache.\n\nPresent on an [`OrderQuote`] only when the quote cache is enabled (`--enable-quote-cache`) and\nthe request was a cache hit; absent on a miss or when the cache is disabled. A hit re-solved at\nthe current block's start is as fresh as a live solve: the cache returns the winning solve from\nthat block and only re-encodes it for this caller. `solved_at_block` exposes the bounded\nstaleness that remains when a per-block refresh was shed under load — the served solve is then\nat most the cache's staleness cutoff behind the chain head.\n\nA cache hit returns the cached entry's server-generated `order_id` (the id from the solve that\nfirst populated the entry), not a fresh id minted for this request.",
+        "required": [
+          "hit",
+          "solved_at_block"
+        ],
+        "properties": {
+          "hit": {
+            "type": "boolean",
+            "description": "Always `true`: this marker is present only on a cache hit.",
+            "example": true
+          },
+          "solved_at_block": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Block the served solve was computed against. Equals the chain head on a fresh per-block\nrefresh; lags by up to the cache's staleness cutoff when a refresh was shed.",
+            "example": 21000000,
+            "minimum": 0
+          }
+        }
+      },
       "ClientFeeParams": {
         "type": "object",
         "description": "Client fee configuration for the Tycho Router.\n\nWhen provided, the router charges a client fee on the swap output. The `signature`\nmust be an EIP-712 signature by the `receiver` over the `ClientFee` typed data.",
@@ -466,6 +488,17 @@
           "block": {
             "$ref": "#/components/schemas/BlockInfo",
             "description": "Block at which this quote was computed."
+          },
+          "cache": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CacheInfo",
+                "description": "Cache provenance, present only when this quote was served from the quote cache.\n\nAbsent on a cache miss and when the cache is disabled, so responses are byte-identical to a\nnon-cached solve unless the entry was served from the cache."
+              }
+            ]
           },
           "fee_breakdown": {
             "oneOf": [

--- a/clients/rust/src/lib.rs
+++ b/clients/rust/src/lib.rs
@@ -81,9 +81,10 @@ pub use signing::{
     SignedSwap, SwapPayload, TxReceipt,
 };
 pub use types::{
-    BackendKind, BatchQuoteParams, BlockInfo, ClientFeeParams, EncodingOptions, FeeBreakdown,
-    HealthStatus, InstanceInfo, Order, OrderSide, PermitDetails, PermitSingle, PriceGuardConfig,
-    Quote, QuoteOptions, QuoteParams, QuoteStatus, Route, Swap, Transaction, UserTransferType,
+    BackendKind, BatchQuoteParams, BlockInfo, CacheInfo, ClientFeeParams, EncodingOptions,
+    FeeBreakdown, HealthStatus, InstanceInfo, Order, OrderSide, PermitDetails, PermitSingle,
+    PriceGuardConfig, Quote, QuoteOptions, QuoteParams, QuoteStatus, Route, Swap, Transaction,
+    UserTransferType,
 };
 
 mod client;

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -9,9 +9,9 @@ use fynd_rpc_types::OrderQuote;
 use crate::{
     error::{ErrorCode, FyndError},
     types::{
-        BackendKind, BatchQuoteParams, BlockInfo, EncodingOptions, FeeBreakdown, HealthStatus,
-        Order, OrderSide, PermitDetails, PermitSingle, Quote, QuoteOptions, QuoteParams,
-        QuoteStatus, Route, Swap, Transaction, UserTransferType,
+        BackendKind, BatchQuoteParams, BlockInfo, CacheInfo, EncodingOptions, FeeBreakdown,
+        HealthStatus, Order, OrderSide, PermitDetails, PermitSingle, Quote, QuoteOptions,
+        QuoteParams, QuoteStatus, Route, Swap, Transaction, UserTransferType,
     },
 };
 // ============================================================================
@@ -238,7 +238,10 @@ fn order_quote_to_quote(
             swaps_hash,
         )
     });
-    Ok(Quote::new(
+    let cache = order_quote
+        .cache()
+        .map(|info| CacheInfo::new(info.solved_at_block()));
+    let mut quote = Quote::new(
         order_quote.order_id().to_string(),
         status,
         BackendKind::Fynd,
@@ -253,7 +256,9 @@ fn order_quote_to_quote(
         receiver,
         transaction,
         fee_breakdown,
-    ))
+    );
+    quote.cache = cache;
+    Ok(quote)
 }
 
 impl From<dto::Transaction> for Transaction {
@@ -562,6 +567,32 @@ mod tests {
         // token_out and receiver are left empty until populated by quote()
         assert!(quote.token_out().is_empty());
         assert!(quote.receiver().is_empty());
+        // A quote without the wire cache marker maps to no cache provenance.
+        assert_eq!(quote.cache(), None);
+    }
+
+    #[test]
+    fn quote_from_dto_with_cache_hit() {
+        let ds: dto::OrderQuote = serde_json::from_str(
+            r#"{
+            "order_id": "test-order-id",
+            "status": "success",
+            "amount_in": "1000",
+            "amount_out": "999",
+            "gas_estimate": "100000",
+            "amount_out_net_gas": "998",
+            "block": {"number": 21000000, "hash": "0xdeadbeef", "timestamp": 1730000000},
+            "cache": {"hit": true, "solved_at_block": 20999998}
+        }"#,
+        )
+        .expect("valid order quote JSON");
+        let quote = order_quote_to_quote(ds, Bytes::new(), Bytes::new()).unwrap();
+        assert_eq!(
+            quote
+                .cache()
+                .map(CacheInfo::solved_at_block),
+            Some(20_999_998)
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -836,6 +836,34 @@ pub struct Quote {
     /// Wall-clock time the server spent solving this request, in milliseconds.
     /// Populated by [`FyndClient::quote`](crate::FyndClient::quote).
     pub(crate) solve_time_ms: u64,
+    /// Cache provenance. Present only when the server served this quote from its quote cache;
+    /// `None` on a fresh solve or when the server's cache is disabled.
+    pub(crate) cache: Option<CacheInfo>,
+}
+
+/// Provenance for a quote the server served from its in-memory quote cache.
+///
+/// A cache hit re-solved at the current block's start is as fresh as a live solve; the server only
+/// re-encodes the cached solve for this request. [`solved_at_block`](Self::solved_at_block) exposes
+/// the bounded staleness that remains when a per-block refresh was shed under load.
+///
+/// A cache hit carries the cached entry's server-generated `order_id` — the id from the solve that
+/// first populated the entry, not a fresh id for this request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CacheInfo {
+    solved_at_block: u64,
+}
+
+impl CacheInfo {
+    pub(crate) fn new(solved_at_block: u64) -> Self {
+        Self { solved_at_block }
+    }
+
+    /// Block the served solve was computed against. Equals the chain head on a fresh per-block
+    /// refresh; lags by up to the server's staleness cutoff when a refresh was shed.
+    pub fn solved_at_block(&self) -> u64 {
+        self.solved_at_block
+    }
 }
 
 impl Quote {
@@ -933,6 +961,13 @@ impl Quote {
         self.solve_time_ms
     }
 
+    /// Cache provenance, present only when the server served this quote from its quote cache.
+    ///
+    /// `None` on a fresh solve or when the server's cache is disabled.
+    pub fn cache(&self) -> Option<&CacheInfo> {
+        self.cache.as_ref()
+    }
+
     /// Patches the 65-byte client fee EIP-712 signature into the transaction
     /// calldata at the offset returned by the server.
     ///
@@ -1000,6 +1035,7 @@ impl Quote {
             transaction,
             fee_breakdown,
             solve_time_ms: 0,
+            cache: None,
         }
     }
 }

--- a/clients/typescript/client/src/index.ts
+++ b/clients/typescript/client/src/index.ts
@@ -3,6 +3,7 @@ export type {
   ApprovalParams,
   BackendKind,
   BlockInfo,
+  CacheInfo,
   ClientFeeParams,
   EncodingOptions,
   FeeBreakdown,

--- a/clients/typescript/client/src/mapping.test.ts
+++ b/clients/typescript/client/src/mapping.test.ts
@@ -352,6 +352,25 @@ describe('fromWireQuote', () => {
     const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, SENDER);
     expect(quote.transaction).toBeUndefined();
   });
+
+  it('cache is undefined on a miss', () => {
+    const quote = fromWireQuote(baseWireSolution, TOKEN_OUT, SENDER);
+    expect(quote.cache).toBeUndefined();
+  });
+
+  it('maps cache provenance on a hit', () => {
+    const wire: WireSolution = {
+      ...baseWireSolution,
+      orders: [
+        {
+          ...baseWireSolution.orders[0]!,
+          cache: { hit: true, solved_at_block: 20999998 },
+        },
+      ],
+    };
+    const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
+    expect(quote.cache).toEqual({ hit: true, solvedAtBlock: 20999998 });
+  });
 });
 
 describe('fromWireHealth', () => {

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -3,6 +3,7 @@ import { FyndError } from "./error.js";
 import type {
     Address,
     BlockInfo,
+    CacheInfo,
     ClientFeeParams,
     EncodingOptions,
     FeeBreakdown,
@@ -33,6 +34,7 @@ type WirePermitSingle = components["schemas"]["PermitSingle"];
 type WirePermitDetails = components["schemas"]["PermitDetails"];
 type WireClientFeeParams = components["schemas"]["ClientFeeParams"];
 type WireFeeBreakdown = components["schemas"]["FeeBreakdown"];
+type WireCacheInfo = components["schemas"]["CacheInfo"];
 
 
 export function toWireRequest(params: QuoteParams): WireSolutionRequest {
@@ -87,6 +89,9 @@ export function fromWireQuote(
     const feeBreakdown = orderSolution.fee_breakdown != null
         ? fromWireFeeBreakdown(orderSolution.fee_breakdown)
         : undefined;
+    const cache = orderSolution.cache != null
+        ? fromWireCacheInfo(orderSolution.cache)
+        : undefined;
     return {
         orderId: orderSolution.order_id,
         status: orderSolution.status,
@@ -102,6 +107,14 @@ export function fromWireQuote(
         ...(transaction !== undefined ? {transaction} : {}),
         ...(priceImpactBps !== undefined ? {priceImpactBps} : {}),
         ...(feeBreakdown !== undefined ? {feeBreakdown} : {}),
+        ...(cache !== undefined ? {cache} : {}),
+    };
+}
+
+function fromWireCacheInfo(wire: WireCacheInfo): CacheInfo {
+    return {
+        hit: wire.hit,
+        solvedAtBlock: wire.solved_at_block,
     };
 }
 

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -99,6 +99,33 @@ export interface components {
             timestamp: number;
         };
         /**
+         * @description Cache provenance for a quote served from Fynd's in-memory quote cache.
+         *
+         *     Present on an [`OrderQuote`] only when the quote cache is enabled (`--enable-quote-cache`) and
+         *     the request was a cache hit; absent on a miss or when the cache is disabled. A hit re-solved at
+         *     the current block's start is as fresh as a live solve: the cache returns the winning solve from
+         *     that block and only re-encodes it for this caller. `solved_at_block` exposes the bounded
+         *     staleness that remains when a per-block refresh was shed under load — the served solve is then
+         *     at most the cache's staleness cutoff behind the chain head.
+         *
+         *     A cache hit returns the cached entry's server-generated `order_id` (the id from the solve that
+         *     first populated the entry), not a fresh id minted for this request.
+         */
+        CacheInfo: {
+            /**
+             * @description Always `true`: this marker is present only on a cache hit.
+             * @example true
+             */
+            hit: boolean;
+            /**
+             * Format: int64
+             * @description Block the served solve was computed against. Equals the chain head on a fresh per-block
+             *     refresh; lags by up to the cache's staleness cutoff when a refresh was shed.
+             * @example 21000000
+             */
+            solved_at_block: number;
+        };
+        /**
          * @description Client fee configuration for the Tycho Router.
          *
          *     When provided, the router charges a client fee on the swap output. The `signature`
@@ -309,6 +336,7 @@ export interface components {
             amount_out_net_gas: string;
             /** @description Block at which this quote was computed. */
             block: components["schemas"]["BlockInfo"];
+            cache?: null | components["schemas"]["CacheInfo"];
             fee_breakdown?: null | components["schemas"]["FeeBreakdown"];
             /**
              * @description Estimated gas cost for executing this route (as decimal string).

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -152,6 +152,21 @@ export interface FeeBreakdown {
   minAmountReceived: bigint;
 }
 
+/**
+ * Provenance for a quote the server served from its in-memory quote cache.
+ *
+ * A cache hit re-solved at the current block's start is as fresh as a live solve; the server only
+ * re-encodes the cached solve for this request. `solvedAtBlock` exposes the bounded staleness that
+ * remains when a per-block refresh was shed under load. A hit carries the cached entry's original
+ * server-generated `orderId`, not a fresh id for this request.
+ */
+export interface CacheInfo {
+  /** Always `true`: present only when the quote was served from the cache. */
+  hit: boolean;
+  /** Block the served solve was computed against; lags the head by up to the staleness cutoff. */
+  solvedAtBlock: number;
+}
+
 /** A solver quote containing the best route, amounts, and optional encoded transaction. */
 export interface Quote {
   orderId: string;
@@ -172,6 +187,8 @@ export interface Quote {
   transaction?: Transaction;
   /** Fee breakdown; present only when `encodingOptions` was set in the quote request. */
   feeBreakdown?: FeeBreakdown;
+  /** Cache provenance; present only when the server served this quote from its quote cache. */
+  cache?: CacheInfo;
 }
 
 /** Solver health status and readiness information. */

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -673,6 +673,16 @@ impl Quote {
     pub fn solve_time_ms(&self) -> u64 {
         self.solve_time_ms
     }
+
+    /// Marks the sole order quote as served from the cache, solved at `solved_at_block`.
+    ///
+    /// The quote cache only serves single-order requests, so the marker always lands on the one
+    /// order in the response; a no-op if the response somehow has no orders.
+    pub fn mark_cache_hit(&mut self, solved_at_block: u64) {
+        if let Some(first_order) = self.orders.first_mut() {
+            first_order.cache = Some(CacheInfo::new(solved_at_block));
+        }
+    }
 }
 
 /// A single swap order to be solved.
@@ -850,6 +860,12 @@ pub struct OrderQuote {
     /// Fee breakdown (populated when encoding options are provided).
     #[serde(skip_serializing_if = "Option::is_none")]
     fee_breakdown: Option<FeeBreakdown>,
+    /// Cache provenance, present only when this quote was served from the quote cache.
+    ///
+    /// Absent on a cache miss and when the cache is disabled, so responses are byte-identical to a
+    /// non-cached solve unless the entry was served from the cache.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cache: Option<CacheInfo>,
 }
 
 impl OrderQuote {
@@ -911,6 +927,52 @@ impl OrderQuote {
     /// Fee breakdown, if encoding options were provided in the request.
     pub fn fee_breakdown(&self) -> Option<&FeeBreakdown> {
         self.fee_breakdown.as_ref()
+    }
+
+    /// Cache provenance, present only when this quote was served from the quote cache.
+    pub fn cache(&self) -> Option<&CacheInfo> {
+        self.cache.as_ref()
+    }
+}
+
+/// Cache provenance for a quote served from Fynd's in-memory quote cache.
+///
+/// Present on an [`OrderQuote`] only when the quote cache is enabled (`--enable-quote-cache`) and
+/// the request was a cache hit; absent on a miss or when the cache is disabled. A hit re-solved at
+/// the current block's start is as fresh as a live solve: the cache returns the winning solve from
+/// that block and only re-encodes it for this caller. `solved_at_block` exposes the bounded
+/// staleness that remains when a per-block refresh was shed under load — the served solve is then
+/// at most the cache's staleness cutoff behind the chain head.
+///
+/// A cache hit returns the cached entry's server-generated `order_id` (the id from the solve that
+/// first populated the entry), not a fresh id minted for this request.
+#[must_use]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+pub struct CacheInfo {
+    /// Always `true`: this marker is present only on a cache hit.
+    #[cfg_attr(feature = "openapi", schema(example = true))]
+    hit: bool,
+    /// Block the served solve was computed against. Equals the chain head on a fresh per-block
+    /// refresh; lags by up to the cache's staleness cutoff when a refresh was shed.
+    #[cfg_attr(feature = "openapi", schema(example = 21000000))]
+    solved_at_block: u64,
+}
+
+impl CacheInfo {
+    /// Create a cache marker for a hit whose solve was computed at `solved_at_block`.
+    pub fn new(solved_at_block: u64) -> Self {
+        Self { hit: true, solved_at_block }
+    }
+
+    /// Whether this quote was served from the cache. Always `true` when the marker is present.
+    pub fn hit(&self) -> bool {
+        self.hit
+    }
+
+    /// Block the served solve was computed against.
+    pub fn solved_at_block(&self) -> u64 {
+        self.solved_at_block
     }
 }
 
@@ -1461,6 +1523,57 @@ mod wire_format_tests {
         assert_eq!(swap.split(), 0.0);
     }
 
+    // ── CacheInfo: cache marker presence/absence ──────────────────────────────
+    //
+    // The marker is additive: absent on a miss so cached-off responses stay
+    // byte-identical, present with `hit: true` + `solved_at_block` on a hit.
+
+    fn order_quote_without_cache() -> OrderQuote {
+        let json = r#"{
+            "order_id": "order-1",
+            "status": "success",
+            "amount_in": "1000000000000000000",
+            "amount_out": "2000000000",
+            "gas_estimate": "150000",
+            "amount_out_net_gas": "1999000000",
+            "block": { "number": 21000000, "hash": "0xdeadbeef", "timestamp": 1700000000 }
+        }"#;
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn order_quote_omits_cache_when_absent() {
+        let quote = order_quote_without_cache();
+        assert_eq!(quote.cache(), None);
+
+        let value = serde_json::to_value(&quote).unwrap();
+        assert!(value.get("cache").is_none(), "cache key must be absent on a miss, got: {value}");
+    }
+
+    #[test]
+    fn quote_serializes_cache_marker_on_hit() {
+        let mut quote = Quote::new(vec![order_quote_without_cache()], BigUint::from(150_000u64), 3);
+        quote.mark_cache_hit(21_000_123);
+
+        let value = serde_json::to_value(&quote).unwrap();
+        assert_eq!(
+            value["orders"][0]["cache"],
+            serde_json::json!({ "hit": true, "solved_at_block": 21_000_123u64 })
+        );
+    }
+
+    #[test]
+    fn cache_info_roundtrips() {
+        let json = r#"{ "hit": true, "solved_at_block": 21000123 }"#;
+        let cache: CacheInfo = serde_json::from_str(json).unwrap();
+        assert!(cache.hit());
+        assert_eq!(cache.solved_at_block(), 21_000_123);
+        assert_eq!(
+            serde_json::to_value(cache).unwrap(),
+            serde_json::from_str::<serde_json::Value>(json).unwrap()
+        );
+    }
+
     // ── EncodingOptions: full request JSON shape ──────────────────────────────
     //
     // Verifies transfer_type serializes as "transfer_from" (snake_case, not
@@ -1732,6 +1845,9 @@ mod conversions {
                 gas_price,
                 transaction,
                 fee_breakdown,
+                // Cache provenance is stamped by the fynd-rpc handler on a hit, never by the
+                // core→DTO conversion; a freshly solved quote is always a miss.
+                cache: None,
             }
         }
     }

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -78,24 +78,31 @@ pub(crate) async fn quote(
         }
     }
 
-    let core_quote = match state.quote_cache() {
+    let (core_quote, cache_hit_block) = match state.quote_cache() {
         Some(cache) => solve_with_cache(&state, cache, core_request, &http_req).await?,
-        None => {
+        None => (
             state
                 .worker_router()
                 .quote(core_request)
-                .await?
-        }
+                .await?,
+            None,
+        ),
     };
 
     info!(
         solve_time_ms = core_quote.solve_time_ms(),
         num_orders = core_quote.orders().len(),
         num_pools = state.worker_router().num_pools(),
+        cache_hit = cache_hit_block.is_some(),
         "quote completed"
     );
 
-    let dto_quote: dto::Quote = core_quote.into();
+    let mut dto_quote: dto::Quote = core_quote.into();
+    // Stamp cache provenance only on a hit. On a miss or with the cache off the response stays
+    // byte-identical to a live solve, so existing callers see no change.
+    if let Some(solved_at_block) = cache_hit_block {
+        dto_quote.mark_cache_hit(solved_at_block);
+    }
 
     Ok(HttpResponse::Ok().json(dto_quote))
 }
@@ -106,18 +113,25 @@ pub(crate) async fn quote(
 /// Only single-order requests are cached. The cache key and re-encode path are per-order, and
 /// multi-order quote→execute is not a v1 pattern, so multi-order requests bypass the cache and
 /// re-solve every time (counted for visibility).
+///
+/// Returns the encoded quote plus, on a hit, the block the served solve was computed against so the
+/// handler can stamp cache provenance on the response. A miss (or multi-order bypass) returns
+/// `None`, leaving the response byte-identical to a live solve.
 async fn solve_with_cache(
     state: &AppState,
     cache: &Arc<QuoteCache>,
     request: fynd_core::QuoteRequest,
     http_req: &HttpRequest,
-) -> Result<fynd_core::Quote, ApiError> {
+) -> Result<(fynd_core::Quote, Option<u64>), ApiError> {
     if request.orders().len() != 1 {
         counter!("quote_cache_multi_order_bypass_total").increment(1);
-        return Ok(state
-            .worker_router()
-            .quote(request)
-            .await?);
+        return Ok((
+            state
+                .worker_router()
+                .quote(request)
+                .await?,
+            None,
+        ));
     }
     let order = request.orders()[0].clone();
 
@@ -125,10 +139,14 @@ async fn solve_with_cache(
     // (market not yet synced) freshness is unverifiable, so fall through to a fresh solve.
     if let Some(head) = state.current_block().await {
         if let Some(cached) = cache.get(&order, head) {
-            return Ok(state
+            // Read the served solve's block before the entry is moved into the encoder; it is kept
+            // current by the refresher and equals the entry's staleness anchor.
+            let solved_at_block = cached.block().number();
+            let quote = state
                 .worker_router()
                 .encode_cached(cached, &order, request.options())
-                .await?);
+                .await?;
+            return Ok((quote, Some(solved_at_block)));
         }
     }
 
@@ -150,7 +168,7 @@ async fn solve_with_cache(
             cache.insert(&order, candidate, request, &identity, solved_at_block);
         }
     }
-    Ok(quote)
+    Ok((quote, None))
 }
 
 /// Extracts the caller identity from the `User-Identity` header, falling back to the shared


### PR DESCRIPTION
Stacked on the refresh-scheduler PR. Additive wire-type change: quote responses gain an optional `cache: {hit, solved_at_block}` object, present only on cache hits when the cache feature is enabled.

- DTO-layer only — `fynd-core` untouched. `From<core OrderQuote>` always sets `cache: None`; the handler stamps hits via `Quote::mark_cache_hit(block)`.
- `#[serde(default, skip_serializing_if = "Option::is_none")]`: miss and cache-off responses are byte-identical to today (asserted in tests).
- Semantics documented on the field: a hit re-solved at the current block's start is as fresh as a live solve; `solved_at_block` exposes bounded staleness when a refresh cycle was shed. Known cosmetic caveat documented: a hit returns the cached entry's server-generated `order_id`.
- OpenAPI regenerated (+33 lines, 0 deletions: `CacheInfo` schema + optional `cache` on `OrderQuote`); Rust and TypeScript clients updated and mapped.

Additive-only: no public signatures changed, new fields are non-public, constructors unchanged. `./check.sh` clean (781 tests); TS typecheck/oxlint/vitest green (152 tests).

Two pre-existing issues found, not fixed here: `clients/typescript/autogen/` appears dead (stale schema, outside the pnpm workspace, unimported, un-CI'd) and `scripts/update-openapi.sh` has a stale header comment — follow-up cleanup candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)