### PR TITLE
fix(hindsight): attribution never picks the wrapped-native contract

### DIFF
--- a/tools/hindsight/src/decoder/solvers/attribution.rs
+++ b/tools/hindsight/src/decoder/solvers/attribution.rs
@@ -58,7 +58,7 @@ pub(crate) fn attribute(
     if let Some(found) = trace::find_solver_frame(root, registry).and_then(|frame| frame.to) {
         return Attribution { solver: registry.label(found), source: AttributionSource::TraceMatch };
     }
-    if let Some(guess) = trace::largest_external_call(root, entry_point, sender) {
+    if let Some(guess) = trace::largest_external_call(root, entry_point, sender, registry) {
         return Attribution {
             solver: registry.label(guess),
             source: AttributionSource::LargestCall,
@@ -180,6 +180,27 @@ mod tests {
         let attribution = attribute(None, &root, client, sender, &registry);
         assert_eq!(attribution.solver, client.to_string());
         assert_eq!(attribution.source, AttributionSource::Fallback);
+    }
+
+    #[test]
+    fn attribution_never_picks_wrapped_native() {
+        // ETH-input swap through an unknown router: the highest-value direct call is the
+        // WETH.deposit() wrapping the input. Infrastructure, not a solver — the guess must
+        // fall through to the real router call.
+        let registry = Registry::ethereum();
+        let sender = addr(1);
+        let client = addr(2);
+        let solver = addr(50);
+
+        let mut root = frame("CALL", sender, client, 0);
+        root.calls = vec![
+            frame("CALL", client, registry.wrapped_native(), 9000), // wrap, skipped
+            frame("CALL", client, solver, 100),
+        ];
+
+        let attribution = attribute(None, &root, client, sender, &registry);
+        assert_eq!(attribution.solver, solver.to_string());
+        assert_eq!(attribution.source, AttributionSource::LargestCall);
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/trace.rs
+++ b/tools/hindsight/src/decoder/trace.rs
@@ -108,7 +108,12 @@ pub(crate) fn find_solver_frame<'a>(
 }
 
 /// The client's direct child call that moved the most native value, excluding
-/// self-calls, refunds to the sender, and Permit2. Best guess at an unknown router.
+/// self-calls, refunds to the sender, Permit2, and the wrapped-native contract. Best guess at
+/// an unknown router.
+///
+/// The wrapped-native exclusion matters most: on an ETH-input swap through an unknown router,
+/// the highest-value call is typically the `WETH.deposit()` wrapping the input — infrastructure,
+/// not a solver (seen live: 83 run6 records attributed to the WETH contract).
 ///
 /// Returns `None` when no candidate moved any value: on a token→token swap every call carries
 /// zero value, so "largest" would degenerate to the first child — typically the token pull, not
@@ -117,6 +122,7 @@ pub(crate) fn largest_external_call(
     root: &CallFrame,
     entry_point: Address,
     sender: Address,
+    registry: &Registry,
 ) -> Option<Address> {
     let mut best: Option<(Address, U256)> = None;
     for child in &root.calls {
@@ -124,7 +130,7 @@ pub(crate) fn largest_external_call(
             continue;
         }
         let Some(to) = child.to else { continue };
-        if to == entry_point || to == sender || to == PERMIT2 {
+        if to == entry_point || to == sender || to == PERMIT2 || to == registry.wrapped_native() {
             continue;
         }
         let value = child.value.unwrap_or_default();


### PR DESCRIPTION
Spotted on the dashboard: the WETH contract address listed as a solver. The largest-external-call attribution fallback excludes Permit2 as infrastructure but not the wrapped-native contract — and on ETH-input swaps through unknown routers, the highest-value direct call is typically the `WETH.deposit()` wrapping the input. All 83 raw-address solver records in run6 are this one address.

Skip `registry.wrapped_native()` exactly like Permit2, with a regression test mirroring the Permit2 one. Affected trades now attribute to the actual router (largest_call tier) or fall back to their entry-point label.

No urgency to redeploy tonight — the 0.84.0 metric-label collapse already renders these as `solver="unknown"` on the dashboard; this fixes the underlying attribution in the JSONL too. Rides the next release + tag bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)