### PR TITLE
ci: make pre-releases safe to cut from any branch

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -108,7 +108,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            # Pre-releases (e.g. 0.90.0-rc.1) must not move the floating tag.
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
             type=sha,prefix=sha-
 
       - name: Create and push manifest
@@ -134,7 +135,9 @@ jobs:
   promote-staging:
     name: Promote to staging
     needs: merge
-    if: github.event_name == 'release'
+    # Pre-releases build and push the image but are deployed deliberately,
+    # not auto-promoted to the staging environment.
+    if: github.event_name == 'release' && !github.event.release.prerelease
     concurrency:
       group: promote-staging
       cancel-in-progress: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,9 @@ env:
 jobs:
   publish-crates:
     name: Publish Crates
+    # Pre-releases build a Docker image only; registry publishing happens on
+    # full releases (or manual dispatch).
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -47,6 +50,9 @@ jobs:
 
   publish-npm:
     name: Publish TypeScript packages to npm
+    # Pre-releases build a Docker image only; registry publishing happens on
+    # full releases (or manual dispatch).
+    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:


### PR DESCRIPTION
GitHub pre-releases currently trigger the same side effects as full releases. This guards three of them on `github.event.release.prerelease`:

- `docker.yaml`: the multi-arch manifest no longer retags `latest` for pre-releases (version and `sha-` tags still push)
- `docker.yaml`: `promote-staging` is skipped for pre-releases — the tag is deployed deliberately instead of auto-promoted
- `release.yaml`: crates.io and npm publish jobs are skipped for pre-releases (manual `workflow_dispatch` still works)

With these guards a pre-release cut from any branch builds and pushes only its own version-tagged image, e.g. `ghcr.io/propeller-heads/fynd:0.90.0-rc.1`. Motivation: pre-release staging deploys of unmerged work (capacity harness, PRs #300/#301) without touching `latest` or the registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)