### PR TITLE
feat: support self-hosted custom chains (quote-only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,7 +3427,6 @@ dependencies = [
  "futures 0.3.32",
  "fynd-test-fixtures",
  "itertools 0.14.0",
- "lazy_static",
  "metrics",
  "num-bigint",
  "num-rational",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -5593,7 +5596,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.4",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6699,6 +6702,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7756,9 +7772,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.331.0"
+version = "0.334.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0016d3b1320e456d9d82690425fd1d32bb1b6ba59d8e2c17466a95bb7ef8171"
+checksum = "b7543a5e1434564cc00de64db37e993b7c04a9a3606998d34223a66338a17446"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7786,11 +7802,12 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.331.0"
+version = "0.334.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c005588841e242b212d2b111bb2283cda4e49e5589f72281ae5a03ea248031f"
+checksum = "68ad315320279aaa0a889c2908a532cce80dd5788bc3029d30d687179abdf5a6"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "async-trait",
  "bytes",
  "chrono",
@@ -7801,6 +7818,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
+ "serde_yaml",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -7813,9 +7831,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.331.0"
+version = "0.334.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d25adf4f79dbcb37e87231815055a5ec6f171ff33355a407434b2368eddbc5e"
+checksum = "ee3b3565cb9dadd29e72faf80ba74bab0894a6d35e6f04eda8a617c733ead42d"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7835,9 +7853,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.331.0"
+version = "0.334.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2122ffa88b5bcf90984e7d03c1ace245a6a14be08372eef45bb2fd18400253b3"
+checksum = "0ee02baad41a76141ef4a82c87c2db21aec586387438dd51916e6c3701a41af0"
 dependencies = [
  "alloy",
  "chrono",
@@ -7856,9 +7874,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.331.0"
+version = "0.334.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7551b85e258e0dd0d71807a26d3532d91f30cf05c45353cf273545994dacdee5"
+checksum = "cbfc16941990a27a1ccc653f24a5d28fb9bc1c0d83ba215a080b12c6d48b864e"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -8001,6 +8019,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -8461,7 +8485,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -8470,16 +8494,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -8497,31 +8512,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -8531,22 +8529,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8555,22 +8541,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8579,22 +8553,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8603,22 +8565,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7829,9 +7829,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.338.0"
+version = "0.340.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7392875f725fa1464eaeb6b572885355beef6240be446854cfb786c42b7901fd"
+checksum = "0fafd846b696c2e5ffe157077b00acc4ff555124b13faf2801f060ac593aab3a"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7859,9 +7859,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.338.0"
+version = "0.340.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aecc6a429b69976747c5fd3a1a30f580d391efb1bb6ffedd4bc2551545374b6"
+checksum = "f4ffbeec48f3afff72185f38a3ad2268a7cd8ac21b0dad899c7677c48c56bc17"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7888,9 +7888,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.338.0"
+version = "0.340.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c0e9dd474bf4180a4a78305480291febacc7bc683107156f6390cfa26e4481"
+checksum = "2d55f97abb648fce75e1577ec711b111992ecb13e60b5641b7afd85496c44ecf"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7910,9 +7910,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.338.0"
+version = "0.340.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709a4ccd33621c819d2caae7dc0fe4cd91ed1324100f258f12096ce747abad5b"
+checksum = "f8ba3522d1bbf13d4d0be537b11ca73ba802105ff71845a018d58aa691312c70"
 dependencies = [
  "alloy",
  "chrono",
@@ -7931,9 +7931,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.338.0"
+version = "0.340.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2228d44660867c09a004561aa7dca8bc5e08ecd613ae8c909b7c781f892dc4"
+checksum = "c910bdc3144e0ab802152f79ba70104b80c155a306f458672d0a1edc9eabed8d"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 
 # Tycho
-tycho-execution = ">=0.331.0"
-tycho-simulation = ">=0.331.0"
+tycho-execution = ">=0.333.0"
+tycho-simulation = ">=0.333.0"
 typetag = "0.2"
 
 # Compression

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-tycho-execution = ">=0.338.0"
-tycho-simulation = ">=0.338.0"
+tycho-execution = ">=0.340.0"
+tycho-simulation = ">=0.340.0"
 typetag = "0.2"
 
 # Compression

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.75.1"
+    "version": "0.89.1"
   },
   "paths": {
     "/v1/health": {
@@ -367,7 +367,6 @@
         "description": "Static metadata about this Fynd instance, returned by `GET /v1/info`.",
         "required": [
           "chain_id",
-          "router_address",
           "permit2_address"
         ],
         "properties": {
@@ -384,8 +383,11 @@
             "example": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
           },
           "router_address": {
-            "type": "string",
-            "description": "Address of the Tycho Router contract on this chain.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Address of the Tycho Router contract on this chain; `null` on a quote-only chain.",
             "example": "0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35"
           }
         }

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.89.2"
+    "version": "0.93.0"
   },
   "paths": {
     "/v1/health": {
@@ -367,7 +367,6 @@
         "description": "Static metadata about this Fynd instance, returned by `GET /v1/info`.",
         "required": [
           "chain_id",
-          "router_address",
           "permit2_address"
         ],
         "properties": {
@@ -384,8 +383,11 @@
             "example": "0x000000000022D473030F116dDEE9F6B43aC78BA3"
           },
           "router_address": {
-            "type": "string",
-            "description": "Address of the Tycho Router contract on this chain.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Address of the Tycho Router contract on this chain; `null` on a quote-only chain.",
             "example": "0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35"
           },
           "version": {

--- a/clients/rust/examples/swap_client_fee.rs
+++ b/clients/rust/examples/swap_client_fee.rs
@@ -85,7 +85,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })?;
 
     let info = client.info().await?;
-    let router_address = info.router_address().clone();
+    let router_address = info
+        .router_address()
+        .expect("example requires a chain with encoding support")
+        .clone();
     let chain_id = info.chain_id();
 
     // Approve the router to spend WETH if the current allowance is insufficient.

--- a/clients/rust/examples/swap_permit2.rs
+++ b/clients/rust/examples/swap_permit2.rs
@@ -69,7 +69,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })?;
 
     let info = client.info().await?;
-    let router = Address::from_slice(info.router_address().as_ref());
+    let router = Address::from_slice(
+        info.router_address()
+            .expect("example requires a chain with encoding support")
+            .as_ref(),
+    );
     let chain_id = info.chain_id();
 
     // Approve the Permit2 contract to spend WETH if the current allowance is insufficient.

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -988,7 +988,7 @@ where
         let spender_addr = match params.transfer_type {
             UserTransferType::TransferFrom => {
                 let router_address = info.router_address().ok_or_else(|| {
-                    FyndError::Protocol(
+                    FyndError::Config(
                         "server has no router_address; encoding is unavailable on this chain"
                             .into(),
                     )
@@ -2002,7 +2002,13 @@ mod tests {
 
         assert_eq!(info1.chain_id(), 1);
         assert_eq!(info2.chain_id(), 1);
-        assert_eq!(info1.router_address().unwrap().as_ref(), &[0x01u8; 20]);
+        assert_eq!(
+            info1
+                .router_address()
+                .expect("mock info response includes a router address")
+                .as_ref(),
+            &[0x01u8; 20],
+        );
         assert_eq!(info1.permit2_address().as_ref(), &[0x02u8; 20]);
         // MockServer verifies expect(1) on drop.
     }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -987,7 +987,13 @@ where
         let info = self.info().await?;
         let spender_addr = match params.transfer_type {
             UserTransferType::TransferFrom => {
-                mapping::bytes_to_alloy_address(info.router_address())?
+                let router_address = info.router_address().ok_or_else(|| {
+                    FyndError::Protocol(
+                        "server has no router_address; encoding is unavailable on this chain"
+                            .into(),
+                    )
+                })?;
+                mapping::bytes_to_alloy_address(router_address)?
             }
             UserTransferType::TransferFromPermit2 => {
                 mapping::bytes_to_alloy_address(info.permit2_address())?
@@ -1996,7 +2002,7 @@ mod tests {
 
         assert_eq!(info1.chain_id(), 1);
         assert_eq!(info2.chain_id(), 1);
-        assert_eq!(info1.router_address().as_ref(), &[0x01u8; 20]);
+        assert_eq!(info1.router_address().unwrap().as_ref(), &[0x01u8; 20]);
         assert_eq!(info1.permit2_address().as_ref(), &[0x02u8; 20]);
         // MockServer verifies expect(1) on drop.
     }

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -355,13 +355,17 @@ impl TryFrom<fynd_rpc_types::InstanceInfo> for crate::types::InstanceInfo {
     type Error = FyndError;
 
     fn try_from(dto: fynd_rpc_types::InstanceInfo) -> Result<Self, Self::Error> {
-        let router = bytes::Bytes::copy_from_slice(dto.router_address().as_ref());
+        let router = dto
+            .router_address()
+            .map(|r| bytes::Bytes::copy_from_slice(r.as_ref()));
         let permit2 = bytes::Bytes::copy_from_slice(dto.permit2_address().as_ref());
-        if router.len() != 20 {
-            return Err(FyndError::Protocol(format!(
-                "router_address must be 20 bytes, got {}",
-                router.len()
-            )));
+        if let Some(router) = &router {
+            if router.len() != 20 {
+                return Err(FyndError::Protocol(format!(
+                    "router_address must be 20 bytes, got {}",
+                    router.len()
+                )));
+            }
         }
         if permit2.len() != 20 {
             return Err(FyndError::Protocol(format!(

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -1007,8 +1007,8 @@ impl Quote {
 /// Static metadata about this Fynd instance, returned by `GET /v1/info`.
 #[derive(Debug, Clone)]
 pub struct InstanceInfo {
-    /// Router contract address (20 raw bytes).
-    router_address: bytes::Bytes,
+    /// Router contract address (20 raw bytes), or `None` on a quote-only chain.
+    router_address: Option<bytes::Bytes>,
     /// Permit2 contract address (20 raw bytes).
     permit2_address: bytes::Bytes,
     /// Chain ID of the network this instance is deployed on.
@@ -1017,16 +1017,16 @@ pub struct InstanceInfo {
 
 impl InstanceInfo {
     pub(crate) fn new(
-        router_address: bytes::Bytes,
+        router_address: Option<bytes::Bytes>,
         permit2_address: bytes::Bytes,
         chain_id: u64,
     ) -> Self {
         Self { router_address, permit2_address, chain_id }
     }
 
-    /// Router contract address (20 raw bytes).
-    pub fn router_address(&self) -> &bytes::Bytes {
-        &self.router_address
+    /// Router contract address (20 raw bytes), or `None` on a quote-only chain.
+    pub fn router_address(&self) -> Option<&bytes::Bytes> {
+        self.router_address.as_ref()
     }
 
     /// Permit2 contract address (20 raw bytes).

--- a/clients/typescript/client/src/client.test.ts
+++ b/clients/typescript/client/src/client.test.ts
@@ -793,6 +793,18 @@ describe('FyndClient.info', () => {
     const info = await client.info();
     expect(info.routerAddress).toBe(ROUTER);
   });
+
+  it('returns a null routerAddress on a quote-only chain', async () => {
+    const client = makeClientWithHttpMock(
+      { status: 200, data: wireSolution },
+      undefined,
+      undefined,
+      { status: 200, data: { ...wireInstanceInfo, router_address: null } },
+    );
+    const info = await client.info();
+    expect(info.routerAddress).toBeNull();
+    expect(info.permit2Address).toBe(PERMIT2);
+  });
 });
 
 describe('FyndClient.approval', () => {
@@ -803,6 +815,19 @@ describe('FyndClient.approval', () => {
     expect(payload).not.toBeNull();
     // approve(address,uint256) selector = 0x095ea7b3
     expect(payload!.tx.data.startsWith('0x095ea7b3')).toBe(true);
+  });
+
+  it('rejects transfer_from approval when routerAddress is null', async () => {
+    const provider = makeMockProvider();
+    const client = makeClientWithHttpMock(
+      { status: 200, data: wireSolution },
+      undefined,
+      { provider },
+      { status: 200, data: { ...wireInstanceInfo, router_address: null } },
+    );
+    await expect(
+      client.approval({ token: TOKEN_IN_ADDR, amount: 1000n }),
+    ).rejects.toThrow(FyndError);
   });
 
   it('sets spender to routerAddress from info', async () => {

--- a/clients/typescript/client/src/client.ts
+++ b/clients/typescript/client/src/client.ts
@@ -493,9 +493,17 @@ export class FyndClient {
     if (params.transferType === 'none') return null;
 
     const info = await this.info();
-    const spender = params.transferType === 'transfer_from_permit2'
-      ? info.permit2Address
-      : info.routerAddress;
+    let spender: Address;
+    if (params.transferType === 'transfer_from_permit2') {
+      spender = info.permit2Address;
+    } else {
+      if (info.routerAddress === null) {
+        throw FyndError.config(
+          "server has no routerAddress; encoding is unavailable on this chain",
+        );
+      }
+      spender = info.routerAddress;
+    }
 
     const provider = this.options.provider;
     if (provider === undefined) throw FyndError.config("provider is required for approval");

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -199,7 +199,7 @@ export function fromWireHealth(wire: WireHealthStatus): HealthStatus {
 
 export function fromWireInstanceInfo(wire: WireInstanceInfo): InstanceInfo {
   return {
-    routerAddress:  wire.router_address as Address,
+    routerAddress:  (wire.router_address ?? null) as Address | null,
     permit2Address: wire.permit2_address as Address,
     chainId:        wire.chain_id,
   };

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -243,10 +243,10 @@ export interface components {
              */
             permit2_address: string;
             /**
-             * @description Address of the Tycho Router contract on this chain.
+             * @description Address of the Tycho Router contract on this chain; `null` on a quote-only chain.
              * @example 0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35
              */
-            router_address: string;
+            router_address?: string | null;
         };
         /**
          * @description A single swap order to be solved.

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -243,10 +243,10 @@ export interface components {
              */
             permit2_address: string;
             /**
-             * @description Address of the Tycho Router contract on this chain.
+             * @description Address of the Tycho Router contract on this chain; `null` on a quote-only chain.
              * @example 0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35
              */
-            router_address: string;
+            router_address?: string | null;
             /**
              * @description Fynd binary version (Cargo package version, e.g. "0.89.1").
              *

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -186,7 +186,8 @@ export interface HealthStatus {
 
 /** Static metadata about a Fynd server instance. */
 export interface InstanceInfo {
-  routerAddress: Address;
+  /** Tycho Router contract address, or `null` on a quote-only chain. */
+  routerAddress: Address | null;
   permit2Address: Address;
   chainId: number;
 }

--- a/docs/guides/server-configuration.md
+++ b/docs/guides/server-configuration.md
@@ -61,6 +61,42 @@ fynd serve \
 
 * RFQ protocols require API keys passed via environment variables. Check the [RFQ protocol docs](https://docs.propellerheads.xyz/tycho/for-solvers/request-for-quote-protocols) for the specific variables each protocol needs.
 
+### Self-hosted Tycho
+
+By default `--tycho-url` points at the [Fynd hosted endpoint](https://docs.propellerheads.xyz/tycho/for-solvers/hosted-endpoints#tycho-fynd) for the selected chain. Fynd talks to Tycho purely over its RPC/WebSocket API, so whether that Tycho is PropellerHeads-hosted or one you run yourself is transparent to Fynd — you only change where it points.
+
+Run your own Tycho when a chain has no hosted Substreams endpoint. The Tycho Indexer can stream from a self-hosted Firehose + Substreams stack; see [Self-Hosted EVM Chain](https://docs.propellerheads.xyz/tycho/for-solvers/self-hosted-evm-chain) for how to stand it up. Once it is serving, point Fynd at it:
+
+```bash
+fynd serve \
+  --chain base \
+  --tycho-url your-self-hosted-tycho.example.com \
+  --rpc-url https://your-node
+```
+
+Notes:
+
+* **TLS** — hosted endpoints use TLS; a local or plain-HTTP Tycho does not. Add `--disable-tls` when your endpoint is not served over TLS.
+* **API key** — the self-hosted indexer's RPC key is its `AUTH_API_KEY` (default `local-dev-key`). Pass it with `--tycho-api-key` / `TYCHO_API_KEY` if your deployment sets one.
+* **Built-in chains** — Fynd's built-in chains are `ethereum`, `base`, `unichain`, `arbitrum`, `polygon`, `bsc`, `starknet`, `zksync`. Self-hosting Tycho for one of these works out of the box.
+
+#### Custom chains
+
+Fynd can also run against a chain that isn't one of Tycho's built-ins, as long as your self-hosted Tycho indexer declares it. Point Fynd at the same `chains.yaml` the indexer uses with `--chains-config` / `TYCHO_CHAINS_CONFIG`, and pass `--tycho-url` and `--rpc-url` explicitly — custom chains have no built-in defaults, so omitting either is an error:
+
+```bash
+fynd serve \
+  --chain tempo \
+  --chains-config ./chains.yaml \
+  --tycho-url your-self-hosted-tycho.example.com \
+  --rpc-url https://your-node \
+  --disable-tls
+```
+
+See Tycho's [Self-Hosted EVM Chain](https://docs.propellerheads.xyz/tycho/for-solvers/self-hosted-evm-chain) guide for the "Declaring a custom chain" (`chains.yaml`) and "Consuming the custom chain" sections.
+
+**Quote-only until the router is deployed** — a custom chain has no Tycho router/executor contracts until ops deploys them. Until then, Fynd runs quote-only for that chain: `GET /v1/info` reports `router_address: null`, and a quote request with `encoding_options` set returns `501 Not Implemented`. Once the router/executor contracts are deployed, encoding works as usual.
+
 ## Flag reference
 
 Run `fynd serve --help` for the full list.
@@ -78,6 +114,7 @@ Run `fynd serve --help` for the full list.
 | `--rpc-url`                        | `RPC_URL`             | `https://eth.llamarpc.com` | Node RPC endpoint for the target chain. Use a dedicated endpoint in production.                                                                                                                                |
 | `--tycho-url`                      | `TYCHO_URL`           | _(chain-specific)_         | Tycho URL. Defaults to the [Fynd hosted endpoint](https://docs.propellerheads.xyz/tycho/for-solvers/hosted-endpoints#tycho-fynd) for the selected chain.                                                       |
 | `--chain`                          | —                     | `Ethereum`                 | Target chain                                                                                                                                                                                                   |
+| `--chains-config`                  | `TYCHO_CHAINS_CONFIG` | _(none)_                   | Path to the custom-chains `chains.yaml`. Required for a chain Tycho does not know as a built-in.                                                                                                              |
 | `-p, --protocols`                  | —                     | _(all on-chain)_           | Protocols to index (comma-separated). If omitted, all on-chain protocols available on your configured Tycho endpoint are fetched. Use `all_onchain` to combine auto-fetched protocols with explicit entries (e.g. `all_onchain,rfq:bebop`). |
 | `--http-host`                      | `HTTP_HOST`           | `0.0.0.0`                  | HTTP bind address                                                                                                                                                                                              |
 | `--http-port`                      | `HTTP_PORT`           | `3000`                     | API port                                                                                                                                                                                                       |

--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -26,7 +26,6 @@ num_cpus.workspace = true
 async-channel.workspace = true
 async-trait.workspace = true
 itertools.workspace = true
-lazy_static.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 thiserror.workspace = true

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -34,12 +34,13 @@ pub const PERMIT2_ADDRESS: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 /// * `tycho_encoder` - Encoder created using the configured chain for encoding solutions into tycho
 ///   compatible transactions
 /// * `chain` - Chain to be used.
-/// * `router_address` - Address of the Tycho Router contract on this chain.
+/// * `router_address` - Address of the Tycho Router contract on this chain, or `None` if Tycho has
+///   no router deployed there — encoding is then unavailable and `encode()` fails clearly.
 /// * `router_fees` - Router fee configuration, refreshed from chain by a background fetcher.
 pub struct Encoder {
-    tycho_encoder: Box<dyn TychoEncoder>,
+    tycho_encoder: Option<Box<dyn TychoEncoder>>,
     chain: Chain,
-    router_address: Bytes,
+    router_address: Option<Bytes>,
     router_fees: SharedRouterFees,
 }
 
@@ -108,6 +109,11 @@ impl TryFrom<&OrderQuote> for Solution {
 }
 
 impl Encoder {
+    /// Whether Tycho has a router deployment (and thus encoding support) for `chain`.
+    pub fn is_supported(chain: Chain) -> bool {
+        get_router_address(&chain).is_ok()
+    }
+
     /// Creates a new `Encoder` for the given chain.
     ///
     /// # Arguments
@@ -115,28 +121,30 @@ impl Encoder {
     /// * `swap_encoder_registry` - Registry of swap encoders for supported protocols.
     ///
     /// # Returns
-    /// A new `Encoder` configured with `TransferFrom` user transfer type.
+    /// A new `Encoder` configured with `TransferFrom` user transfer type. If `chain` has no Tycho
+    /// router deployment, the encoder is returned in a disabled state: it can still be used to
+    /// quote, but [`Self::encode`] will fail with [`SolveError::FailedEncoding`].
     pub fn new(
         chain: Chain,
         swap_encoder_registry: SwapEncoderRegistry,
     ) -> Result<Self, SolveError> {
-        let router_address = get_router_address(&chain)
-            .map_err(|e| SolveError::FailedEncoding(e.to_string()))?
-            .clone();
-        Ok(Self {
-            tycho_encoder: TychoRouterEncoderBuilder::new()
-                .chain(chain)
-                .swap_encoder_registry(swap_encoder_registry)
-                .build()?,
-            chain,
-            router_address,
-            router_fees: SharedRouterFees::default(),
-        })
+        let router_address = get_router_address(&chain).ok().cloned();
+        let tycho_encoder = router_address
+            .is_some()
+            .then(|| {
+                TychoRouterEncoderBuilder::new()
+                    .chain(chain)
+                    .swap_encoder_registry(swap_encoder_registry)
+                    .build()
+            })
+            .transpose()?;
+        Ok(Self { tycho_encoder, chain, router_address, router_fees: SharedRouterFees::default() })
     }
 
-    /// Returns the Tycho Router contract address for this chain.
-    pub fn router_address(&self) -> &Bytes {
-        &self.router_address
+    /// Returns the Tycho Router contract address for this chain, or `None` if encoding is
+    /// unavailable because no router is deployed there.
+    pub fn router_address(&self) -> Option<&Bytes> {
+        self.router_address.as_ref()
     }
 
     /// Returns the shared router fee handle this encoder reads on every encode.
@@ -160,6 +168,14 @@ impl Encoder {
         mut quotes: Vec<OrderQuote>,
         encoding_options: EncodingOptions,
     ) -> Result<Vec<OrderQuote>, SolveError> {
+        let Some(tycho_encoder) = self.tycho_encoder.as_ref() else {
+            return Err(SolveError::FailedEncoding(format!(
+                "encoding is unavailable on chain '{}': no Tycho router is deployed. Fynd is \
+                 running quote-only; contact ops to deploy the router/executor contracts.",
+                self.chain
+            )));
+        };
+
         let slippage = encoding_options.slippage();
         if slippage == 0.0 {
             tracing::warn!("slippage is 0, transaction will likely revert");
@@ -185,9 +201,7 @@ impl Encoder {
             .iter()
             .map(|(_, s)| s.clone())
             .collect();
-        let encoded_solutions = self
-            .tycho_encoder
-            .encode_solutions(solutions)?;
+        let encoded_solutions = tycho_encoder.encode_solutions(solutions)?;
 
         let router_fees = self.router_fees.snapshot();
         for (encoded_solution, (idx, solution)) in encoded_solutions
@@ -588,24 +602,45 @@ mod tests {
         let router_fees = SharedRouterFees::default();
         router_fees.set(RouterFees::new(FEE_SCALE, 100_000, 20_000_000, HashMap::new()));
         Encoder {
-            tycho_encoder: Box::new(MockTychoEncoder),
+            tycho_encoder: Some(Box::new(MockTychoEncoder)),
             chain,
-            router_address: Bytes::from([0u8; 20].as_ref()),
+            router_address: Some(Bytes::from([0u8; 20].as_ref())),
             router_fees,
         }
     }
 
     #[test]
-    fn test_encoder_new_fails_on_unsupported_chain() {
+    fn test_encoder_new_disabled_on_unsupported_chain() {
         // Starknet has no entry in ROUTER_ADDRESSES_JSON.
         // Build a registry for Ethereum (which is valid) but pass Starknet to Encoder::new —
-        // the router address lookup must fail before the encoder builder is invoked.
+        // this must succeed with a disabled encoder rather than fail.
         let registry =
             tycho_execution::encoding::evm::swap_encoder::swap_encoder_registry::SwapEncoderRegistry::new(Chain::Ethereum)
                 .add_default_encoders(None)
                 .expect("registry should build for Ethereum");
-        let result = Encoder::new(Chain::Starknet, registry);
-        assert!(result.is_err(), "expected Err for chain without router address, got Ok");
+        let encoder = Encoder::new(Chain::Starknet, registry)
+            .expect("new must not fail for a router-less chain");
+        assert!(
+            encoder.router_address().is_none(),
+            "expected disabled encoder, got a router address"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_encoder_quotes_but_refuses_to_encode() {
+        // A chain with no Tycho router deployment yields a disabled encoder.
+        let registry = SwapEncoderRegistry::new(Chain::Ethereum)
+            .add_default_encoders(None)
+            .unwrap();
+        let encoder =
+            Encoder::new(Chain::Starknet, registry).expect("new must not fail when disabled");
+        assert!(encoder.router_address().is_none());
+
+        let err = encoder
+            .encode(vec![], EncodingOptions::new(0.01))
+            .await
+            .expect_err("encoding must fail on a router-less chain");
+        assert!(matches!(err, SolveError::FailedEncoding(_)));
     }
 
     #[test]

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -32,7 +32,7 @@ pub const PERMIT2_ADDRESS: &str = "0x000000000022D473030F116dDEE9F6B43aC78BA3";
 ///
 /// # Fields
 /// * `tycho_encoder` - Encoder created using the configured chain for encoding solutions into tycho
-///   compatible transactions
+///   compatible transactions. `None` when the encoder is disabled (router-less / quote-only chain).
 /// * `chain` - Chain to be used.
 /// * `router_address` - Address of the Tycho Router contract on this chain, or `None` if Tycho has
 ///   no router deployed there — encoding is then unavailable and `encode()` fails clearly.
@@ -169,7 +169,7 @@ impl Encoder {
         encoding_options: EncodingOptions,
     ) -> Result<Vec<OrderQuote>, SolveError> {
         let Some(tycho_encoder) = self.tycho_encoder.as_ref() else {
-            return Err(SolveError::FailedEncoding(format!(
+            return Err(SolveError::EncodingUnavailable(format!(
                 "encoding is unavailable on chain '{}': no Tycho router is deployed. Fynd is \
                  running quote-only; contact ops to deploy the router/executor contracts.",
                 self.chain
@@ -640,7 +640,7 @@ mod tests {
             .encode(vec![], EncodingOptions::new(0.01))
             .await
             .expect_err("encoding must fail on a router-less chain");
-        assert!(matches!(err, SolveError::FailedEncoding(_)));
+        assert!(matches!(err, SolveError::EncodingUnavailable(_)));
     }
 
     #[test]

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -194,10 +194,9 @@ pub(crate) fn register_rfq(
     for protocol in protocols {
         match protocol.as_str() {
             "rfq:bebop" => {
-                let user = get_env("BEBOP_USER")?;
                 let key = get_env("BEBOP_KEY")?;
                 info!("Adding {protocol} RFQ client...");
-                let bebop_client = BebopClientBuilder::new(chain, user, key)
+                let bebop_client = BebopClientBuilder::new(chain, key)
                     .tokens(rfq_tokens.clone())
                     .tvl_threshold(min_tvl)
                     .build()

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -344,7 +344,7 @@ struct CustomPoolEntry {
 struct BuiltComponents {
     tycho_feed: TychoFeed,
     gas_price_fetcher: GasPriceFetcher<EthereumRpcClient>,
-    router_fee_fetcher: RouterFeeFetcher,
+    router_fee_fetcher: Option<RouterFeeFetcher>,
     computation_manager: ComputationManager,
     computation_event_rx: broadcast::Receiver<MarketEvent>,
     computation_shutdown_tx: broadcast::Sender<()>,
@@ -355,7 +355,7 @@ struct BuiltComponents {
     derived_data: SharedDerivedDataRef,
     router_fees: SharedRouterFees,
     chain: Chain,
-    router_address: Bytes,
+    router_address: Option<Bytes>,
     pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
     market_event_tx: broadcast::Sender<MarketEvent>,
 }
@@ -764,16 +764,27 @@ impl FyndBuilder {
         };
 
         let chain = self.chain;
-        let router_address = encoder.router_address().clone();
+        let router_address = encoder.router_address().cloned();
         let router_fees = encoder.router_fees();
 
-        let router_fee_fetcher = RouterFeeFetcher::new(
-            self.rpc_url.as_str(),
-            &router_address,
-            router_fees.clone(),
-            defaults::ROUTER_FEE_REFRESH_INTERVAL,
-        )
-        .map_err(|e| SolverBuildError::RouterFeeFetcher(e.to_string()))?;
+        let router_fee_fetcher = match &router_address {
+            Some(addr) => Some(
+                RouterFeeFetcher::new(
+                    self.rpc_url.as_str(),
+                    addr,
+                    router_fees.clone(),
+                    defaults::ROUTER_FEE_REFRESH_INTERVAL,
+                )
+                .map_err(|e| SolverBuildError::RouterFeeFetcher(e.to_string()))?,
+            ),
+            None => {
+                tracing::warn!(
+                    %chain,
+                    "no Tycho router for this chain; running quote-only (encoding disabled)"
+                );
+                None
+            }
+        };
 
         // Only start price providers when the guard is enabled.
         // When disabled, per-request attempts to enable the guard return an error.
@@ -829,9 +840,10 @@ impl FyndBuilder {
         let gas_price_handle = tokio::spawn(async move {
             c.gas_price_fetcher.run().await;
         });
-        let router_fee_handle = tokio::spawn(async move {
-            c.router_fee_fetcher.run().await;
-        });
+        let router_fee_handle = match c.router_fee_fetcher {
+            Some(fetcher) => tokio::spawn(async move { fetcher.run().await }),
+            None => tokio::spawn(async {}),
+        };
         let computation_handle = tokio::spawn(async move {
             c.computation_manager
                 .run(c.computation_event_rx, c.computation_shutdown_rx)
@@ -887,9 +899,10 @@ impl FyndBuilder {
         let gas_price_handle = tokio::spawn(async move {
             c.gas_price_fetcher.run().await;
         });
-        let router_fee_handle = tokio::spawn(async move {
-            c.router_fee_fetcher.run().await;
-        });
+        let router_fee_handle = match c.router_fee_fetcher {
+            Some(fetcher) => tokio::spawn(async move { fetcher.run().await }),
+            None => tokio::spawn(async {}),
+        };
         let computation_handle = tokio::spawn(async move {
             c.computation_manager
                 .run(c.computation_event_rx, c.computation_shutdown_rx)
@@ -956,9 +969,10 @@ impl FyndBuilder {
         let gas_price_handle = tokio::spawn(async move {
             c.gas_price_fetcher.run().await;
         });
-        let router_fee_handle = tokio::spawn(async move {
-            c.router_fee_fetcher.run().await;
-        });
+        let router_fee_handle = match c.router_fee_fetcher {
+            Some(fetcher) => tokio::spawn(async move { fetcher.run().await }),
+            None => tokio::spawn(async {}),
+        };
         let computation_handle = tokio::spawn(async move {
             c.computation_manager
                 .run(c.computation_event_rx, c.computation_shutdown_rx)
@@ -1004,7 +1018,7 @@ pub struct Solver {
     computation_handle: JoinHandle<()>,
     computation_shutdown_tx: broadcast::Sender<()>,
     chain: Chain,
-    router_address: Bytes,
+    router_address: Option<Bytes>,
     market_event_tx: broadcast::Sender<MarketEvent>,
 }
 
@@ -1012,6 +1026,11 @@ impl Solver {
     /// Returns a clone of the shared market data reference.
     pub fn market_data(&self) -> MarketData {
         self.market_data.clone()
+    }
+
+    /// Returns the Tycho Router contract address, or `None` on a quote-only chain.
+    pub fn router_address(&self) -> Option<&Bytes> {
+        self.router_address.as_ref()
     }
 
     /// Returns a clone of the shared derived data reference.
@@ -1203,7 +1222,7 @@ impl Solver {
             Encoder::new(chain, registry).map_err(|e| SolverBuildError::Encoder(e.to_string()))?
         };
 
-        let router_address = encoder.router_address().clone();
+        let router_address = encoder.router_address().cloned();
         // Replay mode has no FeeCalculator to read; seed a zero-fee config at the standard
         // 8-decimal scale so the recording-based solver reports ready (integration tests do
         // not exercise encoding).
@@ -1314,8 +1333,8 @@ pub struct SolverParts {
     computation_shutdown_tx: broadcast::Sender<()>,
     /// Chain this solver is configured for.
     chain: Chain,
-    /// Address of the Tycho Router contract on this chain.
-    router_address: Bytes,
+    /// Address of the Tycho Router contract on this chain, or `None` on a quote-only chain.
+    router_address: Option<Bytes>,
 }
 
 impl SolverParts {
@@ -1324,9 +1343,9 @@ impl SolverParts {
         self.chain
     }
 
-    /// Returns the Tycho Router contract address for this chain.
-    pub fn router_address(&self) -> &Bytes {
-        &self.router_address
+    /// Returns the Tycho Router contract address for this chain, or `None` on a quote-only chain.
+    pub fn router_address(&self) -> Option<&Bytes> {
+        self.router_address.as_ref()
     }
 
     /// Returns a reference to the worker pools.

--- a/fynd-core/src/types/constants.rs
+++ b/fynd-core/src/types/constants.rs
@@ -1,55 +1,6 @@
-use std::collections::HashMap;
+use std::str::FromStr;
 
-use lazy_static::lazy_static;
 use tycho_simulation::{tycho_common::models::Chain, tycho_core::models::Address};
-
-lazy_static! {
-    /// Wrapped native token addresses for each chain.
-    ///
-    /// These are the ERC-20 wrapped versions of each chain's native gas token
-    /// (e.g., WETH on Ethereum, WBNB on BSC).
-    pub(crate) static ref NATIVE_TOKEN: HashMap<Chain, Address> = {
-        let mut map = HashMap::new();
-
-        // Ethereum Mainnet - WETH (0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2)
-        map.insert(Chain::Ethereum, Address::from([
-            0xC0, 0x2A, 0xAA, 0x39, 0xB2, 0x23, 0xFE, 0x8D, 0x0A, 0x0E,
-            0x5C, 0x4F, 0x27, 0xEA, 0xD9, 0x08, 0x3C, 0x75, 0x6C, 0xC2,
-        ]));
-
-        // Base - WETH (0x4200000000000000000000000000000000000006)
-        map.insert(Chain::Base, Address::from([
-            0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06,
-        ]));
-
-        // Unichain - WETH (0x4200000000000000000000000000000000000006)
-        map.insert(Chain::Unichain, Address::from([
-            0x42, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06,
-        ]));
-
-        // Arbitrum - WETH (0x82aF49447D8a07e3bd95BD0d56f35241523fBab1)
-        map.insert(Chain::Arbitrum, Address::from([
-            0x82, 0xAF, 0x49, 0x44, 0x7D, 0x8A, 0x07, 0xE3, 0xBD, 0x95,
-            0xBD, 0x0D, 0x56, 0xF3, 0x52, 0x41, 0x52, 0x3F, 0xBA, 0xB1,
-        ]));
-
-        // Polygon - WPOL/WMATIC (0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270)
-        map.insert(Chain::Polygon, Address::from([
-            0x0D, 0x50, 0x0B, 0x1D, 0x8E, 0x8E, 0xF3, 0x1E, 0x21, 0xC9,
-            0x9D, 0x1D, 0xB9, 0xA6, 0x44, 0x4D, 0x3A, 0xDF, 0x12, 0x70,
-        ]));
-
-        // BSC - WBNB (0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c)
-        map.insert(Chain::Bsc, Address::from([
-            0xBB, 0x4C, 0xDB, 0x9C, 0xBD, 0x36, 0xB0, 0x1B, 0xD1, 0xCB,
-            0xAE, 0xBF, 0x2D, 0xE0, 0x8D, 0x91, 0x73, 0xBC, 0x09, 0x5C,
-        ]));
-
-        map
-    };
-}
 
 /// Error returned when a chain is not supported.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -65,28 +16,25 @@ impl UnsupportedChainError {
     }
 }
 
-/// Returns the wrapped native token address for the given chain.
+/// Returns the wrapped native token address for the given chain, resolving custom chains from the
+/// registry.
 ///
 /// # Errors
-///
-/// Returns `UnsupportedChainError` if the chain is not in the registry.
+/// Returns `UnsupportedChainError` if the chain (custom) is not registered.
 pub fn native_token(chain: &Chain) -> Result<Address, UnsupportedChainError> {
-    NATIVE_TOKEN
-        .get(chain)
-        .cloned()
-        .ok_or(UnsupportedChainError { chain: *chain })
+    chain
+        .try_wrapped_native_token()
+        .map(|token| token.address)
+        .map_err(|_| UnsupportedChainError { chain: *chain })
 }
 
-/// Parses a chain name string (case-insensitive) into a [`Chain`] enum.
+/// Parses a chain name string (case-insensitive) into a [`Chain`].
 ///
-/// Uses serde deserialization so it automatically supports all `Chain` variants.
-///
-/// # Errors
-///
-/// Returns an error if the chain name is not recognized.
+/// Built-in chains resolve directly; any other name resolves against the custom-chain registry
+/// (populated from `TYCHO_CHAINS_CONFIG`), so self-hosted custom chains work once the registry is
+/// installed. Returns an error if the name is neither built-in nor a registered custom chain.
 pub fn parse_chain(chain: &str) -> Result<Chain, ParseChainError> {
-    let candidate = format!("\"{}\"", chain.to_ascii_lowercase());
-    serde_json::from_str::<Chain>(&candidate).map_err(|_| ParseChainError(chain.to_string()))
+    Chain::from_str(&chain.to_ascii_lowercase()).map_err(|_| ParseChainError(chain.to_string()))
 }
 
 /// Error returned when a chain name string cannot be parsed.

--- a/fynd-core/src/types/constants.rs
+++ b/fynd-core/src/types/constants.rs
@@ -22,10 +22,19 @@ impl UnsupportedChainError {
 /// # Errors
 /// Returns `UnsupportedChainError` if the chain (custom) is not registered.
 pub fn native_token(chain: &Chain) -> Result<Address, UnsupportedChainError> {
-    chain
+    let address = chain
         .try_wrapped_native_token()
         .map(|token| token.address)
-        .map_err(|_| UnsupportedChainError { chain: *chain })
+        .map_err(|_| UnsupportedChainError { chain: *chain })?;
+
+    // A zero address is a placeholder (e.g. Starknet) meaning the chain has no real
+    // wrapped-native token; treat it as unsupported so callers still fail fast instead of
+    // deriving a gas token from a placeholder address.
+    if address.is_zero() {
+        return Err(UnsupportedChainError { chain: *chain });
+    }
+
+    Ok(address)
 }
 
 /// Parses a chain name string (case-insensitive) into a [`Chain`].

--- a/fynd-core/src/types/constants.rs
+++ b/fynd-core/src/types/constants.rs
@@ -27,9 +27,13 @@ pub fn native_token(chain: &Chain) -> Result<Address, UnsupportedChainError> {
         .map(|token| token.address)
         .map_err(|_| UnsupportedChainError { chain: *chain })?;
 
-    // A zero address is a placeholder (e.g. Starknet) meaning the chain has no real
-    // wrapped-native token; treat it as unsupported so callers still fail fast instead of
-    // deriving a gas token from a placeholder address.
+    // tycho-common returns a zero-address placeholder for chains with no wrapped-native token
+    // (currently Starknet — see the explicit `0x0` in its `try_wrapped_native_token` arm).
+    // `native_token` feeds the solver's gas token, so accepting a placeholder would silently build
+    // a solver with a 0x0 gas token. Reject it to preserve the fail-fast behavior Fynd had before
+    // this lookup was registry-backed (its old hardcoded map never listed Starknet). A properly
+    // configured custom chain always has a real wrapped-native address, so this never trips for
+    // one.
     if address.is_zero() {
         return Err(UnsupportedChainError { chain: *chain });
     }

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -138,6 +138,10 @@ pub enum SolveError {
     #[error("failed to encode: {0}")]
     FailedEncoding(String),
 
+    /// Encoding is unavailable on this chain because no Tycho router is deployed (quote-only).
+    #[error("encoding unavailable: {0}")]
+    EncodingUnavailable(String),
+
     /// Price check against external source failed.
     #[error("price check failed for order {order_id}")]
     PriceCheckFailed {

--- a/fynd-core/tests/custom_chain.rs
+++ b/fynd-core/tests/custom_chain.rs
@@ -40,4 +40,9 @@ fn resolves_and_reads_native_for_custom_chain() {
 
     // unknown still rejected
     assert!(parse_chain("not_a_chain").is_err());
+
+    // Starknet's wrapped-native is a placeholder zero address; fail fast rather than
+    // returning it as a usable gas token.
+    let starknet = parse_chain("starknet").unwrap();
+    assert!(native_token(&starknet).is_err());
 }

--- a/fynd-core/tests/custom_chain.rs
+++ b/fynd-core/tests/custom_chain.rs
@@ -1,0 +1,43 @@
+use std::str::FromStr;
+
+use fynd_core::types::{native_token, parse_chain};
+use tycho_simulation::tycho_common::models::{
+    chain_config::{init_chain_registry, ChainConfigRegistry},
+    Address,
+};
+
+const CHAINS_YAML: &str = r#"
+chains:
+  - name: tempo
+    chain_id: 12345
+    block_time_secs: 1
+    native:
+      address: "0x0000000000000000000000000000000000000000"
+      symbol: "ETH"
+      decimals: 18
+    wrapped_native:
+      address: "0x4200000000000000000000000000000000000006"
+      symbol: "WETH"
+      decimals: 18
+    default_tvl_thresholds:
+      low: 1000
+      medium: 10000
+"#;
+
+#[test]
+fn resolves_and_reads_native_for_custom_chain() {
+    init_chain_registry(ChainConfigRegistry::from_yaml_str(CHAINS_YAML).unwrap())
+        .expect("registry must be uninitialized in this dedicated test binary");
+
+    // built-in still works
+    let eth = parse_chain("Ethereum").unwrap();
+    assert!(native_token(&eth).is_ok());
+
+    // custom resolves and exposes its wrapped-native
+    let tempo = parse_chain("tempo").expect("custom chain must resolve");
+    let wnative = native_token(&tempo).expect("custom wrapped-native must resolve");
+    assert_eq!(wnative, Address::from_str("0x4200000000000000000000000000000000000006").unwrap());
+
+    // unknown still rejected
+    assert!(parse_chain("not_a_chain").is_err());
+}

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1210,12 +1210,12 @@ pub struct InstanceInfo {
     /// EIP-155 chain ID (e.g. 1 for Ethereum mainnet).
     #[cfg_attr(feature = "openapi", schema(example = 1))]
     chain_id: u64,
-    /// Address of the Tycho Router contract on this chain.
+    /// Address of the Tycho Router contract on this chain; `null` on a quote-only chain.
     #[cfg_attr(
         feature = "openapi",
-        schema(value_type = String, example = "0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35")
+        schema(value_type = Option<String>, example = "0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35")
     )]
-    router_address: Bytes,
+    router_address: Option<Bytes>,
     /// Address of the canonical Permit2 contract (same on all EVM chains).
     #[cfg_attr(
         feature = "openapi",
@@ -1234,7 +1234,7 @@ impl InstanceInfo {
     /// Starts building an instance info from the required immutable fields.
     pub fn builder(
         chain_id: u64,
-        router_address: Bytes,
+        router_address: Option<Bytes>,
         permit2_address: Bytes,
     ) -> InstanceInfoBuilder {
         InstanceInfoBuilder { chain_id, router_address, permit2_address, version: String::new() }
@@ -1245,9 +1245,9 @@ impl InstanceInfo {
         self.chain_id
     }
 
-    /// Address of the Tycho Router contract.
-    pub fn router_address(&self) -> &Bytes {
-        &self.router_address
+    /// Address of the Tycho Router contract, or `None` on a quote-only chain.
+    pub fn router_address(&self) -> Option<&Bytes> {
+        self.router_address.as_ref()
     }
 
     /// Address of the canonical Permit2 contract.
@@ -1265,7 +1265,7 @@ impl InstanceInfo {
 #[derive(Debug, Clone)]
 pub struct InstanceInfoBuilder {
     chain_id: u64,
-    router_address: Bytes,
+    router_address: Option<Bytes>,
     permit2_address: Bytes,
     version: String,
 }
@@ -1548,19 +1548,20 @@ mod wire_format_tests {
         let info: InstanceInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.version(), "1.2.3");
         assert_eq!(info.chain_id(), 1);
-        assert_eq!(info.router_address().as_ref(), [0xAAu8; 20]);
+        assert_eq!(info.router_address().unwrap().as_ref(), [0xAAu8; 20]);
         assert_eq!(info.permit2_address().as_ref(), [0xBBu8; 20]);
     }
 
     #[test]
     fn instance_info_builder_sets_fields() {
-        let info = InstanceInfo::builder(1, Bytes::from([0xAAu8; 20]), Bytes::from([0xBBu8; 20]))
-            .version("0.1.0")
-            .build();
+        let info =
+            InstanceInfo::builder(1, Some(Bytes::from([0xAAu8; 20])), Bytes::from([0xBBu8; 20]))
+                .version("0.1.0")
+                .build();
 
         assert_eq!(info.version(), "0.1.0");
         assert_eq!(info.chain_id(), 1);
-        assert_eq!(info.router_address().as_ref(), [0xAAu8; 20]);
+        assert_eq!(info.router_address().unwrap().as_ref(), [0xAAu8; 20]);
         assert_eq!(info.permit2_address().as_ref(), [0xBBu8; 20]);
     }
 

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1201,12 +1201,12 @@ pub struct InstanceInfo {
     /// EIP-155 chain ID (e.g. 1 for Ethereum mainnet).
     #[cfg_attr(feature = "openapi", schema(example = 1))]
     chain_id: u64,
-    /// Address of the Tycho Router contract on this chain.
+    /// Address of the Tycho Router contract on this chain; `null` on a quote-only chain.
     #[cfg_attr(
         feature = "openapi",
-        schema(value_type = String, example = "0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35")
+        schema(value_type = Option<String>, example = "0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35")
     )]
-    router_address: Bytes,
+    router_address: Option<Bytes>,
     /// Address of the canonical Permit2 contract (same on all EVM chains).
     #[cfg_attr(
         feature = "openapi",
@@ -1217,7 +1217,7 @@ pub struct InstanceInfo {
 
 impl InstanceInfo {
     /// Creates a new instance info.
-    pub fn new(chain_id: u64, router_address: Bytes, permit2_address: Bytes) -> Self {
+    pub fn new(chain_id: u64, router_address: Option<Bytes>, permit2_address: Bytes) -> Self {
         Self { chain_id, router_address, permit2_address }
     }
 
@@ -1226,9 +1226,9 @@ impl InstanceInfo {
         self.chain_id
     }
 
-    /// Address of the Tycho Router contract.
-    pub fn router_address(&self) -> &Bytes {
-        &self.router_address
+    /// Address of the Tycho Router contract, or `None` on a quote-only chain.
+    pub fn router_address(&self) -> Option<&Bytes> {
+        self.router_address.as_ref()
     }
 
     /// Address of the canonical Permit2 contract.
@@ -1495,8 +1495,15 @@ mod wire_format_tests {
 
         let info: InstanceInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.chain_id(), 1);
-        assert_eq!(info.router_address().as_ref(), [0xAAu8; 20]);
+        assert_eq!(info.router_address().unwrap().as_ref(), [0xAAu8; 20]);
         assert_eq!(info.permit2_address().as_ref(), [0xBBu8; 20]);
+    }
+
+    #[test]
+    fn instance_info_router_address_is_nullable() {
+        let info = InstanceInfo::new(12345, None, Bytes::from(vec![0u8; 20]));
+        let v: serde_json::Value = serde_json::to_value(&info).unwrap();
+        assert!(v["router_address"].is_null());
     }
 }
 

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1495,7 +1495,12 @@ mod wire_format_tests {
 
         let info: InstanceInfo = serde_json::from_str(json).unwrap();
         assert_eq!(info.chain_id(), 1);
-        assert_eq!(info.router_address().unwrap().as_ref(), [0xAAu8; 20]);
+        assert_eq!(
+            info.router_address()
+                .expect("router_address is present in this JSON")
+                .as_ref(),
+            [0xAAu8; 20]
+        );
         assert_eq!(info.permit2_address().as_ref(), [0xBBu8; 20]);
     }
 

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -43,6 +43,7 @@ impl ResponseError for ApiError {
                 SolveError::Timeout { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::MarketDataStale { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::ComputationFailed(_) => StatusCode::SERVICE_UNAVAILABLE,
+                SolveError::FailedEncoding(_) => StatusCode::NOT_IMPLEMENTED,
                 _ => StatusCode::UNPROCESSABLE_ENTITY,
             },
             ApiError::ServiceOverloaded => StatusCode::SERVICE_UNAVAILABLE,
@@ -172,5 +173,13 @@ mod tests {
         let (status, body) = json_body(ApiError::SolveFailed(err)).await;
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(body["code"], "STALE_DATA");
+    }
+
+    #[actix_web::test]
+    async fn test_failed_encoding_returns_501() {
+        let err = SolveError::FailedEncoding("no router configured for this chain".to_string());
+        let (status, body) = json_body(ApiError::SolveFailed(err)).await;
+        assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(body["code"], "FAILED_ENCODING");
     }
 }

--- a/fynd-rpc/src/api/error.rs
+++ b/fynd-rpc/src/api/error.rs
@@ -43,7 +43,7 @@ impl ResponseError for ApiError {
                 SolveError::Timeout { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::MarketDataStale { .. } => StatusCode::SERVICE_UNAVAILABLE,
                 SolveError::ComputationFailed(_) => StatusCode::SERVICE_UNAVAILABLE,
-                SolveError::FailedEncoding(_) => StatusCode::NOT_IMPLEMENTED,
+                SolveError::EncodingUnavailable(_) => StatusCode::NOT_IMPLEMENTED,
                 _ => StatusCode::UNPROCESSABLE_ENTITY,
             },
             ApiError::ServiceOverloaded => StatusCode::SERVICE_UNAVAILABLE,
@@ -67,6 +67,7 @@ impl ResponseError for ApiError {
                 SolveError::NotReady(_) => "NOT_READY",
                 SolveError::ComputationFailed(_) => "COMPUTATION_FAILED",
                 SolveError::FailedEncoding(_) => "FAILED_ENCODING",
+                SolveError::EncodingUnavailable(_) => "ENCODING_UNAVAILABLE",
                 SolveError::PriceCheckFailed { .. } => "PRICE_CHECK_FAILED",
                 other => {
                     warn!(?other, "unhandled SolveError variant");
@@ -176,10 +177,19 @@ mod tests {
     }
 
     #[actix_web::test]
-    async fn test_failed_encoding_returns_501() {
-        let err = SolveError::FailedEncoding("no router configured for this chain".to_string());
+    async fn test_encoding_unavailable_returns_501() {
+        let err =
+            SolveError::EncodingUnavailable("no router configured for this chain".to_string());
         let (status, body) = json_body(ApiError::SolveFailed(err)).await;
         assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(body["code"], "ENCODING_UNAVAILABLE");
+    }
+
+    #[actix_web::test]
+    async fn test_failed_encoding_returns_422() {
+        let err = SolveError::FailedEncoding("missing permit2 signature".to_string());
+        let (status, body) = json_body(ApiError::SolveFailed(err)).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(body["code"], "FAILED_ENCODING");
     }
 }

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -143,7 +143,10 @@ pub(crate) async fn health(state: web::Data<AppState>) -> HttpResponse {
 pub(crate) async fn info(state: web::Data<AppState>) -> HttpResponse {
     let body = dto::InstanceInfo::new(
         state.chain_id(),
-        state.router_address().clone().into(),
+        state
+            .router_address()
+            .cloned()
+            .map(Into::into),
         state.permit2_address().clone().into(),
     );
     HttpResponse::Ok().json(body)
@@ -362,7 +365,7 @@ mod tests {
             router,
             health_tracker,
             1,
-            router_address,
+            Some(router_address),
             permit2_address,
             #[cfg(feature = "experimental")]
             derived_data,

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -159,7 +159,7 @@ pub struct AppState {
     worker_router: Arc<WorkerPoolRouter>,
     health_tracker: HealthTracker,
     chain_id: u64,
-    router_address: Bytes,
+    router_address: Option<Bytes>,
     permit2_address: Bytes,
     #[cfg(feature = "experimental")]
     pub(crate) derived_data: SharedDerivedDataRef,
@@ -173,7 +173,7 @@ impl AppState {
         worker_router: WorkerPoolRouter,
         health_tracker: HealthTracker,
         chain_id: u64,
-        router_address: Bytes,
+        router_address: Option<Bytes>,
         permit2_address: Bytes,
         #[cfg(feature = "experimental")] derived_data: SharedDerivedDataRef,
         #[cfg(feature = "experimental")] gas_token: Address,
@@ -203,8 +203,8 @@ impl AppState {
         self.chain_id
     }
 
-    pub(crate) fn router_address(&self) -> &Bytes {
-        &self.router_address
+    pub(crate) fn router_address(&self) -> Option<&Bytes> {
+        self.router_address.as_ref()
     }
 
     pub(crate) fn permit2_address(&self) -> &Bytes {

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -226,7 +226,7 @@ impl FyndRPCBuilder {
 
         let chain = parts.chain();
         let chain_id = chain.id();
-        let router_address = parts.router_address().clone();
+        let router_address = parts.router_address().cloned();
         let permit2_address = {
             use fynd_core::encoding::encoder::PERMIT2_ADDRESS;
             let hex = PERMIT2_ADDRESS

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -11,7 +11,7 @@ use fynd_core::{
 };
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
-use tycho_simulation::tycho_common::models::{Chain, TvlThresholdTier};
+use tycho_simulation::tycho_common::models::{chain_config::TvlThresholdTier, Chain};
 
 use crate::{
     api::{configure_app, AppState, HealthTracker},

--- a/fynd-rpc/src/lib.rs
+++ b/fynd-rpc/src/lib.rs
@@ -25,4 +25,20 @@ pub mod config;
 pub mod protocols;
 
 // Re-export parse_chain so tools that depend on fynd-rpc (not fynd-core) can use it.
+use std::path::Path;
+
 pub use fynd_core::types::parse_chain;
+
+/// Installs the process-global custom-chain registry from a `chains.yaml` file.
+///
+/// Call once at startup before resolving any chain name. No-op-safe to omit for built-in chains.
+pub fn init_chain_registry_from_file(path: &Path) -> Result<(), String> {
+    use tycho_simulation::tycho_common::models::chain_config::{
+        init_chain_registry, ChainConfigRegistry,
+    };
+    let path = path
+        .to_str()
+        .ok_or_else(|| "chains-config path is not valid UTF-8".to_string())?;
+    let registry = ChainConfigRegistry::from_yaml_file(path).map_err(|e| e.to_string())?;
+    init_chain_registry(registry).map_err(|_| "chain registry already initialized".to_string())
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ pub enum Commands {
     /// Print the OpenAPI spec as JSON to stdout
     Openapi,
     /// Analyze live Tycho market data and suggest connector tokens for routing
-    DeriveConnectorTokens(DeriveConnectorTokensArgs),
+    DeriveConnectorTokens(Box<DeriveConnectorTokensArgs>),
 }
 
 /// Arguments for the `serve` subcommand.
@@ -111,6 +111,11 @@ pub struct ServeArgs {
     /// Tycho stream.
     #[arg(long, env)]
     pub blocklist_config: Option<PathBuf>,
+
+    /// Path to the custom-chains config (chains.yaml). Required to run a chain that Tycho does
+    /// not know as a built-in. Uses the same file the indexer reads.
+    #[arg(long, env = "TYCHO_CHAINS_CONFIG")]
+    pub chains_config: Option<PathBuf>,
 
     /// Gas price staleness threshold in seconds. Health returns 503 when exceeded.
     /// Disabled by default.
@@ -226,5 +231,13 @@ mod cli_tests {
     fn test_openapi_subcommand() {
         let cli = Cli::try_parse_from(vec!["fynd", "openapi"]).expect("parse errored");
         assert_eq!(cli.command, Commands::Openapi);
+    }
+
+    #[test]
+    fn parses_chains_config() {
+        let cli = Cli::try_parse_from(vec!["fynd", "serve", "--chains-config", "chains.yaml"])
+            .expect("parse errored");
+        let Commands::Serve(args) = cli.command else { panic!("expected serve") };
+        assert_eq!(args.chains_config, Some(PathBuf::from("chains.yaml")));
     }
 }

--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -8,7 +8,7 @@ use fynd_core::{
 };
 use fynd_rpc::parse_chain;
 use tracing::info;
-use tycho_simulation::tycho_common::models::{Address, TvlThresholdTier};
+use tycho_simulation::tycho_common::models::{chain_config::TvlThresholdTier, Address};
 
 /// Derives recommended connector tokens from live Tycho market data.
 ///

--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use anyhow::{Context, Result};
 use clap::Args;
@@ -63,9 +63,20 @@ pub struct DeriveConnectorTokensArgs {
     /// How long to wait for the initial Tycho snapshot (seconds).
     #[arg(long, default_value_t = 120)]
     pub wait_secs: u64,
+
+    /// Path to the custom-chains config (chains.yaml). Required to run a chain that Tycho does
+    /// not know as a built-in. Uses the same file the indexer reads.
+    #[arg(long, env = "TYCHO_CHAINS_CONFIG")]
+    pub chains_config: Option<PathBuf>,
 }
 
 pub async fn run(args: DeriveConnectorTokensArgs) -> Result<()> {
+    if let Some(path) = &args.chains_config {
+        fynd_rpc::init_chain_registry_from_file(path)
+            .map_err(|e| anyhow::anyhow!("failed to load chains config: {e}"))?;
+        info!(?path, "installed custom chain registry");
+    }
+
     let chain = parse_chain(&args.chain).context("invalid chain")?;
     let tycho_url = crate::resolve_tycho_url(&args.chain, args.tycho_url.as_deref())
         .map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,9 @@ use tokio::{
 };
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use tycho_simulation::{tycho_common::models::TvlThresholdTier, utils::default_blocklist};
+use tycho_simulation::{
+    tycho_common::models::chain_config::TvlThresholdTier, utils::default_blocklist,
+};
 
 fn main() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), anyhow::Error> {
         }
         Commands::DeriveConnectorTokens(args) => tokio::runtime::Runtime::new()
             .expect("failed to create tokio runtime")
-            .block_on(commands::derive_connector_tokens::run(args)),
+            .block_on(commands::derive_connector_tokens::run(*args)),
     }
 }
 
@@ -237,6 +237,12 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
                 SolverError::SetupError(format!("failed to load worker pools config: {}", e))
             })?
         };
+
+    if let Some(path) = &args.chains_config {
+        fynd_rpc::init_chain_registry_from_file(path)
+            .map_err(|e| SolverError::SetupError(format!("failed to load chains config: {e}")))?;
+        info!(?path, "installed custom chain registry");
+    }
 
     // Parse chain
     let chain = parse_chain(&args.chain)

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -336,14 +336,30 @@ async fn main() -> anyhow::Result<()> {
                 .await?;
             }
             let info = client.info().await?;
-            let router_addr = Address::try_from(info.router_address().as_ref())
-                .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
+            let router_addr = Address::try_from(
+                info.router_address()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "server has no router_address; encoding is unavailable on this chain"
+                        )
+                    })?
+                    .as_ref(),
+            )
+            .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
             (EncodingOptions::new(slippage), vec![router_addr])
         }
         TransferType::TransferFromPermit2 => {
             let info = client.info().await?;
-            let router_addr = Address::try_from(info.router_address().as_ref())
-                .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
+            let router_addr = Address::try_from(
+                info.router_address()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "server has no router_address; encoding is unavailable on this chain"
+                        )
+                    })?
+                    .as_ref(),
+            )
+            .map_err(|_| anyhow::anyhow!("invalid router address from /v1/info"))?;
             if cli.execute {
                 // Check against the swap amount but approve max — subsequent swaps won't
                 // need re-approval even after Permit2 deducts from the ERC-20 allowance.


### PR DESCRIPTION
Adds support for running Fynd against a custom EVM chain served by a self-hosted Tycho, plus
docs for pointing Fynd at a self-hosted Tycho on built-in chains.

## What
- **Deps:** bump Tycho (simulation/execution/client/common) 0.331.0 → 0.334.0 for the
  custom-chain registry APIs.
- **Chain resolution:** `parse_chain` now resolves custom chains via the `TYCHO_CHAINS_CONFIG`
  registry, installed explicitly with a new `--chains-config` flag (also on
  `derive-connector-tokens`). `native_token` resolves the wrapped-native token from the registry
  instead of a hardcoded map (fail-fast preserved for chains with no real native token).
- **Quote-only:** where no Tycho router is deployed, Fynd runs quote-only — `GET /v1/info`
  reports `router_address: null` and an encoding-enabled quote returns `501 Not Implemented`
  (`ENCODING_UNAVAILABLE`). Genuine encoding failures still return `422`. Built-in chains are
  unchanged (encoding fully supported).
- **Clients:** OpenAPI spec + TypeScript and Rust clients regenerated for the now-nullable
  `router_address`.
- **Docs:** how to point Fynd at a self-hosted Tycho, and how to run a custom chain.

Router/executor deployment for a custom chain remains an ops flow, synced with clients on demand.

## Testing
`cargo nextest run --workspace --all-targets --all-features` → 948 passed / 10 skipped.
TS client typecheck + lint + vitest → 152 passed. `cargo fmt --check` clean. No OpenAPI drift.

## Follow-ups (non-blocking)
- TS client `use_vaults_funds` vs Rust `Ok(None)` parity on null router.
- `@fynd/autogen` reference in repo docs is stale (schema generates into `client/src/`).

Related Tycho docs: https://docs.propellerheads.xyz/tycho/for-solvers/self-hosted-evm-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)
