### PR TITLE
feat: Record per-pool queue wait and depth metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2976,6 +2976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3435,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "metrics",
+ "metrics-util 0.20.4",
  "num-bigint",
  "num-rational",
  "num-traits",
@@ -4715,7 +4722,7 @@ dependencies = [
  "indexmap 2.14.0",
  "ipnet",
  "metrics",
- "metrics-util",
+ "metrics-util 0.19.1",
  "quanta",
  "thiserror 1.0.69",
  "tokio",
@@ -4735,6 +4742,27 @@ dependencies = [
  "quanta",
  "rand 0.9.4",
  "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "aho-corasick",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "metrics",
+ "ordered-float",
+ "quanta",
+ "radix_trie",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -4797,6 +4825,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -5073,6 +5110,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -5625,6 +5671,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -51,3 +51,4 @@ tempfile.workspace = true
 toml.workspace = true
 fynd-test-fixtures.workspace = true
 tracing-subscriber.workspace = true
+metrics-util = "0.20"

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -114,6 +114,7 @@ impl WorkerPool {
         // Spawn workers
         let params = SpawnWorkersParams {
             algorithm: algorithm.clone(),
+            pool_name: name.clone(),
             num_workers: config.num_workers,
             algorithm_config: config.algorithm_config,
             task_rx,

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -41,6 +41,8 @@ pub(crate) const DEFAULT_ALGORITHM: &str = "most_liquid";
 pub(crate) struct SpawnWorkersParams {
     /// Algorithm name (e.g., "most_liquid") — used for thread naming and logging.
     pub algorithm: String,
+    /// Pool name from configuration (used as the `pool` metric label).
+    pub pool_name: String,
     /// Number of worker threads to spawn.
     pub num_workers: usize,
     /// Configuration for the algorithm used by each worker.
@@ -159,6 +161,7 @@ where
         let algorithm_config = params.algorithm_config.clone();
         let shutdown_rx = params.shutdown_tx.subscribe();
         let algorithm_name = params.algorithm.clone();
+        let pool_name = params.pool_name.clone();
         let factory = factory.clone();
 
         let handle = thread::Builder::new()
@@ -172,8 +175,13 @@ where
                 rt.block_on(async move {
                     let algorithm = factory(algorithm_config);
 
-                    let mut worker =
-                        SolverWorker::new(market_data, derived_data, algorithm, worker_id);
+                    let mut worker = SolverWorker::new(
+                        market_data,
+                        derived_data,
+                        algorithm,
+                        worker_id,
+                        pool_name,
+                    );
 
                     worker.initialize_graph().await;
                     worker
@@ -234,6 +242,7 @@ mod tests {
         let (shutdown_tx, _) = broadcast::channel(1);
         SpawnWorkersParams {
             algorithm: algorithm.to_string(),
+            pool_name: "test_pool".to_string(),
             num_workers,
             algorithm_config: AlgorithmConfig::default(),
             task_rx,
@@ -271,6 +280,7 @@ mod tests {
 
         let params = SpawnWorkersParams {
             algorithm: "most_liquid".to_string(),
+            pool_name: "test_pool".to_string(),
             num_workers: 3,
             algorithm_config: AlgorithmConfig::new(1, 2, Duration::from_millis(50), None).unwrap(),
             task_rx,
@@ -311,6 +321,7 @@ mod tests {
         let registry_err = AlgorithmSpawner::Registry { algorithm: "my_custom_algo".to_string() }
             .spawn(SpawnWorkersParams {
                 algorithm: "my_custom_algo".to_string(),
+                pool_name: "test_pool".to_string(),
                 num_workers: 1,
                 algorithm_config: AlgorithmConfig::default(),
                 task_rx: task_rx.clone(),
@@ -336,6 +347,7 @@ mod tests {
         let workers = AlgorithmSpawner::Custom { algorithm: "my_custom_algo".to_string(), spawner }
             .spawn(SpawnWorkersParams {
                 algorithm: "my_custom_algo".to_string(),
+                pool_name: "test_pool".to_string(),
                 num_workers: 2,
                 algorithm_config: AlgorithmConfig::new(1, 2, Duration::from_millis(50), None)
                     .unwrap(),
@@ -364,6 +376,7 @@ mod tests {
 
         let params = SpawnWorkersParams {
             algorithm: "path_frank_wolfe".to_string(),
+            pool_name: "test_pool".to_string(),
             num_workers: 1,
             algorithm_config: AlgorithmConfig::default(),
             task_rx,

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -65,7 +65,6 @@ where
     /// Whether the graph has been initialized.
     initialized: bool,
     /// Worker identifier (for logging).
-    // TODO: make this a string to include pool name
     worker_id: usize,
     /// Pool name (used as the `pool` metric label).
     pool_name: String,

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -32,6 +32,16 @@ use crate::{
     BlockInfo, Order, OrderQuote, QuoteStatus, SingleOrderQuote, SolveError, SolveParams,
 };
 
+/// Records per-pool queue metrics at task pickup: how long the task waited in the
+/// queue and the depth left behind it. Queue wait growing while solve time stays
+/// flat is the leading indicator of worker saturation.
+fn record_task_pickup_metrics(pool_name: &str, queue_wait: Duration, queue_depth: usize) {
+    metrics::histogram!("worker_pool_queue_wait_seconds", "pool" => pool_name.to_string())
+        .record(queue_wait.as_secs_f64());
+    metrics::gauge!("worker_pool_queue_depth", "pool" => pool_name.to_string())
+        .set(queue_depth as f64);
+}
+
 /// A solver worker instance that maintains a market graph and processes solve requests.
 pub(crate) struct SolverWorker<A>
 where
@@ -57,6 +67,8 @@ where
     /// Worker identifier (for logging).
     // TODO: make this a string to include pool name
     worker_id: usize,
+    /// Pool name (used as the `pool` metric label).
+    pool_name: String,
 }
 
 impl<A> SolverWorker<A>
@@ -74,11 +86,13 @@ where
     /// * `derived_data` - Shared reference to derived data (pool depths, token prices)
     /// * `algorithm` - The algorithm to use for route finding
     /// * `worker_id` - Identifier for this worker (for logging)
+    /// * `pool_name` - Pool name (used as the `pool` metric label)
     pub fn new(
         market_data: MarketData,
         derived_data: SharedDerivedDataRef,
         algorithm: A,
         worker_id: usize,
+        pool_name: String,
     ) -> Self {
         let requirements = algorithm.computation_requirements();
         Self {
@@ -91,6 +105,7 @@ where
             ready_notify: Arc::new(Notify::new()),
             initialized: false,
             worker_id,
+            pool_name,
         }
     }
 
@@ -519,7 +534,11 @@ where
                     match task.ok() {
                         Some(task) => {
                             let task_id = task.id();
-                            let _wait_time = task.wait_time();
+                            record_task_pickup_metrics(
+                                &self.pool_name,
+                                task.wait_time(),
+                                task_rx.len(),
+                            );
 
                             // Wait for derived data readiness before solving
                             // Use algorithm timeout as the max wait time
@@ -690,7 +709,8 @@ mod tests {
     async fn test_quote_rejects_invalid_route() {
         let (market, _) = setup_market_weighted(vec![]);
         let derived = DerivedData::new_shared();
-        let mut worker = SolverWorker::new(market, derived, InvalidRouteAlgorithm, 0);
+        let mut worker =
+            SolverWorker::new(market, derived, InvalidRouteAlgorithm, 0, "test_pool".to_string());
 
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -716,7 +736,7 @@ mod tests {
         let derived = DerivedData::new_shared();
 
         let algorithm = MockAlgorithm::new();
-        let worker = SolverWorker::new(market, derived, algorithm, 0);
+        let worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Should return immediately since there are no requirements
         let result = worker
@@ -734,7 +754,7 @@ mod tests {
             .allow_stale(SpotPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Mark as ready by handling a completion event
         worker
@@ -761,7 +781,7 @@ mod tests {
             .require_fresh(SpotPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let worker = SolverWorker::new(market, derived, algorithm, 0);
+        let worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Should timeout since no events are received
         let result = worker
@@ -787,7 +807,7 @@ mod tests {
             .require_fresh(SpotPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let worker = SolverWorker::new(market, derived, algorithm, 0);
+        let worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Clone the notify handle to simulate the main loop notifying
         let notify = worker.ready_notify.clone();
@@ -819,7 +839,7 @@ mod tests {
             .require_fresh(SpotPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Clone the notify handle and get a reference to the tracker
         let notify = worker.ready_notify.clone();
@@ -862,7 +882,7 @@ mod tests {
             .allow_stale(TokenGasPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         let notify = worker.ready_notify.clone();
 
@@ -907,7 +927,7 @@ mod tests {
             .require_fresh(SpotPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Mark the current block and record a failure for spot_prices
         worker
@@ -955,7 +975,7 @@ mod tests {
             .require_fresh(SpotPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Mark the current block and record a failure for spot_prices
         worker
@@ -997,7 +1017,7 @@ mod tests {
             .require_fresh(SpotPriceComputation::ID)
             .unwrap();
         let algorithm = MockAlgorithm::new().with_requirements(requirements);
-        let mut worker = SolverWorker::new(market, derived, algorithm, 0);
+        let mut worker = SolverWorker::new(market, derived, algorithm, 0, "test_pool".to_string());
 
         // Create channels
         let (_event_tx, event_rx) = broadcast::channel::<MarketEvent>(16);
@@ -1073,7 +1093,8 @@ mod tests {
 
         let (market, _) = setup_market_weighted(vec![]);
         let derived = DerivedData::new_shared();
-        let mut worker = SolverWorker::new(market, derived, MockAlgorithm::new(), 0);
+        let mut worker =
+            SolverWorker::new(market, derived, MockAlgorithm::new(), 0, "test_pool".to_string());
 
         let (_event_tx, event_rx) = broadcast::channel::<MarketEvent>(16);
         let (derived_tx, derived_rx) = broadcast::channel::<DerivedDataEvent>(16);
@@ -1105,5 +1126,48 @@ mod tests {
             closed_warns, 1,
             "closed channel must be handled once, not spun on ({closed_warns} warns)"
         );
+    }
+
+    #[test]
+    fn task_pickup_metrics_recorded() {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            record_task_pickup_metrics("test_pool", std::time::Duration::from_millis(25), 3);
+        });
+
+        let mut wait_seen = false;
+        let mut depth_seen = false;
+        for (key, _unit, _description, value) in snapshotter.snapshot().into_vec() {
+            let key = key.key();
+            let pool_label = key
+                .labels()
+                .find(|label| label.key() == "pool")
+                .map(|label| label.value().to_string());
+            match key.name() {
+                "worker_pool_queue_wait_seconds" => {
+                    assert_eq!(pool_label.as_deref(), Some("test_pool"));
+                    let DebugValue::Histogram(samples) = value else {
+                        panic!("expected histogram, got {value:?}");
+                    };
+                    assert_eq!(samples.len(), 1);
+                    assert!((samples[0].into_inner() - 0.025).abs() < 1e-9);
+                    wait_seen = true;
+                }
+                "worker_pool_queue_depth" => {
+                    assert_eq!(pool_label.as_deref(), Some("test_pool"));
+                    let DebugValue::Gauge(depth) = value else {
+                        panic!("expected gauge, got {value:?}");
+                    };
+                    assert!((depth.into_inner() - 3.0).abs() < f64::EPSILON);
+                    depth_seen = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(wait_seen, "queue wait histogram not recorded");
+        assert!(depth_seen, "queue depth gauge not recorded");
     }
 }


### PR DESCRIPTION
## Summary

Quote requests are dispatched to worker pools via an async_channel task queue; each `SolverWorker` runs on a dedicated OS thread. This adds two Prometheus series, recorded at the point a worker picks a task off the queue:

- `worker_pool_queue_wait_seconds{pool=...}` (histogram) — how long the task sat in the queue before a worker picked it up.
- `worker_pool_queue_depth{pool=...}` (gauge) — the number of tasks still queued behind it at pickup time.

Both are labeled by `pool`, so per-pool saturation is visible when multiple pools (different algorithms) are running.

Queue wait growing while solve time stays flat is the leading indicator of worker saturation: it means work is arriving faster than workers can pick it up, before solve latency itself degrades. It is a better early signal than solve-time percentiles, which only move once the algorithm itself is under pressure.

`SolveTask::wait_time()` was already being computed on task pickup but discarded (`let _wait_time = task.wait_time();`); this now records it instead, alongside `async_channel::Receiver::len()` for the depth gauge.

## Changes

- `SolverWorker::new` gains a 5th parameter, `pool_name: String`, threaded through from `WorkerPoolConfig` (`pool.rs`) → `SpawnWorkersParams` (`registry.rs`) → each spawned worker thread, so the metric label reflects the pool's configured name rather than just the algorithm name.
- New `record_task_pickup_metrics` helper in `worker.rs` records both series.
- Added `metrics-util` as a `fynd-core` dev-dependency to assert on recorded metric values via `DebuggingRecorder`.

## Test plan

- [x] `cargo test -p fynd-core task_pickup_metrics_recorded` — new unit test asserting both series are recorded with the correct pool label and values
- [x] `cargo check --all-features`
- [x] `cargo test -p fynd-core worker` — all worker/registry/pool tests pass
- [x] `./check.sh` (fmt, clippy, doc, nextest) — clean, aside from pre-existing integration tests that fail locally because git-lfs isn't installed in this environment (fixture files are LFS pointers, unrelated to this change; confirmed failing on `main` too)
- [ ] Manual verification against a running local solver (not run in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)