### PR TITLE
Add vm:bopamm and vm:fermiswap protocol decoders

### DIFF
--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -112,6 +112,20 @@ pub(crate) fn register_exchanges(
                     None,
                 );
             }
+            "vm:bopamm" => {
+                builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
+                    "vm:bopamm",
+                    tvl_filter.clone(),
+                    None,
+                );
+            }
+            "vm:fermiswap" => {
+                builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
+                    "vm:fermiswap",
+                    tvl_filter.clone(),
+                    None,
+                );
+            }
             "fluid_v1" => {
                 builder = builder.exchange::<FluidV1>(
                     "fluid_v1",


### PR DESCRIPTION
These VM-simulated protocols were introduced in tycho-simulation 0.328.1 but were missing from the protocol registry match block in `fynd-core/src/feed/protocol_registry.rs`, causing fynd to log `Skipping unknown protocol` and ignore them.

Both follow the same pattern as `vm:curve` and `vm:maverick_v2`: generic `EVMPoolState<PreCachedDB>` with no custom pool filter.

Should be merged after PR #279 (tycho-simulation bump to 0.328.1).