### PR TITLE
refactor: Hindsight clean up

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -1,4 +1,4 @@
-<!-- docs-synced-at: 353a6a831f91313b1b8d5b66985f91b0385da4dc -->
+<!-- docs-synced-at: 4a30359cea111f5590fe698357b3a707fee65ece -->
 # Fynd Codebase Guide
 
 High-performance DeFi route-finding engine built on Tycho. Finds optimal swap routes across
@@ -45,7 +45,11 @@ Both clients wrap the same OpenAPI spec (`clients/openapi.json`, generated via `
 |---|---|---|
 | `fynd-benchmark` | `tools/benchmark/` | Load testing, solver comparison, trade dataset download |
 | `fynd-swap-cli` | `tools/fynd-swap-cli/` | Quote and execute token swaps (ERC-20 or Permit2) |
+| `hindsight` | `tools/hindsight/` | Decode solver swaps from on-chain data; live-monitor re-solve quality |
 | `record-market` | `tools/record-market/` | Record live Tycho market state and generate expected outputs for the integration tests |
+| `fynd-gas-audit` | `tools/fynd-gas-audit/` | Compare quote-time gas estimates against `eth_estimateGas` |
+| `erc20-overrides` | `tools/erc20-overrides/` | ERC-20 storage slot detection for dry-run storage overrides |
+| `fynd-tools-common` | `tools/common/` | Shared internal library for tool crates |
 
 ## Architecture Overview
 
@@ -56,7 +60,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 1. **RouterApi** (`fynd-rpc/src/api/`) — Actix Web HTTP handlers: `POST /v1/quote`, `GET /v1/health`, `GET /v1/info`
 2. **WorkerPoolRouter** (`fynd-core/src/worker_pool_router/`) — Fans out orders to all pools, selects best by `amount_out_net_gas`
 3. **WorkerPool** (`fynd-core/src/worker_pool/`) — N `SolverWorker` instances on dedicated OS threads per pool
-4. **Algorithm trait** (`fynd-core/src/algorithm/`) — Pluggable route-finding; built-in: `MostLiquidAlgorithm`, `BellmanFordAlgorithm`
+4. **Algorithm trait** (`fynd-core/src/algorithm/`) — Pluggable route-finding; built-in: `MostLiquidAlgorithm`, `BellmanFordAlgorithm`, `PathFrankWolfeAlgorithm`
 5. **MarketState** (`fynd-core/src/feed/market_data.rs`) — `Arc<RwLock<>>` of all pool/token/gas state; accessed via `MarketData` handle
 6. **TychoFeed** (`fynd-core/src/feed/tycho_feed.rs`) — Background task: Tycho WebSocket → MarketState → broadcast events
 7. **Derived Data** (`fynd-core/src/derived/`) — Pre-computed spot prices, pool depths, token gas prices
@@ -69,7 +73,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 1. `TychoFeed` receives state updates from Tycho WebSocket
 2. Writes new component/token/state data into `MarketState` (write lock)
 3. Broadcasts `MarketEvent` → each `SolverWorker` updates its local graph via `GraphManager`
-4. Signals `GasPriceFetcher` → fetches gas price from RPC node → writes to `MarketState`
+4. `GasPriceFetcher` runs independently on a timer → fetches gas price from RPC node → writes to `MarketState`
 5. Triggers `ComputationManager` → runs spot prices → pool depths → token gas prices (in dependency order) → broadcasts `DerivedDataEvent` → workers update edge weights
 
 **Quote request path** (`POST /v1/quote`):
@@ -94,7 +98,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 | Variable | Purpose |
 |---|---|
 | `TYCHO_API_KEY` | Tycho API key (optional) |
-| `RPC_URL` | Ethereum RPC endpoint (default: `https://eth.llamarpc.com`) |
+| `RPC_URL` | Ethereum RPC endpoint (chain-specific default) |
 | `TYCHO_URL` | Tycho endpoint (chain-specific default) |
 | `HTTP_HOST` | HTTP bind address (default: `0.0.0.0`) |
 | `HTTP_PORT` | API port (default: `3000`) |
@@ -107,8 +111,9 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 
 | Command | Purpose |
 |---|---|
-| `serve` | Run the solver: Tycho feed + HTTP RPC server. Notable flags: `--enable-price-guard` (default `false`) |
+| `serve` | Run the solver: Tycho feed + HTTP RPC server. Notable flags: `--enable-price-guard` (default `false`), `--partial-blocks` (enable flashblock/partial-block updates from Tycho stream) |
 | `openapi` | Print the OpenAPI spec JSON to stdout |
+| `derive-connector-tokens` | Derive and print connector token lists for configured protocols |
 
 ### Config Files
 

--- a/.claude/knowledge/typescript.md
+++ b/.claude/knowledge/typescript.md
@@ -1,7 +1,7 @@
 # TypeScript Client (`@kayibal/fynd-client`)
 
 TypeScript client for the Fynd RPC API. Lives in `clients/typescript/` as a pnpm workspace with
-two packages.
+two packages: `client` and `examples/tutorial`.
 
 ## Workspace Structure
 
@@ -9,12 +9,10 @@ two packages.
 clients/typescript/
   pnpm-workspace.yaml
   pnpm-lock.yaml
-  autogen/                    # @fynd/autogen — generated OpenAPI types
-    src/
-      schema.d.ts             # Auto-generated from clients/openapi.json
-      index.ts                # Re-exports
   client/                     # @kayibal/fynd-client — typed HTTP client
     src/
+      autogen.ts              # Typed fetch client generated from OpenAPI spec (replaces @fynd/autogen)
+      schema.d.ts             # Auto-generated OpenAPI types from clients/openapi.json
       client.ts               # FyndClient — main client class
       types.ts                # Public types (QuoteRequest, QuoteResponse, etc.)
       mapping.ts              # Maps between API schema types and public types
@@ -31,9 +29,6 @@ clients/typescript/
 ```bash
 # Install dependencies
 pnpm --dir clients/typescript install --frozen-lockfile
-
-# Build autogen first (client depends on it)
-pnpm --dir clients/typescript --filter @fynd/autogen run build
 
 # Typecheck, lint, test the client
 pnpm --dir clients/typescript --filter @kayibal/fynd-client run typecheck
@@ -64,5 +59,5 @@ TYCHO_API_KEY=<key> ./scripts/run-all-examples.sh
 - ESM only (`"type": "module"`)
 - Tooling: `oxlint` for linting, `vitest` for tests, `tsc` for type checking
 - Colocated test files (`*.test.ts` next to source)
-- `@kayibal/fynd-client` depends on `@fynd/autogen` for schema types
-- When adding/changing RPC endpoints, update: Rust types → OpenAPI spec → autogen → client mapping
+- `autogen.ts` and `schema.d.ts` in `client/src/` are auto-generated — do not edit manually
+- When adding/changing RPC endpoints, update: Rust types → OpenAPI spec → regenerate `autogen.ts`/`schema.d.ts` → update client mapping

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -78,17 +78,15 @@ endpoint response shape. This determines which signing and execution paths to us
 
 For full details, see [`.claude/knowledge/typescript.md`](../.claude/knowledge/typescript.md).
 
-pnpm workspace at `clients/typescript/` with two packages:
+pnpm workspace at `clients/typescript/` with two packages: `client` and `examples/tutorial`.
 
-- **`@fynd/autogen`** (`autogen/`) — Generated types from `openapi-typescript`. `schema.d.ts` is
-  auto-generated; do not edit manually.
 - **`@kayibal/fynd-client`** (`client/`) — Typed HTTP client: `FyndClient`, signing, Permit2, error types.
+  Contains `autogen.ts` and `schema.d.ts` (generated from `openapi-typescript`; do not edit manually).
 
 ### Build & Test
 
 ```bash
 pnpm --dir clients/typescript install --frozen-lockfile
-pnpm --dir clients/typescript --filter @fynd/autogen run build
 pnpm --dir clients/typescript --filter @kayibal/fynd-client run typecheck
 pnpm --dir clients/typescript --filter @kayibal/fynd-client run lint
 pnpm --dir clients/typescript --filter @kayibal/fynd-client run test

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -203,6 +203,7 @@ Pluggable interface for route-finding algorithms:
 
 * `MostLiquidAlgorithm` -- BFS path enumeration, depth-weighted scoring, ProtocolSim simulation, gas-adjusted ranking.
 * `BellmanFordAlgorithm` -- Bellman-Ford relaxation with gas-aware edge weights, configurable via `AlgorithmConfig.gas_aware`.
+* `PathFrankWolfeAlgorithm` -- Frank-Wolfe path-based optimization for multi-hop routing.
 
 ***
 

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -7,7 +7,7 @@ applications.
 
 | Module                | Description                                                                                                                                                                        |
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `algorithm/`          | `Algorithm` trait + built-in `MostLiquidAlgorithm`, `BellmanFordAlgorithm`. Pluggable via associated graph types. `AlgorithmConfig` shared by both                                 |
+| `algorithm/`          | `Algorithm` trait + built-in `MostLiquidAlgorithm`, `BellmanFordAlgorithm`, `PathFrankWolfeAlgorithm`. Pluggable via associated graph types. `AlgorithmConfig` shared by all         |
 | `solver.rs`           | `FyndBuilder` assembles the full pipeline (feed + gas + computations + pools + encoder + router). `Solver` runs it                                                                 |
 | `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based |
 | `worker_pool_router/` | `WorkerPoolRouter` fans out orders to all pools, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes          |
@@ -57,6 +57,11 @@ Returns a `Solver` that can `quote()` directly. For standalone (non-HTTP) use.
 
 Price guard methods: `price_guard_enabled(bool)`, `register_price_provider(Box<dyn PriceProvider>)`,
 `add_default_price_providers()` (registers Binance WS + Hyperliquid providers).
+
+Additional builder methods: `partial_blocks(bool)` (enable flashblock/partial-block updates),
+`with_pending_indexer(...)` (attach a pending-block indexer), `build_with_pending()` (build with
+pending-block support). `Solver::subscribe_market_events()` returns a broadcast receiver for
+`MarketEvent`s.
 
 ## Adding a Custom Algorithm
 

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -9,7 +9,7 @@ infrastructure.
 |---|---|
 | `builder.rs` | `FyndRPCBuilder` wraps `FyndBuilder`, adds HTTP server config. `FyndRPC` struct runs the server with graceful shutdown |
 | `config.rs` | `WorkerPoolsConfig` (TOML loader), `BlocklistConfig`, `defaults` module re-exporting `fynd-core` defaults + HTTP-specific ones |
-| `protocols.rs` | `fetch_protocol_systems()` — paginated Tycho RPC call to discover available protocols |
+| `protocols.rs` | `fetch_protocol_systems()` — paginated Tycho RPC call to discover available protocols; `resolve_protocols()` — higher-level wrapper used by `serve` and `scale` that expands `all_onchain`/`native_onchain` tokens and applies min-TVL filtering |
 | `api/` | HTTP endpoint handlers and OpenAPI documentation |
 
 ## Features

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -15,12 +15,13 @@ Developer and operational tooling for the Fynd solver.
 
 See [`tools/benchmark/CLAUDE.md`](benchmark/CLAUDE.md) for the full module overview.
 
-Four subcommands via `cargo run -p fynd-benchmark --release --`:
+Five subcommands via `cargo run -p fynd-benchmark --release --`:
 
 - **`load`** — Load-test a single solver (latency, throughput, histograms)
 - **`compare`** — Compare output quality between two solver instances (amount out diff in bps)
 - **`scale`** — Measure how solver throughput scales with worker thread count (in-process, no external solver needed)
 - **`download-trades`** — Download the full 10k aggregator trade dataset from GitHub Releases
+- **`audit`** — Compare Fynd quote quality against external aggregators (Nordstern, KyberSwap, 0x); writes a JSON report
 
 ---
 
@@ -33,7 +34,6 @@ End-to-end CLI for quoting and executing swaps. Supports both ERC-20 approval an
 | File | Purpose |
 |---|---|
 | `main.rs` | CLI parsing (clap), quote → sign → execute flow |
-| `erc20.rs` | ERC-20 helpers: balance checks, storage slot detection for dry-run overrides |
 | `permit2.rs` | Permit2 helpers: allowance checks, nonce fetching |
 
 ### Key Behaviors

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -6,6 +6,7 @@ Developer and operational tooling for the Fynd solver.
 |---|---|---|
 | [fynd-benchmark](#fynd-benchmark) | `tools/benchmark/` | Load testing, solver comparison, trade dataset download |
 | [fynd-swap-cli](#fynd-swap-cli) | `tools/fynd-swap-cli/` | Quote and execute token swaps (ERC-20 or Permit2) |
+| [hindsight](#hindsight) | `tools/hindsight/` | Decode solver swaps from on-chain data and live-monitor re-solve quality |
 | [record-market](#record-market) | `tools/record-market/` | Record Tycho market state and expected outputs for integration tests |
 
 ---
@@ -47,6 +48,23 @@ End-to-end CLI for quoting and executing swaps. Supports both ERC-20 approval an
   `--transfer-type use-vaults-funds` (funds already in router vault)
 
 See [`docs/guides/swap-cli.md`](../docs/guides/swap-cli.md) for usage instructions.
+
+---
+
+## hindsight
+
+See [`tools/hindsight/CLAUDE.md`](hindsight/CLAUDE.md) for the full module overview.
+
+Three subcommands via `cargo run -p hindsight --release --`:
+
+- **`decode`** — Fetch block receipts, match and trace solver transactions, emit decoded trades
+  (token in/out, amounts, client, solver, settled gas). Accepts `--block N`, `--range START-END`
+  (max 1000 blocks), or defaults to the latest block.
+- **`verify`** — Diff decoded trades against Allium's `aggregator_trades` ground truth. Requires 
+  `ALLIUM_API_KEY` and `ALLIUM_QUERY_ID`.
+- **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block, re-solving
+  each settled trade at top-of-block (N-1) and back-of-block (N). Emits JSONL and exposes
+  Prometheus metrics.
 
 ---
 

--- a/tools/benchmark/CLAUDE.md
+++ b/tools/benchmark/CLAUDE.md
@@ -4,7 +4,7 @@ Benchmark and comparison tooling for Fynd solvers. Requires one or more running 
 
 ## Commands
 
-Three subcommands available via `cargo run -p fynd-benchmark --release --`:
+Five subcommands available via `cargo run -p fynd-benchmark --release --`:
 
 - **`load`** — Load-test a single solver. Measures latency (round-trip, solve time, overhead) and throughput. Supports sequential, fixed-concurrency, and rate-based parallelization modes. Prints statistics and ASCII histograms to stdout; optionally exports results to JSON.
 
@@ -110,7 +110,7 @@ Key fields per participant:
 
 | Module | Purpose |
 |---|---|
-| `main.rs` | CLI entry point. Parses `load` / `compare` subcommands via clap and dispatches to the corresponding handler. |
+| `main.rs` | CLI entry point. Parses subcommands via clap and dispatches to the corresponding handler. |
 | `benchmark.rs` | `load` subcommand handler. Builds a `FyndClient`, checks solver health, loads request templates, runs the benchmark via `runner`, and prints results via `exporter`. |
 | `compare.rs` | `compare` subcommand handler. Builds two `FyndClient` instances, sends identical requests sequentially to both, computes per-request metrics (amount out diff in bps, gas diff, route match), prints a summary table, and exports full results to JSON. |
 | `config.rs` | Shared types: `ParallelizationMode` enum (`Sequential`, `FixedConcurrency`, `RateBased`), `BenchmarkConfig`, `BenchmarkResults`, `TimingStats`. |
@@ -118,6 +118,9 @@ Key fields per participant:
 | `exporter.rs` | Statistics calculation (`TimingStats::from_measurements` — min/max/mean/median/p95/p99/stddev), ASCII histogram rendering, and JSON export of `BenchmarkResults`. |
 | `requests.rs` | Request generation and loading. Provides a default WETH→USDC request, loads embedded aggregator trades, downloads the full 10k dataset, and loads custom requests from a JSON file. |
 | `scale.rs` | `scale` subcommand handler. Resolves protocols once via `resolve_protocols` (`all_onchain`/`native_onchain` expansion), then builds and tears down an in-process Fynd instance for each worker-count iteration (applying `--min-tvl`), runs load tests via `runner`, and exports scaling results to JSON. |
+| `aggregator.rs` | Aggregator API clients (Nordstern, KyberSwap, 0x) used by the `audit` subcommand. |
+| `pair_selector.rs` | Trade pair selection logic for `audit` runs. |
+| `audit/` | `audit` subcommand handler: per-trade result collection, on-chain validation via `eth_call`, JSON report writing. |
 
 ## Data Files
 

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -1,0 +1,89 @@
+# hindsight
+
+Decode solver swaps from on-chain data and live-monitor Fynd's re-solve quality against what
+actually settled.
+
+## Commands
+
+Three subcommands via `cargo run -p hindsight --release --`:
+
+- **`decode`** — Fetch block receipts, match solver transactions, trace each one, and emit decoded
+  trades (token in/out, amounts, client, solver, gas). Accepts `--block N`, `--range START-END`
+  (max 1000 blocks), or defaults to the latest block. Use `--json` for machine-readable output.
+
+- **`verify`** — Dev sanity check: decode a block and diff against Allium's `aggregator_trades`
+  ground truth to confirm the decoder isn't missing or misclassifying trades. Requires
+  `ALLIUM_API_KEY` and `ALLIUM_QUERY_ID`.
+
+- **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block. For each
+  block it decodes settled trades, re-solves each order at top-of-block (state N-1) then
+  back-of-block (state N), and emits `RangeComparison` JSONL records. Exposes a Prometheus
+  metrics endpoint (`--metrics-addr`).
+
+## Environment
+
+| Variable | Purpose |
+|---|---|
+| `RPC_URL` | Ethereum JSON-RPC endpoint |
+| `ALLIUM_API_KEY` | Allium API key (`verify` only) |
+| `ALLIUM_QUERY_ID` | Saved Allium query ID (`verify` only) |
+| `HINDSIGHT_REGISTRY` | Override path for the decoder address-book TOML |
+
+## Architecture
+
+### Decode pipeline (`src/decoder/`)
+
+Match → trace → decode → guard → record.
+
+| File/dir | Purpose |
+|---|---|
+| `strategy.rs` | Selects the decode strategy per matched transaction |
+| `ledger.rs` | Builds a transfer ledger from logs and native ETH flows |
+| `guards.rs` | Vetoes non-comparable shapes (e.g. multi-leg, maker fills) |
+| `registry.rs` | Address book: maps contract addresses to client/solver labels |
+| `clients/` | Per-client decoders (Relay, MetaMask, …) |
+| `solvers/` | Per-solver decoders + embedded-quote extraction + attribution |
+| `allium.rs` | Allium API client for the `verify` subcommand |
+| `verify_decoder.rs` | Diff logic between decoded trades and Allium ground truth |
+
+Three address tiers: **client** (order-flow owner, `tx.to`), **solver** (router that settled the
+trade), **liquidity venues** (pools inside traces — not modeled here).
+
+### Re-solve engine (`src/resolve/`)
+
+| File | Purpose |
+|---|---|
+| `mod.rs` | `SteppingSolver` trait; `resolve_block_range` — solve all trades at top, advance, solve again at back |
+| `compare.rs` | `Verdict` / `Deltas` — bps diff, win/loss/coverage-miss classification |
+| `monitor.rs` | Production `monitor` subcommand: in-process solver, block subscription, JSONL emission |
+| `jsonl.rs` | Append-only JSONL writer used by `monitor` |
+
+### Verdict model
+
+Each re-solved trade produces a `top` (optimistic, state N-1) and `back` (pessimistic, state N)
+result. The headline `verdict` is top-of-block. Possible verdicts: `Win`, `Loss`, `Tie`,
+`CoverageMiss` (Fynd filled <10% of the settled size), `Unsolvable`.
+
+### Key types
+
+- `DecodedTrade` — decoded on-chain trade; amounts are client-fee-adjusted so re-solve compares
+  like-for-like.
+- `RangeComparison` — a trade re-solved at both block states, including gas-netted settled output.
+- `Outcome` — `Solved`, `Partial`, or `Unsolvable`.
+
+## Running
+
+```bash
+# Decode the latest block
+RPC_URL=... cargo run -p hindsight --release -- decode
+
+# Decode a range
+RPC_URL=... cargo run -p hindsight --release -- decode --range 21000000-21000010 --json
+
+# Verify against Allium
+RPC_URL=... ALLIUM_API_KEY=... ALLIUM_QUERY_ID=... \
+  cargo run -p hindsight --release -- verify --block 21000000
+
+# Live monitor (requires a running Tycho feed)
+RPC_URL=... cargo run -p hindsight --release -- monitor --help
+```

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -65,8 +65,8 @@ trade), **liquidity venues** (pools inside traces — not modeled here).
 ### Verdict model
 
 Each re-solved trade produces a `top` (optimistic, state N-1) and `back` (pessimistic, state N)
-result. The headline `verdict` is top-of-block. Possible verdicts: `Win`, `Loss`, `Tie`,
-`CoverageMiss` (Fynd filled <10% of the settled size), `Unsolvable`.
+result. The headline `verdict` is top-of-block. Possible verdicts: `Win`, `Loss`,
+`CoverageMiss` (Fynd filled <50% of the settled size — `MIN_FILL_RATIO = 0.5`), `Unsolvable`.
 
 ### Key types
 

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -40,13 +40,17 @@ Match → trace → decode → guard → record.
 | `strategy.rs` | Selects the decode strategy per matched transaction |
 | `ledger.rs` | Builds a transfer ledger from logs and native ETH flows |
 | `guards.rs` | Vetoes non-comparable shapes (e.g. multi-leg, maker fills) |
-| `registry.rs` | Address book: maps contract addresses to client/solver labels |
-| `clients/` | Per-client decoders (Relay, MetaMask, …) |
+| `registry.rs` | Address book: maps contract addresses to venue/solver labels |
+| `venues/` | Per-venue decoders (Relay, MetaMask, …) — at `src/decoder/venues/` |
 | `solvers/` | Per-solver decoders + embedded-quote extraction + attribution |
-| `allium.rs` | Allium API client for the `verify` subcommand |
-| `verify_decoder.rs` | Diff logic between decoded trades and Allium ground truth |
+| `intent.rs` | Intent/order parsing helpers |
+| `trace.rs` | Transaction trace fetching and processing |
 
-Three address tiers: **client** (order-flow owner, `tx.to`), **solver** (router that settled the
+`src/verify/` contains the Allium integration:
+- `allium.rs` — Allium API client for the `verify` subcommand
+- `mod.rs` — Diff logic between decoded trades and Allium ground truth
+
+Three address tiers: **venue** (order-flow owner, `tx.to`), **solver** (router that settled the
 trade), **liquidity venues** (pools inside traces — not modeled here).
 
 ### Re-solve engine (`src/resolve/`)

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -57,7 +57,6 @@ toml = { workspace = true }
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 # Panic prevention
-unwrap_used = "deny"
 expect_used = "warn"
 panic = "deny"
 panic_in_result_fn = "deny"

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -57,7 +57,6 @@ toml = { workspace = true }
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 # Panic prevention
-expect_used = "warn"
 panic = "deny"
 panic_in_result_fn = "deny"
 unimplemented = "deny"

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -53,3 +53,27 @@ tracing-subscriber = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# Panic prevention
+unwrap_used = "deny"
+expect_used = "warn"
+panic = "deny"
+panic_in_result_fn = "deny"
+unimplemented = "deny"
+# No cheating
+allow_attributes = "deny"
+# Code hygiene
+dbg_macro = "deny"
+todo = "deny"
+print_stdout = "deny"
+print_stderr = "deny"
+# Safety
+await_holding_lock = "deny"
+large_futures = "deny"
+exit = "deny"
+mem_forget = "deny"
+# Pedantic relaxations (too noisy)
+module_name_repetitions = "allow"
+similar_names = "allow"

--- a/tools/hindsight/src/decoder/intent.rs
+++ b/tools/hindsight/src/decoder/intent.rs
@@ -112,7 +112,7 @@ mod tests {
         RootProvider::new(RpcClient::mocked(asserter.clone()))
     }
 
-    /// The maker/pool inverse-swap fixture: maker sells token_a for token_b, pool nets the
+    /// The maker/pool inverse-swap fixture: maker sells `token_a` for `token_b`, pool nets the
     /// inverse.
     fn inverse_swap_ledger() -> TransferLedger {
         let logs = vec![

--- a/tools/hindsight/src/decoder/intent.rs
+++ b/tools/hindsight/src/decoder/intent.rs
@@ -1,7 +1,7 @@
 //! Maker-finding for intent fills and batch settlements.
 //!
 //! Covers transactions where the sender is not the trader: filler-initiated
-//! intent fills (UniswapX, 1inch limit orders) and batch settlements (CoW),
+//! intent fills (`UniswapX`, 1inch limit orders) and batch settlements (`CoW`),
 //! where the real swap is an order maker's net flow.
 
 use std::collections::HashMap;

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -1,9 +1,9 @@
 //! Decode solver trades from on-chain data.
 //!
 //! Terminology — three tiers, two of which appear in every record:
-//! - **venue** (`venues/`): the contract the user entered through (`tx.to`) — Relay, MetaMask.
+//! - **venue** (`venues/`): the contract the user entered through (`tx.to`) — Relay, `MetaMask`.
 //!   Order-flow owners; they pick a solver and may skim a fee.
-//! - **solver** (`solvers/`): the router that computed and settled the route — KyberSwap, 1inch,
+//! - **solver** (`solvers/`): the router that computed and settled the route — `KyberSwap`, 1inch,
 //!   0x. These are Fynd's competitors. Datasets recorded before run6 call this tier `aggregator` in
 //!   their column names; the two words mean the same thing.
 //! - **liquidity venues**: the pools and makers a route executes against (Uniswap, Curve,
@@ -56,7 +56,7 @@ pub(crate) struct DecodedTrade {
     pub venue: String,
     pub solver: String,
     /// The evidence tier the solver label came from (see [`solvers::attribution`]). Downstream
-    /// analysis weighs low-trust tiers (largest_call, fallback) differently — e.g. when judging
+    /// analysis weighs low-trust tiers (`largest_call`, fallback) differently — e.g. when judging
     /// an embedded quote.
     pub solver_source: AttributionSource,
     pub sender: Address,
@@ -79,7 +79,7 @@ pub(crate) struct DecodedTrade {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub venue_fee_out: Option<U256>,
     /// Wei cost of the gas the trader paid for the settled route (`gas_used ×
-    /// effective_gas_price`). For venue-wrapped entries (Relay, MetaMask) the venue's own
+    /// effective_gas_price`). For venue-wrapped entries (Relay, `MetaMask`) the venue's own
     /// overhead is excluded — it is charged whichever router the venue picks, like the venue
     /// fee. `None` when the trader did not pay the transaction's gas (maker fills, solver
     /// rebalances) or the route's gas could not be isolated from the trace.
@@ -131,7 +131,7 @@ impl<P: Provider> Decoder<P> {
     /// Fetches all receipts in one `eth_getBlockReceipts` call, then matches a
     /// transaction two ways: its entry point (`tx.to`) is a known venue or
     /// solver, or one of its logs was emitted by a known solver. The
-    /// second case catches filler-initiated intent fills (UniswapX, 1inch
+    /// second case catches filler-initiated intent fills (`UniswapX`, 1inch
     /// limit orders) where `tx.to` is a rotating filler. Matched transactions are
     /// traced concurrently; the trace recovers native ETH flows and attributes
     /// the settling solver.

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -1,7 +1,7 @@
 //! Decode solver trades from on-chain data.
 //!
 //! Terminology — three tiers, two of which appear in every record:
-//! - **client** (`clients/`): the contract the user entered through (`tx.to`) — Relay, MetaMask.
+//! - **venue** (`venues/`): the contract the user entered through (`tx.to`) — Relay, MetaMask.
 //!   Order-flow owners; they pick a solver and may skim a fee.
 //! - **solver** (`solvers/`): the router that computed and settled the route — KyberSwap, 1inch,
 //!   0x. These are Fynd's competitors. Datasets recorded before run6 call this tier `aggregator` in
@@ -13,7 +13,6 @@
 //! transaction is decoded, `ledger` answers all value-flow questions, `guards` vetoes shapes that
 //! are not comparable trades, and `registry` is the address book behind matching.
 
-mod clients;
 mod guards;
 mod intent;
 mod ledger;
@@ -21,6 +20,7 @@ mod registry;
 mod solvers;
 mod strategy;
 mod trace;
+pub(crate) mod venues;
 
 #[cfg(test)]
 mod test_utils;
@@ -53,7 +53,7 @@ pub(crate) use crate::decoder::{
 pub(crate) struct DecodedTrade {
     pub tx_hash: TxHash,
     pub block_number: u64,
-    pub client: String,
+    pub venue: String,
     pub solver: String,
     /// The evidence tier the solver label came from (see [`solvers::attribution`]). Downstream
     /// analysis weighs low-trust tiers (largest_call, fallback) differently — e.g. when judging
@@ -62,32 +62,32 @@ pub(crate) struct DecodedTrade {
     pub sender: Address,
     pub token_in: Address,
     pub token_out: Address,
-    /// Input amount that actually entered the swap — a client fee skimmed from the input (see
-    /// [`client_fee`]) is already subtracted, so a re-solve compares like-for-like.
+    /// Input amount that actually entered the swap — a venue fee skimmed from the input (see
+    /// [`venue_fee`]) is already subtracted, so a re-solve compares like-for-like.
     pub amount_in: U256,
-    /// Gross swap output — a client fee skimmed from the output (see [`client_fee_out`]) is added
+    /// Gross swap output — a venue fee skimmed from the output (see [`venue_fee_out`]) is added
     /// back, so the settled amount is the full swap proceeds, comparable to Fynd's gross output.
     pub amount_out: U256,
-    /// Client fee skimmed from the input token before swapping (e.g. Relay's fee), in `token_in`
+    /// Venue fee skimmed from the input token before swapping (e.g. Relay's fee), in `token_in`
     /// units. `None` when no known fee collector took a cut. Recorded for transparency; it is
     /// already excluded from `amount_in`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_fee: Option<U256>,
-    /// Client fee skimmed from the output token after swapping, in `token_out` units. `None` when
+    pub venue_fee: Option<U256>,
+    /// Venue fee skimmed from the output token after swapping, in `token_out` units. `None` when
     /// no known fee collector took a cut. Recorded for transparency; it is already added back into
     /// `amount_out`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_fee_out: Option<U256>,
+    pub venue_fee_out: Option<U256>,
     /// Wei cost of the gas the trader paid for the settled route (`gas_used ×
-    /// effective_gas_price`). For client-wrapped entries (Relay, MetaMask) the client's own
-    /// overhead is excluded — it is charged whichever router the client picks, like the client
+    /// effective_gas_price`). For venue-wrapped entries (Relay, MetaMask) the venue's own
+    /// overhead is excluded — it is charged whichever router the venue picks, like the venue
     /// fee. `None` when the trader did not pay the transaction's gas (maker fills, solver
     /// rebalances) or the route's gas could not be isolated from the trace.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settled_gas: Option<U256>,
     /// The solver's own off-chain quote for this swap, recovered from calldata (see
     /// [`solvers::embedded_quote`] for the solvers that declare one). Informational — it is what
-    /// the client compared against at decision time, as opposed to `amount_out`, which is what
+    /// the venue compared against at decision time, as opposed to `amount_out`, which is what
     /// execution delivered.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quote: Option<SolverQuote>,
@@ -129,7 +129,7 @@ impl<P: Provider> Decoder<P> {
     /// Decode solver trades from a block.
     ///
     /// Fetches all receipts in one `eth_getBlockReceipts` call, then matches a
-    /// transaction two ways: its entry point (`tx.to`) is a known client or
+    /// transaction two ways: its entry point (`tx.to`) is a known venue or
     /// solver, or one of its logs was emitted by a known solver. The
     /// second case catches filler-initiated intent fills (UniswapX, 1inch
     /// limit orders) where `tx.to` is a rotating filler. Matched transactions are
@@ -166,10 +166,7 @@ impl<P: Provider> Decoder<P> {
 
         let mut trades = Vec::with_capacity(matched.len());
         for (matched, root) in matched.into_iter().zip(traces) {
-            if let Some(trade) = self
-                .decode_transaction(matched, &root, block_number)
-                .await
-            {
+            if let Some(trade) = self.decode_transaction(matched, &root, block_number).await {
                 trades.push(trade);
             }
         }
@@ -208,7 +205,7 @@ impl<P: Provider> Decoder<P> {
         let Some(mut flow) = flow else {
             warn!(
                 tx = %receipt.transaction_hash,
-                client = %registry.label(entry_point),
+                venue = %registry.label(entry_point),
                 "no token or native ETH flow found"
             );
             return None;
@@ -217,7 +214,7 @@ impl<P: Provider> Decoder<P> {
         if let Some(veto) = guards::veto(&flow, logs, registry) {
             debug!(
                 tx = %receipt.transaction_hash,
-                client = %registry.label(entry_point),
+                venue = %registry.label(entry_point),
                 ?veto,
                 "decoded flow is not a comparable trade; skipping"
             );
@@ -233,7 +230,7 @@ impl<P: Provider> Decoder<P> {
         );
 
         // Gas the trader paid for the settled route, as a wei cost. Only charged when the
-        // tracked trader sent the transaction; for client-wrapped entries the route's gas is
+        // tracked trader sent the transaction; for venue-wrapped entries the route's gas is
         // read from the solver call's trace frame so the wrapper's overhead stays out of the
         // comparison on both sides.
         let settled_gas = flow
@@ -257,7 +254,7 @@ impl<P: Provider> Decoder<P> {
         Some(DecodedTrade {
             tx_hash: receipt.transaction_hash,
             block_number,
-            client: registry.label(entry_point),
+            venue: registry.label(entry_point),
             solver: attribution.solver,
             solver_source: attribution.source,
             sender: flow.tracked,
@@ -265,8 +262,8 @@ impl<P: Provider> Decoder<P> {
             token_out: flow.swap.token_out,
             amount_in: flow.swap.amount_in,
             amount_out: flow.swap.amount_out,
-            client_fee: flow.client_fee,
-            client_fee_out: flow.client_fee_out,
+            venue_fee: flow.venue_fee,
+            venue_fee_out: flow.venue_fee_out,
             settled_gas,
             quote,
         })

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -10,8 +10,8 @@
 //!   prop-AMMs). Not modeled here; they only appear inside traces.
 //!
 //! The pipeline is match → trace → decode → guard → record: `strategy` picks how a matched
-//! transaction is decoded, `ledger` answers all value-flow questions, `guards` vetoes netted
-//! shapes that are not comparable trades, and `registry` is the address book behind matching.
+//! transaction is decoded, `ledger` answers all value-flow questions, `guards` vetoes shapes that
+//! are not comparable trades, and `registry` is the address book behind matching.
 
 mod clients;
 mod guards;
@@ -21,9 +21,6 @@ mod registry;
 mod solvers;
 mod strategy;
 mod trace;
-
-pub(crate) mod allium;
-pub(crate) mod verify_decoder;
 
 #[cfg(test)]
 mod test_utils;

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -166,7 +166,10 @@ impl<P: Provider> Decoder<P> {
 
         let mut trades = Vec::with_capacity(matched.len());
         for (matched, root) in matched.into_iter().zip(traces) {
-            if let Some(trade) = self.decode_transaction(matched, &root, block_number).await {
+            if let Some(trade) = self
+                .decode_transaction(matched, &root, block_number)
+                .await
+            {
                 trades.push(trade);
             }
         }

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -47,6 +47,8 @@ pub(crate) struct VenueAddresses {
 pub(crate) struct Registry {
     /// Solver routers — the venue that actually settles a swap.
     solvers: HashMap<Address, String>,
+    /// Display names of all registered solvers, for O(1) `is_solver_name` checks.
+    solver_names: HashSet<String>,
     /// Every known address (solvers and venues), for name resolution.
     names: HashMap<Address, String>,
     /// Batch-settlement venues where `tx.to` is the settlement contract and
@@ -111,8 +113,10 @@ impl Registry {
                 names.insert(entry_point, name.clone());
             }
         }
+        let solver_names = book.solvers.values().cloned().collect();
 
         Ok(Self {
+            solver_names,
             solvers: book.solvers,
             names,
             batch_settlers: book.batch_settlers,
@@ -135,9 +139,7 @@ impl Registry {
     /// vocabulary: attribution can also produce raw addresses, venue names (fallback tier), and
     /// calldata-declared names from a venue's own vocabulary (`MetaMask` aggregator ids).
     pub(crate) fn is_solver_name(&self, name: &str) -> bool {
-        self.solvers
-            .values()
-            .any(|solver| solver == name)
+        self.solver_names.contains(name)
     }
 
     /// Whether `address` is a batch-settlement venue (e.g. `CoW`). Such trades
@@ -159,12 +161,10 @@ impl Registry {
 
     /// The venue whose entry point this address is, if any.
     pub(crate) fn venue_name(&self, address: Address) -> Option<&str> {
-        for (name, venue) in &self.venues {
-            if venue.entry_points.contains(&address) {
-                return Some(name.as_str());
-            }
-        }
-        None
+        self.names
+            .get(&address)
+            .filter(|name| self.venues.contains_key(name.as_str()))
+            .map(String::as_str)
     }
 
     /// Resolve an address to its known name, or its hex address if unknown.

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -1,4 +1,4 @@
-//! The decoder's address book: which contracts are solvers, clients, batch settlers, and
+//! The decoder's address book: which contracts are solvers, venues, batch settlers, and
 //! venue infrastructure on one chain.
 //!
 //! The data is pure configuration and lives in TOML — the built-in Ethereum book is embedded
@@ -28,18 +28,18 @@ struct AddressBook {
     wrapped_native: Address,
     batch_settlers: HashSet<Address>,
     solvers: HashMap<Address, String>,
-    clients: HashMap<String, ClientAddresses>,
+    venues: HashMap<String, VenueAddresses>,
     labels: HashMap<Address, String>,
 }
 
-/// A client's addresses on one chain: the contracts users enter through and the collectors its
-/// fee skims land on. Keyed by client name in the book; the name binds to a decode strategy at
-/// load time (see [`crate::decoder::clients::Client::from_name`]).
+/// A venue's addresses on one chain: the contracts users enter through and the collectors its
+/// fee skims land on. Keyed by venue name in the book; the name binds to a decode strategy at
+/// load time (see [`crate::decoder::venues::Venue::from_name`]).
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct ClientAddresses {
-    pub entry_points: HashSet<Address>,
-    pub fee_collectors: HashSet<Address>,
+pub(crate) struct VenueAddresses {
+    pub(crate) entry_points: HashSet<Address>,
+    pub(crate) fee_collectors: HashSet<Address>,
 }
 
 /// Per-chain address book for trade decoding, loaded from TOML (see the module docs).
@@ -47,12 +47,12 @@ pub(crate) struct ClientAddresses {
 pub(crate) struct Registry {
     /// Solver routers — the venue that actually settles a swap.
     solvers: HashMap<Address, String>,
-    /// Every known address (solvers and clients), for name resolution.
+    /// Every known address (solvers and venues), for name resolution.
     names: HashMap<Address, String>,
     /// Batch-settlement venues where `tx.to` is the settlement contract and
     /// the transaction sender is a solver, not the trader.
     batch_settlers: HashSet<Address>,
-    /// Display names for entry points that are neither clients nor venues — market-maker
+    /// Display names for entry points that are neither venues nor solvers — market-maker
     /// fillers, solver contracts, bot routers. Label-only: these must NOT be in `names`,
     /// because `is_known` drives strategy selection and filler-entered transactions have to
     /// keep matching via their solver logs (Maker), not sender netting.
@@ -60,8 +60,8 @@ pub(crate) struct Registry {
     /// The chain's wrapped-native token (e.g. WETH), which appears in flows
     /// only as a wrap/unwrap intermediary.
     wrapped_native: Address,
-    /// Client address sets, keyed by the client name from the book.
-    clients: HashMap<String, ClientAddresses>,
+    /// Venue address sets, keyed by the venue name from the book.
+    venues: HashMap<String, VenueAddresses>,
 }
 
 impl Registry {
@@ -92,21 +92,21 @@ impl Registry {
         let book: AddressBook =
             toml::from_str(text).context("failed to parse address book TOML")?;
 
-        // A client section only carries addresses; its behavior is bound by name in code. An
-        // unbound name (a typo, or a client with no strategy yet) must fail here — silently
-        // never matching would just drop that client's trades.
-        for name in book.clients.keys() {
-            if crate::decoder::clients::Client::from_name(name).is_none() {
+        // A venue section only carries addresses; its behavior is bound by name in code. An
+        // unbound name (a typo, or a venue with no strategy yet) must fail here — silently
+        // never matching would just drop that venue's trades.
+        for name in book.venues.keys() {
+            if crate::decoder::venues::Venue::from_name(name).is_none() {
                 anyhow::bail!(
-                    "address book client '{name}' has no decode strategy \
-                     (see clients::Client for the recognized names)"
+                    "address book venue '{name}' has no decode strategy \
+                     (see venues::Venue for the recognized names)"
                 );
             }
         }
 
         let mut names = book.solvers.clone();
-        for (name, client) in &book.clients {
-            for &entry_point in &client.entry_points {
+        for (name, venue) in &book.venues {
+            for &entry_point in &venue.entry_points {
                 names.insert(entry_point, name.clone());
             }
         }
@@ -117,11 +117,11 @@ impl Registry {
             batch_settlers: book.batch_settlers,
             labels: book.labels,
             wrapped_native: book.wrapped_native,
-            clients: book.clients,
+            venues: book.venues,
         })
     }
 
-    /// Whether the address is a known client or solver.
+    /// Whether the address is a known venue or solver.
     pub(crate) fn is_known(&self, address: Address) -> bool {
         self.names.contains_key(&address)
     }
@@ -131,12 +131,10 @@ impl Registry {
     }
 
     /// Whether `name` is a registered solver's display name. Bounds the metric label
-    /// vocabulary: attribution can also produce raw addresses, client names (fallback tier), and
-    /// calldata-declared names from a client's own vocabulary (MetaMask aggregator ids).
+    /// vocabulary: attribution can also produce raw addresses, venue names (fallback tier), and
+    /// calldata-declared names from a venue's own vocabulary (MetaMask aggregator ids).
     pub(crate) fn is_solver_name(&self, name: &str) -> bool {
-        self.solvers
-            .values()
-            .any(|solver| solver == name)
+        self.solvers.values().any(|solver| solver == name)
     }
 
     /// Whether `address` is a batch-settlement venue (e.g. CoW). Such trades
@@ -151,15 +149,15 @@ impl Registry {
         self.wrapped_native
     }
 
-    /// The named client's address book section, when the book has one.
-    pub(crate) fn client(&self, name: &str) -> Option<&ClientAddresses> {
-        self.clients.get(name)
+    /// The named venue's address book section, when the book has one.
+    pub(crate) fn venue(&self, name: &str) -> Option<&VenueAddresses> {
+        self.venues.get(name)
     }
 
-    /// The client whose entry point this address is, if any.
-    pub(crate) fn client_name(&self, address: Address) -> Option<&str> {
-        for (name, client) in &self.clients {
-            if client.entry_points.contains(&address) {
+    /// The venue whose entry point this address is, if any.
+    pub(crate) fn venue_name(&self, address: Address) -> Option<&str> {
+        for (name, venue) in &self.venues {
+            if venue.entry_points.contains(&address) {
                 return Some(name.as_str());
             }
         }
@@ -184,11 +182,10 @@ mod tests {
 
     #[test]
     fn embedded_ethereum_book_parses() {
-        // `ethereum()` expects; this test is what makes that expectation safe.
         let registry = Registry::ethereum();
         assert!(!registry.solvers.is_empty());
         assert!(!registry
-            .client("relay")
+            .venue("relay")
             .unwrap()
             .entry_points
             .is_empty());
@@ -248,34 +245,30 @@ mod tests {
     }
 
     #[test]
-    fn client_sections_resolve_by_name_and_entry_point() {
+    fn venue_sections_resolve_by_name_and_entry_point() {
         let registry = Registry::ethereum();
-        let relay = registry.client("relay").unwrap();
+        let relay = registry.venue("relay").unwrap();
         let collector = address!("0xf70da97812cb96acdf810712aa562db8dfa3dbef");
         let router = address!("0xb92fe925dc43a0ecde6c8b1a2709c170ec4fff4f");
-        assert!(relay
-            .fee_collectors
-            .contains(&collector));
-        // The router that performs the skim is a Relay entry point, not the collector itself.
+        assert!(relay.fee_collectors.contains(&collector));
         assert!(!relay.fee_collectors.contains(&router));
         assert!(relay.entry_points.contains(&router));
 
-        assert_eq!(registry.client_name(router), Some("relay"));
+        assert_eq!(registry.venue_name(router), Some("relay"));
         assert_eq!(
-            registry.client_name(address!("0x881d40237659c251811cec9c364ef91dc08d300c")),
+            registry.venue_name(address!("0x881d40237659c251811cec9c364ef91dc08d300c")),
             Some("metamask")
         );
-        // A fee collector is not an entry point; a solver is not a client.
-        assert_eq!(registry.client_name(collector), None);
-        assert!(registry.client("kyberswap").is_none());
+        assert_eq!(registry.venue_name(collector), None);
+        assert!(registry.venue("kyberswap").is_none());
     }
 
     #[test]
-    fn client_without_strategy_is_rejected() {
-        // A client section whose name has no decode strategy would silently never match, so the
+    fn venue_without_strategy_is_rejected() {
+        // A venue section whose name has no decode strategy would silently never match, so the
         // book must fail to load.
         let text =
-            format!("{ETHEREUM_TOML}\n[clients.reiay]\nentry_points = []\nfee_collectors = []\n");
+            format!("{ETHEREUM_TOML}\n[venues.reiay]\nentry_points = []\nfee_collectors = []\n");
         let err = Registry::from_toml(&text)
             .unwrap_err()
             .to_string();
@@ -295,7 +288,7 @@ mod tests {
     fn display_labels_resolve_without_becoming_known() {
         // Solver/filler labels are display-only: is_known drives strategy selection, and a
         // filler-entered tx must keep matching via its solver logs (Maker), not as a
-        // known-client Sender flow.
+        // known-venue Sender flow.
         let registry = Registry::ethereum();
         let rizzolver = address!("0x225a38bc71102999dd13478bfabd7c4d53f2dc17");
         assert_eq!(registry.label(rizzolver), "rizzolver");

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -84,6 +84,7 @@ impl Registry {
     }
 
     /// The built-in Ethereum address book.
+    #[expect(clippy::expect_used)]
     pub(crate) fn ethereum() -> Self {
         Self::from_toml(ETHEREUM_TOML).expect("embedded ethereum registry must parse")
     }
@@ -132,12 +133,12 @@ impl Registry {
 
     /// Whether `name` is a registered solver's display name. Bounds the metric label
     /// vocabulary: attribution can also produce raw addresses, venue names (fallback tier), and
-    /// calldata-declared names from a venue's own vocabulary (MetaMask aggregator ids).
+    /// calldata-declared names from a venue's own vocabulary (`MetaMask` aggregator ids).
     pub(crate) fn is_solver_name(&self, name: &str) -> bool {
         self.solvers.values().any(|solver| solver == name)
     }
 
-    /// Whether `address` is a batch-settlement venue (e.g. CoW). Such trades
+    /// Whether `address` is a batch-settlement venue (e.g. `CoW`). Such trades
     /// must be decoded by finding the order maker, not by tracking the
     /// sender: a solver settles many orders at once, so its net flow is not a
     /// single swap even when it happens to net to one token on each side.

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -135,7 +135,9 @@ impl Registry {
     /// vocabulary: attribution can also produce raw addresses, venue names (fallback tier), and
     /// calldata-declared names from a venue's own vocabulary (`MetaMask` aggregator ids).
     pub(crate) fn is_solver_name(&self, name: &str) -> bool {
-        self.solvers.values().any(|solver| solver == name)
+        self.solvers
+            .values()
+            .any(|solver| solver == name)
     }
 
     /// Whether `address` is a batch-settlement venue (e.g. `CoW`). Such trades
@@ -251,7 +253,9 @@ mod tests {
         let relay = registry.venue("relay").unwrap();
         let collector = address!("0xf70da97812cb96acdf810712aa562db8dfa3dbef");
         let router = address!("0xb92fe925dc43a0ecde6c8b1a2709c170ec4fff4f");
-        assert!(relay.fee_collectors.contains(&collector));
+        assert!(relay
+            .fee_collectors
+            .contains(&collector));
         assert!(!relay.fee_collectors.contains(&router));
         assert!(relay.entry_points.contains(&router));
 

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -86,7 +86,6 @@ impl Registry {
     }
 
     /// The built-in Ethereum address book.
-    #[expect(clippy::expect_used)]
     pub(crate) fn ethereum() -> Self {
         Self::from_toml(ETHEREUM_TOML).expect("embedded ethereum registry must parse")
     }

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -38,12 +38,12 @@ batch_settlers = ["0x9008d19f58aabd9ed0d60971565aa8510560ab41"]
 "0xfd0b31d2e955fa55e3fa641fe90e08b677188d35" = "tycho"
 "0xda892c989d07a18b5dd3f392d949f00df15c5736" = "tycho"
 
-# Clients — platforms that initiate a trade and route it through a solver found in the
-# trace. Each section name must have a decode strategy in code (clients::Client);
+# Venues — platforms that initiate a trade and route it through a solver found in the
+# trace. Each section name must have a decode strategy in code (venues::Venue);
 # `entry_points` are the contracts users enter through, `fee_collectors` where its skims land.
 
-# Display names for entry points that are neither clients nor venues — market-maker fillers,
-# solver contracts, bot routers. Label-only: these must NOT be clients or solvers, because
+# Display names for entry points that are neither venues nor solvers — market-maker fillers,
+# solver contracts, bot routers. Label-only: these must NOT be venues or solvers, because
 # known-ness drives strategy selection and filler-entered transactions have to keep matching via
 # their solver logs (Maker), not sender netting. Identified from public labels (Etherscan
 # tags, Dune spellbook solver lists, project sites), ranked by observed volume in monitor runs.
@@ -69,7 +69,7 @@ batch_settlers = ["0x9008d19f58aabd9ed0d60971565aa8510560ab41"]
 # Pendle Router V4 (Etherscan name tag) — a protocol router, not a solver.
 "0x888888888889758f76e7103c6cbf23abbf58f946" = "pendle"
 
-[clients.relay]
+[venues.relay]
 # Relay routers (v2 / v2.1 / v3, Cancun) and approval proxies.
 entry_points = [
     "0xf5042e6ffac5a625d4e7848e0b01373d8eb9e222",
@@ -82,7 +82,7 @@ entry_points = [
 # on-chain sample; fee ranges ~1–41 bps depending on Relay's fee tier.
 fee_collectors = ["0xf70da97812cb96acdf810712aa562db8dfa3dbef"]
 
-[clients.metamask]
+[venues.metamask]
 # MetaMask Swap Router.
 entry_points = ["0x881d40237659c251811cec9c364ef91dc08d300c"]
 # MetaMask fee wallets. Both observed in a 28-tx on-chain sample (26 paid one of the two, the

--- a/tools/hindsight/src/decoder/solvers/attribution.rs
+++ b/tools/hindsight/src/decoder/solvers/attribution.rs
@@ -14,7 +14,7 @@ use crate::decoder::{registry::Registry, trace};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum AttributionSource {
-    /// The decode strategy read the solver from calldata (MetaMask's `aggregatorId`).
+    /// The decode strategy read the solver from calldata (`MetaMask`'s `aggregatorId`).
     Declared,
     /// The entry point (`tx.to`) is itself a known solver router: the trade settled there.
     EntryPoint,

--- a/tools/hindsight/src/decoder/solvers/kyberswap.rs
+++ b/tools/hindsight/src/decoder/solvers/kyberswap.rs
@@ -10,11 +10,11 @@ use alloy::primitives::U256;
 
 use crate::decoder::solvers::SolverQuote;
 
-/// Extract KyberSwap's `clientData` quote from transaction calldata.
+/// Extract `KyberSwap`'s `clientData` quote from transaction calldata.
 ///
 /// The blob is plain ASCII JSON inside ABI-encoded bytes, so it is located by its `{"Source"`
 /// marker rather than by decoding the router call — which also finds it when Kyber's calldata is
-/// nested inside a wrapper's (Relay, MetaMask). The JSON is flat, so the object ends at the
+/// nested inside a wrapper's (Relay, `MetaMask`). The JSON is flat, so the object ends at the
 /// first closing brace. Anything malformed or missing returns `None`.
 pub(crate) fn embedded_quote(input: &[u8]) -> Option<SolverQuote> {
     const MARKER: &[u8] = b"{\"Source\"";

--- a/tools/hindsight/src/decoder/solvers/lifi.rs
+++ b/tools/hindsight/src/decoder/solvers/lifi.rs
@@ -1,13 +1,13 @@
 //! LiFi-specific matching rules.
 //!
-//! LiFi's Diamond settles both same-chain swaps (decoded like any solver) and cross-chain
+//! `LiFi`'s Diamond settles both same-chain swaps (decoded like any solver) and cross-chain
 //! bridge orders, which must never decode as swaps.
 
 use alloy::{rpc::types::Log, sol, sol_types::SolEvent};
 
 sol! {
-    /// Emitted by the LiFi Diamond only when an order bridges to another chain (the tuple is
-    /// LiFi's `BridgeData`); same-chain LiFi swaps emit `LiFiGenericSwapCompleted` instead.
+    /// Emitted by the `LiFi` Diamond only when an order bridges to another chain (the tuple is
+    /// `LiFi`'s `BridgeData`); same-chain `LiFi` swaps emit `LiFiGenericSwapCompleted` instead.
     event LiFiTransferStarted(
         (bytes32, string, string, address, address, address, uint256, uint256, bool, bool)
             bridgeData

--- a/tools/hindsight/src/decoder/solvers/lifi.rs
+++ b/tools/hindsight/src/decoder/solvers/lifi.rs
@@ -27,7 +27,7 @@ pub(crate) fn started_bridge_order(logs: &[Log]) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Log as PrimitiveLog, U256};
+    use alloy::primitives::{Bytes, Log as PrimitiveLog, U256};
 
     use super::*;
     use crate::decoder::test_utils::{addr, make_transfer_log};
@@ -40,7 +40,7 @@ mod tests {
         let primitive = PrimitiveLog::new_unchecked(
             diamond,
             vec![LiFiTransferStarted::SIGNATURE_HASH],
-            Default::default(),
+            Bytes::default(),
         );
         let logs = vec![Log { inner: primitive, ..Default::default() }];
         assert!(started_bridge_order(&logs));

--- a/tools/hindsight/src/decoder/solvers/paraswap.rs
+++ b/tools/hindsight/src/decoder/solvers/paraswap.rs
@@ -2,7 +2,7 @@
 //!
 //! Augustus v6 swap methods carry the trade parameters as consecutive 32-byte words —
 //! `…, fromAmount, toAmount, quotedAmount, …` — where `toAmount` is the slippage floor and
-//! `quotedAmount` the off-chain quoted output, kept on-chain for ParaSwap's surplus accounting
+//! `quotedAmount` the off-chain quoted output, kept on-chain for `ParaSwap`'s surplus accounting
 //! (the user is capped at the quote, so settled often equals it exactly). The triple's offset
 //! differs per method selector, so it is located by value rather than per-selector ABI: the word
 //! equal to the trade's decoded input amount, followed by a floor-and-quote pair.
@@ -11,7 +11,7 @@ use alloy::primitives::U256;
 
 use crate::decoder::solvers::SolverQuote;
 
-/// Extract ParaSwap's `quotedAmount` from Augustus calldata.
+/// Extract `ParaSwap`'s `quotedAmount` from Augustus calldata.
 ///
 /// Scans word-aligned calldata for `amount_in` and reads the two words after it as
 /// `(toAmount, quotedAmount)`. A false positive would need a word that equals the exact input

--- a/tools/hindsight/src/decoder/strategy.rs
+++ b/tools/hindsight/src/decoder/strategy.rs
@@ -2,7 +2,7 @@
 //!
 //! [`select`] decides *which* transactions are solver trades and where their trader sits
 //! ([`TraderStrategy`]); [`TraderStrategy::decode`] is the single seam the orchestrator calls.
-//! This module is tier-neutral — client-specific behavior lives in `clients/`, solver-specific
+//! This module is tier-neutral — venue-specific behavior lives in `venues/`, solver-specific
 //! knowledge in `solvers/`, and maker-finding for intent fills in `intent`.
 
 use std::collections::HashMap;
@@ -15,10 +15,11 @@ use alloy::{
 use tracing::debug;
 
 use crate::decoder::{
-    clients, intent,
+    intent,
     ledger::{NetSwap, TransferLedger},
     registry::Registry,
     solvers::lifi,
+    venues,
 };
 
 /// Everything a decode strategy may need from one matched transaction, so every strategy is
@@ -45,12 +46,12 @@ pub(crate) enum TraderStrategy {
     /// discovered via a known solver log (`tx.to` is a rotating filler) or
     /// `tx.to` is a batch settler entered by a solver.
     Maker,
-    /// The sender is the trader, but it entered through a client platform's own contract
+    /// The sender is the trader, but it entered through a venue platform's own contract
     /// (Relay's router, MetaMask's Swap Router) which then calls the solver inside the same
-    /// transaction. Decoding is still sender netting, plus that client's corrections — its fee
+    /// transaction. Decoding is still sender netting, plus that venue's corrections — its fee
     /// skim is backed out, and its contract overhead is excluded from gas accounting — so the
-    /// recovered swap is what the client actually asked the solver for.
-    Client(clients::Client),
+    /// recovered swap is what the venue actually asked the solver for.
+    Venue(venues::Venue),
 }
 
 impl TraderStrategy {
@@ -69,19 +70,19 @@ impl TraderStrategy {
                 )
                 .await
             }
-            Self::Client(client) => {
-                client.decode(ctx.ledger, ctx.sender, ctx.entry_point, ctx.input, ctx.registry)
+            Self::Venue(venue) => {
+                venue.decode(ctx.ledger, ctx.sender, ctx.entry_point, ctx.input, ctx.registry)
             }
         }
     }
 
-    /// Whether the trade runs inside a client's own contract (see [`TraderStrategy::Client`]).
-    /// The receipt's gas then includes the client's overhead — charged whichever solver the
-    /// client picks — so gas accounting reads the solver call's trace frame instead of the
+    /// Whether the trade runs inside a venue's own contract (see [`TraderStrategy::Venue`]).
+    /// The receipt's gas then includes the venue's overhead — charged whichever solver the
+    /// venue picks — so gas accounting reads the solver call's trace frame instead of the
     /// whole receipt.
     pub(crate) fn routes_via_wrapper(&self) -> bool {
         match self {
-            Self::Client(_) => true,
+            Self::Venue(_) => true,
             Self::Sender | Self::Maker => false,
         }
     }
@@ -99,12 +100,10 @@ pub(crate) struct Flow {
     /// The address whose net flow the swap was read from.
     pub tracked: Address,
     pub swap: NetSwap,
-    /// Client fee skimmed from the input token, already backed out of
-    /// `swap.amount_in`.
-    pub client_fee: Option<U256>,
-    /// Client fee skimmed from the output token, already added back into
-    /// `swap.amount_out`.
-    pub client_fee_out: Option<U256>,
+    /// Venue fee skimmed from the input token, already backed out of `swap.amount_in`.
+    pub venue_fee: Option<U256>,
+    /// Venue fee skimmed from the output token, already added back into `swap.amount_out`.
+    pub venue_fee_out: Option<U256>,
     /// Solver label asserted by the strategy itself (e.g. MetaMask declares its
     /// solver in calldata), overriding trace-based attribution.
     pub solver_override: Option<String>,
@@ -119,8 +118,8 @@ impl Flow {
         Self {
             tracked,
             swap,
-            client_fee: None,
-            client_fee_out: None,
+            venue_fee: None,
+            venue_fee_out: None,
             solver_override: None,
             trader_paid_gas: false,
         }
@@ -130,7 +129,7 @@ impl Flow {
 /// Match a receipt and choose its decode strategy.
 ///
 /// A transaction qualifies two ways: its entry point (`tx.to`) is a known
-/// client or solver, or one of its logs was emitted by a known solver
+/// venue or solver, or one of its logs was emitted by a known solver
 /// (filler-initiated intent fills, where `tx.to` is a rotating filler).
 /// Matched transactions that start a cross-chain bridge order are vetoed here
 /// (see [`lifi::started_bridge_order`]), before they cost a trace.
@@ -142,7 +141,7 @@ pub(crate) fn select<'a>(
     if lifi::started_bridge_order(matched.receipt.logs()) {
         debug!(
             tx = %matched.receipt.transaction_hash,
-            client = %registry.label(matched.entry_point),
+            venue = %registry.label(matched.entry_point),
             "cross-chain bridge order; skipping"
         );
         return None;
@@ -156,11 +155,11 @@ fn match_entry<'a>(receipt: &'a TransactionReceipt, registry: &Registry) -> Opti
         return None;
     }
     let entry_point = receipt.to?;
-    if let Some(client) = registry
-        .client_name(entry_point)
-        .and_then(clients::Client::from_name)
+    if let Some(venue) = registry
+        .venue_name(entry_point)
+        .and_then(venues::Venue::from_name)
     {
-        return Some(Matched { receipt, entry_point, strategy: TraderStrategy::Client(client) });
+        return Some(Matched { receipt, entry_point, strategy: TraderStrategy::Venue(venue) });
     }
     if registry.is_known(entry_point) {
         // Batch settlers (e.g. CoW) are entered by a solver, not the trader, so the real swap is

--- a/tools/hindsight/src/decoder/strategy.rs
+++ b/tools/hindsight/src/decoder/strategy.rs
@@ -47,7 +47,7 @@ pub(crate) enum TraderStrategy {
     /// `tx.to` is a batch settler entered by a solver.
     Maker,
     /// The sender is the trader, but it entered through a venue platform's own contract
-    /// (Relay's router, MetaMask's Swap Router) which then calls the solver inside the same
+    /// (Relay's router, `MetaMask`'s Swap Router) which then calls the solver inside the same
     /// transaction. Decoding is still sender netting, plus that venue's corrections — its fee
     /// skim is backed out, and its contract overhead is excluded from gas accounting — so the
     /// recovered swap is what the venue actually asked the solver for.
@@ -104,7 +104,7 @@ pub(crate) struct Flow {
     pub venue_fee: Option<U256>,
     /// Venue fee skimmed from the output token, already added back into `swap.amount_out`.
     pub venue_fee_out: Option<U256>,
-    /// Solver label asserted by the strategy itself (e.g. MetaMask declares its
+    /// Solver label asserted by the strategy itself (e.g. `MetaMask` declares its
     /// solver in calldata), overriding trace-based attribution.
     pub solver_override: Option<String>,
     /// Whether the tracked trader sent the transaction and therefore paid its gas. Decides if the

--- a/tools/hindsight/src/decoder/trace.rs
+++ b/tools/hindsight/src/decoder/trace.rs
@@ -61,7 +61,7 @@ fn transfers_value(call_type: &str) -> bool {
     matches!(call_type, "CALL" | "CALLCODE" | "CREATE" | "CREATE2" | "SELFDESTRUCT")
 }
 
-/// Gas consumed by the settled route inside a client-wrapped transaction (Relay, MetaMask), in
+/// Gas consumed by the settled route inside a client-wrapped transaction (Relay, `MetaMask`), in
 /// gas units.
 ///
 /// The wrapper's own gas — fee skim, forwarding, the base transaction cost — is charged whichever

--- a/tools/hindsight/src/decoder/venues/metamask.rs
+++ b/tools/hindsight/src/decoder/venues/metamask.rs
@@ -1,9 +1,9 @@
 //! MetaMask-specific decoding.
 //!
-//! MetaMask's Swap Router routes through a real solver and skims its fee (~87.5 bps, plus a gas
+//! `MetaMask`'s Swap Router routes through a real solver and skims its fee (~87.5 bps, plus a gas
 //! recoup on gasless "smart swaps") to a fee wallet — from the input token before swapping or
 //! from the output after. Without backing that skim out, every comparison credits Fynd with
-//! MetaMask's own fee: the skim is charged whichever router MetaMask plugs in, so it is not
+//! `MetaMask`'s own fee: the skim is charged whichever router `MetaMask` plugs in, so it is not
 //! value better routing can recover. On dust trades the skim dominates and fabricated
 //! extreme "wins".
 
@@ -17,7 +17,7 @@ use crate::decoder::{
 };
 
 sol! {
-    /// The MetaMask Swap Router entry point (selector `0x5f575529`): `aggregatorId` names the
+    /// The `MetaMask` Swap Router entry point (selector `0x5f575529`): `aggregatorId` names the
     /// solver API that produced the route.
     function swap(string aggregatorId, address tokenFrom, uint256 amount, bytes data);
 }
@@ -25,7 +25,7 @@ sol! {
 /// The solver label declared in the router calldata's `aggregatorId`, normalized to the
 /// registry's solver names.
 ///
-/// MetaMask states which solver API it routed through (e.g. "oneInchV6FeeDynamic",
+/// `MetaMask` states which solver API it routed through (e.g. "oneInchV6FeeDynamic",
 /// "uniswapPermit2FeeDynamic"). Trace attribution often cannot resolve these — a token→token
 /// route moves no native value and enters through Permit2 — so the calldata declaration is the
 /// authoritative source. Unrecognized ids pass through as-is: "airswapV4" is still more

--- a/tools/hindsight/src/decoder/venues/metamask.rs
+++ b/tools/hindsight/src/decoder/venues/metamask.rs
@@ -10,10 +10,7 @@
 use alloy::{primitives::Address, sol, sol_types::SolCall};
 
 use crate::decoder::{
-    ledger::TransferLedger,
-    registry::Registry,
-    strategy::Flow,
-    venues::venue_fee_flow,
+    ledger::TransferLedger, registry::Registry, strategy::Flow, venues::venue_fee_flow,
 };
 
 sol! {

--- a/tools/hindsight/src/decoder/venues/metamask.rs
+++ b/tools/hindsight/src/decoder/venues/metamask.rs
@@ -1,6 +1,6 @@
 //! MetaMask-specific decoding.
 //!
-//! MetaMask's Swap Router routes through a real venue and skims its fee (~87.5 bps, plus a gas
+//! MetaMask's Swap Router routes through a real solver and skims its fee (~87.5 bps, plus a gas
 //! recoup on gasless "smart swaps") to a fee wallet — from the input token before swapping or
 //! from the output after. Without backing that skim out, every comparison credits Fynd with
 //! MetaMask's own fee: the skim is charged whichever router MetaMask plugs in, so it is not
@@ -10,7 +10,10 @@
 use alloy::{primitives::Address, sol, sol_types::SolCall};
 
 use crate::decoder::{
-    clients::client_fee_flow, ledger::TransferLedger, registry::Registry, strategy::Flow,
+    ledger::TransferLedger,
+    registry::Registry,
+    strategy::Flow,
+    venues::venue_fee_flow,
 };
 
 sol! {
@@ -19,8 +22,8 @@ sol! {
     function swap(string aggregatorId, address tokenFrom, uint256 amount, bytes data);
 }
 
-/// The venue label declared in the router calldata's `aggregatorId`, normalized to the
-/// registry's venue names.
+/// The solver label declared in the router calldata's `aggregatorId`, normalized to the
+/// registry's solver names.
 ///
 /// MetaMask states which solver API it routed through (e.g. "oneInchV6FeeDynamic",
 /// "uniswapPermit2FeeDynamic"). Trace attribution often cannot resolve these — a token→token
@@ -53,8 +56,8 @@ fn normalize(id: &str) -> String {
     id.to_string()
 }
 
-/// Decode a MetaMask-entered transaction: net the sender's flow, back the client fee out of it,
-/// and attribute the venue from the router calldata (`input`).
+/// Decode a MetaMask-entered transaction: net the sender's flow, back the venue fee out of it,
+/// and attribute the solver from the router calldata (`input`).
 pub(crate) fn decode(
     ledger: &TransferLedger,
     sender: Address,
@@ -62,8 +65,8 @@ pub(crate) fn decode(
     input: &[u8],
     registry: &Registry,
 ) -> Option<Flow> {
-    let metamask = registry.client("metamask")?;
-    let mut flow = client_fee_flow(ledger, sender, entry_point, &metamask.fee_collectors)?;
+    let metamask = registry.venue("metamask")?;
+    let mut flow = venue_fee_flow(ledger, sender, entry_point, &metamask.fee_collectors)?;
     flow.solver_override = solver_from_calldata(input);
     Some(flow)
 }
@@ -75,10 +78,9 @@ mod tests {
     use super::*;
     use crate::decoder::test_utils::{addr, make_transfer_log, swap};
 
-    /// One of the real MetaMask fee wallets, so tests exercise the registry entries.
     fn fee_wallet(registry: &Registry) -> Address {
         *registry
-            .client("metamask")
+            .venue("metamask")
             .unwrap()
             .fee_collectors
             .iter()
@@ -86,10 +88,9 @@ mod tests {
             .unwrap()
     }
 
-    /// The real MetaMask Swap Router entry point.
     fn router(registry: &Registry) -> Address {
         *registry
-            .client("metamask")
+            .venue("metamask")
             .unwrap()
             .entry_points
             .iter()
@@ -149,15 +150,15 @@ mod tests {
         let flow = decode(&ledger, user, router, &[], &registry).unwrap();
         assert_eq!(flow.tracked, user);
         assert_eq!(flow.swap, swap(token_in, 15_000_000, Address::ZERO, 8_408));
-        assert_eq!(flow.client_fee, None);
-        assert_eq!(flow.client_fee_out, Some(U256::from(883)));
+        assert_eq!(flow.venue_fee, None);
+        assert_eq!(flow.venue_fee_out, Some(U256::from(883)));
         assert!(flow.trader_paid_gas);
     }
 
     #[test]
     fn decode_backs_out_input_side_skim() {
         // ETH in, token out: the router skims the fee from the native input before forwarding
-        // the rest to the venue. amount_in shrinks to what actually entered the swap.
+        // the rest to the solver. amount_in shrinks to what actually entered the swap.
         let registry = Registry::ethereum();
         let collector = fee_wallet(&registry);
         let user = addr(1);
@@ -175,13 +176,13 @@ mod tests {
 
         let flow = decode(&ledger, user, router, &[], &registry).unwrap();
         assert_eq!(flow.swap, swap(Address::ZERO, 991, token_out, 2_000));
-        assert_eq!(flow.client_fee, Some(U256::from(9)));
-        assert_eq!(flow.client_fee_out, None);
+        assert_eq!(flow.venue_fee, Some(U256::from(9)));
+        assert_eq!(flow.venue_fee_out, None);
     }
 
     #[test]
-    fn decode_asserts_venue_from_calldata() {
-        // The declared aggregatorId lands on the flow as the venue override, so the orchestrator
+    fn decode_asserts_solver_from_calldata() {
+        // The declared aggregatorId lands on the flow as the solver override, so the orchestrator
         // needs no MetaMask-specific attribution branch.
         let registry = Registry::ethereum();
         let user = addr(1);
@@ -204,7 +205,6 @@ mod tests {
 
     #[test]
     fn decode_keeps_fee_free_trade_unchanged() {
-        // Some pairs are genuinely fee-free; nothing reached a fee wallet, nothing is backed out.
         let registry = Registry::ethereum();
         let user = addr(1);
         let pool = addr(50);
@@ -219,7 +219,7 @@ mod tests {
 
         let flow = decode(&ledger, user, router(&registry), &[], &registry).unwrap();
         assert_eq!(flow.swap, swap(token_in, 1_000, token_out, 2_000));
-        assert_eq!(flow.client_fee, None);
-        assert_eq!(flow.client_fee_out, None);
+        assert_eq!(flow.venue_fee, None);
+        assert_eq!(flow.venue_fee_out, None);
     }
 }

--- a/tools/hindsight/src/decoder/venues/metamask.rs
+++ b/tools/hindsight/src/decoder/venues/metamask.rs
@@ -70,7 +70,7 @@ pub(crate) fn decode(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::U256;
+    use alloy::primitives::{Bytes, U256};
 
     use super::*;
     use crate::decoder::test_utils::{addr, make_transfer_log, swap};
@@ -113,7 +113,7 @@ mod tests {
                 aggregatorId: id.to_string(),
                 tokenFrom: addr(10),
                 amount: U256::from(1000),
-                data: Default::default(),
+                data: Bytes::default(),
             };
             assert_eq!(solver_from_calldata(&call.abi_encode()).as_deref(), Some(want));
         }
@@ -192,7 +192,7 @@ mod tests {
             aggregatorId: "oneInchV6FeeDynamic".to_string(),
             tokenFrom: addr(10),
             amount: U256::from(1_000),
-            data: Default::default(),
+            data: Bytes::default(),
         };
         let ledger = TransferLedger::from_transaction(&logs, &[]);
 

--- a/tools/hindsight/src/decoder/venues/mod.rs
+++ b/tools/hindsight/src/decoder/venues/mod.rs
@@ -1,10 +1,10 @@
-//! Client-specific decoding: the platforms users enter through (Relay, MetaMask).
+//! Venue-specific decoding: the platforms users enter through (Relay, MetaMask).
 //!
-//! A client owns the order flow — it picks a solver and may skim a fee — so decoding one means
-//! sender netting plus the client's own quirks: backing the fee skim out
-//! ([`client_fee_flow`]), Relay's solver-rebalance fills, MetaMask's calldata solver
-//! declaration. A module here is one client; its addresses come from the address book's
-//! `[clients.<name>]` section, bound to behavior by [`Client::from_name`].
+//! A venue owns the order flow — it picks a solver and may skim a fee — so decoding one means
+//! sender netting plus the venue's own quirks: backing the fee skim out ([`venue_fee_flow`]),
+//! Relay's solver-rebalance fills, MetaMask's calldata solver declaration. A module here is one
+//! venue; its addresses come from the address book's `[venues.<name>]` section, bound to behavior
+//! by [`Venue::from_name`].
 
 pub(crate) mod metamask;
 pub(crate) mod relay;
@@ -19,17 +19,17 @@ use crate::decoder::{
     strategy::{sender_flow, Flow},
 };
 
-/// A client platform with a decode module in this directory.
-pub(crate) enum Client {
+/// A venue platform with a decode module in this directory.
+pub(crate) enum Venue {
     Relay,
     Metamask,
 }
 
-impl Client {
-    /// The client bound to a name from the address book.
+impl Venue {
+    /// The venue bound to a name from the address book.
     ///
-    /// A `[clients.<name>]` section in the book only carries addresses; this is where its name
-    /// gets behavior. The registry validates every configured client name against this binding
+    /// A `[venues.<name>]` section in the book only carries addresses; this is where its name
+    /// gets behavior. The registry validates every configured venue name against this binding
     /// at load time, so a typo'd section fails fast instead of silently never matching.
     pub(crate) fn from_name(name: &str) -> Option<Self> {
         match name {
@@ -39,7 +39,7 @@ impl Client {
         }
     }
 
-    /// Decode a transaction entered through this client's contract.
+    /// Decode a transaction entered through this venue's contract.
     pub(crate) fn decode(
         &self,
         ledger: &TransferLedger,
@@ -55,13 +55,13 @@ impl Client {
     }
 }
 
-/// Net the sender's flow and back the client's fee skim out of it — the shared shape of every
-/// fee-skimming client entry (Relay, MetaMask).
+/// Net the sender's flow and back the venue's fee skim out of it — the shared shape of every
+/// fee-skimming venue entry (Relay, MetaMask).
 ///
 /// One exception: when the tracked trader IS a fee collector, the transaction is a treasury
 /// operation — the collector's receipts are its own output, not a skim, and backing them "out"
 /// would add the output to itself and double it.
-fn client_fee_flow(
+pub(crate) fn venue_fee_flow(
     ledger: &TransferLedger,
     sender: Address,
     entry_point: Address,
@@ -71,39 +71,39 @@ fn client_fee_flow(
     if fee_collectors.contains(&flow.tracked) {
         return Some(flow);
     }
-    Some(back_out_client_fees(flow, ledger, fee_collectors))
+    Some(back_out_venue_fees(flow, ledger, fee_collectors))
 }
 
-/// Back a client-fee skim out of a decoded user flow.
+/// Back a venue-fee skim out of a decoded user flow.
 ///
 /// The collector can skim on either side. An input-side skim is subtracted
 /// from `amount_in` (the user's gross spend included money that never entered
 /// the swap) and an output-side skim is added back into `amount_out` (the
 /// swap produced more than the user kept), so both sides are the amounts
 /// actually swapped — the like-for-like basis vs Fynd.
-fn back_out_client_fees(
+fn back_out_venue_fees(
     flow: Flow,
     ledger: &TransferLedger,
     fee_collectors: &HashSet<Address>,
 ) -> Flow {
     let fees = ledger.received_by(fee_collectors);
-    let client_fee = fees
+    let venue_fee = fees
         .get(&flow.swap.token_in)
         .copied()
         .filter(|fee| !fee.is_zero());
     let amount_in =
-        client_fee.map_or(flow.swap.amount_in, |fee| flow.swap.amount_in.saturating_sub(fee));
-    let client_fee_out = fees
+        venue_fee.map_or(flow.swap.amount_in, |fee| flow.swap.amount_in.saturating_sub(fee));
+    let venue_fee_out = fees
         .get(&flow.swap.token_out)
         .copied()
         .filter(|fee| !fee.is_zero());
-    let amount_out =
-        client_fee_out.map_or(flow.swap.amount_out, |fee| flow.swap.amount_out.saturating_add(fee));
+    let amount_out = venue_fee_out
+        .map_or(flow.swap.amount_out, |fee| flow.swap.amount_out.saturating_add(fee));
     Flow {
         tracked: flow.tracked,
         swap: NetSwap { amount_in, amount_out, ..flow.swap },
-        client_fee,
-        client_fee_out,
+        venue_fee,
+        venue_fee_out,
         solver_override: flow.solver_override,
         trader_paid_gas: flow.trader_paid_gas,
     }
@@ -117,7 +117,7 @@ mod tests {
     use crate::decoder::test_utils::{addr, make_transfer_log, swap};
 
     #[test]
-    fn client_fee_flow_backs_out_input_skim() {
+    fn venue_fee_flow_backs_out_input_skim() {
         // Router skims part of the input token to the collector; the rest goes to the pool.
         let user = addr(1);
         let router = addr(2);
@@ -135,14 +135,14 @@ mod tests {
         ];
         let ledger = TransferLedger::from_transaction(&logs, &[]);
 
-        let flow = client_fee_flow(&ledger, user, router, &collectors).unwrap();
+        let flow = venue_fee_flow(&ledger, user, router, &collectors).unwrap();
         assert_eq!(flow.swap, swap(token_in, 960, token_out, 2000));
-        assert_eq!(flow.client_fee, Some(U256::from(40)));
-        assert_eq!(flow.client_fee_out, None);
+        assert_eq!(flow.venue_fee, Some(U256::from(40)));
+        assert_eq!(flow.venue_fee_out, None);
     }
 
     #[test]
-    fn client_fee_flow_keeps_fee_free_trade_unchanged() {
+    fn venue_fee_flow_keeps_fee_free_trade_unchanged() {
         // Nothing reached a fee wallet, nothing is backed out.
         let user = addr(1);
         let pool = addr(50);
@@ -154,9 +154,9 @@ mod tests {
         ];
         let ledger = TransferLedger::from_transaction(&logs, &[]);
 
-        let flow = client_fee_flow(&ledger, user, pool, &collectors).unwrap();
+        let flow = venue_fee_flow(&ledger, user, pool, &collectors).unwrap();
         assert_eq!(flow.swap, swap(addr(10), 1000, addr(11), 2000));
-        assert_eq!(flow.client_fee, None);
-        assert_eq!(flow.client_fee_out, None);
+        assert_eq!(flow.venue_fee, None);
+        assert_eq!(flow.venue_fee_out, None);
     }
 }

--- a/tools/hindsight/src/decoder/venues/mod.rs
+++ b/tools/hindsight/src/decoder/venues/mod.rs
@@ -97,8 +97,8 @@ fn back_out_venue_fees(
         .get(&flow.swap.token_out)
         .copied()
         .filter(|fee| !fee.is_zero());
-    let amount_out = venue_fee_out
-        .map_or(flow.swap.amount_out, |fee| flow.swap.amount_out.saturating_add(fee));
+    let amount_out =
+        venue_fee_out.map_or(flow.swap.amount_out, |fee| flow.swap.amount_out.saturating_add(fee));
     Flow {
         tracked: flow.tracked,
         swap: NetSwap { amount_in, amount_out, ..flow.swap },

--- a/tools/hindsight/src/decoder/venues/mod.rs
+++ b/tools/hindsight/src/decoder/venues/mod.rs
@@ -1,8 +1,8 @@
-//! Venue-specific decoding: the platforms users enter through (Relay, MetaMask).
+//! Venue-specific decoding: the platforms users enter through (Relay, `MetaMask`).
 //!
 //! A venue owns the order flow — it picks a solver and may skim a fee — so decoding one means
 //! sender netting plus the venue's own quirks: backing the fee skim out ([`venue_fee_flow`]),
-//! Relay's solver-rebalance fills, MetaMask's calldata solver declaration. A module here is one
+//! Relay's solver-rebalance fills, `MetaMask`'s calldata solver declaration. A module here is one
 //! venue; its addresses come from the address book's `[venues.<name>]` section, bound to behavior
 //! by [`Venue::from_name`].
 
@@ -56,7 +56,7 @@ impl Venue {
 }
 
 /// Net the sender's flow and back the venue's fee skim out of it — the shared shape of every
-/// fee-skimming venue entry (Relay, MetaMask).
+/// fee-skimming venue entry (Relay, `MetaMask`).
 ///
 /// One exception: when the tracked trader IS a fee collector, the transaction is a treasury
 /// operation — the collector's receipts are its own output, not a skim, and backing them "out"

--- a/tools/hindsight/src/decoder/venues/relay.rs
+++ b/tools/hindsight/src/decoder/venues/relay.rs
@@ -1,7 +1,7 @@
 //! Relay-specific decoding.
 //!
 //! Relay differs from direct solver swaps in two ways: its router skims a
-//! client fee to a collector address on either side of the swap, and its
+//! venue fee to a collector address on either side of the swap, and its
 //! solvers submit rebalancing fills whose transaction sender has no net flow.
 
 use std::collections::HashSet;
@@ -9,16 +9,16 @@ use std::collections::HashSet;
 use alloy::primitives::{Address, U256};
 
 use crate::decoder::{
-    clients::client_fee_flow,
     ledger::{NetSwap, TransferLedger},
     registry::Registry,
     strategy::Flow,
+    venues::venue_fee_flow,
 };
 
 /// Decode a Relay-entered transaction.
 ///
 /// The common case is a user swap: net the sender's flow, then back the
-/// client fee out of it. When the sender has no net flow the transaction is a
+/// venue fee out of it. When the sender has no net flow the transaction is a
 /// solver-initiated rebalancing fill, decoded by anchoring on the fee
 /// collector instead (Relay funds the swap from it); the collector is the
 /// funding source there, not a skim, so no fee is backed out.
@@ -28,8 +28,8 @@ pub(crate) fn decode(
     entry_point: Address,
     registry: &Registry,
 ) -> Option<Flow> {
-    let relay = registry.client("relay")?;
-    if let Some(flow) = client_fee_flow(ledger, sender, entry_point, &relay.fee_collectors) {
+    let relay = registry.venue("relay")?;
+    if let Some(flow) = venue_fee_flow(ledger, sender, entry_point, &relay.fee_collectors) {
         return Some(flow);
     }
     decode_rebalance(ledger, &relay.fee_collectors, &relay.entry_points, registry.wrapped_native())
@@ -53,7 +53,6 @@ fn decode_rebalance(
     relay_entry_points: &HashSet<Address>,
     wrapped_native: Address,
 ) -> Option<NetSwap> {
-    // token_in: the single token the collector(s) net-send.
     let net_in: Vec<(Address, U256)> = ledger
         .group_net_sent(fee_collectors)
         .into_iter()
@@ -78,7 +77,7 @@ fn decode_rebalance(
 
     // C1 external fill: the single pure-sink recipient, excluding infrastructure (routers,
     // collector, the wrapped-native token, the zero address) and the input token.
-    let mut outputs: Vec<(Address, U256)> = Vec::new(); // (token_out, amount)
+    let mut outputs: Vec<(Address, U256)> = Vec::new();
     for (recipient, token, amount) in ledger.sink_receipts() {
         if relay_entry_points.contains(&recipient) ||
             fee_collectors.contains(&recipient) ||
@@ -117,7 +116,6 @@ mod tests {
 
     #[test]
     fn rebalance_external_token_fill() {
-        // Collector funds token_in -> pool -> token_out delivered to an external recipient.
         let fee = addr(99);
         let pool = addr(50);
         let recipient = addr(7);
@@ -135,9 +133,6 @@ mod tests {
 
     #[test]
     fn rebalance_external_native_eth_out() {
-        // C1 with native-ETH output: collector funds token_in into a pool, which converts and
-        // sends native ETH on to the recipient. The pool both receives and sends, marking a
-        // genuine conversion (an absorbing counterparty would read as an unconverted payout).
         let fee = addr(99);
         let pool = addr(50);
         let recipient = addr(7);
@@ -153,7 +148,6 @@ mod tests {
 
     #[test]
     fn rebalance_internal_back_to_collector() {
-        // C2: collector sends token_in, receives token_out back (inventory rebalance).
         let fee = addr(99);
         let pool = addr(50);
         let token_in = addr(10);
@@ -170,7 +164,6 @@ mod tests {
 
     #[test]
     fn rebalance_declines_multi_recipient() {
-        // One input token but two external recipients = batched multi-order fill -> decline.
         let fee = addr(99);
         let pool = addr(50);
         let token_in = addr(10);
@@ -210,7 +203,6 @@ mod tests {
 
     #[test]
     fn rebalance_declines_without_collector_outflow() {
-        // No transfer from a fee collector -> nothing to anchor on.
         let logs = vec![make_transfer_log(addr(10), addr(1), addr(50), U256::from(1000))];
         let collectors = HashSet::from([addr(99)]);
         let routers = HashSet::from([addr(2)]);
@@ -223,7 +215,7 @@ mod tests {
         // the real Relay collector. The fee is backed out of amount_in.
         let registry = Registry::ethereum();
         let collector = *registry
-            .client("relay")
+            .venue("relay")
             .unwrap()
             .fee_collectors
             .iter()
@@ -245,9 +237,8 @@ mod tests {
         let flow = decode(&ledger(&logs, &[]), user, router, &registry).unwrap();
         assert_eq!(flow.tracked, user);
         assert_eq!(flow.swap, swap(token_in, 960, token_out, 2000));
-        assert_eq!(flow.client_fee, Some(U256::from(40)));
-        assert_eq!(flow.client_fee_out, None);
-        // The user sent the transaction, so the settled route's gas is chargeable.
+        assert_eq!(flow.venue_fee, Some(U256::from(40)));
+        assert_eq!(flow.venue_fee_out, None);
         assert!(flow.trader_paid_gas);
     }
 
@@ -258,7 +249,7 @@ mod tests {
         // output.
         let registry = Registry::ethereum();
         let collector = *registry
-            .client("relay")
+            .venue("relay")
             .unwrap()
             .fee_collectors
             .iter()
@@ -273,8 +264,8 @@ mod tests {
         let flow = decode(&ledger(&logs, &native), collector, router, &registry).unwrap();
         assert_eq!(flow.tracked, collector);
         assert_eq!(flow.swap, swap(weth, 1000, Address::ZERO, 1000));
-        assert_eq!(flow.client_fee, None);
-        assert_eq!(flow.client_fee_out, None);
+        assert_eq!(flow.venue_fee, None);
+        assert_eq!(flow.venue_fee_out, None);
     }
 
     #[test]
@@ -282,7 +273,7 @@ mod tests {
         // Solver fill: the sender has no net flow; the collector funds the swap. No fee back-out.
         let registry = Registry::ethereum();
         let collector = *registry
-            .client("relay")
+            .venue("relay")
             .unwrap()
             .fee_collectors
             .iter()
@@ -303,9 +294,8 @@ mod tests {
         let flow = decode(&ledger(&logs, &[]), solver, router, &registry).unwrap();
         assert_eq!(flow.tracked, solver);
         assert_eq!(flow.swap, swap(token_in, 1000, token_out, 2000));
-        assert_eq!(flow.client_fee, None);
-        assert_eq!(flow.client_fee_out, None);
-        // A solver paid this fill's gas, not the order's trader — no gas deduction.
+        assert_eq!(flow.venue_fee, None);
+        assert_eq!(flow.venue_fee_out, None);
         assert!(!flow.trader_paid_gas);
     }
 }

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -1,3 +1,13 @@
+// Test code uses unwrap/expect/println pervasively — these are idiomatic in tests and need no
+// special handling (a panic in test code is the desired failure mode).
+#![cfg_attr(test, allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::unwrap_err_used,
+    clippy::print_stdout,
+    clippy::print_stderr,
+))]
+
 mod decoder;
 mod resolve;
 mod telemetry;
@@ -23,7 +33,7 @@ struct Cli {
 enum Command {
     /// Decode solver trades from a block or range.
     Decode(DecodeArgs),
-    /// Decode and compare against Allium's aggregator_trades ground truth.
+    /// Decode and compare against Allium's `aggregator_trades` ground truth.
     Verify(VerifyArgs),
     /// Live monitor: drive an in-process solver block-by-block, re-solving each block's settled
     /// trades at top-of-block (N-1) and back-of-block (N).
@@ -83,13 +93,13 @@ struct VerifyArgs {
     /// workspace that created it, so register this SQL in your own Allium workspace and pass its
     /// ID:
     ///
-    ///   SELECT project, protocol, token_sold_address, token_sold_symbol, token_sold_amount,
-    ///          usd_sold_amount, token_bought_address, token_bought_symbol, token_bought_amount,
-    ///          usd_bought_amount, sender_address, to_address, transaction_hash,
-    ///          transaction_fees_usd, block_number, block_timestamp, log_index
-    ///   FROM ethereum.dex.aggregator_trades
-    ///   WHERE block_number = {{block_number}}
-    ///   ORDER BY log_index
+    ///   SELECT project, protocol, `token_sold_address`, `token_sold_symbol`, `token_sold_amount`,
+    ///          `usd_sold_amount`, `token_bought_address`, `token_bought_symbol`, `token_bought_amount`,
+    ///          `usd_bought_amount`, `sender_address`, `to_address`, `transaction_hash`,
+    ///          `transaction_fees_usd`, `block_number`, `block_timestamp`, `log_index`
+    ///   FROM `ethereum.dex.aggregator_trades`
+    ///   WHERE `block_number` = {{`block_number`}}
+    ///   ORDER BY `log_index`
     #[arg(long, env = "ALLIUM_QUERY_ID")]
     allium_query_id: String,
 
@@ -103,12 +113,14 @@ struct VerifyArgs {
 }
 
 #[tokio::main]
+#[expect(clippy::expect_used)]
 async fn main() -> anyhow::Result<()> {
     // ANSI colors only on a real terminal: in a pod they end up as escape sequences inside
     // Loki, where they break plain name=value field extraction.
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::from_env("RUST_LOG").add_directive("hindsight=info".parse().unwrap()),
+            EnvFilter::from_env("RUST_LOG")
+                .add_directive("hindsight=info".parse().expect("valid static directive")),
         )
         .with_target(false)
         .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stdout()))
@@ -121,6 +133,7 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+#[expect(clippy::print_stdout)]
 async fn run_decode(args: DecodeArgs) -> anyhow::Result<()> {
     let provider = provider_from(&args.rpc.rpc_url)?;
     let blocks = resolve_blocks(&provider, args.blocks.block, args.blocks.range.as_deref()).await?;
@@ -159,6 +172,7 @@ async fn run_decode(args: DecodeArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[expect(clippy::print_stdout)]
 async fn run_verify(args: VerifyArgs) -> anyhow::Result<()> {
     let provider = provider_from(&args.rpc.rpc_url)?;
     let blocks = resolve_blocks(&provider, args.blocks.block, args.blocks.range.as_deref()).await?;
@@ -205,6 +219,7 @@ pub(crate) async fn resolve_blocks<P: Provider>(
     }
 }
 
+#[expect(clippy::print_stdout)]
 fn print_trades(trades: &[decoder::DecodedTrade]) {
     if trades.is_empty() {
         println!("No solver trades found.");

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -2,6 +2,7 @@ mod decoder;
 mod resolve;
 mod telemetry;
 mod usd;
+mod verify;
 
 use std::time::Instant;
 
@@ -161,14 +162,14 @@ async fn run_decode(args: DecodeArgs) -> anyhow::Result<()> {
 async fn run_verify(args: VerifyArgs) -> anyhow::Result<()> {
     let provider = provider_from(&args.rpc.rpc_url)?;
     let blocks = resolve_blocks(&provider, args.blocks.block, args.blocks.range.as_deref()).await?;
-    let allium = decoder::allium::AlliumClient::new(args.allium_key, args.allium_query_id);
+    let allium = verify::allium::AlliumClient::new(args.allium_key, args.allium_query_id);
     let registry = decoder::Registry::load("ethereum", args.rpc.registry.as_deref())?;
     let mut decoder = decoder::Decoder::new(provider, registry);
 
     info!(blocks = blocks.len(), "verifying decoded trades against Allium");
     let start = Instant::now();
     let report =
-        decoder::verify_decoder::run(&mut decoder, &allium, &blocks, args.tolerance_bps).await?;
+        verify::run(&mut decoder, &allium, &blocks, args.tolerance_bps).await?;
     info!(elapsed_ms = start.elapsed().as_millis(), "verification complete");
 
     if args.json {

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -233,6 +233,8 @@ fn print_trades(trades: &[decoder::DecodedTrade]) {
     }
 }
 
+const MAX_RANGE_BLOCKS: u64 = 1000;
+
 fn parse_range(range: &str) -> anyhow::Result<Vec<u64>> {
     let parts: Vec<&str> = range.split('-').collect();
     if parts.len() != 2 {
@@ -247,8 +249,8 @@ fn parse_range(range: &str) -> anyhow::Result<Vec<u64>> {
     if end < start {
         anyhow::bail!("end block ({end}) must be >= start block ({start})");
     }
-    if end - start > 1000 {
-        anyhow::bail!("range too large: {} blocks (max 1000)", end - start);
+    if end - start > MAX_RANGE_BLOCKS {
+        anyhow::bail!("range too large: {} blocks (max {MAX_RANGE_BLOCKS})", end - start);
     }
     Ok((start..=end).collect())
 }

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -103,7 +103,6 @@ struct VerifyArgs {
 }
 
 #[tokio::main]
-#[expect(clippy::expect_used)]
 async fn main() -> anyhow::Result<()> {
     // ANSI colors only on a real terminal: in a pod they end up as escape sequences inside
     // Loki, where they break plain name=value field extraction.

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -1,12 +1,15 @@
 // Test code uses unwrap/expect/println pervasively — these are idiomatic in tests and need no
 // special handling (a panic in test code is the desired failure mode).
-#![cfg_attr(test, allow(
-    clippy::unwrap_used,
-    clippy::expect_used,
-    clippy::unwrap_err_used,
-    clippy::print_stdout,
-    clippy::print_stderr,
-))]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::unwrap_err_used,
+        clippy::print_stdout,
+        clippy::print_stderr,
+    )
+)]
 
 mod decoder;
 mod resolve;
@@ -94,10 +97,10 @@ struct VerifyArgs {
     /// ID:
     ///
     ///   SELECT project, protocol, `token_sold_address`, `token_sold_symbol`, `token_sold_amount`,
-    ///          `usd_sold_amount`, `token_bought_address`, `token_bought_symbol`, `token_bought_amount`,
-    ///          `usd_bought_amount`, `sender_address`, `to_address`, `transaction_hash`,
-    ///          `transaction_fees_usd`, `block_number`, `block_timestamp`, `log_index`
-    ///   FROM `ethereum.dex.aggregator_trades`
+    ///          `usd_sold_amount`, `token_bought_address`, `token_bought_symbol`,
+    /// `token_bought_amount`,          `usd_bought_amount`, `sender_address`, `to_address`,
+    /// `transaction_hash`,          `transaction_fees_usd`, `block_number`, `block_timestamp`,
+    /// `log_index`   FROM `ethereum.dex.aggregator_trades`
     ///   WHERE `block_number` = {{`block_number`}}
     ///   ORDER BY `log_index`
     #[arg(long, env = "ALLIUM_QUERY_ID")]
@@ -119,8 +122,11 @@ async fn main() -> anyhow::Result<()> {
     // Loki, where they break plain name=value field extraction.
     tracing_subscriber::fmt()
         .with_env_filter(
-            EnvFilter::from_env("RUST_LOG")
-                .add_directive("hindsight=info".parse().expect("valid static directive")),
+            EnvFilter::from_env("RUST_LOG").add_directive(
+                "hindsight=info"
+                    .parse()
+                    .expect("valid static directive"),
+            ),
         )
         .with_target(false)
         .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stdout()))
@@ -182,8 +188,7 @@ async fn run_verify(args: VerifyArgs) -> anyhow::Result<()> {
 
     info!(blocks = blocks.len(), "verifying decoded trades against Allium");
     let start = Instant::now();
-    let report =
-        verify::run(&mut decoder, &allium, &blocks, args.tolerance_bps).await?;
+    let report = verify::run(&mut decoder, &allium, &blocks, args.tolerance_bps).await?;
     info!(elapsed_ms = start.elapsed().as_millis(), "verification complete");
 
     if args.json {

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -215,8 +215,8 @@ fn print_trades(trades: &[decoder::DecodedTrade]) {
     for trade in trades {
         println!("  tx:         {}", trade.tx_hash);
         println!("  block:      {}", trade.block_number);
-        println!("  client:     {}", trade.client);
-        println!("  solver: {}", trade.solver);
+        println!("  venue:      {}", trade.venue);
+        println!("  solver:     {}", trade.solver);
         println!("  sender:     {}", trade.sender);
         println!("  token_in:   {}", trade.token_in);
         println!("  amount_in:  {}", trade.amount_in);

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -1,16 +1,3 @@
-// Test code uses unwrap/expect/println pervasively — these are idiomatic in tests and need no
-// special handling (a panic in test code is the desired failure mode).
-#![cfg_attr(
-    test,
-    allow(
-        clippy::unwrap_used,
-        clippy::expect_used,
-        clippy::unwrap_err_used,
-        clippy::print_stdout,
-        clippy::print_stderr,
-    )
-)]
-
 mod decoder;
 mod resolve;
 mod telemetry;

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -97,15 +97,11 @@ pub(crate) fn compare(
 /// often legitimately unattributable (most Relay settlements are submitted by Relay's own
 /// operators, so the trader paid no gas), and a net-vs-gross fallback would mix comparison bases
 /// across records. The net numbers are still recorded ([`Deltas::net_bps`]) for later analysis.
-pub(crate) fn verdict(
-    outcome: &Outcome,
-    settled_amount_out: U256,
-    settled_net_gas: U256,
-) -> Verdict {
+pub(crate) fn verdict(outcome: &Outcome, deltas: &Deltas) -> Verdict {
     if let Outcome::Partial(_) = outcome {
         return Verdict::CoverageMiss;
     }
-    match compare(outcome, settled_amount_out, settled_net_gas).raw_bps {
+    match deltas.raw_bps {
         Some(d) if d > 0.0 => Verdict::Win,
         Some(_) => Verdict::Loss,
         None => Verdict::Unsolvable,
@@ -172,7 +168,8 @@ mod tests {
     #[test]
     fn verdict_win_only_when_net_positive() {
         let (settled, net) = gross(10_000);
-        assert_eq!(verdict(&solved(10_100, 10_050), settled, net), Verdict::Win);
+        let outcome = solved(10_100, 10_050);
+        assert_eq!(verdict(&outcome, &compare(&outcome, settled, net)), Verdict::Win);
     }
 
     #[test]
@@ -180,7 +177,8 @@ mod tests {
         // Gross output wins even though Fynd's own gas would eat the edge: the headline verdict
         // compares gross vs gross, and the net delta stays available as a secondary number.
         let (settled, net) = gross(10_000);
-        assert_eq!(verdict(&solved(10_100, 9_990), settled, net), Verdict::Win);
+        let outcome = solved(10_100, 9_990);
+        assert_eq!(verdict(&outcome, &compare(&outcome, settled, net)), Verdict::Win);
     }
 
     #[test]
@@ -188,19 +186,21 @@ mod tests {
         // The settled trader's gas does not move the verdict in either direction — only the
         // gross outputs do.
         let fynd = solved(10_050, 9_990);
-        assert_eq!(verdict(&fynd, U256::from(10_000u64), U256::from(10_000u64)), Verdict::Win);
-        assert_eq!(verdict(&fynd, U256::from(10_000u64), U256::from(9_900u64)), Verdict::Win);
+        let settled = U256::from(10_000u64);
+        assert_eq!(verdict(&fynd, &compare(&fynd, settled, settled)), Verdict::Win);
+        assert_eq!(verdict(&fynd, &compare(&fynd, settled, U256::from(9_900u64))), Verdict::Win);
         let worse = solved(9_900, 9_800);
-        assert_eq!(verdict(&worse, U256::from(10_000u64), U256::from(9_000u64)), Verdict::Loss);
+        assert_eq!(
+            verdict(&worse, &compare(&worse, settled, U256::from(9_000u64))),
+            Verdict::Loss
+        );
     }
 
     #[test]
     fn verdict_unsolvable_passthrough() {
         let (settled, net) = gross(10_000);
-        assert_eq!(
-            verdict(&Outcome::Unsolvable("missing token".into()), settled, net),
-            Verdict::Unsolvable
-        );
+        let outcome = Outcome::Unsolvable("missing token".into());
+        assert_eq!(verdict(&outcome, &compare(&outcome, settled, net)), Verdict::Unsolvable);
     }
 
     #[test]
@@ -209,7 +209,7 @@ mod tests {
         let outcome = served(solved(400, 390), U256::from(1_000u64));
         assert!(matches!(outcome, Outcome::Partial(_)));
         let (settled, net) = gross(1_000);
-        assert_eq!(verdict(&outcome, settled, net), Verdict::CoverageMiss);
+        assert_eq!(verdict(&outcome, &compare(&outcome, settled, net)), Verdict::CoverageMiss);
     }
 
     #[test]

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -190,10 +190,7 @@ mod tests {
         assert_eq!(verdict(&fynd, &compare(&fynd, settled, settled)), Verdict::Win);
         assert_eq!(verdict(&fynd, &compare(&fynd, settled, U256::from(9_900u64))), Verdict::Win);
         let worse = solved(9_900, 9_800);
-        assert_eq!(
-            verdict(&worse, &compare(&worse, settled, U256::from(9_000u64))),
-            Verdict::Loss
-        );
+        assert_eq!(verdict(&worse, &compare(&worse, settled, U256::from(9_000u64))), Verdict::Loss);
     }
 
     #[test]

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -5,7 +5,7 @@ use fynd_tools_common::bps::raw_bps_diff;
 use num_bigint::BigUint;
 use serde::Serialize;
 
-use crate::resolve::Outcome;
+use crate::{resolve::Outcome, usd};
 
 /// Convert an alloy `U256` token amount to `BigUint` for the bps helpers, big-endian and without a
 /// decimal string round-trip.
@@ -60,15 +60,8 @@ pub(crate) fn served(outcome: Outcome, settled_amount_out: U256) -> Outcome {
     let Outcome::Solved(ref solved) = outcome else {
         return outcome;
     };
-    let settled: f64 = settled_amount_out
-        .to_string()
-        .parse()
-        .unwrap_or(0.0);
-    let fynd: f64 = solved
-        .amount_out
-        .to_string()
-        .parse()
-        .unwrap_or(0.0);
+    let settled = usd::u256_to_f64(settled_amount_out);
+    let fynd = usd::u256_to_f64(solved.amount_out);
     if settled > 0.0 && fynd < MIN_FILL_RATIO * settled {
         return Outcome::Partial(format!(
             "partial route: {:.0}% of settled size",

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -255,7 +255,7 @@ fn slim_transaction(transaction: &Transaction) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, U256};
+    use alloy::primitives::{Address, TxHash, U256};
     use num_bigint::BigUint;
 
     use super::*;
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn comparison_record_carries_solver_quote() {
         let trade = DecodedTrade {
-            tx_hash: Default::default(),
+            tx_hash: TxHash::default(),
             block_number: 25_480_207,
             venue: "relay".into(),
             solver: "kyberswap".into(),
@@ -374,7 +374,7 @@ mod tests {
         let prices = usd::PriceMap::from([(usdc, 2e-9), (weth, 1.0)]);
 
         let trade = DecodedTrade {
-            tx_hash: Default::default(),
+            tx_hash: TxHash::default(),
             block_number: 25_000_000,
             venue: "relay".into(),
             solver: "1inch".into(),
@@ -453,7 +453,7 @@ mod tests {
     #[test]
     fn comparison_record_captures_unsolvable_reason_and_null_quote() {
         let trade = DecodedTrade {
-            tx_hash: Default::default(),
+            tx_hash: TxHash::default(),
             block_number: 25_000_000,
             venue: "relay".into(),
             solver: "1inch".into(),

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -22,7 +22,7 @@ use crate::{
 
 /// Append-only comparisons writer that rotates to a new file at each UTC day boundary —
 /// `comparisons-YYYY-MM-DD.jsonl` inside its directory — so an external sync job (e.g. an S3
-/// upload CronJob) ships closed daily files instead of re-shipping one ever-growing one.
+/// upload `CronJob`) ships closed daily files instead of re-shipping one ever-growing one.
 pub(crate) struct RotatingWriter {
     dir: PathBuf,
     date: String,
@@ -68,7 +68,7 @@ impl RotatingWriter {
                 self.date = date;
             }
             Err(e) => {
-                warn!(error = %e, "failed to rotate comparisons file; keeping the previous day's")
+                warn!(error = %e, "failed to rotate comparisons file; keeping the previous day's");
             }
         }
     }
@@ -100,7 +100,7 @@ fn utc_date() -> String {
 /// Civil date for a unix timestamp (UTC), via the days-to-civil-calendar algorithm — exact for
 /// the whole unix era, so no calendar dependency is needed for a filename.
 fn date_from_unix(secs: u64) -> String {
-    let z = (secs / 86_400) as i64 + 719_468;
+    let z = (secs / 86_400).cast_signed() + 719_468_i64;
     let era = z.div_euclid(146_097);
     let day_of_era = z.rem_euclid(146_097);
     let year_of_era =

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -150,7 +150,7 @@ fn comparison_record(
     serde_json::json!({
         "block": range.block_number,
         "settled_tx": range.tx_hash,
-        "client": range.client,
+        "venue": range.venue,
         "solver": range.solver,
         "solver_source": range.solver_source,
         "token_in": format!("{:#x}", range.token_in),
@@ -305,7 +305,7 @@ mod tests {
         let trade = DecodedTrade {
             tx_hash: Default::default(),
             block_number: 25_480_207,
-            client: "relay".into(),
+            venue: "relay".into(),
             solver: "kyberswap".into(),
             solver_source: AttributionSource::TraceMatch,
             sender: Address::ZERO,
@@ -313,8 +313,8 @@ mod tests {
             token_out: Address::repeat_byte(0x22),
             amount_in: U256::from(1_000u64),
             amount_out: U256::from(69_996_280_564u64),
-            client_fee: None,
-            client_fee_out: None,
+            venue_fee: None,
+            venue_fee_out: None,
             settled_gas: None,
             quote: Some(SolverQuote {
                 amount_out: U256::from(70_400_409_935u64),
@@ -376,7 +376,7 @@ mod tests {
         let trade = DecodedTrade {
             tx_hash: Default::default(),
             block_number: 25_000_000,
-            client: "relay".into(),
+            venue: "relay".into(),
             solver: "1inch".into(),
             solver_source: AttributionSource::TraceMatch,
             sender: Address::ZERO,
@@ -384,8 +384,8 @@ mod tests {
             token_out: usdc,
             amount_in: U256::from(1_000u64),
             amount_out: U256::from(1_000_000_000u64), // settled 1000 USDC
-            client_fee: None,
-            client_fee_out: None,
+            venue_fee: None,
+            venue_fee_out: None,
             settled_gas: None,
             quote: None,
         };
@@ -455,7 +455,7 @@ mod tests {
         let trade = DecodedTrade {
             tx_hash: Default::default(),
             block_number: 25_000_000,
-            client: "relay".into(),
+            venue: "relay".into(),
             solver: "1inch".into(),
             solver_source: AttributionSource::TraceMatch,
             sender: Address::ZERO,
@@ -463,8 +463,8 @@ mod tests {
             token_out: Address::repeat_byte(0x22),
             amount_in: U256::from(1_000u64),
             amount_out: U256::from(1_000u64),
-            client_fee: None,
-            client_fee_out: None,
+            venue_fee: None,
+            venue_fee_out: None,
             settled_gas: None,
             quote: None,
         };

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -10,7 +10,7 @@ mod compare;
 mod jsonl;
 pub(crate) mod monitor;
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
 pub(crate) use compare::{Deltas, Verdict};
 use serde::Serialize;
@@ -58,7 +58,7 @@ impl StateResult {
     fn new(outcome: Outcome, settled_amount_out: U256, settled_net_gas: U256) -> Self {
         let outcome = compare::served(outcome, settled_amount_out);
         let deltas = compare::compare(&outcome, settled_amount_out, settled_net_gas);
-        let verdict = compare::verdict(&outcome, settled_amount_out, settled_net_gas);
+        let verdict = compare::verdict(&outcome, &deltas);
         Self { outcome, deltas, verdict }
     }
 }
@@ -66,7 +66,7 @@ impl StateResult {
 /// A trade re-solved at both block states, presented as a range.
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct RangeComparison {
-    pub tx_hash: String,
+    pub tx_hash: TxHash,
     pub block_number: u64,
     pub venue: String,
     pub solver: String,
@@ -123,7 +123,7 @@ pub(crate) fn build_range(
     let back = StateResult::new(back, trade.amount_out, settled_net_gas);
     let verdict = top.verdict;
     RangeComparison {
-        tx_hash: trade.tx_hash.to_string(),
+        tx_hash: trade.tx_hash,
         block_number: trade.block_number,
         venue: trade.venue.clone(),
         solver: trade.solver.clone(),

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -68,7 +68,7 @@ impl StateResult {
 pub(crate) struct RangeComparison {
     pub tx_hash: String,
     pub block_number: u64,
-    pub client: String,
+    pub venue: String,
     pub solver: String,
     /// The evidence tier the solver label came from (from the decoder).
     pub solver_source: AttributionSource,
@@ -125,7 +125,7 @@ pub(crate) fn build_range(
     RangeComparison {
         tx_hash: trade.tx_hash.to_string(),
         block_number: trade.block_number,
-        client: trade.client.clone(),
+        venue: trade.venue.clone(),
         solver: trade.solver.clone(),
         solver_source: trade.solver_source,
         token_in: trade.token_in,
@@ -178,7 +178,7 @@ mod tests {
         DecodedTrade {
             tx_hash: Default::default(),
             block_number: 21_000_000,
-            client: "relay".into(),
+            venue: "relay".into(),
             solver: "tycho".into(),
             solver_source: AttributionSource::TraceMatch,
             sender: Address::ZERO,
@@ -186,8 +186,8 @@ mod tests {
             token_out: Address::repeat_byte(0x22),
             amount_in: U256::from(1_000u64),
             amount_out: U256::from(settled),
-            client_fee: None,
-            client_fee_out: None,
+            venue_fee: None,
+            venue_fee_out: None,
             settled_gas: None,
             quote: None,
         }

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -176,7 +176,7 @@ mod tests {
 
     fn trade(settled: u64) -> DecodedTrade {
         DecodedTrade {
-            tx_hash: Default::default(),
+            tx_hash: TxHash::default(),
             block_number: 21_000_000,
             venue: "relay".into(),
             solver: "tycho".into(),

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -561,12 +561,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     #[ignore = "requires live TYCHO_URL + RPC_URL"]
     async fn monitor_one_block_smoke() {
-        let (Ok(rpc_url), Ok(tycho_url)) = (std::env::var("RPC_URL"), std::env::var("TYCHO_URL"))
-        else {
-            eprintln!("skipping: set RPC_URL and TYCHO_URL");
-            return;
-        };
-
+        let rpc_url = std::env::var("RPC_URL").expect("set RPC_URL");
+        let tycho_url = std::env::var("TYCHO_URL").expect("set TYCHO_URL");
         let api_key = std::env::var("TYCHO_API_KEY").ok();
         run(MonitorArgs {
             rpc: crate::RpcArgs { rpc_url, registry: None },

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -230,10 +230,16 @@ fn order_quote_to_outcome(quote: &OrderQuote) -> Outcome {
 }
 
 fn biguint_to_u256(value: &BigUint) -> U256 {
-    value
-        .to_string()
-        .parse()
-        .unwrap_or(U256::ZERO)
+    // Convert via big-endian bytes: avoids a decimal string round-trip and catches overflow
+    // without relying on parse. U256 fits in 32 bytes; a larger value is a solver bug.
+    let bytes = value.to_bytes_be();
+    if bytes.len() > 32 {
+        warn!(bits = value.bits(), "solver quote amount overflows U256; treating as zero");
+        return U256::ZERO;
+    }
+    let mut buf = [0u8; 32];
+    buf[32 - bytes.len()..].copy_from_slice(&bytes);
+    U256::from_be_bytes(buf)
 }
 
 /// Decode `block`, first waiting out any RPC lag. The HTTP RPC used for receipts can trail the
@@ -245,11 +251,13 @@ async fn decode_block_when_available<P: Provider>(
     block: u64,
 ) -> anyhow::Result<Vec<DecodedTrade>> {
     for attempt in 0..DECODE_RPC_LAG_RETRIES {
-        let head = decoder
-            .provider()
-            .get_block_number()
-            .await
-            .unwrap_or(0);
+        let head = match decoder.provider().get_block_number().await {
+            Ok(h) => h,
+            Err(e) => {
+                warn!(block, attempt, "failed to fetch RPC block number: {e}");
+                0
+            }
+        };
         if head >= block {
             break;
         }

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -33,13 +33,13 @@ use crate::{
 };
 
 /// How often to warn while the solver has not applied the next block.
-const STALL_WARN_INTERVAL: Duration = Duration::from_secs(300);
+const STALL_WARN_INTERVAL: Duration = Duration::from_mins(5);
 /// No block for this long means the feed is dead, not slow. The observed failure mode: one
 /// server-side subscription goes silent, tycho-client's block synchronizer stops emitting while
 /// it waits for it, and ~35 minutes later backpressure kills the remaining subscriptions
 /// ("Buffer full, unsubscribing!"). Nothing resubscribes, so the stream never recovers — the
 /// monitor rebuilds the solver instead of waiting.
-const FEED_DEAD_TIMEOUT: Duration = Duration::from_secs(900);
+const FEED_DEAD_TIMEOUT: Duration = Duration::from_mins(15);
 /// Pause between solver rebuild attempts after a feed death, so a struggling Tycho server is not
 /// hammered in a tight loop.
 const REBUILD_BACKOFF: Duration = Duration::from_secs(30);
@@ -128,7 +128,7 @@ impl StepAdapter<'_> {
             .read()
             .await
             .last_updated()
-            .map(|b| b.number())
+            .map(fynd_core::BlockInfo::number)
     }
 }
 
@@ -159,11 +159,9 @@ impl SteppingSolver for StepAdapter<'_> {
         match self.solver.quote(request).await {
             Ok(quote) => quote
                 .orders()
-                .first()
-                .map(order_quote_to_outcome)
-                .unwrap_or_else(|| {
+                .first().map_or_else(|| {
                     Outcome::Unsolvable("solver returned no order quote".to_string())
-                }),
+                }, order_quote_to_outcome),
             Err(e) => Outcome::Unsolvable(format!("solve error: {e}")),
         }
     }
@@ -201,7 +199,7 @@ impl SteppingSolver for StepAdapter<'_> {
                 next_warn += STALL_WARN_INTERVAL;
             }
             tokio::select! {
-                _ = tokio::time::sleep(POLL_INTERVAL) => {}
+                () = tokio::time::sleep(POLL_INTERVAL) => {}
                 peeked = self.controller.peek_next_block() => {
                     if peeked.is_none() {
                         anyhow::bail!("tycho stream ended while waiting for the next block");

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -157,11 +157,10 @@ impl SteppingSolver for StepAdapter<'_> {
         );
 
         match self.solver.quote(request).await {
-            Ok(quote) => quote
-                .orders()
-                .first().map_or_else(|| {
-                    Outcome::Unsolvable("solver returned no order quote".to_string())
-                }, order_quote_to_outcome),
+            Ok(quote) => quote.orders().first().map_or_else(
+                || Outcome::Unsolvable("solver returned no order quote".to_string()),
+                order_quote_to_outcome,
+            ),
             Err(e) => Outcome::Unsolvable(format!("solve error: {e}")),
         }
     }
@@ -249,7 +248,11 @@ async fn decode_block_when_available<P: Provider>(
     block: u64,
 ) -> anyhow::Result<Vec<DecodedTrade>> {
     for attempt in 0..DECODE_RPC_LAG_RETRIES {
-        let head = match decoder.provider().get_block_number().await {
+        let head = match decoder
+            .provider()
+            .get_block_number()
+            .await
+        {
             Ok(h) => h,
             Err(e) => {
                 warn!(block, attempt, "failed to fetch RPC block number: {e}");

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -33,14 +33,14 @@ fn is_usd_outlier(usd: f64) -> bool {
     usd.abs() >= USD_OUTLIER_THRESHOLD
 }
 
-/// Metric label for a range's client: registered clients (the registry's `[clients.*]` sections
+/// Metric label for a range's venue: registered venues (the registry's `[venues.*]` sections
 /// — the integrator front-ends the comparison is pitched at) keep their name; everything else —
 /// direct router entries, bots, unregistered addresses — collapses to "other". Keeps the
-/// dashboard's client filter to the registered names plus "other"; full client detail stays in
+/// dashboard's venue filter to the registered names plus "other"; full venue detail stays in
 /// the JSONL records.
-fn client_label<'a>(client: &'a str, registry: &Registry) -> &'a str {
-    if registry.client(client).is_some() {
-        client
+fn venue_label<'a>(venue: &'a str, registry: &Registry) -> &'a str {
+    if registry.venue(venue).is_some() {
+        venue
     } else {
         "other"
     }
@@ -48,7 +48,7 @@ fn client_label<'a>(client: &'a str, registry: &Registry) -> &'a str {
 
 /// Metric label for a range's settling solver: registered solver names pass through, everything
 /// else collapses to "unknown". Attribution can also produce raw addresses (largest-call guess),
-/// client names (fallback tier), and calldata-declared names from a client's own vocabulary
+/// venue names (fallback tier), and calldata-declared names from a venue's own vocabulary
 /// (MetaMask aggregator ids like "pancakeSwapRouterFeeDynamic") — none belong in the bounded
 /// metric vocabulary. The original label stays in the JSONL records, where it serves as the
 /// registry-expansion worklist.
@@ -62,7 +62,7 @@ fn solver_label<'a>(solver: &'a str, registry: &Registry) -> &'a str {
 
 /// The bounded label set shared by every per-trade metric, computed once per range.
 struct MetricLabels<'a> {
-    client: &'a str,
+    venue: &'a str,
     solver: &'a str,
     chain: &'a str,
 }
@@ -81,7 +81,7 @@ pub(crate) fn outcome_label(verdict: Verdict) -> &'static str {
 pub(crate) fn describe() {
     describe_counter!(
         TRADES_TOTAL,
-        "Re-solved trades, labeled by client / solver / chain / outcome / state (top|back). \
+        "Re-solved trades, labeled by venue / solver / chain / outcome / state (top|back). \
          Per-pair detail lives in the JSONL comparison output; a token-pair label here is unbounded \
          on mainnet and would explode Prometheus series cardinality over a long run."
     );
@@ -97,12 +97,12 @@ pub(crate) fn describe() {
     );
     describe_histogram!(
         IMPROVEMENT_USD,
-        "Gross USD uplift on trades Fynd would improve (losses excluded — a client routes \
+        "Gross USD uplift on trades Fynd would improve (losses excluded — a venue routes \
          elsewhere when Fynd is worse). Sum = value of adding Fynd; count = improving trades"
     );
     describe_histogram!(
         VOLUME_USD,
-        "Observed settled trade volume in USD, labeled by client / solver / outcome (headline \
+        "Observed settled trade volume in USD, labeled by venue / solver / outcome (headline \
          verdict). Valued from the output leg, falling back to the input leg when the output \
          token is unpriced"
     );
@@ -130,7 +130,7 @@ pub(crate) fn record_range(
     registry: &Registry,
 ) {
     let labels = MetricLabels {
-        client: client_label(&range.client, registry),
+        venue: venue_label(&range.venue, registry),
         solver: solver_label(&range.solver, registry),
         chain,
     };
@@ -146,7 +146,7 @@ pub(crate) fn record_range(
     if let Some(volume) = volume {
         histogram!(
             VOLUME_USD,
-            "client" => labels.client.to_string(),
+            "venue" => labels.venue.to_string(),
             "solver" => labels.solver.to_string(),
             "chain" => labels.chain.to_string(),
             "outcome" => outcome_label(range.verdict).to_string(),
@@ -166,7 +166,7 @@ pub(crate) fn record_range(
         info!(
             tx = %range.tx_hash,
             block = range.block_number,
-            client = %range.client,
+            venue = %range.venue,
             solver = %range.solver,
             token_in = %range.token_in,
             token_out = %range.token_out,
@@ -183,7 +183,7 @@ pub(crate) fn record_range(
 
 /// Record one block-state of a range under a `state` label. Emits the trade counter, and — for a
 /// solved state — the gross bps delta, the signed USD savings, and the USD uplift (only when
-/// Fynd beats the settled trade; a client routes elsewhere when Fynd is worse). All highlighted
+/// Fynd beats the settled trade; a venue routes elsewhere when Fynd is worse). All highlighted
 /// metrics compare gross vs gross, matching the headline verdict.
 ///
 /// Returns the signed USD savings it recorded, `None` when the state is unsolved or unpriced.
@@ -196,7 +196,7 @@ fn record_state(
 ) -> Option<f64> {
     counter!(
         TRADES_TOTAL,
-        "client" => labels.client.to_string(),
+        "venue" => labels.venue.to_string(),
         "solver" => labels.solver.to_string(),
         "chain" => labels.chain.to_string(),
         "outcome" => outcome_label(state.verdict).to_string(),
@@ -207,7 +207,7 @@ fn record_state(
     if let Some(bps) = state.deltas.raw_bps {
         histogram!(
             SAVINGS_BPS,
-            "client" => labels.client.to_string(),
+            "venue" => labels.venue.to_string(),
             "solver" => labels.solver.to_string(),
             "chain" => labels.chain.to_string(),
             "state" => state_label,
@@ -225,7 +225,7 @@ fn record_state(
             tx = %range.tx_hash,
             block = range.block_number,
             state = state_label,
-            client = %range.client,
+            venue = %range.venue,
             solver = %range.solver,
             token_in = %range.token_in,
             token_out = %range.token_out,
@@ -239,7 +239,7 @@ fn record_state(
     }
     histogram!(
         SAVINGS_USD,
-        "client" => labels.client.to_string(),
+        "venue" => labels.venue.to_string(),
         "solver" => labels.solver.to_string(),
         "chain" => labels.chain.to_string(),
         "state" => state_label,
@@ -249,7 +249,7 @@ fn record_state(
     if usd > 0.0 {
         histogram!(
             IMPROVEMENT_USD,
-            "client" => labels.client.to_string(),
+            "venue" => labels.venue.to_string(),
             "solver" => labels.solver.to_string(),
             "chain" => labels.chain.to_string(),
             "state" => state_label,
@@ -355,7 +355,7 @@ mod tests {
         DecodedTrade {
             tx_hash: Default::default(),
             block_number: 21_000_000,
-            client: "relay".into(),
+            venue: "relay".into(),
             solver: "tycho".into(),
             solver_source: AttributionSource::TraceMatch,
             sender: Address::ZERO,
@@ -363,8 +363,8 @@ mod tests {
             token_out,
             amount_in: U256::from(1_000u64),
             amount_out: U256::from(settled),
-            client_fee: None,
-            client_fee_out: None,
+            venue_fee: None,
+            venue_fee_out: None,
             settled_gas: None,
             quote: None,
         }
@@ -423,7 +423,7 @@ mod tests {
         assert!(rendered.contains("state=\"back\""), "rendered: {rendered}");
         assert!(rendered.contains("outcome=\"win\""));
         assert!(rendered.contains("outcome=\"loss\""));
-        assert!(rendered.contains("client=\"relay\""));
+        assert!(rendered.contains("venue=\"relay\""));
         // Top beats settled → uplift recorded; volume recorded once, tagged with the headline
         // verdict so the dashboard can split volume by outcome.
         assert!(rendered.contains("hindsight_improvement_usd"));
@@ -444,14 +444,14 @@ mod tests {
 
     #[test]
     fn label_vocabulary_is_registry_bounded() {
-        // Every metric label value must come from the registry vocabulary: registered client and
+        // Every metric label value must come from the registry vocabulary: registered venue and
         // solver names pass through; raw addresses, unregistered names, and calldata-declared
-        // aggregator ids collapse — clients to "other", solvers to "unknown".
+        // aggregator ids collapse — venues to "other", solvers to "unknown".
         let registry = Registry::ethereum();
-        assert_eq!(client_label("relay", &registry), "relay");
-        assert_eq!(client_label("metamask", &registry), "metamask");
-        assert_eq!(client_label("okx", &registry), "other");
-        assert_eq!(client_label("0xD720183DdA64a8CDb424B5c13aF73baf713521f8", &registry), "other");
+        assert_eq!(venue_label("relay", &registry), "relay");
+        assert_eq!(venue_label("metamask", &registry), "metamask");
+        assert_eq!(venue_label("okx", &registry), "other");
+        assert_eq!(venue_label("0xD720183DdA64a8CDb424B5c13aF73baf713521f8", &registry), "other");
         assert_eq!(solver_label("kyberswap", &registry), "kyberswap");
         assert_eq!(solver_label("relay", &registry), "unknown");
         assert_eq!(solver_label("pancakeSwapRouterFeeDynamic", &registry), "unknown");
@@ -463,11 +463,11 @@ mod tests {
 
     #[test]
     fn raw_address_labels_collapse() {
-        // Unknown clients/solvers carry raw 0x… addresses; every distinct address would mint a
-        // fresh series set, unbounded over a long run. Clients outside the registry's
-        // [clients.*] sections collapse to "other", solvers outside [solvers] to "unknown".
+        // Unknown venues/solvers carry raw 0x… addresses; every distinct address would mint a
+        // fresh series set, unbounded over a long run. Venues outside the registry's
+        // [venues.*] sections collapse to "other", solvers outside [solvers] to "unknown".
         let mut t = trade(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 1_000);
-        t.client = "0xD720183DdA64a8CDb424B5c13aF73baf713521f8".to_string();
+        t.venue = "0xD720183DdA64a8CDb424B5c13aF73baf713521f8".to_string();
         t.solver = "0xB6F54cAed61C318027c022c47B94BAF139a99Dab".to_string();
         let range =
             build_range(&t, &usd::PriceMap::new(), solved(1_100, 1_050), solved(1_100, 1_050));
@@ -484,14 +484,14 @@ mod tests {
             );
         });
         let rendered = handle.render();
-        assert!(rendered.contains("client=\"other\""), "rendered: {rendered}");
+        assert!(rendered.contains("venue=\"other\""), "rendered: {rendered}");
         assert!(rendered.contains("solver=\"unknown\""));
         assert!(!rendered.contains("0xD720183DdA64a8CDb424B5c13aF73baf713521f8"));
     }
 
     #[test]
     fn fallback_solver_label_collapses_to_unknown() {
-        // The Fallback tier labels the solver with the entry point — a client name like "relay",
+        // The Fallback tier labels the solver with the entry point — a venue name like "relay",
         // not a solver — which would pollute the dashboard's solver dropdown. The metric label
         // must collapse to "unknown"; the JSONL keeps the entry-point detail.
         let mut t = trade(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 1_000);

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -345,7 +345,7 @@ fn configure_buckets(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, Address, U256};
+    use alloy::primitives::{address, Address, TxHash, U256};
     use metrics_exporter_prometheus::PrometheusBuilder;
 
     use super::*;
@@ -356,7 +356,7 @@ mod tests {
 
     fn trade(token_out: Address, settled: u64) -> DecodedTrade {
         DecodedTrade {
-            tx_hash: Default::default(),
+            tx_hash: TxHash::default(),
             block_number: 21_000_000,
             venue: "relay".into(),
             solver: "tycho".into(),

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -88,7 +88,8 @@ pub(crate) fn describe() {
     describe_histogram!(
         SAVINGS_BPS,
         Unit::Count,
-        "Gross bps delta of Fynd vs settled (positive = Fynd better), the headline basis"
+        "Gross bps delta of Fynd vs settled (positive = Fynd better), labeled by venue / solver / \
+         chain / outcome / state (top|back)"
     );
     describe_histogram!(
         SAVINGS_USD,
@@ -210,6 +211,7 @@ fn record_state(
             "venue" => labels.venue.to_string(),
             "solver" => labels.solver.to_string(),
             "chain" => labels.chain.to_string(),
+            "outcome" => outcome_label(state.verdict).to_string(),
             "state" => state_label,
         )
         .record(bps);
@@ -435,9 +437,16 @@ mod tests {
         assert!(volume_line.contains("outcome=\"win\""), "volume line: {volume_line}");
         // Histograms must render as true histograms (le-labeled _bucket series), not summaries:
         // the dashboard reads them with histogram_quantile(..., *_bucket).
+        // outcome label on savings_bps lets the dashboard show median per win/loss.
         assert!(
             rendered.contains("hindsight_savings_bps_bucket"),
             "savings_bps rendered as a summary, not a histogram: {rendered}"
+        );
+        assert!(
+            rendered
+                .lines()
+                .any(|l| l.contains("hindsight_savings_bps_bucket") && l.contains("outcome=")),
+            "savings_bps missing outcome label: {rendered}"
         );
         assert!(rendered.contains("hindsight_savings_usd_bucket"));
         assert!(rendered.contains("le=\"3\""));

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -49,7 +49,7 @@ fn venue_label<'a>(venue: &'a str, registry: &Registry) -> &'a str {
 /// Metric label for a range's settling solver: registered solver names pass through, everything
 /// else collapses to "unknown". Attribution can also produce raw addresses (largest-call guess),
 /// venue names (fallback tier), and calldata-declared names from a venue's own vocabulary
-/// (MetaMask aggregator ids like "pancakeSwapRouterFeeDynamic") — none belong in the bounded
+/// (`MetaMask` aggregator ids like "pancakeSwapRouterFeeDynamic") — none belong in the bounded
 /// metric vocabulary. The original label stays in the JSONL records, where it serves as the
 /// registry-expansion worklist.
 fn solver_label<'a>(solver: &'a str, registry: &Registry) -> &'a str {
@@ -271,6 +271,7 @@ pub(crate) fn record_feed_rebuild() {
     counter!(FEED_REBUILDS).increment(1);
 }
 
+#[expect(clippy::unused_async)]
 async fn metrics_handler(handle: PrometheusHandle) -> impl Responder {
     HttpResponse::Ok()
         .content_type("text/plain; version=0.0.4; charset=utf-8")

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -34,6 +34,8 @@ const STABLECOINS: &[(Address, u32)] = &[
 /// Powers of 2 are exactly representable in f64, so the limb-scaling is lossless up to the
 /// mantissa width. Precision is lost above ~2^53 (≈9e15 native units) — acceptable for USD
 /// estimates.
+// Precision loss is intentional: this function exists specifically to approximate a U256 as f64.
+#[expect(clippy::cast_precision_loss)]
 pub(crate) fn u256_to_f64(amount: U256) -> f64 {
     let [a, b, c, d] = amount.as_limbs();
     (*a as f64) +

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -29,6 +29,19 @@ const STABLECOINS: &[(Address, u32)] = &[
     (address!("0xdc035d45d973e3ec169d2276ddab16f1e407384f"), 18), // USDS
 ];
 
+/// Convert a `U256` token amount to `f64` via its four 64-bit limbs (little-endian).
+///
+/// Powers of 2 are exactly representable in f64, so the limb-scaling is lossless up to the
+/// mantissa width. Precision is lost above ~2^53 (≈9e15 native units) — acceptable for USD
+/// estimates.
+pub(crate) fn u256_to_f64(amount: U256) -> f64 {
+    let [a, b, c, d] = amount.as_limbs();
+    (*a as f64)
+        + (*b as f64) * 2f64.powi(64)
+        + (*c as f64) * 2f64.powi(128)
+        + (*d as f64) * 2f64.powi(192)
+}
+
 /// Positive, finite price of `token`, treating native ETH and WETH as interchangeable.
 fn price_of(prices: &PriceMap, token: Address) -> Option<f64> {
     let direct = prices.get(&token).copied();
@@ -66,7 +79,7 @@ fn usd_per_eth_wei(prices: &PriceMap) -> Option<f64> {
 pub(crate) fn value_usd(token: Address, amount: U256, prices: &PriceMap) -> Option<f64> {
     let usd_per_eth_wei = usd_per_eth_wei(prices)?;
     let price = price_of(prices, token)?;
-    let amount: f64 = amount.to_string().parse().ok()?;
+    let amount = u256_to_f64(amount);
     let usd = amount * usd_per_eth_wei / price;
     usd.is_finite().then_some(usd)
 }

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -95,11 +95,8 @@ pub(crate) fn value_usd(token: Address, amount: U256, prices: &PriceMap) -> Opti
 #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub(crate) fn gas_in_token(gas_wei: U256, token: Address, prices: &PriceMap) -> Option<U256> {
     let price = price_of(prices, token)?;
-    let gas: f64 = gas_wei.to_string().parse().ok()?;
-    let units = gas * price;
-    units
-        .is_finite()
-        .then(|| U256::from(units as u128))
+    let units = u256_to_f64(gas_wei) * price;
+    units.is_finite().then(|| U256::from(units as u128))
 }
 
 /// Signed USD savings of Fynd's output vs the settled amount (positive = Fynd better).

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -65,7 +65,7 @@ fn usd_per_eth_wei(prices: &PriceMap) -> Option<f64> {
     let mut count = 0u32;
     for &(stable, decimals) in STABLECOINS {
         if let Some(price) = price_of(prices, stable) {
-            sum += price / 10f64.powi(decimals as i32);
+            sum += price / 10f64.powi(decimals.cast_signed());
             count += 1;
         }
     }
@@ -90,6 +90,9 @@ pub(crate) fn value_usd(token: Address, amount: U256, prices: &PriceMap) -> Opti
 /// multiplication. Returns `None` when `token` is not priced. The f64 round-trip loses wei-level
 /// precision, which is acceptable for a gas deduction — the cost itself is exact but its value in
 /// the output token is an estimate by nature.
+// Truncation is intentional: whole token units are sufficient for a gas estimate.
+// Sign loss is impossible: gas_wei is from a U256 and price_of only returns positive values.
+#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
 pub(crate) fn gas_in_token(gas_wei: U256, token: Address, prices: &PriceMap) -> Option<U256> {
     let price = price_of(prices, token)?;
     let gas: f64 = gas_wei.to_string().parse().ok()?;

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -36,10 +36,10 @@ const STABLECOINS: &[(Address, u32)] = &[
 /// estimates.
 pub(crate) fn u256_to_f64(amount: U256) -> f64 {
     let [a, b, c, d] = amount.as_limbs();
-    (*a as f64)
-        + (*b as f64) * 2f64.powi(64)
-        + (*c as f64) * 2f64.powi(128)
-        + (*d as f64) * 2f64.powi(192)
+    (*a as f64) +
+        (*b as f64) * 2f64.powi(64) +
+        (*c as f64) * 2f64.powi(128) +
+        (*d as f64) * 2f64.powi(192)
 }
 
 /// Positive, finite price of `token`, treating native ETH and WETH as interchangeable.
@@ -96,7 +96,9 @@ pub(crate) fn value_usd(token: Address, amount: U256, prices: &PriceMap) -> Opti
 pub(crate) fn gas_in_token(gas_wei: U256, token: Address, prices: &PriceMap) -> Option<U256> {
     let price = price_of(prices, token)?;
     let units = u256_to_f64(gas_wei) * price;
-    units.is_finite().then(|| U256::from(units as u128))
+    units
+        .is_finite()
+        .then(|| U256::from(units as u128))
 }
 
 /// Signed USD savings of Fynd's output vs the settled amount (positive = Fynd better).

--- a/tools/hindsight/src/verify/allium.rs
+++ b/tools/hindsight/src/verify/allium.rs
@@ -139,7 +139,11 @@ impl AlliumClient {
 fn parse_status_value(value: &Value) -> Option<String> {
     value
         .as_str()
-        .or_else(|| value.get("status").and_then(Value::as_str))
+        .or_else(|| {
+            value
+                .get("status")
+                .and_then(Value::as_str)
+        })
         .map(str::to_string)
 }
 

--- a/tools/hindsight/src/verify/allium.rs
+++ b/tools/hindsight/src/verify/allium.rs
@@ -52,6 +52,7 @@ impl AlliumClient {
 
     async fn start_run(&self, block_number: u64) -> anyhow::Result<String> {
         let url = format!("{BASE_URL}/queries/{}/run-async", self.query_id);
+        // The saved query takes block_number as a string parameter.
         let body = json!({
             "parameters": {"block_number": block_number.to_string()},
             "run_config": {"limit": ROW_LIMIT},

--- a/tools/hindsight/src/verify/allium.rs
+++ b/tools/hindsight/src/verify/allium.rs
@@ -1,3 +1,9 @@
+//! Allium API client for the `verify` subcommand.
+//!
+//! A saved query (`query_id`) parameterized by `block_number` is run per block: kick off an async
+//! run, poll until it succeeds, then fetch results. The API rate-limits aggressively, so requests
+//! retry on HTTP 429 with a linear backoff.
+
 use std::time::Duration;
 
 use anyhow::{bail, Context};
@@ -11,40 +17,34 @@ const RATE_LIMIT_BACKOFF: Duration = Duration::from_secs(10);
 const MAX_RETRIES: u32 = 5;
 const ROW_LIMIT: u64 = 10_000;
 
-/// One row of Allium's `aggregator_trades` table — our ground truth for a
-/// single settled swap leg. Extra columns in the response are ignored.
+/// One row of Allium's `aggregator_trades` table — the ground truth for a single settled swap leg.
 ///
-/// Every field is optional: Allium rows can carry nulls (e.g. an unresolved
-/// token address), and one patchy row must not abort a whole verify run.
+/// Every field is optional: Allium rows can carry nulls (e.g. an unresolved token address), and
+/// one patchy row must not abort a whole verify run.
 #[derive(serde::Deserialize, Debug, Clone)]
-pub struct AlliumRow {
-    pub project: Option<String>,
-    pub token_sold_address: Option<String>,
-    pub token_sold_amount: Option<f64>,
-    pub token_bought_address: Option<String>,
-    pub token_bought_amount: Option<f64>,
-    pub transaction_hash: Option<String>,
+pub(crate) struct AlliumRow {
+    pub(crate) project: Option<String>,
+    pub(crate) token_sold_address: Option<String>,
+    pub(crate) token_sold_amount: Option<f64>,
+    pub(crate) token_bought_address: Option<String>,
+    pub(crate) token_bought_amount: Option<f64>,
+    pub(crate) transaction_hash: Option<String>,
 }
 
 /// Client for Allium's async Explorer API.
-///
-/// A saved query (`query_id`) parameterized by `block_number` is run per
-/// block: kick off an async run, poll until it succeeds, then fetch results.
-/// The API rate-limits aggressively, so requests retry on HTTP 429 with a
-/// linear backoff.
-pub struct AlliumClient {
+pub(crate) struct AlliumClient {
     http: reqwest::Client,
     api_key: String,
     query_id: String,
 }
 
 impl AlliumClient {
-    pub fn new(api_key: String, query_id: String) -> Self {
+    pub(crate) fn new(api_key: String, query_id: String) -> Self {
         Self { http: reqwest::Client::new(), api_key, query_id }
     }
 
     /// Fetch every `aggregator_trades` row for a block.
-    pub async fn fetch_block(&self, block_number: u64) -> anyhow::Result<Vec<AlliumRow>> {
+    pub(crate) async fn fetch_block(&self, block_number: u64) -> anyhow::Result<Vec<AlliumRow>> {
         let run_id = self.start_run(block_number).await?;
         self.await_success(&run_id).await?;
         self.results(&run_id).await
@@ -52,7 +52,6 @@ impl AlliumClient {
 
     async fn start_run(&self, block_number: u64) -> anyhow::Result<String> {
         let url = format!("{BASE_URL}/queries/{}/run-async", self.query_id);
-        // The saved query takes block_number as a string parameter.
         let body = json!({
             "parameters": {"block_number": block_number.to_string()},
             "run_config": {"limit": ROW_LIMIT},
@@ -81,11 +80,7 @@ impl AlliumClient {
         let value = self.get(url).await?;
         value
             .as_str()
-            .or_else(|| {
-                value
-                    .get("status")
-                    .and_then(Value::as_str)
-            })
+            .or_else(|| value.get("status").and_then(Value::as_str))
             .map(str::to_string)
             .with_context(|| format!("unexpected Allium status response: {value}"))
     }
@@ -104,8 +99,7 @@ impl AlliumClient {
     }
 
     async fn post(&self, url: &str, body: &Value) -> anyhow::Result<Value> {
-        self.send(|| self.http.post(url).json(body))
-            .await
+        self.send(|| self.http.post(url).json(body)).await
     }
 
     async fn send<F>(&self, build: F) -> anyhow::Result<Value>
@@ -125,18 +119,49 @@ impl AlliumClient {
                 continue;
             }
             if !status.is_success() {
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_default();
+                let body = response.text().await.unwrap_or_default();
                 bail!("Allium returned {status}: {body}");
             }
 
-            return response
-                .json::<Value>()
-                .await
-                .context("failed to decode Allium response");
+            return response.json::<Value>().await.context("failed to decode Allium response");
         }
         bail!("Allium rate limit: exhausted {MAX_RETRIES} retries")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_parses_bare_string() {
+        // The API sometimes returns a bare JSON string "success" instead of {"status": "success"}.
+        let value: Value = serde_json::from_str("\"success\"").unwrap();
+        let result = value
+            .as_str()
+            .or_else(|| value.get("status").and_then(Value::as_str))
+            .map(str::to_string);
+        assert_eq!(result, Some("success".to_string()));
+    }
+
+    #[test]
+    fn status_parses_object_form() {
+        // The API can also return {"status": "running"}.
+        let value: Value = serde_json::from_str(r#"{"status": "running"}"#).unwrap();
+        let result = value
+            .as_str()
+            .or_else(|| value.get("status").and_then(Value::as_str))
+            .map(str::to_string);
+        assert_eq!(result, Some("running".to_string()));
+    }
+
+    #[test]
+    fn status_returns_none_for_unexpected_shape() {
+        let value: Value = serde_json::from_str(r#"{"other_key": "val"}"#).unwrap();
+        let result = value
+            .as_str()
+            .or_else(|| value.get("status").and_then(Value::as_str))
+            .map(str::to_string);
+        assert_eq!(result, None);
     }
 }

--- a/tools/hindsight/src/verify/allium.rs
+++ b/tools/hindsight/src/verify/allium.rs
@@ -79,14 +79,7 @@ impl AlliumClient {
 
     async fn status(&self, url: &str) -> anyhow::Result<String> {
         let value = self.get(url).await?;
-        value
-            .as_str()
-            .or_else(|| {
-                value
-                    .get("status")
-                    .and_then(Value::as_str)
-            })
-            .map(str::to_string)
+        parse_status_value(&value)
             .with_context(|| format!("unexpected Allium status response: {value}"))
     }
 
@@ -141,6 +134,15 @@ impl AlliumClient {
     }
 }
 
+/// Parse a status value from the Allium API, which returns either a bare JSON string
+/// (`"success"`) or an object (`{"status": "running"}`).
+fn parse_status_value(value: &Value) -> Option<String> {
+    value
+        .as_str()
+        .or_else(|| value.get("status").and_then(Value::as_str))
+        .map(str::to_string)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -149,43 +151,19 @@ mod tests {
     fn status_parses_bare_string() {
         // The API sometimes returns a bare JSON string "success" instead of {"status": "success"}.
         let value: Value = serde_json::from_str("\"success\"").unwrap();
-        let result = value
-            .as_str()
-            .or_else(|| {
-                value
-                    .get("status")
-                    .and_then(Value::as_str)
-            })
-            .map(str::to_string);
-        assert_eq!(result, Some("success".to_string()));
+        assert_eq!(parse_status_value(&value), Some("success".to_string()));
     }
 
     #[test]
     fn status_parses_object_form() {
         // The API can also return {"status": "running"}.
         let value: Value = serde_json::from_str(r#"{"status": "running"}"#).unwrap();
-        let result = value
-            .as_str()
-            .or_else(|| {
-                value
-                    .get("status")
-                    .and_then(Value::as_str)
-            })
-            .map(str::to_string);
-        assert_eq!(result, Some("running".to_string()));
+        assert_eq!(parse_status_value(&value), Some("running".to_string()));
     }
 
     #[test]
     fn status_returns_none_for_unexpected_shape() {
         let value: Value = serde_json::from_str(r#"{"other_key": "val"}"#).unwrap();
-        let result = value
-            .as_str()
-            .or_else(|| {
-                value
-                    .get("status")
-                    .and_then(Value::as_str)
-            })
-            .map(str::to_string);
-        assert_eq!(result, None);
+        assert_eq!(parse_status_value(&value), None);
     }
 }

--- a/tools/hindsight/src/verify/allium.rs
+++ b/tools/hindsight/src/verify/allium.rs
@@ -80,7 +80,11 @@ impl AlliumClient {
         let value = self.get(url).await?;
         value
             .as_str()
-            .or_else(|| value.get("status").and_then(Value::as_str))
+            .or_else(|| {
+                value
+                    .get("status")
+                    .and_then(Value::as_str)
+            })
             .map(str::to_string)
             .with_context(|| format!("unexpected Allium status response: {value}"))
     }
@@ -99,7 +103,8 @@ impl AlliumClient {
     }
 
     async fn post(&self, url: &str, body: &Value) -> anyhow::Result<Value> {
-        self.send(|| self.http.post(url).json(body)).await
+        self.send(|| self.http.post(url).json(body))
+            .await
     }
 
     async fn send<F>(&self, build: F) -> anyhow::Result<Value>
@@ -119,11 +124,17 @@ impl AlliumClient {
                 continue;
             }
             if !status.is_success() {
-                let body = response.text().await.unwrap_or_default();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_default();
                 bail!("Allium returned {status}: {body}");
             }
 
-            return response.json::<Value>().await.context("failed to decode Allium response");
+            return response
+                .json::<Value>()
+                .await
+                .context("failed to decode Allium response");
         }
         bail!("Allium rate limit: exhausted {MAX_RETRIES} retries")
     }
@@ -139,7 +150,11 @@ mod tests {
         let value: Value = serde_json::from_str("\"success\"").unwrap();
         let result = value
             .as_str()
-            .or_else(|| value.get("status").and_then(Value::as_str))
+            .or_else(|| {
+                value
+                    .get("status")
+                    .and_then(Value::as_str)
+            })
             .map(str::to_string);
         assert_eq!(result, Some("success".to_string()));
     }
@@ -150,7 +165,11 @@ mod tests {
         let value: Value = serde_json::from_str(r#"{"status": "running"}"#).unwrap();
         let result = value
             .as_str()
-            .or_else(|| value.get("status").and_then(Value::as_str))
+            .or_else(|| {
+                value
+                    .get("status")
+                    .and_then(Value::as_str)
+            })
             .map(str::to_string);
         assert_eq!(result, Some("running".to_string()));
     }
@@ -160,7 +179,11 @@ mod tests {
         let value: Value = serde_json::from_str(r#"{"other_key": "val"}"#).unwrap();
         let result = value
             .as_str()
-            .or_else(|| value.get("status").and_then(Value::as_str))
+            .or_else(|| {
+                value
+                    .get("status")
+                    .and_then(Value::as_str)
+            })
             .map(str::to_string);
         assert_eq!(result, None);
     }

--- a/tools/hindsight/src/verify/mod.rs
+++ b/tools/hindsight/src/verify/mod.rs
@@ -372,11 +372,7 @@ fn parse_addr(value: &str) -> Option<Address> {
 }
 
 fn normalize_amount(amount: U256, decimals: u8) -> f64 {
-    let raw: f64 = amount
-        .to_string()
-        .parse()
-        .unwrap_or(0.0);
-    raw / 10f64.powi(i32::from(decimals))
+    crate::usd::u256_to_f64(amount) / 10f64.powi(i32::from(decimals))
 }
 
 fn bps_diff(ours: f64, theirs: f64) -> f64 {

--- a/tools/hindsight/src/verify/mod.rs
+++ b/tools/hindsight/src/verify/mod.rs
@@ -63,6 +63,7 @@ pub(crate) struct VerifyReport {
 }
 
 impl VerifyReport {
+    #[expect(clippy::print_stdout)]
     pub(crate) fn print(&self) {
         let count = |status: Status| {
             self.comparisons

--- a/tools/hindsight/src/verify/mod.rs
+++ b/tools/hindsight/src/verify/mod.rs
@@ -1,3 +1,11 @@
+//! Decoder verification against Allium's `aggregator_trades` ground truth.
+//!
+//! The `verify` subcommand decodes a block locally, fetches the same block from Allium, and diffs
+//! the two sets of trades — reporting matches, token/solver/amount mismatches, and gaps in either
+//! direction. This is a development sanity check, not a production code path.
+
+pub(crate) mod allium;
+
 use std::collections::{HashMap, HashSet};
 
 use alloy::{
@@ -8,9 +16,9 @@ use alloy::{
 use anyhow::Context;
 use tracing::warn;
 
-use crate::decoder::{
-    allium::{AlliumClient, AlliumRow},
-    DecodedTrade, Decoder,
+use crate::{
+    decoder::{DecodedTrade, Decoder},
+    verify::allium::{AlliumClient, AlliumRow},
 };
 
 const NATIVE_DECIMALS: u8 = 18;
@@ -20,7 +28,7 @@ const DECIMALS_SELECTOR: [u8; 4] = [0x31, 0x3c, 0xe5, 0x67];
 /// Outcome of comparing one transaction's decode against Allium.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum Status {
+pub(crate) enum Status {
     Match,
     TokenMismatch,
     SolverMismatch,
@@ -43,19 +51,19 @@ impl Status {
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
-pub struct TxComparison {
-    pub tx_hash: TxHash,
-    pub status: Status,
-    pub detail: String,
+pub(crate) struct TxComparison {
+    pub(crate) tx_hash: TxHash,
+    pub(crate) status: Status,
+    pub(crate) detail: String,
 }
 
 #[derive(Debug, serde::Serialize)]
-pub struct VerifyReport {
-    pub comparisons: Vec<TxComparison>,
+pub(crate) struct VerifyReport {
+    pub(crate) comparisons: Vec<TxComparison>,
 }
 
 impl VerifyReport {
-    pub fn print(&self) {
+    pub(crate) fn print(&self) {
         let count = |status: Status| {
             self.comparisons
                 .iter()
@@ -66,7 +74,7 @@ impl VerifyReport {
         println!("  compared txs:          {}", self.comparisons.len());
         println!("  matches:               {}", count(Status::Match));
         println!("  token mismatches:      {}", count(Status::TokenMismatch));
-        println!("  solver mismatches: {}", count(Status::SolverMismatch));
+        println!("  solver mismatches:     {}", count(Status::SolverMismatch));
         println!("  amount mismatches:     {}", count(Status::AmountMismatch));
         println!("  ours only:             {}", count(Status::OursOnly));
         println!("  allium only (gaps):    {}", count(Status::AlliumOnly));
@@ -90,7 +98,7 @@ impl VerifyReport {
 }
 
 /// Decode each block locally and compare against Allium's `aggregator_trades`.
-pub async fn run<P: Provider>(
+pub(crate) async fn run<P: Provider>(
     decoder: &mut Decoder<P>,
     allium: &AlliumClient,
     blocks: &[u64],
@@ -110,15 +118,8 @@ pub async fn run<P: Provider>(
             .fetch_block(block)
             .await
             .with_context(|| format!("failed to fetch Allium trades for block {block}"))?;
-        compare_block(
-            decoder.provider(),
-            &ours,
-            &theirs,
-            tolerance_bps,
-            &mut decimals,
-            &mut comparisons,
-        )
-        .await;
+        compare_block(decoder.provider(), &ours, &theirs, tolerance_bps, &mut decimals, &mut comparisons)
+            .await;
     }
     Ok(VerifyReport { comparisons })
 }
@@ -131,10 +132,8 @@ async fn compare_block<P: Provider>(
     decimals: &mut HashMap<Address, u8>,
     out: &mut Vec<TxComparison>,
 ) {
-    let our_by_tx: HashMap<TxHash, &DecodedTrade> = ours
-        .iter()
-        .map(|t| (t.tx_hash, t))
-        .collect();
+    let our_by_tx: HashMap<TxHash, &DecodedTrade> =
+        ours.iter().map(|t| (t.tx_hash, t)).collect();
     let mut their_by_tx: HashMap<TxHash, Vec<&AlliumRow>> = HashMap::new();
     for row in theirs {
         let Some(tx) = row
@@ -145,10 +144,7 @@ async fn compare_block<P: Provider>(
             warn!(hash = ?row.transaction_hash, "skipping Allium row with unusable tx hash");
             continue;
         };
-        their_by_tx
-            .entry(tx)
-            .or_default()
-            .push(row);
+        their_by_tx.entry(tx).or_default().push(row);
     }
 
     for (tx, trade) in &our_by_tx {
@@ -189,7 +185,8 @@ async fn compare_trade<P: Provider>(
     let mut detail = Vec::new();
     let token_ok = tokens_agree(ours, rows, &mut detail);
     let solver_ok = solver_agrees(ours, rows, &mut detail);
-    let amount_ok = amounts_agree(provider, ours, rows, tolerance_bps, decimals, &mut detail).await;
+    let amount_ok =
+        amounts_agree(provider, ours, rows, tolerance_bps, decimals, &mut detail).await;
 
     let status = if !token_ok {
         Status::TokenMismatch
@@ -204,25 +201,14 @@ async fn compare_trade<P: Provider>(
     TxComparison { tx_hash: ours.tx_hash, status, detail: detail.join("; ") }
 }
 
-/// Allium splits a trade into per-leg rows. Treat the decode as agreeing if
-/// our netted input token appears among the sold tokens and our output token
-/// among the bought tokens.
 fn tokens_agree(ours: &DecodedTrade, rows: &[&AlliumRow], detail: &mut Vec<String>) -> bool {
     let sold: HashSet<Address> = rows
         .iter()
-        .filter_map(|r| {
-            r.token_sold_address
-                .as_deref()
-                .and_then(parse_addr)
-        })
+        .filter_map(|r| r.token_sold_address.as_deref().and_then(parse_addr))
         .collect();
     let bought: HashSet<Address> = rows
         .iter()
-        .filter_map(|r| {
-            r.token_bought_address
-                .as_deref()
-                .and_then(parse_addr)
-        })
+        .filter_map(|r| r.token_bought_address.as_deref().and_then(parse_addr))
         .collect();
 
     let in_ok = sold.contains(&ours.token_in);
@@ -243,10 +229,7 @@ fn solver_agrees(ours: &DecodedTrade, rows: &[&AlliumRow], detail: &mut Vec<Stri
         .filter_map(|r| r.project.as_deref())
         .any(|project| names_match(&ours_norm, &normalize_name(project)));
     if !agrees {
-        let projects: Vec<&str> = rows
-            .iter()
-            .filter_map(|r| r.project.as_deref())
-            .collect();
+        let projects: Vec<&str> = rows.iter().filter_map(|r| r.project.as_deref()).collect();
         detail.push(format!("solver {} vs Allium {projects:?}", ours.solver));
     }
     agrees
@@ -260,10 +243,6 @@ async fn amounts_agree<P: Provider>(
     decimals: &mut HashMap<Address, u8>,
     detail: &mut Vec<String>,
 ) -> bool {
-    // Allium records each leg of a split swap as its own row, so a single decoded trade can map to
-    // several Allium rows for the same tx. We net the whole swap into one in/out pair, which has no
-    // per-leg counterpart to compare against, so only compare amounts when Allium also reported a
-    // single leg.
     let [row] = rows else {
         detail.push(format!("amount not compared ({} Allium legs for this tx)", rows.len()));
         return true;
@@ -273,8 +252,12 @@ async fn amounts_agree<P: Provider>(
         return true;
     };
 
-    let in_leg =
-        AmountLeg { token: ours.token_in, ours: ours.amount_in, theirs: sold, field: "amount_in" };
+    let in_leg = AmountLeg {
+        token: ours.token_in,
+        ours: ours.amount_in,
+        theirs: sold,
+        field: "amount_in",
+    };
     let out_leg = AmountLeg {
         token: ours.token_out,
         ours: ours.amount_out,
@@ -287,7 +270,6 @@ async fn amounts_agree<P: Provider>(
     in_ok && out_ok
 }
 
-/// One side of a trade to compare: our decoded amount against Allium's.
 struct AmountLeg {
     token: Address,
     ours: U256,
@@ -303,7 +285,10 @@ async fn amount_within<P: Provider>(
     detail: &mut Vec<String>,
 ) -> bool {
     let Some(decimals) = token_decimals(provider, leg.token, cache).await else {
-        detail.push(format!("{} not compared (decimals unavailable for {})", leg.field, leg.token));
+        detail.push(format!(
+            "{} not compared (decimals unavailable for {})",
+            leg.field, leg.token
+        ));
         return true;
     };
     let normalized = normalize_amount(leg.ours, decimals);
@@ -351,8 +336,6 @@ async fn fetch_decimals<P: Provider>(provider: &P, token: Address) -> anyhow::Re
         .call(tx)
         .await
         .with_context(|| format!("decimals() call failed for {token}"))?;
-    // decimals() returns uint8 right-aligned in a 32-byte word: the value is
-    // the last byte.
     result
         .last()
         .copied()
@@ -364,10 +347,7 @@ fn parse_addr(value: &str) -> Option<Address> {
 }
 
 fn normalize_amount(amount: U256, decimals: u8) -> f64 {
-    let raw: f64 = amount
-        .to_string()
-        .parse()
-        .unwrap_or(0.0);
+    let raw: f64 = amount.to_string().parse().unwrap_or(0.0);
     raw / 10f64.powi(i32::from(decimals))
 }
 
@@ -378,8 +358,6 @@ fn bps_diff(ours: f64, theirs: f64) -> f64 {
     ((ours - theirs).abs() / theirs) * 10_000.0
 }
 
-/// Lowercase, strip non-alphanumerics, and fold venue aliases so `uniswap_x`
-/// and `uniswap`, `1inch` and `1inch_ar_v6`, or `0x` and `zeroex` compare equal.
 fn normalize_name(name: &str) -> String {
     let normalized: String = name
         .chars()
@@ -398,8 +376,16 @@ fn names_match(a: &str, b: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::U256;
+
     use super::*;
-    use crate::decoder::{test_utils::addr, AttributionSource};
+    use crate::decoder::AttributionSource;
+
+    fn addr(n: u8) -> Address {
+        let mut bytes = [0u8; 20];
+        bytes[19] = n;
+        Address::from(bytes)
+    }
 
     fn trade(token_in: Address, token_out: Address, solver: &str) -> DecodedTrade {
         DecodedTrade {

--- a/tools/hindsight/src/verify/mod.rs
+++ b/tools/hindsight/src/verify/mod.rs
@@ -119,8 +119,15 @@ pub(crate) async fn run<P: Provider>(
             .fetch_block(block)
             .await
             .with_context(|| format!("failed to fetch Allium trades for block {block}"))?;
-        compare_block(decoder.provider(), &ours, &theirs, tolerance_bps, &mut decimals, &mut comparisons)
-            .await;
+        compare_block(
+            decoder.provider(),
+            &ours,
+            &theirs,
+            tolerance_bps,
+            &mut decimals,
+            &mut comparisons,
+        )
+        .await;
     }
     Ok(VerifyReport { comparisons })
 }
@@ -133,8 +140,10 @@ async fn compare_block<P: Provider>(
     decimals: &mut HashMap<Address, u8>,
     out: &mut Vec<TxComparison>,
 ) {
-    let our_by_tx: HashMap<TxHash, &DecodedTrade> =
-        ours.iter().map(|t| (t.tx_hash, t)).collect();
+    let our_by_tx: HashMap<TxHash, &DecodedTrade> = ours
+        .iter()
+        .map(|t| (t.tx_hash, t))
+        .collect();
     let mut their_by_tx: HashMap<TxHash, Vec<&AlliumRow>> = HashMap::new();
     for row in theirs {
         let Some(tx) = row
@@ -145,7 +154,10 @@ async fn compare_block<P: Provider>(
             warn!(hash = ?row.transaction_hash, "skipping Allium row with unusable tx hash");
             continue;
         };
-        their_by_tx.entry(tx).or_default().push(row);
+        their_by_tx
+            .entry(tx)
+            .or_default()
+            .push(row);
     }
 
     for (tx, trade) in &our_by_tx {
@@ -186,8 +198,7 @@ async fn compare_trade<P: Provider>(
     let mut detail = Vec::new();
     let token_ok = tokens_agree(ours, rows, &mut detail);
     let solver_ok = solver_agrees(ours, rows, &mut detail);
-    let amount_ok =
-        amounts_agree(provider, ours, rows, tolerance_bps, decimals, &mut detail).await;
+    let amount_ok = amounts_agree(provider, ours, rows, tolerance_bps, decimals, &mut detail).await;
 
     let status = if !token_ok {
         Status::TokenMismatch
@@ -205,11 +216,19 @@ async fn compare_trade<P: Provider>(
 fn tokens_agree(ours: &DecodedTrade, rows: &[&AlliumRow], detail: &mut Vec<String>) -> bool {
     let sold: HashSet<Address> = rows
         .iter()
-        .filter_map(|r| r.token_sold_address.as_deref().and_then(parse_addr))
+        .filter_map(|r| {
+            r.token_sold_address
+                .as_deref()
+                .and_then(parse_addr)
+        })
         .collect();
     let bought: HashSet<Address> = rows
         .iter()
-        .filter_map(|r| r.token_bought_address.as_deref().and_then(parse_addr))
+        .filter_map(|r| {
+            r.token_bought_address
+                .as_deref()
+                .and_then(parse_addr)
+        })
         .collect();
 
     let in_ok = sold.contains(&ours.token_in);
@@ -230,7 +249,10 @@ fn solver_agrees(ours: &DecodedTrade, rows: &[&AlliumRow], detail: &mut Vec<Stri
         .filter_map(|r| r.project.as_deref())
         .any(|project| names_match(&ours_norm, &normalize_name(project)));
     if !agrees {
-        let projects: Vec<&str> = rows.iter().filter_map(|r| r.project.as_deref()).collect();
+        let projects: Vec<&str> = rows
+            .iter()
+            .filter_map(|r| r.project.as_deref())
+            .collect();
         detail.push(format!("solver {} vs Allium {projects:?}", ours.solver));
     }
     agrees
@@ -253,12 +275,8 @@ async fn amounts_agree<P: Provider>(
         return true;
     };
 
-    let in_leg = AmountLeg {
-        token: ours.token_in,
-        ours: ours.amount_in,
-        theirs: sold,
-        field: "amount_in",
-    };
+    let in_leg =
+        AmountLeg { token: ours.token_in, ours: ours.amount_in, theirs: sold, field: "amount_in" };
     let out_leg = AmountLeg {
         token: ours.token_out,
         ours: ours.amount_out,
@@ -286,10 +304,7 @@ async fn amount_within<P: Provider>(
     detail: &mut Vec<String>,
 ) -> bool {
     let Some(decimals) = token_decimals(provider, leg.token, cache).await else {
-        detail.push(format!(
-            "{} not compared (decimals unavailable for {})",
-            leg.field, leg.token
-        ));
+        detail.push(format!("{} not compared (decimals unavailable for {})", leg.field, leg.token));
         return true;
     };
     let normalized = normalize_amount(leg.ours, decimals);
@@ -348,7 +363,10 @@ fn parse_addr(value: &str) -> Option<Address> {
 }
 
 fn normalize_amount(amount: U256, decimals: u8) -> f64 {
-    let raw: f64 = amount.to_string().parse().unwrap_or(0.0);
+    let raw: f64 = amount
+        .to_string()
+        .parse()
+        .unwrap_or(0.0);
     raw / 10f64.powi(i32::from(decimals))
 }
 

--- a/tools/hindsight/src/verify/mod.rs
+++ b/tools/hindsight/src/verify/mod.rs
@@ -391,7 +391,7 @@ mod tests {
         DecodedTrade {
             tx_hash: TxHash::ZERO,
             block_number: 1,
-            client: "relay".to_string(),
+            venue: "relay".to_string(),
             solver: solver.to_string(),
             solver_source: AttributionSource::TraceMatch,
             sender: addr(1),
@@ -399,8 +399,8 @@ mod tests {
             token_out,
             amount_in: U256::from(1000),
             amount_out: U256::from(2000),
-            client_fee: None,
-            client_fee_out: None,
+            venue_fee: None,
+            venue_fee_out: None,
             settled_gas: None,
             quote: None,
         }

--- a/tools/hindsight/src/verify/mod.rs
+++ b/tools/hindsight/src/verify/mod.rs
@@ -213,6 +213,9 @@ async fn compare_trade<P: Provider>(
     TxComparison { tx_hash: ours.tx_hash, status, detail: detail.join("; ") }
 }
 
+/// Allium splits a multi-leg swap into per-leg rows, so check membership in sets rather than
+/// exact one-to-one matching: our netted `token_in` must appear among the sold tokens and our
+/// `token_out` among the bought tokens across all rows for this tx.
 fn tokens_agree(ours: &DecodedTrade, rows: &[&AlliumRow], detail: &mut Vec<String>) -> bool {
     let sold: HashSet<Address> = rows
         .iter()
@@ -266,6 +269,9 @@ async fn amounts_agree<P: Provider>(
     decimals: &mut HashMap<Address, u8>,
     detail: &mut Vec<String>,
 ) -> bool {
+    // Allium records each leg of a multi-leg swap as its own row. We net the whole swap into one
+    // in/out pair, which has no per-leg counterpart to compare against — only compare amounts when
+    // Allium also reported a single leg.
     let [row] = rows else {
         detail.push(format!("amount not compared ({} Allium legs for this tx)", rows.len()));
         return true;
@@ -289,6 +295,8 @@ async fn amounts_agree<P: Provider>(
     in_ok && out_ok
 }
 
+/// One side of a decoded trade to compare: our on-chain amount (raw integer) vs Allium's
+/// human-readable float, which must be normalized to the same decimal scale before comparison.
 struct AmountLeg {
     token: Address,
     ours: U256,
@@ -352,6 +360,7 @@ async fn fetch_decimals<P: Provider>(provider: &P, token: Address) -> anyhow::Re
         .call(tx)
         .await
         .with_context(|| format!("decimals() call failed for {token}"))?;
+    // decimals() returns uint8 right-aligned in a 32-byte ABI word; the value is the last byte.
     result
         .last()
         .copied()
@@ -377,6 +386,8 @@ fn bps_diff(ours: f64, theirs: f64) -> f64 {
     ((ours - theirs).abs() / theirs) * 10_000.0
 }
 
+/// Lowercase and strip non-alphanumerics, then fold known aliases: `zeroex` → `0x`, so that
+/// e.g. `uniswap_x`/`uniswap`, `1inch`/`1inch_ar_v6`, and `0x`/`zeroex` compare equal.
 fn normalize_name(name: &str) -> String {
     let normalized: String = name
         .chars()


### PR DESCRIPTION
  Refactor and clean up of tools/hindsight:

  - Renamed client → venue throughout — the old name was ambiguous; "venue" matches what the field actually represents
  (tx.to, the order-flow owner where a user initiated their swap).
  - Moved Allium + verify logic to `src/verify/` — was scattered inline; now has a proper module boundary.
  - Added clippy lint config (`[lints.clippy]`) with pedantic + anti-panic lints.
  - Replaced `u256_to_f64` string round-trip with a limb-based conversion — clearly documented assumptions made to avoid throwing errors.
  - Added outcome label to hindsight_savings_bps histogram, enabling histogram_quantile median queries split by win/loss on the dashboard.