### PR TITLE
feat: use jemalloc as the global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "fynd-core",
  "fynd-rpc",
  "hex",
+ "metrics",
  "metrics-exporter-prometheus",
  "num-bigint",
  "num-traits",
@@ -3362,6 +3363,8 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -7164,6 +7167,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,15 @@ description = "High-performance DeFi route-finding engine — embeddable library
 license = "MIT"
 
 [features]
-default = ["metrics"]
+default = ["metrics", "jemalloc"]
 # Enables the Prometheus metrics exporter on a separate HTTP server.
 # Disable with `--no-default-features` to omit Actix-Web and the Prometheus
 # recorder from the binary (e.g. for embedded/minimal builds).
 metrics = ["dep:actix-web", "dep:metrics-exporter-prometheus"]
+# Uses jemalloc as the global allocator. Under concurrent load jemalloc returns
+# freed pages to the OS instead of retaining them as RSS the way glibc's per-thread
+# arenas do; disable with `--no-default-features` for minimal builds.
+jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 
 [dependencies]
 fynd-rpc = { workspace = true }
@@ -39,6 +43,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
 
 # Serialization (for OpenAPI spec output)
@@ -53,6 +58,11 @@ tycho-simulation = { workspace = true }
 # Encoding/formatting for derive-connector-tokens
 chrono = { workspace = true }
 hex = { workspace = true }
+
+# Allocator (gated behind the `jemalloc` feature). tikv-jemalloc-ctl reads heap
+# stats for the periodic reporter in `jemalloc_stats`.
+tikv-jemallocator = { workspace = true, optional = true }
+tikv-jemalloc-ctl = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
@@ -164,6 +174,10 @@ chrono = "0.4"
 itertools = "0.14.0"
 hex = "0.4"
 sha2 = "0.10"
+
+# Allocator
+tikv-jemallocator = "0.7"
+tikv-jemalloc-ctl = { version = "0.7", features = ["stats"] }
 
 # Internal crates
 fynd-core = { path = "fynd-core", version = "0.89.1" }

--- a/src/jemalloc_stats.rs
+++ b/src/jemalloc_stats.rs
@@ -1,0 +1,43 @@
+//! jemalloc heap-statistics reporter.
+//!
+//! Compiled only with the `jemalloc` feature. Emits Prometheus gauges so the
+//! resident-vs-allocated split is observable: a rising `resident` while
+//! `allocated` stays flat means the allocator is holding freed pages
+//! (fragmentation / arena retention) rather than the application leaking. The
+//! gauge calls are no-ops when the `metrics` feature is off (no recorder installed).
+
+use std::time::Duration;
+
+use metrics::gauge;
+use tikv_jemalloc_ctl::{epoch, stats};
+use tracing::error;
+
+const REPORT_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Spawns a task that emits jemalloc heap statistics every [`REPORT_INTERVAL`].
+pub fn spawn_stats_reporter() -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async {
+        let mut ticker = tokio::time::interval(REPORT_INTERVAL);
+        loop {
+            ticker.tick().await;
+            // A read only fails if jemalloc was built without `stats`, i.e. a
+            // permanent build misconfiguration. Surface it once and stop rather
+            // than spamming the log on every interval.
+            if let Err(err) = report_once() {
+                error!("jemalloc stats reporter stopping, read failed: {err}");
+                break;
+            }
+        }
+    })
+}
+
+fn report_once() -> Result<(), tikv_jemalloc_ctl::Error> {
+    // jemalloc caches stats; advancing the epoch refreshes every reading below.
+    epoch::advance()?;
+    gauge!("jemalloc_allocated_bytes").set(stats::allocated::read()? as f64);
+    gauge!("jemalloc_active_bytes").set(stats::active::read()? as f64);
+    gauge!("jemalloc_resident_bytes").set(stats::resident::read()? as f64);
+    gauge!("jemalloc_retained_bytes").set(stats::retained::read()? as f64);
+    gauge!("jemalloc_mapped_bytes").set(stats::mapped::read()? as f64);
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,10 @@
 
 use std::time::Duration;
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[cfg(feature = "metrics")]
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 use anyhow::anyhow;
@@ -43,6 +47,8 @@ use fynd_rpc::{
 };
 mod cli;
 mod commands;
+#[cfg(feature = "jemalloc")]
+mod jemalloc_stats;
 use cli::{Cli, Commands};
 #[cfg(feature = "metrics")]
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
@@ -311,6 +317,9 @@ async fn run_solver(args: cli::ServeArgs) -> Result<(), SolverError> {
 
     #[cfg(feature = "metrics")]
     let _metrics_task = create_metrics_exporter(args.metrics_port);
+
+    #[cfg(feature = "jemalloc")]
+    let _jemalloc_stats_task = jemalloc_stats::spawn_stats_reporter();
 
     // Setup solver, but allow SIGINT to cancel it for fast exit during startup
     let solver = tokio::select! {


### PR DESCRIPTION
## What
Makes jemalloc the global allocator behind a default-on `jemalloc` cargo feature. Adds a stats-reporter task emitting jemalloc allocated/active/resident/retained/mapped byte gauges every 60s (no-op without the `metrics` feature).

## Why
Under Fynd's concurrent load (worker-pool solver threads + tokio), glibc's per-thread malloc arenas retain freed memory as RSS instead of returning pages to the OS, so RSS climbs to a fragmentation plateau. jemalloc returns freed pages, keeping the working set flat. Mirrors tycho #994 and turbine #904, which validated the same switch under equivalent load.

## Changes
- `jemalloc` feature (default) pulling in `tikv-jemallocator` + `tikv-jemalloc-ctl`.
- `#[global_allocator]` in the `fynd` binary, gated on the feature.
- `src/jemalloc_stats.rs`: 60s reporter emitting five `jemalloc_*_bytes` gauges via the `metrics` facade.

## Notes
- Only the `fynd` binary swaps its allocator; library embedders of `fynd-core` are unaffected.
- No CI/Docker changes: CI builds `--all-features`, the Dockerfile builds default features with the C toolchain present, and jemalloc links statically. Disable with `--no-default-features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)