### PR TITLE
feat(feed): report fynd_version to Tycho via client metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7756,9 +7756,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.328.1"
+version = "0.331.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260bfa6e48e757b65a97ad61c188db43d70a6902fb1be86881b611b64613e23e"
+checksum = "f0016d3b1320e456d9d82690425fd1d32bb1b6ba59d8e2c17466a95bb7ef8171"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7786,9 +7786,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.328.1"
+version = "0.331.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cbbcfa5921531b4d559255b6687c1782951379e7c171cded2055885b9b4ea8"
+checksum = "9c005588841e242b212d2b111bb2283cda4e49e5589f72281ae5a03ea248031f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7813,9 +7813,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.328.1"
+version = "0.331.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c365a61880cac3e81837017c5b6a0eb2b8b358841a3a68a7da477636badc789"
+checksum = "0d25adf4f79dbcb37e87231815055a5ec6f171ff33355a407434b2368eddbc5e"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7835,9 +7835,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.328.1"
+version = "0.331.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4876623450f4cce734e818ed4cfcc786f07402106bf46e3119e4c09f5c0cebbc"
+checksum = "2122ffa88b5bcf90984e7d03c1ace245a6a14be08372eef45bb2fd18400253b3"
 dependencies = [
  "alloy",
  "chrono",
@@ -7856,9 +7856,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.328.1"
+version = "0.331.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b143b98c8cf0c701ef0e012c294c44a42d550a5fc29457c2cb477f3ec6f2f7"
+checksum = "7551b85e258e0dd0d71807a26d3532d91f30cf05c45353cf273545994dacdee5"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 
 # Tycho
-tycho-execution = ">=0.328.1"
-tycho-simulation = ">=0.328.1"
+tycho-execution = ">=0.331.0"
+tycho-simulation = ">=0.331.0"
 typetag = "0.2"
 
 # Compression

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -53,6 +53,11 @@ pub(crate) struct TychoFeed {
     event_tx: broadcast::Sender<MarketEvent>,
 }
 
+/// Client-metadata entries Fynd reports to Tycho via the `X-Tycho-Client-Metadata` header.
+fn fynd_client_metadata() -> [(&'static str, &'static str); 1] {
+    [("fynd_version", env!("CARGO_PKG_VERSION"))]
+}
+
 impl TychoFeed {
     /// Creates a new TychoFeed.
     ///
@@ -132,7 +137,8 @@ impl TychoFeed {
             .auth_key(self.config.tycho_api_key.clone())
             .no_tls(!self.config.use_tls)
             .skip_state_decode_failures(true)
-            .min_token_quality(self.config.min_token_quality as u32);
+            .min_token_quality(self.config.min_token_quality as u32)
+            .add_client_metadata(fynd_client_metadata());
 
             if self.config.partial_blocks {
                 stream_builder = stream_builder.enable_partial_blocks();
@@ -323,6 +329,7 @@ impl TychoFeed {
         .auth_key(self.config.tycho_api_key.clone())
         .skip_state_decode_failures(true)
         .min_token_quality(self.config.min_token_quality as u32)
+        .add_client_metadata(fynd_client_metadata())
         .set_tokens(all_tokens.clone())
         .await;
 
@@ -522,7 +529,8 @@ impl TychoFeed {
         }
         .auth_key(self.config.tycho_api_key.clone())
         .skip_state_decode_failures(true)
-        .min_token_quality(self.config.min_token_quality as u32);
+        .min_token_quality(self.config.min_token_quality as u32)
+        .add_client_metadata(fynd_client_metadata());
 
         if self.config.partial_blocks {
             stream_builder = stream_builder.enable_partial_blocks();
@@ -1354,6 +1362,14 @@ mod tests {
             Ok(_) => panic!("Should not broadcast event for empty update"),
             Err(e) => panic!("Unexpected error: {:?}", e),
         }
+    }
+
+    #[test]
+    fn fynd_client_metadata_reports_version() {
+        // Pins the wire key the server telemetry keys off and guarantees a non-empty version.
+        let [(key, value)] = fynd_client_metadata();
+        assert_eq!(key, "fynd_version");
+        assert!(!value.is_empty());
     }
 
     #[tokio::test(flavor = "multi_thread")] // Multi-thread needed because tycho decoder does some blocking operations


### PR DESCRIPTION
Bumps `tycho-simulation` and `tycho-execution` to 0.331.0, which exposes `ProtocolStreamBuilder::add_client_metadata`, and attaches a `fynd_version` entry (`env!("CARGO_PKG_VERSION")`) to every outbound Tycho stream.

The Fynd release version is now sent in the `X-Tycho-Client-Metadata` header on all Tycho connections. `User-Agent` is unchanged. This lets the Tycho server attribute traffic and version usage to Fynd.

The entry is applied at all three stream-build paths — `run`, `run_with_pending`, and `run_with_step_controller` — through a shared `fynd_client_metadata()` helper, so telemetry is consistent regardless of feed mode. `fynd_preset` is deferred until preset resolution exists in Fynd.

Wire-level header emission (WS + RPC, ordering, validation) is covered by tycho-client's own tests; the Fynd-side test pins the reported metadata key and a non-empty version.
