### PR TITLE
fix(hindsight): no ANSI codes off-terminal, unquoted verdict field

### DIFF
--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -103,11 +103,14 @@ struct VerifyArgs {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // ANSI colors only on a real terminal: in a pod they end up as escape sequences inside
+    // Loki, where they break plain name=value field extraction.
     tracing_subscriber::fmt()
         .with_env_filter(
             EnvFilter::from_env("RUST_LOG").add_directive("hindsight=info".parse().unwrap()),
         )
         .with_target(false)
+        .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stdout()))
         .init();
 
     match Cli::parse().command {

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -168,7 +168,7 @@ pub(crate) fn record_range(
             solver = %range.solver,
             token_in = %range.token_in,
             token_out = %range.token_out,
-            verdict = outcome_label(range.verdict),
+            verdict = %outcome_label(range.verdict),
             volume_usd = volume.unwrap_or(0.0),
             savings_usd,
             "trade comparison"


### PR DESCRIPTION
Hindsight's pod stdout is ingested by Loki, and the tracing subscriber writes ANSI color codes there — every field name arrives wrapped in escape sequences (`\x1b[3mtx\x1b[0m\x1b[2m=\x1b[0m0x…`), which breaks plain `name=value` LogQL extraction. The dashboard's top-trades query now tolerates the codes either way, but the logs shouldn't contain them: colors are now enabled only when stdout is a terminal. The `verdict` log field also switches to Display so it renders `verdict=win` instead of Debug-quoted `verdict="win"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)