### PR TITLE
feat(hindsight): detect sandwich attacks around decoded trades

### DIFF
--- a/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
+++ b/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
@@ -13,14 +13,15 @@ sandwiches, record the evidence, and classify them apart from real wins and loss
 
 ## Detection methodology
 
-Bracket-pair with pool overlap — the zeromev/EigenPhi heuristic without direction decoding.
+Bracket-pair with pool overlap — the zeromev/EigenPhi heuristic — plus a log-level direction
+check on the attacker's token flow.
 
 Detection runs inside `Decoder::decode_block`, which already fetches every receipt of the block in
 one `eth_getBlockReceipts` call. All signals below come from those receipts; detection makes no
 additional RPC calls.
 
 For a victim trade at transaction index `i`, scan a window of `W = 2` transactions on each side for
-a pair `(front, back)` with `front.index < i < back.index` satisfying both conditions:
+a pair `(front, back)` with `front.index < i < back.index` satisfying all three conditions:
 
 1. **Attacker link** — `front.from == back.from`, or `front.to == back.to` where that shared
    target is not a registry-known client or solver. The registry exclusion prevents two unrelated
@@ -33,10 +34,19 @@ a pair `(front, back)` with `front.index < i < back.index` satisfying both condi
    emitters (token contracts), the wrapped-native token (its `Deposit`/`Withdrawal` logs appear
    on every wrapping transaction), and Permit2. Counting any of those would give two
    transactions that merely share a token or its plumbing a trivial overlap.
+3. **Direction** — some linked entity accumulated the victim's output token in `front` and
+   disposed of it in `back` (per that leg's ERC-20 `Transfer` logs), the shape of buying before
+   the victim and selling after. Checked on the linking address and, for a shared-sender link,
+   on the pair's shared target contract too — a bot's inventory usually sits in its private
+   contract, not the signing EOA. A native-ETH output is checked as its wrapped form (native
+   moves emit no log; pools settle in WETH). Without this condition, an arbitrage bot trading
+   the same busy pool twice inside the window would flag every unrelated trade between its two
+   transactions.
 
 Known coarseness: Uniswap V4's singleton PoolManager collapses all V4 pools into one log address,
-so overlap there is per-protocol rather than per-pool. Acceptable — the attacker link must also
-hold.
+so overlap there is per-protocol rather than per-pool. Acceptable — the attacker link and
+direction must also hold. The direction condition misses an attacker whose legs move only native
+ETH (invisible in receipts) — rare, since bots keep inventory wrapped.
 
 The first matching pair (closest bracket) wins; multi-victim grouping is out of scope.
 
@@ -89,7 +99,9 @@ Unit tests in `sandwich.rs` with synthetic receipts:
 - window boundary: pairs beyond `W = 2` on either side are ignored;
 - self-sandwich (linking address == victim sender) excluded;
 - token-contract logs (Transfer/Approval emitters), the wrapped-native token, and Permit2 do not
-  count as pools.
+  count as pools;
+- direction: a linked pair with no token flow, or accumulating on both legs (arbitrage repeat),
+  is not flagged; inventory held in the bot contract and native-output (WETH-mapped) flows are.
 
 Plus: `build_range` verdict override test, JSONL serialization test for the new fields, and a
 telemetry test that sandwiched states skip the savings histograms. The existing `verify`
@@ -97,7 +109,7 @@ subcommand remains a live check that detection does not disturb decoding.
 
 ## Out of scope
 
-- Direction-aware decoding of attacker swaps (opposite-direction verification).
 - Changes to the Python analysis package under `tools/hindsight/analysis` — the new fields are
   additive; segmentation on them can come later.
 - Multi-victim sandwich grouping.
+- Amount-aware direction checks (back-leg disposal sized against the front-leg accumulation).

--- a/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
+++ b/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
@@ -1,0 +1,100 @@
+# Hindsight Sandwich Detection — Design
+
+Date: 2026-07-13
+Status: Approved
+
+## Problem
+
+Large "improvement" opportunities reported by hindsight are often sandwich victims: a frontrun
+degraded the settled output, so Fynd's top-of-block re-solve looks like a big win. These trades
+inflate the win and USD-uplift aggregates with value Fynd could not actually have captured (the
+victim's execution was moved by MEV, not by inferior routing). Hindsight should recognize likely
+sandwiches, record the evidence, and classify them apart from real wins and losses.
+
+## Detection methodology
+
+Bracket-pair with pool overlap — the zeromev/EigenPhi heuristic without direction decoding.
+
+Detection runs inside `Decoder::decode_block`, which already fetches every receipt of the block in
+one `eth_getBlockReceipts` call. All signals below come from those receipts; detection makes no
+additional RPC calls.
+
+For a victim trade at transaction index `i`, scan a window of `W = 2` transactions on each side for
+a pair `(front, back)` with `front.index < i < back.index` satisfying both conditions:
+
+1. **Attacker link** — `front.from == back.from`, or `front.to == back.to` where that shared
+   target is not a registry-known client or solver. The registry exclusion prevents two unrelated
+   users entering the same popular router (Universal Router, 1inch) from tripping the same-`to`
+   check; real sandwich bots settle through private contracts. Pairs where the linking address
+   equals the victim's sender are excluded (self-trades are not sandwiches).
+2. **Pool overlap** — both `front` and `back` emitted at least one log from a pool contract the
+   victim's swap touched. Pool contracts are the addresses that emitted a non-ERC20-Transfer log
+   (`topic0 != Transfer`) in the victim transaction; filtering out Transfer-emitters keeps token
+   contracts (WETH, USDC) from producing trivial overlaps.
+
+Known coarseness: Uniswap V4's singleton PoolManager collapses all V4 pools into one log address,
+so overlap there is per-protocol rather than per-pool. Acceptable — the attacker link must also
+hold.
+
+The first matching pair (closest bracket) wins; multi-victim grouping is out of scope.
+
+### Evidence
+
+```rust
+pub(crate) struct SandwichEvidence {
+    pub front_tx: TxHash,
+    pub back_tx: TxHash,
+    /// The linking address: shared sender, or the shared non-router target contract.
+    pub attacker: Address,
+    /// The overlapping pool contracts.
+    pub pools: Vec<Address>,
+}
+```
+
+New module: `tools/hindsight/src/decoder/sandwich.rs`.
+
+## Data plumbing
+
+- `DecodedTrade` gains `tx_index: u64` (from the receipt) and
+  `sandwich: Option<SandwichEvidence>` (skipped in serialization when `None`).
+- `RangeComparison` carries both through; the JSONL comparison record gains `tx_index` and a
+  `sandwich` object (`front_tx`, `back_tx`, `attacker`, `pools`). Fields are additive, so existing
+  JSONL consumers are unaffected.
+- The `decode` subcommand's human-readable and JSON output includes both.
+
+## Verdict
+
+New variant `Verdict::Sandwiched`, following the `CoverageMiss` pattern: in `build_range`, a trade
+with sandwich evidence gets `Sandwiched` as its headline verdict and both per-state verdicts. The
+bps and USD deltas are still computed and written to JSONL — only the classification changes — so
+the size of MEV-inflated deltas remains studyable offline.
+
+## Telemetry
+
+- `TRADES_TOTAL` and `VOLUME_USD` gain the `outcome="sandwiched"` label value.
+- Sandwiched trades skip the `SAVINGS_BPS`, `SAVINGS_USD`, and `IMPROVEMENT_USD` histograms:
+  those carry no outcome label, so skipping is the only way to keep the "value of adding Fynd"
+  aggregates clean.
+- The per-trade Loki info line keeps logging, with `verdict=sandwiched`.
+
+## Testing
+
+Unit tests in `sandwich.rs` with synthetic receipts:
+
+- same-`from` bracket pair detected;
+- same-`to` pair detected only when the target is not a registry-known client/solver;
+- no flag when the attacker link holds but pool overlap fails (and vice versa);
+- window boundary: pairs beyond `W = 2` on either side are ignored;
+- self-sandwich (linking address == victim sender) excluded;
+- token-contract logs (Transfer-only emitters) do not count as pools.
+
+Plus: `build_range` verdict override test, JSONL serialization test for the new fields, and a
+telemetry test that sandwiched states skip the savings histograms. The existing `verify`
+subcommand remains a live check that detection does not disturb decoding.
+
+## Out of scope
+
+- Direction-aware decoding of attacker swaps (opposite-direction verification).
+- Changes to the Python analysis package under `tools/hindsight/analysis` — the new fields are
+  additive; segmentation on them can come later.
+- Multi-victim sandwich grouping.

--- a/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
+++ b/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
@@ -95,10 +95,13 @@ New module: `tools/hindsight/src/decoder/sandwich.rs`.
 
 ## Verdict
 
-New variant `Verdict::Sandwiched`, following the `CoverageMiss` pattern: in `build_range`, a trade
-with sandwich evidence gets `Sandwiched` as its headline verdict and both per-state verdicts. The
-bps and USD deltas are still computed and written to JSONL — only the classification changes — so
-the size of MEV-inflated deltas remains studyable offline.
+New variant `Verdict::Sandwiched`, following the `CoverageMiss` pattern: in `build_range`, a
+*solved* state of a trade with sandwich evidence gets `Sandwiched` as its verdict (the headline
+follows top-of-block) — its win or loss measures the MEV that moved the settled output, not
+routing quality. Unsolved states keep `Unsolvable`/`CoverageMiss`: the sandwich explains the
+settled price, not why Fynd had no route, so the coverage shares the dashboard reports are
+unaffected by reclassification. The bps and USD deltas are still computed and written to JSONL —
+only the classification changes — so the size of MEV-inflated deltas remains studyable offline.
 
 ## Telemetry
 

--- a/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
+++ b/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
@@ -43,12 +43,31 @@ a pair `(front, back)` with `front.index < i < back.index` satisfying all three 
    the same busy pool twice inside the window would flag every unrelated trade between its two
    transactions.
 
-Known coarseness: Uniswap V4's singleton PoolManager collapses all V4 pools into one log address,
-so overlap there is per-protocol rather than per-pool. Acceptable — the attacker link and
-direction must also hold. The direction condition misses an attacker whose legs move only native
-ETH (invisible in receipts) — rare, since bots keep inventory wrapped.
-
 The first matching pair (closest bracket) wins; multi-victim grouping is out of scope.
+
+### Known limitations
+
+The heuristic is bounded in both directions; the effect on the aggregates differs:
+
+**False negatives** — a real sandwich is not flagged, so its MEV-inflated "win" keeps polluting
+the savings aggregates exactly as every sandwich did before this feature. Detection reduces that
+pollution; it does not eliminate it:
+
+- an attacker sandwiching an intermediate hop of a multi-hop victim (direction is checked on the
+  victim's output token only);
+- an attacker whose legs move only native ETH — invisible in receipts; rare, since pools settle
+  in WETH;
+- an attacker rotating both its sender and its contract between the two legs (no link holds);
+- middle victims of a sandwich spanning more than `W = 2` transactions per side;
+- Uniswap V4: the singleton PoolManager collapses all V4 pools into one log address, so overlap
+  there is per-protocol rather than per-pool (coarser evidence, not a miss by itself — the link
+  and direction must still hold).
+
+**False positives** — a genuine comparison is reclassified to `sandwiched` and drops out of the
+savings aggregates: a filler or batch-settlement solver EOA settling two opposite-direction
+fills around an unrelated victim satisfies all three conditions. Label-known addresses cannot be
+blanket-excluded, because several labeled operators are themselves sandwich bots. The evidence
+keeps the attacker address, so the rate is measurable from the JSONL by joining attacker labels.
 
 ### Evidence
 

--- a/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
+++ b/docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md
@@ -28,9 +28,11 @@ a pair `(front, back)` with `front.index < i < back.index` satisfying both condi
    check; real sandwich bots settle through private contracts. Pairs where the linking address
    equals the victim's sender are excluded (self-trades are not sandwiches).
 2. **Pool overlap** — both `front` and `back` emitted at least one log from a pool contract the
-   victim's swap touched. Pool contracts are the addresses that emitted a non-ERC20-Transfer log
-   (`topic0 != Transfer`) in the victim transaction; filtering out Transfer-emitters keeps token
-   contracts (WETH, USDC) from producing trivial overlaps.
+   victim's swap touched. Pool contracts are the addresses that emitted a log in the victim
+   transaction, excluding everything known not to be a pool: ERC-20 `Transfer` and `Approval`
+   emitters (token contracts), the wrapped-native token (its `Deposit`/`Withdrawal` logs appear
+   on every wrapping transaction), and Permit2. Counting any of those would give two
+   transactions that merely share a token or its plumbing a trivial overlap.
 
 Known coarseness: Uniswap V4's singleton PoolManager collapses all V4 pools into one log address,
 so overlap there is per-protocol rather than per-pool. Acceptable — the attacker link must also
@@ -86,7 +88,8 @@ Unit tests in `sandwich.rs` with synthetic receipts:
 - no flag when the attacker link holds but pool overlap fails (and vice versa);
 - window boundary: pairs beyond `W = 2` on either side are ignored;
 - self-sandwich (linking address == victim sender) excluded;
-- token-contract logs (Transfer-only emitters) do not count as pools.
+- token-contract logs (Transfer/Approval emitters), the wrapped-native token, and Permit2 do not
+  count as pools.
 
 Plus: `build_range` verdict override test, JSONL serialization test for the new fields, and a
 telemetry test that sandwiched states skip the savings histograms. The existing `verify`

--- a/tools/hindsight/src/decoder/ledger.rs
+++ b/tools/hindsight/src/decoder/ledger.rs
@@ -43,7 +43,7 @@ sol! {
 }
 
 /// Convert an RPC log to a primitive log for event decoding.
-fn to_primitive_log(log: &Log) -> PrimitiveLog {
+pub(crate) fn to_primitive_log(log: &Log) -> PrimitiveLog {
     PrimitiveLog::new_unchecked(log.address(), log.topics().to_vec(), log.data().data.clone())
 }
 

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -17,6 +17,7 @@ mod guards;
 mod intent;
 mod ledger;
 mod registry;
+mod sandwich;
 mod solvers;
 mod strategy;
 mod trace;
@@ -43,6 +44,7 @@ use crate::decoder::{
 };
 pub(crate) use crate::decoder::{
     registry::Registry,
+    sandwich::SandwichEvidence,
     solvers::{attribution::AttributionSource, SolverQuote},
 };
 
@@ -53,6 +55,9 @@ pub(crate) use crate::decoder::{
 pub(crate) struct DecodedTrade {
     pub tx_hash: TxHash,
     pub block_number: u64,
+    /// The transaction's position in its block, from the receipt (falls back to its position in
+    /// the fetched receipt slice when the RPC omitted it).
+    pub tx_index: u64,
     pub venue: String,
     pub solver: String,
     /// The evidence tier the solver label came from (see [`solvers::attribution`]). Downstream
@@ -91,6 +96,10 @@ pub(crate) struct DecodedTrade {
     /// execution delivered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quote: Option<SolverQuote>,
+    /// Evidence that a front-run and a back-run bracketed this trade (see
+    /// [`sandwich::detect`]). `None` when no bracket pair was found.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandwich: Option<SandwichEvidence>,
 }
 
 /// Max concurrent trace requests per block. Bounds RPC load so a block
@@ -146,9 +155,15 @@ impl<P: Provider> Decoder<P> {
             .with_context(|| format!("failed to fetch receipts for block {block_number}"))?
             .ok_or_else(|| anyhow::anyhow!("block {block_number} not found"))?;
 
-        let matched: Vec<Matched> = receipts
+        // Paired with each receipt's position in the slice, since that position — not the
+        // transaction_index field, which the RPC may omit — is what "neighbor" means for the
+        // sandwich scan below: receipts are already in block order.
+        let matched: Vec<(usize, Matched)> = receipts
             .iter()
-            .filter_map(|receipt| strategy::select(receipt, &self.registry))
+            .enumerate()
+            .filter_map(|(index, receipt)| {
+                strategy::select(receipt, &self.registry).map(|matched| (index, matched))
+            })
             .collect();
 
         // Per-block batch: trace every matched tx concurrently (bounded),
@@ -158,18 +173,23 @@ impl<P: Provider> Decoder<P> {
         let traces = futures::stream::iter(
             matched
                 .iter()
-                .map(|m| fetch_trace(&self.provider, m.receipt.transaction_hash)),
+                .map(|(_, m)| fetch_trace(&self.provider, m.receipt.transaction_hash)),
         )
         .buffered(TRACE_CONCURRENCY)
         .try_collect::<Vec<_>>()
         .await?;
 
         let mut trades = Vec::with_capacity(matched.len());
-        for (matched, root) in matched.into_iter().zip(traces) {
-            if let Some(trade) = self
-                .decode_transaction(matched, &root, block_number)
+        for ((index, matched), root) in matched.into_iter().zip(traces) {
+            let tx_index = matched
+                .receipt
+                .transaction_index
+                .unwrap_or(index as u64);
+            if let Some(mut trade) = self
+                .decode_transaction(matched, &root, block_number, tx_index)
                 .await
             {
+                trade.sandwich = sandwich::detect(&receipts, index, trade.sender, &self.registry);
                 trades.push(trade);
             }
         }
@@ -183,6 +203,7 @@ impl<P: Provider> Decoder<P> {
         matched: Matched<'_>,
         root: &CallFrame,
         block_number: u64,
+        tx_index: u64,
     ) -> Option<DecodedTrade> {
         let Self { provider, registry, code_cache } = self;
         let Matched { receipt, entry_point, strategy } = matched;
@@ -257,6 +278,7 @@ impl<P: Provider> Decoder<P> {
         Some(DecodedTrade {
             tx_hash: receipt.transaction_hash,
             block_number,
+            tx_index,
             venue: registry.label(entry_point),
             solver: attribution.solver,
             solver_source: attribution.source,
@@ -269,6 +291,9 @@ impl<P: Provider> Decoder<P> {
             venue_fee_out: flow.venue_fee_out,
             settled_gas,
             quote,
+            // The full receipts slice isn't available here (this fn only sees the one matched
+            // transaction); the caller (`decode_block`) fills this in once decoding succeeds.
+            sandwich: None,
         })
     }
 }

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -189,7 +189,8 @@ impl<P: Provider> Decoder<P> {
                 .decode_transaction(matched, &root, block_number, tx_index)
                 .await
             {
-                trade.sandwich = sandwich::detect(&receipts, index, trade.sender, &self.registry);
+                let evidence = sandwich::detect(&receipts, index, &trade, &self.registry);
+                trade.sandwich = evidence;
                 trades.push(trade);
             }
         }

--- a/tools/hindsight/src/decoder/sandwich.rs
+++ b/tools/hindsight/src/decoder/sandwich.rs
@@ -211,6 +211,36 @@ mod tests {
     }
 
     #[test]
+    fn front_only_pool_overlap_is_not_flagged() {
+        // Both legs must re-touch a victim pool: an attacker-linked pair where only the front
+        // leg overlaps is not a bracket.
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(addr(51))]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn back_only_pool_overlap_is_not_flagged() {
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(addr(51))]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(pool)]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
     fn pool_overlap_without_attacker_link_is_not_flagged() {
         let victim_sender = addr(1);
         let pool = addr(50);

--- a/tools/hindsight/src/decoder/sandwich.rs
+++ b/tools/hindsight/src/decoder/sandwich.rs
@@ -13,10 +13,17 @@ use std::collections::HashSet;
 use alloy::{
     primitives::{Address, TxHash},
     rpc::types::TransactionReceipt,
+    sol,
     sol_types::SolEvent,
 };
 
-use crate::decoder::{ledger::Transfer, registry::Registry};
+use crate::decoder::{ledger::Transfer, registry::Registry, trace::PERMIT2};
+
+sol! {
+    /// ERC-20 `Approval` — emitted by token contracts, never by pools, so its emitters are
+    /// filtered out of pool candidates like `Transfer`'s.
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
 
 /// Transactions scanned on each side of the victim for a bracket pair.
 const WINDOW: usize = 2;
@@ -46,7 +53,7 @@ pub(crate) fn detect(
     victim_sender: Address,
     registry: &Registry,
 ) -> Option<SandwichEvidence> {
-    let victim_pools = pool_addresses(&receipts[victim_index]);
+    let victim_pools = pool_addresses(&receipts[victim_index], registry);
     if victim_pools.is_empty() {
         return None;
     }
@@ -61,7 +68,7 @@ pub(crate) fn detect(
             let Some(attacker) = shared_attacker(front, back, victim_sender, registry) else {
                 continue;
             };
-            let Some(pools) = overlapping_pools(&victim_pools, front, back) else {
+            let Some(pools) = overlapping_pools(&victim_pools, front, back, registry) else {
                 continue;
             };
             return Some(SandwichEvidence {
@@ -106,12 +113,13 @@ fn overlapping_pools(
     victim_pools: &HashSet<Address>,
     front: &TransactionReceipt,
     back: &TransactionReceipt,
+    registry: &Registry,
 ) -> Option<Vec<Address>> {
-    let front_overlap: HashSet<Address> = pool_addresses(front)
+    let front_overlap: HashSet<Address> = pool_addresses(front, registry)
         .intersection(victim_pools)
         .copied()
         .collect();
-    let back_overlap: HashSet<Address> = pool_addresses(back)
+    let back_overlap: HashSet<Address> = pool_addresses(back, registry)
         .intersection(victim_pools)
         .copied()
         .collect();
@@ -126,15 +134,26 @@ fn overlapping_pools(
     Some(pools)
 }
 
-/// The addresses that emitted a non-ERC20-`Transfer` log in a transaction — candidate pool
-/// contracts. Filtering out Transfer-emitters keeps token contracts (WETH, USDC) from producing
-/// trivial overlaps between transactions that merely share a token.
-fn pool_addresses(receipt: &TransactionReceipt) -> HashSet<Address> {
+/// The addresses that emitted a log in a transaction, minus everything known not to be a pool —
+/// candidate pool contracts.
+///
+/// `Transfer` and `Approval` emitters are token contracts, and the wrapped-native token
+/// (`Deposit`/`Withdrawal`) and Permit2 (its own permit events) log on most swaps without being
+/// pools: counting any of them would give two transactions that merely share a token or its
+/// plumbing a trivial "pool" overlap.
+fn pool_addresses(receipt: &TransactionReceipt, registry: &Registry) -> HashSet<Address> {
     let mut pools = HashSet::new();
     for log in receipt.logs() {
-        if log.topics().first() != Some(&Transfer::SIGNATURE_HASH) {
-            pools.insert(log.address());
+        let token_event = log
+            .topics()
+            .first()
+            .is_some_and(|topic| {
+                *topic == Transfer::SIGNATURE_HASH || *topic == Approval::SIGNATURE_HASH
+            });
+        if token_event || log.address() == registry.wrapped_native() || log.address() == PERMIT2 {
+            continue;
         }
+        pools.insert(log.address());
     }
     pools
 }
@@ -333,6 +352,47 @@ mod tests {
                 vec![make_transfer_log(token, victim_sender, addr(11), U256::from(1u64))],
             ),
             receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(addr(50))]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn wrapped_native_logs_are_not_pools() {
+        // Every ETH-wrapping transaction logs from the WETH contract (Deposit/Withdrawal are not
+        // Transfer events), so WETH alone must never count as a shared pool.
+        let registry = Registry::ethereum();
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let weth = registry.wrapped_native();
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(weth)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(weth)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(weth)]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &registry).is_none());
+    }
+
+    #[test]
+    fn approval_logs_are_not_pools() {
+        // ERC-20 Approval is emitted by token contracts; a shared token approval is not a
+        // shared pool.
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let token = addr(60);
+        let approval = |owner: Address| {
+            let primitive = alloy::primitives::Log::new_unchecked(
+                token,
+                vec![Approval::SIGNATURE_HASH, owner.into_word(), addr(70).into_word()],
+                alloy::primitives::Bytes::new(),
+            );
+            alloy::rpc::types::Log { inner: primitive, ..Default::default() }
+        };
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![approval(attacker)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![approval(victim_sender)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![approval(attacker)]),
         ];
 
         assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());

--- a/tools/hindsight/src/decoder/sandwich.rs
+++ b/tools/hindsight/src/decoder/sandwich.rs
@@ -1,0 +1,319 @@
+//! Bracket-pair sandwich detection.
+//!
+//! For a victim trade, scans the receipts immediately around it — already fetched by
+//! [`super::Decoder::decode_block`] in one `eth_getBlockReceipts` call, so detection makes no
+//! extra RPC calls — for a front-run/back-run pair that both link to one attacker and both touch
+//! a pool the victim's swap touched. See
+//! `docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md` for the heuristic
+//! and its known coarseness (Uniswap V4's singleton pool manager collapses per-pool overlap to
+//! per-protocol).
+
+use std::collections::HashSet;
+
+use alloy::{
+    primitives::{Address, TxHash},
+    rpc::types::TransactionReceipt,
+    sol_types::SolEvent,
+};
+
+use crate::decoder::{ledger::Transfer, registry::Registry};
+
+/// Transactions scanned on each side of the victim for a bracket pair.
+const WINDOW: usize = 2;
+
+/// Evidence that a victim trade was bracketed by a front-run and a back-run sharing an attacker
+/// and a pool.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct SandwichEvidence {
+    pub front_tx: TxHash,
+    pub back_tx: TxHash,
+    /// The linking address: shared sender, or the shared non-registry-known target contract.
+    pub attacker: Address,
+    /// The overlapping pool contracts.
+    pub pools: Vec<Address>,
+}
+
+/// Scan the window around `victim_index` for the closest front/back pair that brackets the
+/// victim trade (see the module docs for the two conditions a pair must satisfy).
+///
+/// `receipts` is the block's full receipt list in block order; `victim_index` is the victim's
+/// position in that slice, and `victim_sender` its trader (excluded as a linking address — a
+/// trader on both sides of their own trade is not a sandwich). Candidate pairs are tried closest
+/// front first, then closest back, so the first match found is the tightest bracket.
+pub(crate) fn detect(
+    receipts: &[TransactionReceipt],
+    victim_index: usize,
+    victim_sender: Address,
+    registry: &Registry,
+) -> Option<SandwichEvidence> {
+    let victim_pools = pool_addresses(&receipts[victim_index]);
+    if victim_pools.is_empty() {
+        return None;
+    }
+
+    let front_start = victim_index.saturating_sub(WINDOW);
+    let back_end = (victim_index + WINDOW).min(receipts.len().saturating_sub(1));
+
+    for front_index in (front_start..victim_index).rev() {
+        for back_index in (victim_index + 1)..=back_end {
+            let front = &receipts[front_index];
+            let back = &receipts[back_index];
+            let Some(attacker) = shared_attacker(front, back, victim_sender, registry) else {
+                continue;
+            };
+            let Some(pools) = overlapping_pools(&victim_pools, front, back) else {
+                continue;
+            };
+            return Some(SandwichEvidence {
+                front_tx: front.transaction_hash,
+                back_tx: back.transaction_hash,
+                attacker,
+                pools,
+            });
+        }
+    }
+    None
+}
+
+/// Whether `front` and `back` share a link that plausibly identifies one attacker running both
+/// legs: the same sender, or the same target contract that is not a registry-known venue or
+/// solver. The registry exclusion keeps two unrelated users entering the same popular router
+/// (Universal Router, 1inch) from tripping the same-`to` check — real sandwich bots settle
+/// through private contracts. A link matching the victim's own sender is excluded: a trader on
+/// both sides of their own trade is not a sandwich.
+fn shared_attacker(
+    front: &TransactionReceipt,
+    back: &TransactionReceipt,
+    victim_sender: Address,
+    registry: &Registry,
+) -> Option<Address> {
+    if front.from == back.from && front.from != victim_sender {
+        return Some(front.from);
+    }
+    let (Some(front_to), Some(back_to)) = (front.to, back.to) else {
+        return None;
+    };
+    if front_to == back_to && front_to != victim_sender && !registry.is_known(front_to) {
+        return Some(front_to);
+    }
+    None
+}
+
+/// The victim's pool contracts (see [`pool_addresses`]) that `front` and `back` each
+/// independently re-emitted a log from — `front` and `back` need not touch the same one. `None`
+/// when either leg missed the overlap.
+fn overlapping_pools(
+    victim_pools: &HashSet<Address>,
+    front: &TransactionReceipt,
+    back: &TransactionReceipt,
+) -> Option<Vec<Address>> {
+    let front_overlap: HashSet<Address> = pool_addresses(front)
+        .intersection(victim_pools)
+        .copied()
+        .collect();
+    let back_overlap: HashSet<Address> = pool_addresses(back)
+        .intersection(victim_pools)
+        .copied()
+        .collect();
+    if front_overlap.is_empty() || back_overlap.is_empty() {
+        return None;
+    }
+    let mut pools: Vec<Address> = front_overlap
+        .union(&back_overlap)
+        .copied()
+        .collect();
+    pools.sort();
+    Some(pools)
+}
+
+/// The addresses that emitted a non-ERC20-`Transfer` log in a transaction — candidate pool
+/// contracts. Filtering out Transfer-emitters keeps token contracts (WETH, USDC) from producing
+/// trivial overlaps between transactions that merely share a token.
+fn pool_addresses(receipt: &TransactionReceipt) -> HashSet<Address> {
+    let mut pools = HashSet::new();
+    for log in receipt.logs() {
+        if log.topics().first() != Some(&Transfer::SIGNATURE_HASH) {
+            pools.insert(log.address());
+        }
+    }
+    pools
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{address, U256};
+
+    use super::*;
+    use crate::decoder::test_utils::{addr, make_pool_log, make_transfer_log, receipt, tx_hash};
+
+    #[test]
+    fn detects_same_from_bracket() {
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(pool)]),
+        ];
+
+        let evidence = detect(&receipts, 1, victim_sender, &Registry::ethereum()).unwrap();
+        assert_eq!(evidence.front_tx, tx_hash(1));
+        assert_eq!(evidence.back_tx, tx_hash(3));
+        assert_eq!(evidence.attacker, attacker);
+        assert_eq!(evidence.pools, vec![pool]);
+    }
+
+    #[test]
+    fn detects_same_to_when_not_registry_known() {
+        let victim_sender = addr(1);
+        let shared_to = addr(77);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), addr(20), Some(shared_to), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), addr(21), Some(shared_to), vec![make_pool_log(pool)]),
+        ];
+
+        let evidence = detect(&receipts, 1, victim_sender, &Registry::ethereum()).unwrap();
+        assert_eq!(evidence.attacker, shared_to);
+    }
+
+    #[test]
+    fn same_to_registry_known_is_not_flagged() {
+        // 1inch is a registered solver: two unrelated traders entering it must not read as a
+        // shared-attacker link.
+        let victim_sender = addr(1);
+        let oneinch = address!("0x111111125421ca6dc452d289314280a0f8842a65");
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), addr(20), Some(oneinch), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), addr(21), Some(oneinch), vec![make_pool_log(pool)]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn attacker_link_without_pool_overlap_is_not_flagged() {
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let unrelated_pool = addr(51);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(unrelated_pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(unrelated_pool)]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn pool_overlap_without_attacker_link_is_not_flagged() {
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), addr(20), Some(addr(30)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), addr(21), Some(addr(31)), vec![make_pool_log(pool)]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn pairs_outside_window_are_ignored() {
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        // Victim at index 3; the matching pair sits at distance 3 on each side (indices 0 and 6),
+        // one step outside the W=2 window, so no bracket must be reported.
+        let receipts = vec![
+            receipt(tx_hash(0), attacker, Some(addr(40)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(1), addr(21), Some(addr(41)), vec![]),
+            receipt(tx_hash(2), addr(22), Some(addr(42)), vec![]),
+            receipt(tx_hash(3), victim_sender, Some(addr(43)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(4), addr(24), Some(addr(44)), vec![]),
+            receipt(tx_hash(5), addr(25), Some(addr(45)), vec![]),
+            receipt(tx_hash(6), attacker, Some(addr(46)), vec![make_pool_log(pool)]),
+        ];
+
+        assert!(detect(&receipts, 3, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn closest_bracket_pair_wins() {
+        let close_attacker = addr(90);
+        let far_attacker = addr(91);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(0), far_attacker, Some(addr(20)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(1), close_attacker, Some(addr(21)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(22)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), close_attacker, Some(addr(23)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(4), far_attacker, Some(addr(24)), vec![make_pool_log(pool)]),
+        ];
+
+        let evidence = detect(&receipts, 2, victim_sender, &Registry::ethereum()).unwrap();
+        assert_eq!(evidence.attacker, close_attacker);
+    }
+
+    #[test]
+    fn self_sandwich_by_shared_sender_excluded() {
+        // The victim's own address appears on both sides — not a sandwich.
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), victim_sender, Some(addr(10)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), victim_sender, Some(addr(12)), vec![make_pool_log(pool)]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn self_sandwich_by_shared_target_excluded() {
+        // The victim's own address is the shared `to` — also not a sandwich.
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), addr(20), Some(victim_sender), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), addr(30), Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), addr(21), Some(victim_sender), vec![make_pool_log(pool)]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn transfer_only_victim_logs_yield_no_pools() {
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let token = addr(60);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(addr(50))]),
+            receipt(
+                tx_hash(2),
+                victim_sender,
+                Some(addr(11)),
+                vec![make_transfer_log(token, victim_sender, addr(11), U256::from(1u64))],
+            ),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(addr(50))]),
+        ];
+
+        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn victim_at_block_edge_does_not_panic() {
+        let victim_sender = addr(1);
+        let receipts =
+            vec![receipt(tx_hash(0), victim_sender, Some(addr(9)), vec![make_pool_log(addr(50))])];
+
+        assert!(detect(&receipts, 0, victim_sender, &Registry::ethereum()).is_none());
+    }
+}

--- a/tools/hindsight/src/decoder/sandwich.rs
+++ b/tools/hindsight/src/decoder/sandwich.rs
@@ -2,8 +2,9 @@
 //!
 //! For a victim trade, scans the receipts immediately around it — already fetched by
 //! [`super::Decoder::decode_block`] in one `eth_getBlockReceipts` call, so detection makes no
-//! extra RPC calls — for a front-run/back-run pair that both link to one attacker and both touch
-//! a pool the victim's swap touched. See
+//! extra RPC calls — for a front-run/back-run pair that links to one attacker, touches a pool
+//! the victim's swap touched, and moves the victim's output token in sandwich direction
+//! (accumulate before the victim, dispose after). See
 //! `docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md` for the heuristic
 //! and its known coarseness (Uniswap V4's singleton pool manager collapses per-pool overlap to
 //! per-protocol).
@@ -11,13 +12,18 @@
 use std::collections::HashSet;
 
 use alloy::{
-    primitives::{Address, TxHash},
+    primitives::{Address, TxHash, U256},
     rpc::types::TransactionReceipt,
     sol,
     sol_types::SolEvent,
 };
 
-use crate::decoder::{ledger::Transfer, registry::Registry, trace::PERMIT2};
+use crate::decoder::{
+    ledger::{to_primitive_log, Transfer},
+    registry::Registry,
+    trace::PERMIT2,
+    DecodedTrade,
+};
 
 sol! {
     /// ERC-20 `Approval` — emitted by token contracts, never by pools, so its emitters are
@@ -41,22 +47,23 @@ pub(crate) struct SandwichEvidence {
 }
 
 /// Scan the window around `victim_index` for the closest front/back pair that brackets the
-/// victim trade (see the module docs for the two conditions a pair must satisfy).
+/// victim trade (see the module docs for the three conditions a pair must satisfy).
 ///
 /// `receipts` is the block's full receipt list in block order; `victim_index` is the victim's
-/// position in that slice, and `victim_sender` its trader (excluded as a linking address — a
-/// trader on both sides of their own trade is not a sandwich). Candidate pairs are tried closest
-/// front first, then closest back, so the first match found is the tightest bracket.
+/// position in that slice. The victim's sender is excluded as a linking address — a trader on
+/// both sides of their own trade is not a sandwich. Candidate pairs are tried closest front
+/// first, then closest back, so the first match found is the tightest bracket.
 pub(crate) fn detect(
     receipts: &[TransactionReceipt],
     victim_index: usize,
-    victim_sender: Address,
+    victim: &DecodedTrade,
     registry: &Registry,
 ) -> Option<SandwichEvidence> {
     let victim_pools = pool_addresses(&receipts[victim_index], registry);
     if victim_pools.is_empty() {
         return None;
     }
+    let token = direction_token(victim.token_out, registry);
 
     let front_start = victim_index.saturating_sub(WINDOW);
     let back_end = (victim_index + WINDOW).min(receipts.len().saturating_sub(1));
@@ -65,12 +72,16 @@ pub(crate) fn detect(
         for back_index in (victim_index + 1)..=back_end {
             let front = &receipts[front_index];
             let back = &receipts[back_index];
-            let Some(attacker) = shared_attacker(front, back, victim_sender, registry) else {
+            let Some(attacker) = shared_attacker(front, back, victim.sender, registry) else {
                 continue;
             };
             let Some(pools) = overlapping_pools(&victim_pools, front, back, registry) else {
                 continue;
             };
+            let entities = direction_entities(front, back, attacker, victim.sender, registry);
+            if !accumulates_then_disposes(front, back, &entities, token) {
+                continue;
+            }
             return Some(SandwichEvidence {
                 front_tx: front.transaction_hash,
                 back_tx: back.transaction_hash,
@@ -158,12 +169,133 @@ fn pool_addresses(receipt: &TransactionReceipt, registry: &Registry) -> HashSet<
     pools
 }
 
+/// The token whose flow confirms sandwich direction: the victim's output token, in the form
+/// receipts can see. Native ETH moves emit no log, so the wrapped form stands in — pools hold
+/// and transfer WETH even when the trader's side settles native.
+fn direction_token(victim_token_out: Address, registry: &Registry) -> Address {
+    if victim_token_out == Address::ZERO {
+        registry.wrapped_native()
+    } else {
+        victim_token_out
+    }
+}
+
+/// The addresses whose token flow can confirm the attacker's direction: the linking address
+/// itself, plus the pair's shared target contract when the link was a shared sender — a bot's
+/// inventory usually sits in its private contract, not in the EOA that signs.
+fn direction_entities(
+    front: &TransactionReceipt,
+    back: &TransactionReceipt,
+    attacker: Address,
+    victim_sender: Address,
+    registry: &Registry,
+) -> Vec<Address> {
+    let mut entities = vec![attacker];
+    if let (Some(front_to), Some(back_to)) = (front.to, back.to) {
+        if front_to == back_to &&
+            front_to != attacker &&
+            front_to != victim_sender &&
+            !registry.is_known(front_to)
+        {
+            entities.push(front_to);
+        }
+    }
+    entities
+}
+
+/// Whether any linked entity accumulated `token` in the front leg and disposed of it in the back
+/// leg — the shape of a real sandwich (buy the victim's output token before them, sell it after).
+///
+/// A linked pair without this flow is far more often benign repeat activity on a busy pool (an
+/// arbitrage bot trading it twice in the window) than a sandwich, so it is not flagged. The cost
+/// is missing an attacker whose legs move only native ETH — invisible in receipts — which is rare:
+/// bots keep inventory wrapped precisely because pools settle in WETH.
+fn accumulates_then_disposes(
+    front: &TransactionReceipt,
+    back: &TransactionReceipt,
+    entities: &[Address],
+    token: Address,
+) -> bool {
+    entities.iter().any(|&entity| {
+        let (front_received, front_sent) = token_flow(front, entity, token);
+        let (back_received, back_sent) = token_flow(back, entity, token);
+        front_received > front_sent && back_sent > back_received
+    })
+}
+
+/// `(received, sent)` totals of `token` for `entity` across a receipt's ERC-20 `Transfer` logs.
+fn token_flow(receipt: &TransactionReceipt, entity: Address, token: Address) -> (U256, U256) {
+    let mut received = U256::ZERO;
+    let mut sent = U256::ZERO;
+    for log in receipt.logs() {
+        if log.address() != token {
+            continue;
+        }
+        let Ok(transfer) = Transfer::decode_log(&to_primitive_log(log)) else {
+            continue;
+        };
+        if transfer.to == entity {
+            received = received.saturating_add(transfer.value);
+        }
+        if transfer.from == entity {
+            sent = sent.saturating_add(transfer.value);
+        }
+    }
+    (received, sent)
+}
+
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, U256};
+    use alloy::{
+        primitives::{address, U256},
+        rpc::types::Log,
+    };
 
     use super::*;
-    use crate::decoder::test_utils::{addr, make_pool_log, make_transfer_log, receipt, tx_hash};
+    use crate::decoder::{
+        test_utils::{addr, make_pool_log, make_transfer_log, receipt, tx_hash},
+        AttributionSource,
+    };
+
+    /// The victim fixture's output token, unless a test overrides it.
+    fn token_out() -> Address {
+        addr(60)
+    }
+
+    fn victim(sender: Address) -> DecodedTrade {
+        victim_swapping_into(sender, token_out())
+    }
+
+    fn victim_swapping_into(sender: Address, token_out: Address) -> DecodedTrade {
+        DecodedTrade {
+            tx_hash: TxHash::default(),
+            block_number: 1,
+            tx_index: 0,
+            venue: "relay".into(),
+            solver: "1inch".into(),
+            solver_source: AttributionSource::TraceMatch,
+            sender,
+            token_in: addr(59),
+            token_out,
+            amount_in: U256::from(1_000u64),
+            amount_out: U256::from(2_000u64),
+            venue_fee: None,
+            venue_fee_out: None,
+            settled_gas: None,
+            quote: None,
+            sandwich: None,
+        }
+    }
+
+    /// Front-leg logs: touch `pool` and accumulate `token` into `entity` (the pool pays out).
+    fn buys(pool: Address, token: Address, entity: Address) -> Vec<Log> {
+        vec![make_pool_log(pool), make_transfer_log(token, pool, entity, U256::from(500u64))]
+    }
+
+    /// Back-leg logs: touch `pool` and dispose of `token` from `entity` (paid into the pool).
+    fn sells(pool: Address, token: Address, entity: Address) -> Vec<Log> {
+        vec![make_pool_log(pool), make_transfer_log(token, entity, pool, U256::from(500u64))]
+    }
 
     #[test]
     fn detects_same_from_bracket() {
@@ -171,12 +303,12 @@ mod tests {
         let victim_sender = addr(1);
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(1), attacker, Some(addr(10)), buys(pool, token_out(), attacker)),
             receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), sells(pool, token_out(), attacker)),
         ];
 
-        let evidence = detect(&receipts, 1, victim_sender, &Registry::ethereum()).unwrap();
+        let evidence = detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).unwrap();
         assert_eq!(evidence.front_tx, tx_hash(1));
         assert_eq!(evidence.back_tx, tx_hash(3));
         assert_eq!(evidence.attacker, attacker);
@@ -189,29 +321,29 @@ mod tests {
         let shared_to = addr(77);
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(1), addr(20), Some(shared_to), vec![make_pool_log(pool)]),
+            receipt(tx_hash(1), addr(20), Some(shared_to), buys(pool, token_out(), shared_to)),
             receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), addr(21), Some(shared_to), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), addr(21), Some(shared_to), sells(pool, token_out(), shared_to)),
         ];
 
-        let evidence = detect(&receipts, 1, victim_sender, &Registry::ethereum()).unwrap();
+        let evidence = detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).unwrap();
         assert_eq!(evidence.attacker, shared_to);
     }
 
     #[test]
     fn same_to_registry_known_is_not_flagged() {
         // 1inch is a registered solver: two unrelated traders entering it must not read as a
-        // shared-attacker link.
+        // shared-attacker link, even when the token flows happen to line up.
         let victim_sender = addr(1);
         let oneinch = address!("0x111111125421ca6dc452d289314280a0f8842a65");
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(1), addr(20), Some(oneinch), vec![make_pool_log(pool)]),
+            receipt(tx_hash(1), addr(20), Some(oneinch), buys(pool, token_out(), oneinch)),
             receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), addr(21), Some(oneinch), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), addr(21), Some(oneinch), sells(pool, token_out(), oneinch)),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -221,12 +353,22 @@ mod tests {
         let pool = addr(50);
         let unrelated_pool = addr(51);
         let receipts = vec![
-            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(unrelated_pool)]),
+            receipt(
+                tx_hash(1),
+                attacker,
+                Some(addr(10)),
+                buys(unrelated_pool, token_out(), attacker),
+            ),
             receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(unrelated_pool)]),
+            receipt(
+                tx_hash(3),
+                attacker,
+                Some(addr(12)),
+                sells(unrelated_pool, token_out(), attacker),
+            ),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -237,12 +379,12 @@ mod tests {
         let victim_sender = addr(1);
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(1), attacker, Some(addr(10)), buys(pool, token_out(), attacker)),
             receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(addr(51))]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), sells(addr(51), token_out(), attacker)),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -251,12 +393,12 @@ mod tests {
         let victim_sender = addr(1);
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(addr(51))]),
+            receipt(tx_hash(1), attacker, Some(addr(10)), buys(addr(51), token_out(), attacker)),
             receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), sells(pool, token_out(), attacker)),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -269,7 +411,88 @@ mod tests {
             receipt(tx_hash(3), addr(21), Some(addr(31)), vec![make_pool_log(pool)]),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn linked_pair_without_token_flow_is_not_flagged() {
+        // Attacker link and pool overlap hold, but neither leg moves the victim's output token
+        // for any linked entity — repeat activity on a busy pool, not a bracket.
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(pool)]),
+        ];
+
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn same_direction_both_legs_is_not_flagged() {
+        // An arbitrage bot buying the same token on the same pool twice around an unrelated
+        // victim accumulates on both legs — no dispose leg, no sandwich.
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), buys(pool, token_out(), attacker)),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), buys(pool, token_out(), attacker)),
+        ];
+
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
+    }
+
+    #[test]
+    fn inventory_in_shared_contract_confirms_direction() {
+        // Typical bot shape: one EOA signs both legs (the link), but the token inventory moves
+        // through its private contract — the shared `to` — not the EOA itself.
+        let attacker_eoa = addr(90);
+        let bot_contract = addr(80);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(
+                tx_hash(1),
+                attacker_eoa,
+                Some(bot_contract),
+                buys(pool, token_out(), bot_contract),
+            ),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(
+                tx_hash(3),
+                attacker_eoa,
+                Some(bot_contract),
+                sells(pool, token_out(), bot_contract),
+            ),
+        ];
+
+        let evidence = detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).unwrap();
+        assert_eq!(evidence.attacker, attacker_eoa);
+    }
+
+    #[test]
+    fn native_output_checks_wrapped_flow() {
+        // The victim receives native ETH, which emits no log: the attacker's legs show as WETH
+        // transfers instead, so direction is confirmed on the wrapped form.
+        let registry = Registry::ethereum();
+        let weth = registry.wrapped_native();
+        let attacker = addr(90);
+        let victim_sender = addr(1);
+        let pool = addr(50);
+        let receipts = vec![
+            receipt(tx_hash(1), attacker, Some(addr(10)), buys(pool, weth, attacker)),
+            receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), sells(pool, weth, attacker)),
+        ];
+
+        let evidence =
+            detect(&receipts, 1, &victim_swapping_into(victim_sender, Address::ZERO), &registry)
+                .unwrap();
+        assert_eq!(evidence.attacker, attacker);
     }
 
     #[test]
@@ -280,16 +503,16 @@ mod tests {
         // Victim at index 3; the matching pair sits at distance 3 on each side (indices 0 and 6),
         // one step outside the W=2 window, so no bracket must be reported.
         let receipts = vec![
-            receipt(tx_hash(0), attacker, Some(addr(40)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(0), attacker, Some(addr(40)), buys(pool, token_out(), attacker)),
             receipt(tx_hash(1), addr(21), Some(addr(41)), vec![]),
             receipt(tx_hash(2), addr(22), Some(addr(42)), vec![]),
             receipt(tx_hash(3), victim_sender, Some(addr(43)), vec![make_pool_log(pool)]),
             receipt(tx_hash(4), addr(24), Some(addr(44)), vec![]),
             receipt(tx_hash(5), addr(25), Some(addr(45)), vec![]),
-            receipt(tx_hash(6), attacker, Some(addr(46)), vec![make_pool_log(pool)]),
+            receipt(tx_hash(6), attacker, Some(addr(46)), sells(pool, token_out(), attacker)),
         ];
 
-        assert!(detect(&receipts, 3, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 3, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -299,14 +522,34 @@ mod tests {
         let victim_sender = addr(1);
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(0), far_attacker, Some(addr(20)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(1), close_attacker, Some(addr(21)), vec![make_pool_log(pool)]),
+            receipt(
+                tx_hash(0),
+                far_attacker,
+                Some(addr(20)),
+                buys(pool, token_out(), far_attacker),
+            ),
+            receipt(
+                tx_hash(1),
+                close_attacker,
+                Some(addr(21)),
+                buys(pool, token_out(), close_attacker),
+            ),
             receipt(tx_hash(2), victim_sender, Some(addr(22)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), close_attacker, Some(addr(23)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(4), far_attacker, Some(addr(24)), vec![make_pool_log(pool)]),
+            receipt(
+                tx_hash(3),
+                close_attacker,
+                Some(addr(23)),
+                sells(pool, token_out(), close_attacker),
+            ),
+            receipt(
+                tx_hash(4),
+                far_attacker,
+                Some(addr(24)),
+                sells(pool, token_out(), far_attacker),
+            ),
         ];
 
-        let evidence = detect(&receipts, 2, victim_sender, &Registry::ethereum()).unwrap();
+        let evidence = detect(&receipts, 2, &victim(victim_sender), &Registry::ethereum()).unwrap();
         assert_eq!(evidence.attacker, close_attacker);
     }
 
@@ -316,12 +559,22 @@ mod tests {
         let victim_sender = addr(1);
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(1), victim_sender, Some(addr(10)), vec![make_pool_log(pool)]),
+            receipt(
+                tx_hash(1),
+                victim_sender,
+                Some(addr(10)),
+                buys(pool, token_out(), victim_sender),
+            ),
             receipt(tx_hash(2), victim_sender, Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), victim_sender, Some(addr(12)), vec![make_pool_log(pool)]),
+            receipt(
+                tx_hash(3),
+                victim_sender,
+                Some(addr(12)),
+                sells(pool, token_out(), victim_sender),
+            ),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -330,12 +583,22 @@ mod tests {
         let victim_sender = addr(1);
         let pool = addr(50);
         let receipts = vec![
-            receipt(tx_hash(1), addr(20), Some(victim_sender), vec![make_pool_log(pool)]),
+            receipt(
+                tx_hash(1),
+                addr(20),
+                Some(victim_sender),
+                buys(pool, token_out(), victim_sender),
+            ),
             receipt(tx_hash(2), addr(30), Some(addr(11)), vec![make_pool_log(pool)]),
-            receipt(tx_hash(3), addr(21), Some(victim_sender), vec![make_pool_log(pool)]),
+            receipt(
+                tx_hash(3),
+                addr(21),
+                Some(victim_sender),
+                sells(pool, token_out(), victim_sender),
+            ),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -344,17 +607,17 @@ mod tests {
         let victim_sender = addr(1);
         let token = addr(60);
         let receipts = vec![
-            receipt(tx_hash(1), attacker, Some(addr(10)), vec![make_pool_log(addr(50))]),
+            receipt(tx_hash(1), attacker, Some(addr(10)), buys(addr(50), token_out(), attacker)),
             receipt(
                 tx_hash(2),
                 victim_sender,
                 Some(addr(11)),
                 vec![make_transfer_log(token, victim_sender, addr(11), U256::from(1u64))],
             ),
-            receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(addr(50))]),
+            receipt(tx_hash(3), attacker, Some(addr(12)), sells(addr(50), token_out(), attacker)),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -371,7 +634,7 @@ mod tests {
             receipt(tx_hash(3), attacker, Some(addr(12)), vec![make_pool_log(weth)]),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &registry).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &registry).is_none());
     }
 
     #[test]
@@ -387,7 +650,7 @@ mod tests {
                 vec![Approval::SIGNATURE_HASH, owner.into_word(), addr(70).into_word()],
                 alloy::primitives::Bytes::new(),
             );
-            alloy::rpc::types::Log { inner: primitive, ..Default::default() }
+            Log { inner: primitive, ..Default::default() }
         };
         let receipts = vec![
             receipt(tx_hash(1), attacker, Some(addr(10)), vec![approval(attacker)]),
@@ -395,7 +658,7 @@ mod tests {
             receipt(tx_hash(3), attacker, Some(addr(12)), vec![approval(attacker)]),
         ];
 
-        assert!(detect(&receipts, 1, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 1, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 
     #[test]
@@ -404,6 +667,6 @@ mod tests {
         let receipts =
             vec![receipt(tx_hash(0), victim_sender, Some(addr(9)), vec![make_pool_log(addr(50))])];
 
-        assert!(detect(&receipts, 0, victim_sender, &Registry::ethereum()).is_none());
+        assert!(detect(&receipts, 0, &victim(victim_sender), &Registry::ethereum()).is_none());
     }
 }

--- a/tools/hindsight/src/decoder/test_utils.rs
+++ b/tools/hindsight/src/decoder/test_utils.rs
@@ -1,6 +1,7 @@
 use alloy::{
-    primitives::{Address, Bytes, Log as PrimitiveLog, B256, U256},
-    rpc::types::{trace::geth::CallFrame, Log},
+    consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom},
+    primitives::{Address, Bloom, Bytes, Log as PrimitiveLog, TxHash, B256, U256},
+    rpc::types::{trace::geth::CallFrame, Log, TransactionReceipt},
     sol_types::SolEvent,
 };
 
@@ -11,6 +12,13 @@ pub(crate) fn addr(n: u8) -> Address {
     let mut bytes = [0u8; 20];
     bytes[19] = n;
     Address::from(bytes)
+}
+
+/// A transaction hash with `n` in its last byte, for readable test fixtures.
+pub(crate) fn tx_hash(n: u8) -> TxHash {
+    let mut bytes = [0u8; 32];
+    bytes[31] = n;
+    TxHash::from(bytes)
 }
 
 /// A [`NetSwap`] literal, for concise assertions.
@@ -63,5 +71,40 @@ pub(crate) fn frame(typ: &str, from: Address, to: Address, value: u64) -> CallFr
         value: Some(U256::from(value)),
         typ: typ.to_string(),
         ..Default::default()
+    }
+}
+
+/// A log with an arbitrary non-`Transfer` topic0, standing in for a pool event (`Swap`, `Sync`,
+/// …) whose payload sandwich detection never decodes — only the emitting address matters.
+pub(crate) fn make_pool_log(pool: Address) -> Log {
+    let primitive = PrimitiveLog::new_unchecked(pool, vec![B256::repeat_byte(0xAA)], Bytes::new());
+    Log { inner: primitive, ..Default::default() }
+}
+
+/// A synthetic transaction receipt for decoder tests that need block-level context (sandwich
+/// detection): a sender, an optional entry point (`to`), and its logs. Every other field is
+/// irrelevant to the code under test.
+pub(crate) fn receipt(
+    hash: TxHash,
+    from: Address,
+    to: Option<Address>,
+    logs: Vec<Log>,
+) -> TransactionReceipt {
+    TransactionReceipt {
+        inner: ReceiptEnvelope::Legacy(ReceiptWithBloom {
+            receipt: Receipt { status: Eip658Value::Eip658(true), cumulative_gas_used: 0, logs },
+            logs_bloom: Bloom::default(),
+        }),
+        transaction_hash: hash,
+        transaction_index: None,
+        block_hash: None,
+        block_number: None,
+        gas_used: 0,
+        effective_gas_price: 0,
+        blob_gas_used: None,
+        blob_gas_price: None,
+        from,
+        to,
+        contract_address: None,
     }
 }

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -220,6 +220,7 @@ fn print_trades(trades: &[decoder::DecodedTrade]) {
     println!("\n{} solver trade(s) found:\n", trades.len());
     for trade in trades {
         println!("  tx:         {}", trade.tx_hash);
+        println!("  tx_index:   {}", trade.tx_index);
         println!("  block:      {}", trade.block_number);
         println!("  venue:      {}", trade.venue);
         println!("  solver:     {}", trade.solver);
@@ -228,6 +229,12 @@ fn print_trades(trades: &[decoder::DecodedTrade]) {
         println!("  amount_in:  {}", trade.amount_in);
         println!("  token_out:  {}", trade.token_out);
         println!("  amount_out: {}", trade.amount_out);
+        if let Some(sandwich) = &trade.sandwich {
+            println!(
+                "  sandwich:   front={} back={} attacker={}",
+                sandwich.front_tx, sandwich.back_tx, sandwich.attacker
+            );
+        }
         println!();
     }
 }

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -42,6 +42,11 @@ pub(crate) enum Verdict {
     CoverageMiss,
     /// Fynd could not solve the trade at all.
     Unsolvable,
+    /// The trade's settlement was bracketed by a front-run and a back-run (see
+    /// `decoder::sandwich`): the settled output was moved by MEV, not by inferior routing, so
+    /// this is not a fair win or loss. The bps/USD deltas are still computed and written to
+    /// JSONL for offline analysis; only the classification changes.
+    Sandwiched,
 }
 
 /// Minimum fraction of the settled output Fynd must produce for the result to count as a real

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -524,12 +524,16 @@ mod tests {
             pools: vec![Address::repeat_byte(0x44)],
         });
 
-        let range = build_range(
-            &trade,
-            &usd::PriceMap::new(),
-            Outcome::Unsolvable("x".into()),
-            Outcome::Unsolvable("x".into()),
-        );
+        // Solved states: only those are reclassified as sandwiched (unsolved keep their verdict).
+        let solved = |amount: u64| {
+            Outcome::Solved(SolvedAmount {
+                amount_out: U256::from(amount),
+                amount_out_net_gas: U256::from(amount),
+                gas_estimate: U256::from(21_000u64),
+                quote_json: None,
+            })
+        };
+        let range = build_range(&trade, &usd::PriceMap::new(), solved(1_100), solved(1_050));
         let rec = comparison_record(&range, &usd::PriceMap::new(), &usd::PriceMap::new());
 
         assert_eq!(rec.pointer("/tx_index").unwrap(), 42);

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -149,6 +149,7 @@ fn comparison_record(
 ) -> serde_json::Value {
     serde_json::json!({
         "block": range.block_number,
+        "tx_index": range.tx_index,
         "settled_tx": range.tx_hash,
         "venue": range.venue,
         "solver": range.solver,
@@ -162,6 +163,7 @@ fn comparison_record(
         "quoted_amount_out": range.quote.as_ref().map(|q| q.amount_out.to_string()),
         "quote_source": range.quote.as_ref().and_then(|q| q.source.clone()),
         "quote_timestamp": range.quote.as_ref().and_then(|q| q.timestamp),
+        "sandwich": range.sandwich,
         "top": state_record(&range.top, range, prices_top),
         "back": state_record(&range.back, range, prices_back),
     })
@@ -260,7 +262,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        decoder::{AttributionSource, DecodedTrade, SolverQuote},
+        decoder::{AttributionSource, DecodedTrade, SandwichEvidence, SolverQuote},
         resolve::{build_range, SolvedAmount},
     };
 
@@ -305,6 +307,7 @@ mod tests {
         let trade = DecodedTrade {
             tx_hash: TxHash::default(),
             block_number: 25_480_207,
+            tx_index: 3,
             venue: "relay".into(),
             solver: "kyberswap".into(),
             solver_source: AttributionSource::TraceMatch,
@@ -321,6 +324,7 @@ mod tests {
                 source: Some("relay".to_string()),
                 timestamp: Some(1_783_421_726),
             }),
+            sandwich: None,
         };
         let range = build_range(
             &trade,
@@ -329,6 +333,7 @@ mod tests {
             Outcome::Unsolvable("x".into()),
         );
         let rec = comparison_record(&range, &usd::PriceMap::new(), &usd::PriceMap::new());
+        assert_eq!(rec.pointer("/tx_index").unwrap(), 3);
         assert_eq!(
             rec.pointer("/quoted_amount_out")
                 .unwrap(),
@@ -376,6 +381,7 @@ mod tests {
         let trade = DecodedTrade {
             tx_hash: TxHash::default(),
             block_number: 25_000_000,
+            tx_index: 0,
             venue: "relay".into(),
             solver: "1inch".into(),
             solver_source: AttributionSource::TraceMatch,
@@ -388,6 +394,7 @@ mod tests {
             venue_fee_out: None,
             settled_gas: None,
             quote: None,
+            sandwich: None,
         };
         // quote_json is already the slim projection (what order_quote_to_outcome stores).
         let quote = Some(
@@ -455,6 +462,7 @@ mod tests {
         let trade = DecodedTrade {
             tx_hash: TxHash::default(),
             block_number: 25_000_000,
+            tx_index: 0,
             venue: "relay".into(),
             solver: "1inch".into(),
             solver_source: AttributionSource::TraceMatch,
@@ -467,6 +475,7 @@ mod tests {
             venue_fee_out: None,
             settled_gas: None,
             quote: None,
+            sandwich: None,
         };
         // A coverage gap: Fynd could not solve at either state.
         let range = build_range(
@@ -486,5 +495,55 @@ mod tests {
             .pointer("/top/quote")
             .unwrap()
             .is_null());
+    }
+
+    #[test]
+    fn comparison_record_carries_sandwich_evidence_and_becomes_sandwiched_verdict() {
+        let mut trade = DecodedTrade {
+            tx_hash: TxHash::default(),
+            block_number: 25_000_000,
+            tx_index: 42,
+            venue: "relay".into(),
+            solver: "1inch".into(),
+            solver_source: AttributionSource::TraceMatch,
+            sender: Address::ZERO,
+            token_in: Address::repeat_byte(0x11),
+            token_out: Address::repeat_byte(0x22),
+            amount_in: U256::from(1_000u64),
+            amount_out: U256::from(1_000u64),
+            venue_fee: None,
+            venue_fee_out: None,
+            settled_gas: None,
+            quote: None,
+            sandwich: None,
+        };
+        trade.sandwich = Some(SandwichEvidence {
+            front_tx: TxHash::repeat_byte(0x11),
+            back_tx: TxHash::repeat_byte(0x22),
+            attacker: Address::repeat_byte(0x33),
+            pools: vec![Address::repeat_byte(0x44)],
+        });
+
+        let range = build_range(
+            &trade,
+            &usd::PriceMap::new(),
+            Outcome::Unsolvable("x".into()),
+            Outcome::Unsolvable("x".into()),
+        );
+        let rec = comparison_record(&range, &usd::PriceMap::new(), &usd::PriceMap::new());
+
+        assert_eq!(rec.pointer("/tx_index").unwrap(), 42);
+        assert_eq!(rec.pointer("/top/verdict").unwrap(), "sandwiched");
+        assert_eq!(rec.pointer("/back/verdict").unwrap(), "sandwiched");
+        assert_eq!(
+            rec.pointer("/sandwich/attacker")
+                .unwrap(),
+            &format!("{:#x}", Address::repeat_byte(0x33))
+        );
+        assert_eq!(
+            rec.pointer("/sandwich/pools/0")
+                .unwrap(),
+            &format!("{:#x}", Address::repeat_byte(0x44))
+        );
     }
 }

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use compare::{Deltas, Verdict};
 use serde::Serialize;
 
 use crate::{
-    decoder::{AttributionSource, DecodedTrade, SolverQuote},
+    decoder::{AttributionSource, DecodedTrade, SandwichEvidence, SolverQuote},
     usd,
 };
 
@@ -68,6 +68,7 @@ impl StateResult {
 pub(crate) struct RangeComparison {
     pub tx_hash: TxHash,
     pub block_number: u64,
+    pub tx_index: u64,
     pub venue: String,
     pub solver: String,
     /// The evidence tier the solver label came from (from the decoder).
@@ -84,6 +85,9 @@ pub(crate) struct RangeComparison {
     pub settled_gas: Option<U256>,
     /// The solver's own off-chain quote from its calldata, when declared (from the decoder).
     pub quote: Option<SolverQuote>,
+    /// Evidence that a front-run and a back-run bracketed this trade (from the decoder). `None`
+    /// when no bracket pair was found.
+    pub sandwich: Option<SandwichEvidence>,
     /// Optimistic: solved at state N-1, before the block's swaps moved the pools.
     pub top: StateResult,
     /// Pessimistic: solved at state N, after the block's swaps moved the pools.
@@ -109,6 +113,11 @@ pub(crate) trait SteppingSolver {
 /// into `token_out` units at the `prices` snapshot (top-of-block — a fine approximation for a gas
 /// deduction) and subtracted from the settled output, so both sides of the net comparison carry
 /// their own gas.
+///
+/// When the decoder flagged the trade as sandwiched, both per-state verdicts (and therefore the
+/// headline verdict) become [`Verdict::Sandwiched`] — the settled output was moved by MEV, not by
+/// inferior routing — but the bps/USD deltas are left untouched, so the size of MEV-inflated
+/// deltas stays studyable offline.
 pub(crate) fn build_range(
     trade: &DecodedTrade,
     prices: &usd::PriceMap,
@@ -119,12 +128,17 @@ pub(crate) fn build_range(
         .settled_gas
         .and_then(|gas| usd::gas_in_token(gas, trade.token_out, prices))
         .map_or(trade.amount_out, |gas_out| trade.amount_out.saturating_sub(gas_out));
-    let top = StateResult::new(top, trade.amount_out, settled_net_gas);
-    let back = StateResult::new(back, trade.amount_out, settled_net_gas);
+    let mut top = StateResult::new(top, trade.amount_out, settled_net_gas);
+    let mut back = StateResult::new(back, trade.amount_out, settled_net_gas);
+    if trade.sandwich.is_some() {
+        top.verdict = Verdict::Sandwiched;
+        back.verdict = Verdict::Sandwiched;
+    }
     let verdict = top.verdict;
     RangeComparison {
         tx_hash: trade.tx_hash,
         block_number: trade.block_number,
+        tx_index: trade.tx_index,
         venue: trade.venue.clone(),
         solver: trade.solver.clone(),
         solver_source: trade.solver_source,
@@ -135,6 +149,7 @@ pub(crate) fn build_range(
         settled_amount_out_net_gas: settled_net_gas,
         settled_gas: trade.settled_gas,
         quote: trade.quote.clone(),
+        sandwich: trade.sandwich.clone(),
         top,
         back,
         verdict,
@@ -172,12 +187,15 @@ pub(crate) async fn resolve_block_range<S: SteppingSolver + ?Sized>(
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::TxHash;
+
     use super::*;
 
     fn trade(settled: u64) -> DecodedTrade {
         DecodedTrade {
             tx_hash: TxHash::default(),
             block_number: 21_000_000,
+            tx_index: 0,
             venue: "relay".into(),
             solver: "tycho".into(),
             solver_source: AttributionSource::TraceMatch,
@@ -190,6 +208,7 @@ mod tests {
             venue_fee_out: None,
             settled_gas: None,
             quote: None,
+            sandwich: None,
         }
     }
 
@@ -253,6 +272,30 @@ mod tests {
         assert_eq!(range.verdict, Verdict::CoverageMiss);
         assert_eq!(range.top.deltas, Deltas { raw_bps: None, net_bps: None });
         assert!(matches!(range.top.outcome, Outcome::Partial(_)));
+    }
+
+    #[test]
+    fn build_range_sandwiched_trade_overrides_verdict_but_keeps_deltas() {
+        let mut sandwiched = trade(10_000);
+        sandwiched.sandwich = Some(SandwichEvidence {
+            front_tx: TxHash::repeat_byte(0xaa),
+            back_tx: TxHash::repeat_byte(0xbb),
+            attacker: Address::repeat_byte(0xcc),
+            pools: vec![Address::repeat_byte(0xdd)],
+        });
+        let range = build_range(
+            &sandwiched,
+            &usd::PriceMap::new(),
+            solved(10_200, 10_100),
+            solved(9_800, 9_700),
+        );
+
+        assert_eq!(range.verdict, Verdict::Sandwiched);
+        assert_eq!(range.top.verdict, Verdict::Sandwiched);
+        assert_eq!(range.back.verdict, Verdict::Sandwiched);
+        // Deltas are unaffected by the override: still computed for offline analysis.
+        assert!(range.top.deltas.raw_bps.unwrap() > 0.0);
+        assert!(range.back.deltas.raw_bps.unwrap() < 0.0);
     }
 
     #[test]

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -114,10 +114,12 @@ pub(crate) trait SteppingSolver {
 /// deduction) and subtracted from the settled output, so both sides of the net comparison carry
 /// their own gas.
 ///
-/// When the decoder flagged the trade as sandwiched, both per-state verdicts (and therefore the
-/// headline verdict) become [`Verdict::Sandwiched`] — the settled output was moved by MEV, not by
-/// inferior routing — but the bps/USD deltas are left untouched, so the size of MEV-inflated
-/// deltas stays studyable offline.
+/// When the decoder flagged the trade as sandwiched, each *solved* state's verdict becomes
+/// [`Verdict::Sandwiched`]: its win or loss measures the MEV that moved the settled output, not
+/// routing quality. Unsolved states keep their verdicts — a sandwich explains the settled price,
+/// not why Fynd had no route, so the coverage buckets (`Unsolvable`, `CoverageMiss`) stay
+/// intact. The bps/USD deltas are left untouched either way, so the size of MEV-inflated deltas
+/// stays studyable offline.
 pub(crate) fn build_range(
     trade: &DecodedTrade,
     prices: &usd::PriceMap,
@@ -131,8 +133,11 @@ pub(crate) fn build_range(
     let mut top = StateResult::new(top, trade.amount_out, settled_net_gas);
     let mut back = StateResult::new(back, trade.amount_out, settled_net_gas);
     if trade.sandwich.is_some() {
-        top.verdict = Verdict::Sandwiched;
-        back.verdict = Verdict::Sandwiched;
+        for state in [&mut top, &mut back] {
+            if let Outcome::Solved(_) = state.outcome {
+                state.verdict = Verdict::Sandwiched;
+            }
+        }
     }
     let verdict = top.verdict;
     RangeComparison {
@@ -296,6 +301,29 @@ mod tests {
         // Deltas are unaffected by the override: still computed for offline analysis.
         assert!(range.top.deltas.raw_bps.unwrap() > 0.0);
         assert!(range.back.deltas.raw_bps.unwrap() < 0.0);
+    }
+
+    #[test]
+    fn build_range_sandwich_override_spares_unsolved_states() {
+        // The sandwich explains the settled price, not why Fynd had no route: an unsolved state
+        // keeps its verdict so the coverage buckets are unaffected by the reclassification.
+        let mut sandwiched = trade(10_000);
+        sandwiched.sandwich = Some(SandwichEvidence {
+            front_tx: TxHash::repeat_byte(0xaa),
+            back_tx: TxHash::repeat_byte(0xbb),
+            attacker: Address::repeat_byte(0xcc),
+            pools: vec![Address::repeat_byte(0xdd)],
+        });
+        let range = build_range(
+            &sandwiched,
+            &usd::PriceMap::new(),
+            solved(10_200, 10_100),
+            Outcome::Unsolvable("missing token in Tycho".into()),
+        );
+
+        assert_eq!(range.top.verdict, Verdict::Sandwiched);
+        assert_eq!(range.back.verdict, Verdict::Unsolvable);
+        assert_eq!(range.verdict, Verdict::Sandwiched); // headline follows top
     }
 
     #[test]

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -405,6 +405,7 @@ mod tests {
         assert_eq!(outcome_label(Verdict::Loss), "loss");
         assert_eq!(outcome_label(Verdict::CoverageMiss), "coverage_miss");
         assert_eq!(outcome_label(Verdict::Unsolvable), "unsolvable");
+        assert_eq!(outcome_label(Verdict::Sandwiched), "sandwiched");
     }
 
     #[test]

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -74,6 +74,7 @@ pub(crate) fn outcome_label(verdict: Verdict) -> &'static str {
         Verdict::Loss => "loss",
         Verdict::CoverageMiss => "coverage_miss",
         Verdict::Unsolvable => "unsolvable",
+        Verdict::Sandwiched => "sandwiched",
     }
 }
 
@@ -187,7 +188,13 @@ pub(crate) fn record_range(
 /// Fynd beats the settled trade; a venue routes elsewhere when Fynd is worse). All highlighted
 /// metrics compare gross vs gross, matching the headline verdict.
 ///
-/// Returns the signed USD savings it recorded, `None` when the state is unsolved or unpriced.
+/// A sandwiched state's output was moved by MEV, not by Fynd's own routing, so it skips the
+/// `SAVINGS_BPS`/`SAVINGS_USD`/`IMPROVEMENT_USD` histograms — the USD pair carry no outcome
+/// label, so skipping is the only way to keep the "value of adding Fynd" aggregates clean. The
+/// USD value is still computed and returned so the per-trade Loki line (in [`record_range`])
+/// keeps logging.
+///
+/// Returns the signed USD savings it computed, `None` when the state is unsolved or unpriced.
 fn record_state(
     range: &RangeComparison,
     state: &StateResult,
@@ -205,16 +212,20 @@ fn record_state(
     )
     .increment(1);
 
-    if let Some(bps) = state.deltas.raw_bps {
-        histogram!(
-            SAVINGS_BPS,
-            "venue" => labels.venue.to_string(),
-            "solver" => labels.solver.to_string(),
-            "chain" => labels.chain.to_string(),
-            "outcome" => outcome_label(state.verdict).to_string(),
-            "state" => state_label,
-        )
-        .record(bps);
+    let sandwiched = state.verdict == Verdict::Sandwiched;
+
+    if !sandwiched {
+        if let Some(bps) = state.deltas.raw_bps {
+            histogram!(
+                SAVINGS_BPS,
+                "venue" => labels.venue.to_string(),
+                "solver" => labels.solver.to_string(),
+                "chain" => labels.chain.to_string(),
+                "outcome" => outcome_label(state.verdict).to_string(),
+                "state" => state_label,
+            )
+            .record(bps);
+        }
     }
 
     let Outcome::Solved(solved) = &state.outcome else {
@@ -222,6 +233,10 @@ fn record_state(
     };
     let usd =
         usd::savings_usd(range.token_out, solved.amount_out, range.settled_amount_out, prices)?;
+    if sandwiched {
+        return Some(usd);
+    }
+
     if is_usd_outlier(usd) {
         warn!(
             tx = %range.tx_hash,
@@ -350,7 +365,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        decoder::{AttributionSource, DecodedTrade},
+        decoder::{AttributionSource, DecodedTrade, SandwichEvidence},
         resolve::{build_range, SolvedAmount},
     };
 
@@ -358,6 +373,7 @@ mod tests {
         DecodedTrade {
             tx_hash: TxHash::default(),
             block_number: 21_000_000,
+            tx_index: 0,
             venue: "relay".into(),
             solver: "tycho".into(),
             solver_source: AttributionSource::TraceMatch,
@@ -370,6 +386,7 @@ mod tests {
             venue_fee_out: None,
             settled_gas: None,
             quote: None,
+            sandwich: None,
         }
     }
 
@@ -582,5 +599,42 @@ mod tests {
         // No solved state and no prices → no savings/improvement samples.
         assert!(!rendered.contains("hindsight_savings_bps"));
         assert!(!rendered.contains("hindsight_improvement_usd"));
+    }
+
+    #[test]
+    fn record_range_skips_savings_when_sandwiched() {
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        let mut sandwiched = trade(usdc, 1_000_000_000);
+        sandwiched.sandwich = Some(SandwichEvidence {
+            front_tx: TxHash::repeat_byte(0xaa),
+            back_tx: TxHash::repeat_byte(0xbb),
+            attacker: Address::repeat_byte(0xcc),
+            pools: vec![Address::repeat_byte(0xdd)],
+        });
+        let prices = usd::PriceMap::from([(usdc, 2e-9)]);
+        let range = build_range(
+            &sandwiched,
+            &prices,
+            solved(1_100_000_000, 1_090_000_000),
+            solved(1_100_000_000, 1_090_000_000),
+        );
+        assert_eq!(range.verdict, Verdict::Sandwiched);
+
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(&range, "ethereum", &prices, &prices, &Registry::ethereum());
+        });
+        let rendered = handle.render();
+
+        assert!(rendered.contains("outcome=\"sandwiched\""), "rendered: {rendered}");
+        // Volume is still tracked, tagged with the sandwiched outcome — only the "value of adding
+        // Fynd" histograms are excluded.
+        assert!(rendered.contains("hindsight_volume_usd"));
+        assert!(!rendered.contains("hindsight_savings_bps"), "rendered: {rendered}");
+        assert!(!rendered.contains("hindsight_savings_usd"), "rendered: {rendered}");
+        assert!(!rendered.contains("hindsight_improvement_usd"), "rendered: {rendered}");
     }
 }

--- a/tools/hindsight/src/verify/mod.rs
+++ b/tools/hindsight/src/verify/mod.rs
@@ -417,6 +417,7 @@ mod tests {
         DecodedTrade {
             tx_hash: TxHash::ZERO,
             block_number: 1,
+            tx_index: 0,
             venue: "relay".to_string(),
             solver: solver.to_string(),
             solver_source: AttributionSource::TraceMatch,
@@ -429,6 +430,7 @@ mod tests {
             venue_fee_out: None,
             settled_gas: None,
             quote: None,
+            sandwich: None,
         }
     }
 


### PR DESCRIPTION
## What

hindsight now detects likely sandwich attacks around decoded solver trades and classifies them apart from real wins and losses.

- New `decoder/sandwich.rs`: for each decoded trade, scans a window of 2 transactions on each side — using the block receipts `decode_block` already fetched, so no extra RPC calls — for a front/back pair that (a) links to one attacker (same sender, or same non-registry-known target contract), (b) both re-emit a log from a pool contract the victim's swap touched, and (c) moves the victim's output token in sandwich direction: a linked entity receives it in the front leg and sends it in the back leg, read from each leg's Transfer logs. A native-ETH output is checked as its wrapped form. Pool candidates exclude token contracts (Transfer/Approval emitters), the wrapped-native token, and Permit2, so transactions sharing only a token or its plumbing cannot produce a fake overlap.
- `DecodedTrade` and `RangeComparison` gain `tx_index` and `sandwich` evidence (`front_tx`, `back_tx`, `attacker`, `pools`); both appear in the JSONL comparison records and the `decode` subcommand output. All fields are additive.
- New `Verdict::Sandwiched`: a flagged trade's solved states are reclassified (the headline follows top-of-block) while bps/USD deltas are still computed and written, so the size of MEV-inflated deltas stays analyzable offline. Unsolved states keep `Unsolvable`/`CoverageMiss` — a sandwich explains the settled price, not a missing route — so coverage shares are unaffected.
- Telemetry: trade/volume metrics gain the `outcome="sandwiched"` label; sandwiched states skip the savings/improvement histograms so the "value of adding Fynd" aggregates exclude MEV-degraded settlements. The per-trade Loki line keeps logging with `verdict=sandwiched`.

Known limitations (false negatives keep polluting savings as all sandwiches did before this feature; false positives exclude real comparisons) are listed in the design spec: `docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md`.

## Why

Many of the largest "improvement" opportunities in hindsight output were sandwich victims: a frontrun degraded the settled output, so the top-of-block re-solve looked like a large win Fynd could not actually have captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)