### PR TITLE
fix(core): drop NaN-scored gas-price paths instead of panicking

### DIFF
--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -404,9 +404,8 @@ impl TokenGasPriceComputation {
             .collect();
 
         // Sort each token's paths: lowest spread last (for popping). A NaN score (degenerate
-        // pool math in the spread computation) is meaningless as a candidate and, worse, makes
-        // partial_cmp-based sorting panic — which killed the ComputationManager task in
-        // production. Drop those candidates and sort with the float total order.
+        // pool math in the spread computation) cannot rank a path and would panic a
+        // partial_cmp-based sort, so drop those candidates and sort with the float total order.
         for paths in paths_by_token.values_mut() {
             paths.retain(|path| !path.score.is_nan());
             paths.sort_by(|a, b| b.score.total_cmp(&a.score));
@@ -780,10 +779,8 @@ mod tests {
 
     #[tokio::test]
     async fn nan_scored_paths_are_dropped_not_panicked_on() {
-        // Degenerate pool math can yield a NaN spot-price spread; sorting candidates with
-        // partial_cmp().unwrap() panicked on it and silently killed the ComputationManager task
-        // in production (dev + prod, 2026-07-09). NaN-scored candidates must be dropped, and
-        // the affected token simply gets no price.
+        // Degenerate pool math can yield a NaN spot-price spread. A NaN-scored candidate must
+        // be dropped — never panicked on — and the affected token simply gets no price.
         let eth = token(0, "ETH");
         let usdc = token(1, "USDC");
 

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -403,9 +403,13 @@ impl TokenGasPriceComputation {
             })
             .collect();
 
-        // Sort each token's paths: lowest spread last (for popping)
+        // Sort each token's paths: lowest spread last (for popping). A NaN score (degenerate
+        // pool math in the spread computation) is meaningless as a candidate and, worse, makes
+        // partial_cmp-based sorting panic — which killed the ComputationManager task in
+        // production. Drop those candidates and sort with the float total order.
         for paths in paths_by_token.values_mut() {
-            paths.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+            paths.retain(|path| !path.score.is_nan());
+            paths.sort_by(|a, b| b.score.total_cmp(&a.score));
         }
 
         // Round-robin: pop one candidate per token each round, keep best by spread
@@ -772,6 +776,35 @@ mod tests {
         assert_eq!(target_paths[0].path.edge_data[0].component_id, "hop1");
         assert_eq!(target_paths[0].path.edge_data[1].component_id, "hop2");
         assert_eq!(target_paths[0].score, 0.0);
+    }
+
+    #[tokio::test]
+    async fn nan_scored_paths_are_dropped_not_panicked_on() {
+        // Degenerate pool math can yield a NaN spot-price spread; sorting candidates with
+        // partial_cmp().unwrap() panicked on it and silently killed the ComputationManager task
+        // in production (dev + prod, 2026-07-09). NaN-scored candidates must be dropped, and
+        // the affected token simply gets no price.
+        let eth = token(0, "ETH");
+        let usdc = token(1, "USDC");
+
+        let (market, _) =
+            setup_market_weighted(vec![("nan_pool", &eth, &usdc, MockProtocolSim::new(2000.0))]);
+        // Inject NaN spot prices directly: the spread |forward - 1/reverse| becomes NaN.
+        let mut spot_prices = SpotPrices::default();
+        spot_prices
+            .insert(("nan_pool".to_string(), eth.address.clone(), usdc.address.clone()), f64::NAN);
+        spot_prices
+            .insert(("nan_pool".to_string(), usdc.address.clone(), eth.address.clone()), f64::NAN);
+
+        let computation = computation_for(&eth.address);
+        let (prices, _, _) = computation
+            .simulate_token_prices(&market, &spot_prices, None)
+            .await
+            .expect("a NaN-scored path must not fail the computation");
+        assert!(
+            !prices.contains_key(&usdc.address),
+            "the NaN-scored path must be dropped, not selected"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`TokenGasPriceComputation` sorts candidate paths by float score with:

```rust
paths.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
```

The score is a spot-price spread (`|forward − 1/reverse|`); degenerate pool math can make it NaN, `partial_cmp` then returns `None`, and the `unwrap` panics.

## Consequences

This is the root cause of both 2026-07-09 hindsight outages (prod ~14:00Z, dev ~22:01Z) — confirmed via the panic messages in Loki, identical in both:

```
thread 'tokio-rt-worker' panicked at fynd-core/src/derived/computations/token_gas_price.rs:408:64
```

The panic kills the ComputationManager task **silently** — its JoinHandle is only awaited at teardown (solver.rs) — which drops the derived-data sender, closes the channel for every worker, and triggered the worker busy-spin fixed in #294. One NaN from one pool took down the deployment. The fynd API shares this code path.

## Fix

Drop NaN-scored candidates before sorting (a NaN score is meaningless as a routing candidate; the affected token simply gets no gas price that block) and sort with `total_cmp`, which is defined for all floats.

Regression test injects NaN spot prices and asserts the computation completes with the path dropped; it panics on the old code.

## Related

- #294 — the worker busy-spin this panic triggered (independent defect, keeps the next publisher death from cascading)
- Follow-up worth discussing: monitor the ComputationManager's JoinHandle so a task death is fatal/visible instead of silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)