### PR TITLE
chore: dashboard titles say gross, matching the metrics

### DIFF
--- a/tools/hindsight/grafana/hindsight.json
+++ b/tools/hindsight/grafana/hindsight.json
@@ -34,7 +34,7 @@
   "panels": [
     {
       "id": 1,
-      "title": "Win rate (Fynd better, net of gas)",
+      "title": "Win rate (Fynd better, gross)",
       "type": "stat",
       "datasource": "${datasource}",
       "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
@@ -71,7 +71,7 @@
     },
     {
       "id": 4,
-      "title": "Median net-of-gas savings (bps)",
+      "title": "Median gross savings (bps)",
       "type": "timeseries",
       "datasource": "${datasource}",
       "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },


### PR DESCRIPTION
Follow-up to the gross-vs-gross headline change: two panel titles in the local grafana dashboard still said net-of-gas. Keeps the source copy in sync with the provisioned one (terraform-infrastructure #192).

🤖 Generated with [Claude Code](https://claude.com/claude-code)