### PR TITLE
feat: expose Fynd version via /v1/info and build_info metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3351,6 +3351,7 @@ dependencies = [
  "fynd-core",
  "fynd-rpc",
  "hex",
+ "metrics",
  "metrics-exporter-prometheus",
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = ["metrics"]
 # Enables the Prometheus metrics exporter on a separate HTTP server.
 # Disable with `--no-default-features` to omit Actix-Web and the Prometheus
 # recorder from the binary (e.g. for embedded/minimal builds).
-metrics = ["dep:actix-web", "dep:metrics-exporter-prometheus"]
+metrics = ["dep:actix-web", "dep:metrics-exporter-prometheus", "dep:metrics"]
 
 [dependencies]
 fynd-rpc = { workspace = true }
@@ -39,6 +39,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+metrics = { workspace = true, optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
 
 # Serialization (for OpenAPI spec output)

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.75.1"
+    "version": "0.89.2"
   },
   "paths": {
     "/v1/health": {
@@ -387,6 +387,11 @@
             "type": "string",
             "description": "Address of the Tycho Router contract on this chain.",
             "example": "0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35"
+          },
+          "version": {
+            "type": "string",
+            "description": "Fynd binary version (Cargo package version, e.g. \"0.89.1\").\n\nDefaults to empty when absent so newer clients tolerate older servers that predate it.",
+            "example": "0.89.1"
           }
         }
       },

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -369,7 +369,12 @@ impl TryFrom<fynd_rpc_types::InstanceInfo> for crate::types::InstanceInfo {
                 permit2.len()
             )));
         }
-        Ok(crate::types::InstanceInfo::new(router, permit2, dto.chain_id()))
+        Ok(crate::types::InstanceInfo::new(
+            router,
+            permit2,
+            dto.chain_id(),
+            dto.version().to_string(),
+        ))
     }
 }
 
@@ -442,6 +447,27 @@ mod tests {
         }"#,
         )
         .expect("valid order quote JSON")
+    }
+
+    // -----------------------------------------------------------------------
+    // InstanceInfo conversion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn instance_info_maps_version() {
+        let dto: fynd_rpc_types::InstanceInfo = serde_json::from_str(
+            r#"{
+            "version": "9.9.9",
+            "chain_id": 1,
+            "router_address": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "permit2_address": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }"#,
+        )
+        .expect("valid instance info JSON");
+
+        let mapped: crate::types::InstanceInfo = dto.try_into().expect("maps");
+        assert_eq!(mapped.version(), "9.9.9");
+        assert_eq!(mapped.chain_id(), 1);
     }
 
     // -----------------------------------------------------------------------

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -1013,6 +1013,8 @@ pub struct InstanceInfo {
     permit2_address: bytes::Bytes,
     /// Chain ID of the network this instance is deployed on.
     chain_id: u64,
+    /// Fynd binary version reported by the server.
+    version: String,
 }
 
 impl InstanceInfo {
@@ -1020,8 +1022,9 @@ impl InstanceInfo {
         router_address: bytes::Bytes,
         permit2_address: bytes::Bytes,
         chain_id: u64,
+        version: String,
     ) -> Self {
-        Self { router_address, permit2_address, chain_id }
+        Self { router_address, permit2_address, chain_id, version }
     }
 
     /// Router contract address (20 raw bytes).
@@ -1037,6 +1040,11 @@ impl InstanceInfo {
     /// Chain ID of the network this instance is deployed on.
     pub fn chain_id(&self) -> u64 {
         self.chain_id
+    }
+
+    /// Fynd binary version reported by the server.
+    pub fn version(&self) -> &str {
+        &self.version
     }
 }
 

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -247,6 +247,13 @@ export interface components {
              * @example 0xfD0b31d2E955fA55e3fa641Fe90e08b677188d35
              */
             router_address: string;
+            /**
+             * @description Fynd binary version (Cargo package version, e.g. "0.89.1").
+             *
+             *     Defaults to empty when absent so newer clients tolerate older servers that predate it.
+             * @example 0.89.1
+             */
+            version?: string;
         };
         /**
          * @description A single swap order to be solved.

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1197,6 +1197,7 @@ impl HealthStatus {
 /// Static metadata about this Fynd instance, returned by `GET /v1/info`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
+#[non_exhaustive]
 pub struct InstanceInfo {
     /// EIP-155 chain ID (e.g. 1 for Ethereum mainnet).
     #[cfg_attr(feature = "openapi", schema(example = 1))]
@@ -1213,12 +1214,22 @@ pub struct InstanceInfo {
         schema(value_type = String, example = "0x000000000022D473030F116dDEE9F6B43aC78BA3")
     )]
     permit2_address: Bytes,
+    /// Fynd binary version (Cargo package version, e.g. "0.89.1").
+    ///
+    /// Defaults to empty when absent so newer clients tolerate older servers that predate it.
+    #[serde(default)]
+    #[cfg_attr(feature = "openapi", schema(example = "0.89.1"))]
+    version: String,
 }
 
 impl InstanceInfo {
-    /// Creates a new instance info.
-    pub fn new(chain_id: u64, router_address: Bytes, permit2_address: Bytes) -> Self {
-        Self { chain_id, router_address, permit2_address }
+    /// Starts building an instance info from the required immutable fields.
+    pub fn builder(
+        chain_id: u64,
+        router_address: Bytes,
+        permit2_address: Bytes,
+    ) -> InstanceInfoBuilder {
+        InstanceInfoBuilder { chain_id, router_address, permit2_address, version: String::new() }
     }
 
     /// EIP-155 chain ID.
@@ -1234,6 +1245,38 @@ impl InstanceInfo {
     /// Address of the canonical Permit2 contract.
     pub fn permit2_address(&self) -> &Bytes {
         &self.permit2_address
+    }
+
+    /// Fynd binary version.
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+/// Builder for [`InstanceInfo`]. Keeps future `/v1/info` fields cheap to add.
+#[derive(Debug, Clone)]
+pub struct InstanceInfoBuilder {
+    chain_id: u64,
+    router_address: Bytes,
+    permit2_address: Bytes,
+    version: String,
+}
+
+impl InstanceInfoBuilder {
+    /// Sets the Fynd binary version.
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.version = version.into();
+        self
+    }
+
+    /// Finalizes into an [`InstanceInfo`].
+    pub fn build(self) -> InstanceInfo {
+        InstanceInfo {
+            chain_id: self.chain_id,
+            router_address: self.router_address,
+            permit2_address: self.permit2_address,
+            version: self.version,
+        }
     }
 }
 
@@ -1487,6 +1530,7 @@ mod wire_format_tests {
     #[test]
     fn instance_info_deserializes_and_ignores_unknown_fields() {
         let json = r#"{
+            "version": "1.2.3",
             "chain_id": 1,
             "router_address": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "permit2_address": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -1494,9 +1538,36 @@ mod wire_format_tests {
         }"#;
 
         let info: InstanceInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.version(), "1.2.3");
         assert_eq!(info.chain_id(), 1);
         assert_eq!(info.router_address().as_ref(), [0xAAu8; 20]);
         assert_eq!(info.permit2_address().as_ref(), [0xBBu8; 20]);
+    }
+
+    #[test]
+    fn instance_info_builder_sets_fields() {
+        let info = InstanceInfo::builder(1, Bytes::from([0xAAu8; 20]), Bytes::from([0xBBu8; 20]))
+            .version("0.1.0")
+            .build();
+
+        assert_eq!(info.version(), "0.1.0");
+        assert_eq!(info.chain_id(), 1);
+        assert_eq!(info.router_address().as_ref(), [0xAAu8; 20]);
+        assert_eq!(info.permit2_address().as_ref(), [0xBBu8; 20]);
+    }
+
+    #[test]
+    fn instance_info_deserializes_without_version() {
+        // A new client talking to an older server (no `version` field) must still deserialize.
+        let json = r#"{
+            "chain_id": 1,
+            "router_address": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "permit2_address": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }"#;
+
+        let info: InstanceInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.version(), "");
+        assert_eq!(info.chain_id(), 1);
     }
 }
 

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1195,13 +1195,14 @@ impl HealthStatus {
 }
 
 /// Static metadata about this Fynd instance, returned by `GET /v1/info`.
-///
-/// `/v1/info` is a public wire contract. When extending this type: add the field with
-/// `#[serde(default)]` and a builder setter — additive, so older clients ignore it and newer
-/// clients still deserialize responses from older servers. Never rename, remove, or retype an
-/// existing field: that breaks the contract. Every shape change is surfaced by the OpenAPI/TS
-/// drift check (regenerate via `./scripts/update-openapi.sh`) and the semver gate, so it cannot
-/// merge unnoticed.
+//
+// Dev note (source-only, deliberately not a doc comment so it stays out of the wire schema):
+// `/v1/info` is a public wire contract. When extending this type, add the field with
+// `#[serde(default)]` and a builder setter — additive, so older clients ignore it and newer
+// clients still deserialize responses from older servers. Never rename, remove, or retype an
+// existing field: that breaks the contract. Every shape change is surfaced by the OpenAPI/TS
+// drift check (regenerate via `./scripts/update-openapi.sh`) and the semver gate, so it cannot
+// merge unnoticed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[non_exhaustive]

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -1195,6 +1195,13 @@ impl HealthStatus {
 }
 
 /// Static metadata about this Fynd instance, returned by `GET /v1/info`.
+///
+/// `/v1/info` is a public wire contract. When extending this type: add the field with
+/// `#[serde(default)]` and a builder setter — additive, so older clients ignore it and newer
+/// clients still deserialize responses from older servers. Never rename, remove, or retype an
+/// existing field: that breaks the contract. Every shape change is surfaced by the OpenAPI/TS
+/// drift check (regenerate via `./scripts/update-openapi.sh`) and the semver gate, so it cannot
+/// merge unnoticed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 #[non_exhaustive]

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -141,11 +141,13 @@ pub(crate) async fn health(state: web::Data<AppState>) -> HttpResponse {
     )
 )]
 pub(crate) async fn info(state: web::Data<AppState>) -> HttpResponse {
-    let body = dto::InstanceInfo::new(
+    let body = dto::InstanceInfo::builder(
         state.chain_id(),
         state.router_address().clone().into(),
         state.permit2_address().clone().into(),
-    );
+    )
+    .version(env!("CARGO_PKG_VERSION"))
+    .build();
     HttpResponse::Ok().json(body)
 }
 
@@ -592,5 +594,23 @@ mod tests {
             addr.contains("fd0b31d2e955fa55e3fa641fe90e08b677188d35"),
             "expected Ethereum Tycho Router address, got {addr}"
         );
+    }
+
+    #[actix_web::test]
+    async fn test_info_response_includes_version() {
+        let state = make_test_state();
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .route("/v1/info", web::get().to(super::info)),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/v1/info")
+            .to_request();
+        let body: serde_json::Value = test::call_and_read_body_json(&app, req).await;
+
+        assert_eq!(body["version"], env!("CARGO_PKG_VERSION"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,6 +160,8 @@ fn create_metrics_exporter(port: u16) -> tokio::task::JoinHandle<()> {
         .install_recorder()
         .expect("Failed to install Prometheus recorder");
 
+    record_build_info();
+
     tokio::spawn(async move {
         async fn metrics_handler(handle: PrometheusHandle) -> impl Responder {
             let metrics = handle.render();
@@ -185,6 +187,17 @@ fn create_metrics_exporter(port: u16) -> tokio::task::JoinHandle<()> {
             error!("Metrics server failed: {}", e);
         }
     })
+}
+
+/// Records a constant-1 gauge labelled with the Fynd binary version, so operators can see which
+/// build a running instance is on. The value carries no meaning; the version lives in the label.
+#[cfg(feature = "metrics")]
+fn record_build_info() {
+    metrics::describe_gauge!(
+        "fynd_build_info",
+        "Fynd build information exposed as a constant-1 gauge labelled by version."
+    );
+    metrics::gauge!("fynd_build_info", "version" => env!("CARGO_PKG_VERSION")).set(1.0);
 }
 
 /// Resolves the Tycho WebSocket URL: uses the override if provided, otherwise looks up the
@@ -369,4 +382,24 @@ async fn run_solver(args: cli::ServeArgs) -> Result<(), SolverError> {
         let _ = provider.shutdown();
     }
     Ok(())
+}
+
+#[cfg(all(test, feature = "metrics"))]
+mod tests {
+    use metrics_exporter_prometheus::PrometheusBuilder;
+
+    #[test]
+    fn record_build_info_emits_versioned_gauge() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, super::record_build_info);
+        let rendered = handle.render();
+        assert!(
+            rendered.contains(&format!(
+                "fynd_build_info{{version=\"{}\"}} 1",
+                env!("CARGO_PKG_VERSION")
+            )),
+            "unexpected metrics output:\n{rendered}"
+        );
+    }
 }


### PR DESCRIPTION
Implements ENG-6178 (Fynd Auto tech doc §3, steps F1 + F2): makes the Fynd binary version observable. Both changes are additive and backward-compatible.

## Changes

**`/v1/info` version (F1)**
- `InstanceInfo` gains a `version` field (populated from `CARGO_PKG_VERSION` in the `/v1/info` handler). It is `#[serde(default)]`, so a newer client tolerates an older server that predates the field.
- `InstanceInfo` moves from a positional `new(...)` to a builder and is marked `#[non_exhaustive]`, so future instance-metadata fields don't churn call sites.
- The Rust client's `InstanceInfo` and its mapping carry `version` through, so `FyndClient::info()` surfaces it.
- Regenerated `clients/openapi.json` and the TypeScript schema.

**`fynd_build_info` metric (F2)**
- Emits `fynd_build_info{version="x.y.z"} 1` on `/metrics` at startup, behind the `metrics` feature.

## Verification
- Full CI (format, clippy, doc, nextest, OpenAPI/TS drift) passes locally.
- `/v1/info` returns `version`; `/metrics` exposes `fynd_build_info` with the version label.
