### PR TITLE
ci: fix release pipeline — fynd-tools-common as path-only dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,10 @@ fynd-rpc = { path = "fynd-rpc", version = "0.82.3" }
 fynd-rpc-types = { path = "fynd-rpc-types", version = "0.82.3" }
 fynd-client = { path = "clients/rust", version = "0.82.3" }
 erc20-overrides = { path = "tools/erc20-overrides", version = "0.82.3" }
-fynd-tools-common = { path = "tools/common", version = "0.82.3" }
+# Path-only (like fynd-test-fixtures): unpublished internal crate, so it must not carry a
+# version requirement -- release.config.js bumps the workspace version without bumping
+# requirements it does not know about, and a stale requirement sends cargo to crates.io.
+fynd-tools-common = { path = "tools/common" }
 fynd-test-fixtures = { path = "test-fixtures" }
 
 # Dev dependencies


### PR DESCRIPTION
The `release / release` job has failed on the last two main runs (the merges of #278 and #271), so no release has been cut since 0.82.3 — which also blocks publishing the first image containing the hindsight binary.

Cause: the semantic-release exec script (release.config.js) bumps `workspace.package.version` and the five published crates' dependency requirements, but `fynd-tools-common` is not in that list. Its requirement stays `^0.82.3` while the crate's actual version (`version.workspace = true`) becomes 0.83.0, which caret semantics reject. Cargo then falls back to crates.io, where the crate was never published:

```
error: failed to select a version for the requirement `fynd-tools-common = "^0.82.3"`
candidate versions found which didn't match: 0.83.0
```

Fix: drop the version requirement — `fynd-tools-common` is an unpublished internal crate (only the benchmark and hindsight binaries depend on it), so path-only is correct, matching `fynd-test-fixtures`. This also removes the trap permanently instead of adding another line to release.config.js to keep in sync.

Verified by replaying the release script's exact toml-set + cargo-update sequence locally: reproduces the CI error without this change, succeeds with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)