### PR TITLE
feat: use native CurveState decoder and add vm:bopamm/vm:fermiswap

### DIFF
--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -6,6 +6,7 @@ use tycho_simulation::{
         engine_db::tycho_db::PreCachedDB,
         protocol::{
             aerodrome_slipstreams::state::AerodromeSlipstreamsState,
+            curve::CurveState,
             ekubo::state::EkuboState,
             ekubo_v3::{self, state::EkuboV3State},
             erc4626::state::ERC4626State,
@@ -92,11 +93,7 @@ pub(crate) fn register_exchanges(
                 builder = builder.exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None);
             }
             "vm:curve" => {
-                builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
-                    "vm:curve",
-                    tvl_filter.clone(),
-                    None,
-                );
+                builder = builder.exchange::<CurveState>("vm:curve", tvl_filter.clone(), None);
             }
             "uniswap_v4_hooks" => {
                 builder = builder.exchange::<UniswapV4State>(
@@ -108,6 +105,20 @@ pub(crate) fn register_exchanges(
             "vm:maverick_v2" => {
                 builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
                     "vm:maverick_v2",
+                    tvl_filter.clone(),
+                    None,
+                );
+            }
+            "vm:bopamm" => {
+                builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
+                    "vm:bopamm",
+                    tvl_filter.clone(),
+                    None,
+                );
+            }
+            "vm:fermiswap" => {
+                builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
+                    "vm:fermiswap",
                     tvl_filter.clone(),
                     None,
                 );


### PR DESCRIPTION
## Changes

### Native Curve decoder
Switch `vm:curve` from `EVMPoolState<PreCachedDB>` (deprecated VM adapter) to the native `CurveState` introduced in tycho-simulation 0.324.0.

The hybrid implementation uses pure-Rust quote math (vendored from MIT-licensed `curve-math`/`curve-adapter`) over VM-indexed storage, which is more performant than running full EVM execution for every swap simulation. The release notes for 0.324.0 explicitly warn when `vm:curve` uses the deprecated VM adapter.

### New protocol decoders
Add `vm:bopamm` and `vm:fermiswap` to the protocol registry — both were introduced in tycho-simulation 0.328.1 but were missing from the match block, causing fynd to log `Skipping unknown protocol` and ignore them.

Both follow the same pattern as `vm:maverick_v2`: `EVMPoolState<PreCachedDB>` with no custom pool filter.

`cargo check --package fynd-core` passes clean.