### PR TITLE
ci: promote releases to staging automatically

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -80,6 +80,8 @@ jobs:
     timeout-minutes: 10
     needs: build
     if: github.event_name == 'release'
+    outputs:
+      image_tag: ${{ steps.semver_tag.outputs.image_tag }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -117,3 +119,32 @@ jobs:
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Validate semver tag for promotion
+        id: semver_tag
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::metadata version '$VERSION' is not semver; refusing to promote to staging"
+            exit 1
+          fi
+          echo "image_tag=$VERSION" >> "$GITHUB_OUTPUT"
+
+  promote-staging:
+    name: Promote to staging
+    needs: merge
+    if: github.event_name == 'release'
+    concurrency:
+      group: promote-staging
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    uses: propeller-heads/ci-cd-templates/.github/workflows/promote-to-dev.yaml@main
+    with:
+      image_name: fynd
+      image_tag: ${{ needs.merge.outputs.image_tag }}
+      environment: staging
+    secrets:
+      app_id: ${{ secrets.APP_ID }}
+      app_private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
After the multi-arch manifest is pushed on a release, call the shared promote-to-dev workflow with environment=staging to bump fynd's tag in helm-configuration staging/versions.yml, which triggers the staging deployment. The promoted tag is the docker metadata version output, validated to be semver so a non-semver release tag fails the job instead of silently promoting "latest". Staging is treated like dev: no manual approval, only prod promotion stays manual.

Requires propeller-heads/ci-cd-templates PR adding the environment input to be merged first.