### PR TITLE
ci: drop unused id-token permission from reusable CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
   workflow_call:
 
 permissions:
-  id-token: write
   contents: read
 
 env:


### PR DESCRIPTION
## Problem

Every push to main since Jul 12 fails with `startup_failure` before any job runs, blocking releases (e.g. run [29199752483](https://github.com/propeller-heads/fynd/actions/runs/29199752483)):

> Invalid workflow file: .github/workflows/v2-main-workflow.yaml#L9
> The workflow is requesting 'id-token: write', but is only allowed 'id-token: none'.

The repo's default workflow permissions were restricted to read-only between Jul 10 and Jul 12. `ci.yaml` declares `id-token: write`, but the `tests-and-lints` caller job in `v2-main-workflow.yaml` passes no explicit permissions, so it can no longer grant that scope to the called workflow. The workflow files themselves are unchanged since the last successful run.

## Fix

Remove `id-token: write` from `ci.yaml`. No job in it uses OIDC — the permission has been unused since the initial CI setup.

Merging this unblocks the Main workflow on main, which will pick up the pending `fix(core)` commit and cut the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)