### PR TITLE
refactor(hindsight): move chain and protocol knowledge into the address book

### DIFF
--- a/tools/hindsight/src/decoder/intent.rs
+++ b/tools/hindsight/src/decoder/intent.rs
@@ -18,13 +18,12 @@ use crate::decoder::{
 /// Find the order maker's trade in a filler-initiated intent fill.
 ///
 /// The transaction sender is the filler, not the swapper, so we look for the
-/// externally-owned account whose net flow is a clean two-token swap. Pools
-/// and routers net the inverse swap or residue dust but carry code, so
-/// contracts (via `eth_getCode`) never qualify — a fill with no clean-net EOA
-/// is declined rather than guessed: a routing intermediary's leftover dust
-/// nets as an absurd "swap" (seen live as a WETH → 2.4e-7 AAVE decode).
-/// Known registry contracts and the excluded addresses (filler, entry point)
-/// never qualify either.
+/// externally-owned account whose net flow is a clean two-token swap. Contracts
+/// never qualify (checked via `eth_getCode`): pools and routers net the inverse
+/// swap or leftover dust, and recording an intermediary's dust as the trade
+/// produces absurd "swaps" (seen live: WETH → 2.4e-7 AAVE). Known registry
+/// contracts and the excluded addresses (filler, entry point) are skipped too.
+/// A fill with no clean-net EOA is declined rather than guessed.
 ///
 /// v0 limitations (tracked for a decode/attribution rework):
 /// - **One maker per transaction.** The first clean-net EOA wins, so a batch that settles several

--- a/tools/hindsight/src/decoder/ledger.rs
+++ b/tools/hindsight/src/decoder/ledger.rs
@@ -13,10 +13,10 @@
 //! sent and received per token, subtract, and require **exactly one token net-out and one token
 //! net-in**. Intermediate hops (multi-hop routes, wrap/unwrap legs) net to zero on their own, so
 //! they disappear without being modeled. The strict one-in/one-out rule is what keeps the
-//! re-solve comparison honest: a net with more tokens on a side is a batch settlement or an
-//! unmodeled shape, and amounts across tokens are not comparable, so guessing a "dominant" leg
-//! would pair unrelated tokens. Ambiguous nets are declined, with one provable exception —
-//! see [`TransferLedger::net_swap`] on residue legs.
+//! re-solve comparison honest. A net with more tokens on a side is a batch settlement or a
+//! shape this model doesn't cover, and guessing a "dominant" leg there would pair unrelated
+//! tokens — so ambiguous nets are declined, with one provable exception (residue legs, see
+//! [`TransferLedger::net_swap`]).
 //!
 //! # Assumptions
 //!
@@ -148,7 +148,7 @@ impl TransferLedger {
     }
 
     /// Gross total received per token by any of `recipients` (native ETH keyed by
-    /// [`Address::ZERO`]). Used for client-fee accounting: what reached the fee collectors,
+    /// [`Address::ZERO`]). Used for venue-fee accounting: what reached the fee collectors,
     /// regardless of sender.
     pub(crate) fn received_by(&self, recipients: &HashSet<Address>) -> HashMap<Address, U256> {
         let mut totals: HashMap<Address, U256> = HashMap::new();

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -68,9 +68,9 @@ pub(crate) struct DecodedTrade {
     pub token_in: Address,
     pub token_out: Address,
     /// Input amount that actually entered the swap — a venue fee skimmed from the input (see
-    /// [`venue_fee`]) is already subtracted, so a re-solve compares like-for-like.
+    /// `venue_fee`) is already subtracted, so a re-solve compares like-for-like.
     pub amount_in: U256,
-    /// Gross swap output — a venue fee skimmed from the output (see [`venue_fee_out`]) is added
+    /// Gross swap output — a venue fee skimmed from the output (see `venue_fee_out`) is added
     /// back, so the settled amount is the full swap proceeds, comparable to Fynd's gross output.
     pub amount_out: U256,
     /// Venue fee skimmed from the input token before swapping (e.g. Relay's fee), in `token_in`

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -26,6 +26,7 @@ const ETHEREUM_TOML: &str = include_str!("registry/ethereum.toml");
 #[serde(deny_unknown_fields)]
 struct AddressBook {
     wrapped_native: Address,
+    usd_stablecoins: HashMap<Address, u32>,
     batch_settlers: HashSet<Address>,
     solvers: HashMap<Address, String>,
     venues: HashMap<String, VenueAddresses>,
@@ -62,6 +63,9 @@ pub(crate) struct Registry {
     /// The chain's wrapped-native token (e.g. WETH), which appears in flows
     /// only as a wrap/unwrap intermediary.
     wrapped_native: Address,
+    /// `(stablecoin, decimals)` anchors for valuing trades in USD (see `crate::usd`), sorted by
+    /// address for deterministic averaging.
+    usd_stablecoins: Vec<(Address, u32)>,
     /// Venue address sets, keyed by the venue name from the book.
     venues: HashMap<String, VenueAddresses>,
 }
@@ -113,6 +117,11 @@ impl Registry {
             }
         }
         let solver_names = book.solvers.values().cloned().collect();
+        let mut usd_stablecoins: Vec<(Address, u32)> = book
+            .usd_stablecoins
+            .into_iter()
+            .collect();
+        usd_stablecoins.sort_unstable();
 
         Ok(Self {
             solver_names,
@@ -121,6 +130,7 @@ impl Registry {
             batch_settlers: book.batch_settlers,
             labels: book.labels,
             wrapped_native: book.wrapped_native,
+            usd_stablecoins,
             venues: book.venues,
         })
     }
@@ -151,6 +161,11 @@ impl Registry {
 
     pub(crate) fn wrapped_native(&self) -> Address {
         self.wrapped_native
+    }
+
+    /// The chain's `(stablecoin, decimals)` anchors for USD valuation.
+    pub(crate) fn stablecoin_anchors(&self) -> &[(Address, u32)] {
+        &self.usd_stablecoins
     }
 
     /// The named venue's address book section, when the book has one.

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -1,9 +1,9 @@
 //! The decoder's address book: which contracts are solvers, venues, batch settlers, and
 //! venue infrastructure on one chain.
 //!
-//! The data is pure configuration and lives in TOML — the built-in Ethereum book is embedded
-//! from `registry/ethereum.toml`; `--registry <path>` loads a modified or per-chain book without
-//! recompiling. This module only holds the lookups the decode strategies ask
+//! The data is pure configuration and lives in TOML — the built-in Ethereum address book is
+//! embedded from `registry/ethereum.toml`; `--registry <path>` loads a modified or per-chain
+//! address book without recompiling. This module only holds the lookups the decode strategies ask
 //! ([`Registry::is_solver`], [`Registry::is_batch_settler`], [`Registry::label`], …).
 
 use std::{
@@ -34,9 +34,9 @@ struct AddressBook {
     labels: HashMap<Address, String>,
 }
 
-/// A venue's book section on one chain: the contracts users enter through, the collectors its
-/// fee skims land on, and its calldata solver vocabulary. Keyed by venue name in the book; the
-/// name binds to a decode strategy at load time (see
+/// A venue's address-book section on one chain: the contracts users enter through, the
+/// collectors its fee skims land on, and its calldata solver vocabulary. Keyed by venue name in
+/// the address book; the name binds to a decode strategy at load time (see
 /// [`crate::decoder::venues::Venue::from_name`]).
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -44,18 +44,18 @@ pub(crate) struct VenueAddresses {
     pub(crate) entry_points: HashSet<Address>,
     pub(crate) fee_collectors: HashSet<Address>,
     /// Lowercase substrings of the venue's calldata solver ids, mapped to the solver name used
-    /// in this book. Ordered for deterministic matching; empty for venues that declare no
-    /// solver in calldata.
+    /// in the address book. Ordered for deterministic matching; empty for venues that declare
+    /// no solver in calldata.
     #[serde(default)]
     solver_aliases: BTreeMap<String, String>,
 }
 
 impl VenueAddresses {
-    /// Normalize a solver id this venue declared in calldata to the book's solver vocabulary:
-    /// the first alias needle (in alias order) contained in the lowercased id names the solver,
-    /// trimming the venue's id decoration ("oneInchV6FeeDynamic" → "1inch") — not a 1:1 rename.
-    /// Unmatched ids pass through as-is: still more informative than a raw executor address,
-    /// and a signal to extend the book.
+    /// Normalize a solver id this venue declared in calldata to the address book's solver
+    /// vocabulary: the first alias needle (in alias order) contained in the lowercased id names
+    /// the solver, trimming the venue's id decoration ("oneInchV6FeeDynamic" → "1inch") — not a
+    /// 1:1 rename. Unmatched ids pass through as-is: still more informative than a raw executor
+    /// address, and a signal to extend the address book.
     pub(crate) fn normalize_solver(&self, id: &str) -> String {
         let lower = id.to_lowercase();
         for (needle, name) in &self.solver_aliases {
@@ -93,7 +93,7 @@ pub(crate) struct Registry {
     /// `(stablecoin, decimals)` anchors for valuing trades in USD (see `crate::usd`), sorted by
     /// address for deterministic averaging.
     usd_stablecoins: Vec<(Address, u32)>,
-    /// Venue address sets, keyed by the venue name from the book.
+    /// Venue address sets, keyed by the venue name from the address book.
     venues: HashMap<String, VenueAddresses>,
 }
 
@@ -149,8 +149,8 @@ impl Registry {
             .into_iter()
             .collect();
         usd_stablecoins.sort_unstable();
-        // Alias needles match against lowercased ids, so a mixed-case needle in the book would
-        // silently never match — canonicalize at load.
+        // Alias needles match against lowercased ids, so a mixed-case needle in the address
+        // book would silently never match — canonicalize at load.
         for venue in book.venues.values_mut() {
             venue.solver_aliases = std::mem::take(&mut venue.solver_aliases)
                 .into_iter()
@@ -315,8 +315,8 @@ mod tests {
 
     #[test]
     fn mixed_case_alias_needle_still_matches() {
-        // Needles are canonicalized to lowercase at load, so a capitalized needle in the book
-        // matches the same ids as a lowercase one.
+        // Needles are canonicalized to lowercase at load, so a capitalized needle in the
+        // address book matches the same ids as a lowercase one.
         let book = ETHEREUM_TOML.replace(
             "[venues.metamask.solver_aliases]",
             "[venues.metamask.solver_aliases]\nBeBop = \"bebop\"",
@@ -369,7 +369,7 @@ mod tests {
     #[test]
     fn venue_without_strategy_is_rejected() {
         // A venue section whose name has no decode strategy would silently never match, so the
-        // book must fail to load.
+        // address book must fail to load.
         let text =
             format!("{ETHEREUM_TOML}\n[venues.reiay]\nentry_points = []\nfee_collectors = []\n");
         let err = Registry::from_toml(&text)

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -26,6 +26,7 @@ const ETHEREUM_TOML: &str = include_str!("registry/ethereum.toml");
 #[serde(deny_unknown_fields)]
 struct AddressBook {
     wrapped_native: Address,
+    infrastructure: HashSet<Address>,
     usd_stablecoins: HashMap<Address, u32>,
     batch_settlers: HashSet<Address>,
     solvers: HashMap<Address, String>,
@@ -63,6 +64,9 @@ pub(crate) struct Registry {
     /// The chain's wrapped-native token (e.g. WETH), which appears in flows
     /// only as a wrap/unwrap intermediary.
     wrapped_native: Address,
+    /// Token-movement infrastructure (e.g. Permit2): contracts traces touch on most swaps
+    /// without ever being the settling venue.
+    infrastructure: HashSet<Address>,
     /// `(stablecoin, decimals)` anchors for valuing trades in USD (see `crate::usd`), sorted by
     /// address for deterministic averaging.
     usd_stablecoins: Vec<(Address, u32)>,
@@ -130,6 +134,7 @@ impl Registry {
             batch_settlers: book.batch_settlers,
             labels: book.labels,
             wrapped_native: book.wrapped_native,
+            infrastructure: book.infrastructure,
             usd_stablecoins,
             venues: book.venues,
         })
@@ -161,6 +166,13 @@ impl Registry {
 
     pub(crate) fn wrapped_native(&self) -> Address {
         self.wrapped_native
+    }
+
+    /// Whether the address is token-movement infrastructure (Permit2, the wrapped-native
+    /// token): contracts a trace touches on most swaps without ever being the settling venue,
+    /// so attribution guesses must skip them.
+    pub(crate) fn is_infrastructure(&self, address: Address) -> bool {
+        self.infrastructure.contains(&address) || address == self.wrapped_native
     }
 
     /// The chain's `(stablecoin, decimals)` anchors for USD valuation.
@@ -249,6 +261,15 @@ mod tests {
         assert!(registry.is_solver(oneinch));
         assert!(registry.is_known(relay));
         assert!(!registry.is_solver(relay));
+    }
+
+    #[test]
+    fn infrastructure_covers_permit2_and_wrapped_native() {
+        let registry = Registry::ethereum();
+        let permit2 = address!("0x000000000022d473030f116ddee9f6b43ac78ba3");
+        assert!(registry.is_infrastructure(permit2));
+        assert!(registry.is_infrastructure(registry.wrapped_native()));
+        assert!(!registry.is_infrastructure(addr(123)));
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -7,7 +7,7 @@
 //! ([`Registry::is_solver`], [`Registry::is_batch_settler`], [`Registry::label`], …).
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fs,
     path::Path,
 };
@@ -34,14 +34,37 @@ struct AddressBook {
     labels: HashMap<Address, String>,
 }
 
-/// A venue's addresses on one chain: the contracts users enter through and the collectors its
-/// fee skims land on. Keyed by venue name in the book; the name binds to a decode strategy at
-/// load time (see [`crate::decoder::venues::Venue::from_name`]).
+/// A venue's book section on one chain: the contracts users enter through, the collectors its
+/// fee skims land on, and its calldata solver vocabulary. Keyed by venue name in the book; the
+/// name binds to a decode strategy at load time (see
+/// [`crate::decoder::venues::Venue::from_name`]).
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct VenueAddresses {
     pub(crate) entry_points: HashSet<Address>,
     pub(crate) fee_collectors: HashSet<Address>,
+    /// Lowercase substrings of the venue's calldata solver ids, mapped to the solver name used
+    /// in this book. Ordered for deterministic matching; empty for venues that declare no
+    /// solver in calldata.
+    #[serde(default)]
+    solver_aliases: BTreeMap<String, String>,
+}
+
+impl VenueAddresses {
+    /// Normalize a solver id this venue declared in calldata to the book's solver vocabulary:
+    /// the first alias needle (in alias order) contained in the lowercased id names the solver,
+    /// trimming the venue's id decoration ("oneInchV6FeeDynamic" → "1inch") — not a 1:1 rename.
+    /// Unmatched ids pass through as-is: still more informative than a raw executor address,
+    /// and a signal to extend the book.
+    pub(crate) fn normalize_solver(&self, id: &str) -> String {
+        let lower = id.to_lowercase();
+        for (needle, name) in &self.solver_aliases {
+            if lower.contains(needle) {
+                return name.clone();
+            }
+        }
+        id.to_string()
+    }
 }
 
 /// Per-chain address book for trade decoding, loaded from TOML (see the module docs).
@@ -99,7 +122,7 @@ impl Registry {
     }
 
     fn from_toml(text: &str) -> anyhow::Result<Self> {
-        let book: AddressBook =
+        let mut book: AddressBook =
             toml::from_str(text).context("failed to parse address book TOML")?;
 
         // A venue section only carries addresses; its behavior is bound by name in code. An
@@ -126,6 +149,14 @@ impl Registry {
             .into_iter()
             .collect();
         usd_stablecoins.sort_unstable();
+        // Alias needles match against lowercased ids, so a mixed-case needle in the book would
+        // silently never match — canonicalize at load.
+        for venue in book.venues.values_mut() {
+            venue.solver_aliases = std::mem::take(&mut venue.solver_aliases)
+                .into_iter()
+                .map(|(needle, name)| (needle.to_lowercase(), name))
+                .collect();
+        }
 
         Ok(Self {
             solver_names,
@@ -261,6 +292,38 @@ mod tests {
         assert!(registry.is_solver(oneinch));
         assert!(registry.is_known(relay));
         assert!(!registry.is_solver(relay));
+    }
+
+    #[test]
+    fn normalize_solver_trims_metamask_ids_and_passes_unknown_through() {
+        let registry = Registry::ethereum();
+        let metamask = registry.venue("metamask").unwrap();
+        assert_eq!(metamask.normalize_solver("oneInchV6FeeDynamic"), "1inch");
+        assert_eq!(metamask.normalize_solver("uniswapPermit2FeeDynamic"), "uniswap");
+        assert_eq!(metamask.normalize_solver("okx6"), "okx");
+        assert_eq!(metamask.normalize_solver("someFutureSolver"), "someFutureSolver");
+    }
+
+    #[test]
+    fn solver_aliases_are_scoped_to_their_venue() {
+        // The alias table is one venue's calldata vocabulary; a venue without one passes every
+        // id through unchanged.
+        let registry = Registry::ethereum();
+        let relay = registry.venue("relay").unwrap();
+        assert_eq!(relay.normalize_solver("oneInchV6FeeDynamic"), "oneInchV6FeeDynamic");
+    }
+
+    #[test]
+    fn mixed_case_alias_needle_still_matches() {
+        // Needles are canonicalized to lowercase at load, so a capitalized needle in the book
+        // matches the same ids as a lowercase one.
+        let book = ETHEREUM_TOML.replace(
+            "[venues.metamask.solver_aliases]",
+            "[venues.metamask.solver_aliases]\nBeBop = \"bebop\"",
+        );
+        let registry = Registry::from_toml(&book).unwrap();
+        let metamask = registry.venue("metamask").unwrap();
+        assert_eq!(metamask.normalize_solver("bebopJamV2"), "bebop");
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -1,4 +1,4 @@
-# Ethereum address book for trade decoding: which contracts are solvers, clients, batch
+# Ethereum address book for trade decoding: which contracts are solvers, venues, batch
 # settlers, and venue infrastructure. Loaded by `Registry` (see registry.rs for what each section
 # drives); pass a modified copy via `--registry` to extend it without recompiling.
 
@@ -110,7 +110,7 @@ fee_collectors = [
 
 # MetaMask's router names the solver API behind each swap in a calldata aggregatorId like
 # "oneInchV6FeeDynamic" or "okx6". Each entry maps a lowercase substring of that id to a solver
-# name used in this book; ids that match no entry are recorded as-is.
+# name used in this address book; ids that match no entry are recorded as-is.
 [venues.metamask.solver_aliases]
 oneinch = "1inch"
 zeroex = "0x"

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -10,6 +10,15 @@ wrapped_native = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
 # a solver, not the trader (CoW Protocol Settlement).
 batch_settlers = ["0x9008d19f58aabd9ed0d60971565aa8510560ab41"]
 
+# Stablecoins anchoring the native token to USD for reporting (address = decimals): a priced
+# stablecoin is worth ~$1 per 10^decimals native units, which pins the native token's USD value.
+[usd_stablecoins]
+"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48" = 6  # USDC
+"0xdac17f958d2ee523a2206206994597c13d831ec7" = 6  # USDT
+"0x6b175474e89094c44da98b954eedeac495271d0f" = 18 # DAI
+"0x4c9edd5852cd905f086c759e8383e09bff1e68b3" = 18 # USDe
+"0xdc035d45d973e3ec169d2276ddab16f1e407384f" = 18 # USDS
+
 # Solver routers — the venue that actually settles a swap.
 [solvers]
 # 1inch v6 and v5 Aggregation Routers

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -105,3 +105,19 @@ fee_collectors = [
     "0xe3478b0bb1a5084567c319096437924948be1964",
     "0xf326e4de8f66a0bdc0970b79e0924e33c79f1915",
 ]
+
+# MetaMask's calldata solver vocabulary: its router names the solver API behind each swap in an
+# aggregatorId like "oneInchV6FeeDynamic" or "okx6". The first substring below found in the
+# lowercased id maps it to the solver label used in this book — trimming MetaMask's version/fee
+# decoration, not a 1:1 rename. Ids matching nothing pass through as-is: still more informative
+# than a raw executor address, and a signal to extend this table.
+[venues.metamask.solver_aliases]
+oneinch = "1inch"
+zeroex = "0x"
+uniswap = "uniswap"
+okx = "okx"
+kyber = "kyberswap"
+paraswap = "paraswap"
+airswap = "airswap"
+openocean = "openocean"
+hashflow = "hashflow"

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -6,6 +6,10 @@
 # intermediary.
 wrapped_native = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
 
+# Token-movement infrastructure that traces touch on most swaps without ever being the settling
+# venue: attribution guesses skip these (the wrapped-native token above is always skipped too).
+infrastructure = ["0x000000000022d473030f116ddee9f6b43ac78ba3"]
+
 # Batch-settlement venues where `tx.to` is the settlement contract and the transaction sender is
 # a solver, not the trader (CoW Protocol Settlement).
 batch_settlers = ["0x9008d19f58aabd9ed0d60971565aa8510560ab41"]

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -6,9 +6,11 @@
 # intermediary.
 wrapped_native = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
 
-# Token-movement infrastructure that traces touch on most swaps without ever being the settling
-# venue: attribution guesses skip these (the wrapped-native token above is always skipped too).
-infrastructure = ["0x000000000022d473030f116ddee9f6b43ac78ba3"]
+# Contracts nearly every swap routes through but that never settle the trade. Hindsight guesses
+# an unknown swap's settling venue from on-chain activity; without this list those guesses would
+# land on the plumbing instead of the real venue. The wrapped-native token above is skipped the
+# same way.
+infrastructure = ["0x000000000022d473030f116ddee9f6b43ac78ba3"] # Permit2
 
 # Batch-settlement venues where `tx.to` is the settlement contract and the transaction sender is
 # a solver, not the trader (CoW Protocol Settlement).
@@ -106,11 +108,9 @@ fee_collectors = [
     "0xf326e4de8f66a0bdc0970b79e0924e33c79f1915",
 ]
 
-# MetaMask's calldata solver vocabulary: its router names the solver API behind each swap in an
-# aggregatorId like "oneInchV6FeeDynamic" or "okx6". The first substring below found in the
-# lowercased id maps it to the solver label used in this book — trimming MetaMask's version/fee
-# decoration, not a 1:1 rename. Ids matching nothing pass through as-is: still more informative
-# than a raw executor address, and a signal to extend this table.
+# MetaMask's router names the solver API behind each swap in a calldata aggregatorId like
+# "oneInchV6FeeDynamic" or "okx6". Each entry maps a lowercase substring of that id to a solver
+# name used in this book; ids that match no entry are recorded as-is.
 [venues.metamask.solver_aliases]
 oneinch = "1inch"
 zeroex = "0x"

--- a/tools/hindsight/src/decoder/sandwich.rs
+++ b/tools/hindsight/src/decoder/sandwich.rs
@@ -1,13 +1,14 @@
 //! Bracket-pair sandwich detection.
 //!
-//! For a victim trade, scans the receipts immediately around it — already fetched by
-//! [`super::Decoder::decode_block`] in one `eth_getBlockReceipts` call, so detection makes no
-//! extra RPC calls — for a front-run/back-run pair that links to one attacker, touches a pool
-//! the victim's swap touched, and moves the victim's output token in sandwich direction
-//! (accumulate before the victim, dispose after). See
-//! `docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md` for the heuristic
-//! and its known coarseness (Uniswap V4's singleton pool manager collapses per-pool overlap to
-//! per-protocol).
+//! For each victim trade, scan the transactions immediately around it in the block for a
+//! front-run/back-run pair that satisfies three conditions: both legs link to one attacker,
+//! both touch a pool the victim's swap touched, and the attacker accumulates the victim's
+//! output token before the victim trades and disposes of it after. The block's receipts were
+//! already fetched for decoding, so detection costs no extra RPC calls.
+//!
+//! See `docs/superpowers/specs/2026-07-13-hindsight-sandwich-detection-design.md` for the
+//! heuristic and its known coarseness (Uniswap V4's singleton pool manager collapses per-pool
+//! overlap to per-protocol).
 
 use std::collections::HashSet;
 
@@ -93,11 +94,12 @@ pub(crate) fn detect(
 }
 
 /// Whether `front` and `back` share a link that plausibly identifies one attacker running both
-/// legs: the same sender, or the same target contract that is not a registry-known venue or
-/// solver. The registry exclusion keeps two unrelated users entering the same popular router
-/// (Universal Router, 1inch) from tripping the same-`to` check — real sandwich bots settle
-/// through private contracts. A link matching the victim's own sender is excluded: a trader on
-/// both sides of their own trade is not a sandwich.
+/// legs: the same sender, or the same target contract.
+///
+/// A shared target only counts when it is not a known venue or solver — otherwise two unrelated
+/// users entering the same popular router (Universal Router, 1inch) would look linked, while
+/// real sandwich bots settle through private contracts. A link matching the victim's own sender
+/// is also excluded: a trader on both sides of their own trade is not a sandwich.
 fn shared_attacker(
     front: &TransactionReceipt,
     back: &TransactionReceipt,

--- a/tools/hindsight/src/decoder/sandwich.rs
+++ b/tools/hindsight/src/decoder/sandwich.rs
@@ -21,7 +21,6 @@ use alloy::{
 use crate::decoder::{
     ledger::{to_primitive_log, Transfer},
     registry::Registry,
-    trace::PERMIT2,
     DecodedTrade,
 };
 
@@ -148,10 +147,10 @@ fn overlapping_pools(
 /// The addresses that emitted a log in a transaction, minus everything known not to be a pool —
 /// candidate pool contracts.
 ///
-/// `Transfer` and `Approval` emitters are token contracts, and the wrapped-native token
-/// (`Deposit`/`Withdrawal`) and Permit2 (its own permit events) log on most swaps without being
-/// pools: counting any of them would give two transactions that merely share a token or its
-/// plumbing a trivial "pool" overlap.
+/// `Transfer` and `Approval` emitters are token contracts, and the registry's infrastructure
+/// addresses (the wrapped-native token's `Deposit`/`Withdrawal`, Permit2's permit events) log on
+/// most swaps without being pools: counting any of them would give two transactions that merely
+/// share a token or its plumbing a trivial "pool" overlap.
 fn pool_addresses(receipt: &TransactionReceipt, registry: &Registry) -> HashSet<Address> {
     let mut pools = HashSet::new();
     for log in receipt.logs() {
@@ -161,7 +160,7 @@ fn pool_addresses(receipt: &TransactionReceipt, registry: &Registry) -> HashSet<
             .is_some_and(|topic| {
                 *topic == Transfer::SIGNATURE_HASH || *topic == Approval::SIGNATURE_HASH
             });
-        if token_event || log.address() == registry.wrapped_native() || log.address() == PERMIT2 {
+        if token_event || registry.is_infrastructure(log.address()) {
             continue;
         }
         pools.insert(log.address());

--- a/tools/hindsight/src/decoder/solvers/attribution.rs
+++ b/tools/hindsight/src/decoder/solvers/attribution.rs
@@ -18,13 +18,13 @@ pub(crate) enum AttributionSource {
     Declared,
     /// The entry point (`tx.to`) is itself a known solver router: the trade settled there.
     EntryPoint,
-    /// A known solver router was called inside the trace (client-wrapped entries).
+    /// A known solver router was called inside the trace (venue-wrapped entries).
     TraceMatch,
     /// No known router anywhere: best guess is the external call that moved the most native
     /// value (an unknown router's address).
     LargestCall,
     /// Even the guess was indeterminate (e.g. a token→token trace where no call moves value).
-    /// The record is labeled with its entry point — typically the client's name — flagging it
+    /// The record is labeled with its entry point — typically the venue's name — flagging it
     /// for registry expansion.
     Fallback,
 }

--- a/tools/hindsight/src/decoder/solvers/attribution.rs
+++ b/tools/hindsight/src/decoder/solvers/attribution.rs
@@ -72,10 +72,7 @@ mod tests {
     use alloy::primitives::address;
 
     use super::*;
-    use crate::decoder::{
-        test_utils::{addr, frame},
-        trace::PERMIT2,
-    };
+    use crate::decoder::test_utils::{addr, frame, PERMIT2};
 
     #[test]
     fn declared_solver_outranks_the_trace() {

--- a/tools/hindsight/src/decoder/solvers/kyberswap.rs
+++ b/tools/hindsight/src/decoder/solvers/kyberswap.rs
@@ -4,7 +4,7 @@
 //! verbatim in the swap calldata: a flat JSON object carrying the integrator's name and — the
 //! valuable part — the off-chain quoted output (`AmountOut`) the route was chosen on. The settled
 //! amount tells us what the user got; the quote tells us what the solver promised at decision
-//! time, which is the number a client like Relay actually compared against ours.
+//! time, which is the number a venue like Relay actually compared against ours.
 
 use alloy::primitives::U256;
 

--- a/tools/hindsight/src/decoder/solvers/lifi.rs
+++ b/tools/hindsight/src/decoder/solvers/lifi.rs
@@ -19,7 +19,7 @@ sol! {
 /// A bridge deposit is not a same-chain swap: the real output lands on the destination chain,
 /// and the trader's only same-chain receipt is a leftover refund. Netting that as a swap pairs
 /// the full input with the refund — a phantom trade with an absurd rate. A matching-time
-/// veto (see [`crate::decoder::strategy::select`]): rejected transactions never cost a trace.
+/// veto (see [`super::match_veto`]): rejected transactions never cost a trace.
 pub(crate) fn started_bridge_order(logs: &[Log]) -> bool {
     logs.iter()
         .any(|log| log.topics().first() == Some(&LiFiTransferStarted::SIGNATURE_HASH))

--- a/tools/hindsight/src/decoder/solvers/lifi.rs
+++ b/tools/hindsight/src/decoder/solvers/lifi.rs
@@ -18,8 +18,8 @@ sol! {
 ///
 /// A bridge deposit is not a same-chain swap: the real output lands on the destination chain,
 /// and the trader's only same-chain receipt is a leftover refund. Netting that as a swap pairs
-/// the full input with the refund — a phantom trade with an absurd rate. A matching-time
-/// veto (see [`super::match_veto`]): rejected transactions never cost a trace.
+/// the full input with the refund — a phantom trade with an absurd rate. This runs as a
+/// matching-time veto (see [`super::match_veto`]), so rejected transactions never cost a trace.
 pub(crate) fn started_bridge_order(logs: &[Log]) -> bool {
     logs.iter()
         .any(|log| log.topics().first() == Some(&LiFiTransferStarted::SIGNATURE_HASH))

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -13,7 +13,7 @@ use alloy::{primitives::U256, rpc::types::Log};
 
 /// A solver's own off-chain quote for the swap, recovered from calldata.
 ///
-/// This is the number the client compared against at decision time — what the solver's API
+/// This is the number the venue compared against at decision time — what the solver's API
 /// promised — as opposed to the settled amount, which is what execution delivered. The fields
 /// carry no solver name (the record's `solver` column already says who); see
 /// [`embedded_quote`] for which solvers declare one and how.

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod kyberswap;
 pub(crate) mod lifi;
 pub(crate) mod paraswap;
 
-use alloy::primitives::U256;
+use alloy::{primitives::U256, rpc::types::Log};
 
 /// A solver's own off-chain quote for the swap, recovered from calldata.
 ///
@@ -28,6 +28,14 @@ pub(crate) struct SolverQuote {
     /// Unix timestamp of the quote, when present. Joined against block time downstream to
     /// separate stale-quote slippage from routing quality.
     pub timestamp: Option<u64>,
+}
+
+/// Match-time veto: order shapes a solver's own logs mark as not same-chain swaps, checked
+/// before the transaction costs a trace. Netting such a transaction would pair its input with a
+/// leftover refund as a phantom trade. Adding a solver's veto is one check here — the matching
+/// in `strategy` stays solver-agnostic.
+pub(crate) fn match_veto(logs: &[Log]) -> Option<&'static str> {
+    lifi::started_bridge_order(logs).then_some("cross-chain bridge order")
 }
 
 /// The solver's off-chain quote declared in the transaction's calldata, when the attributed
@@ -56,7 +64,27 @@ pub(crate) fn plausible_quote(quote: &SolverQuote, settled_amount_out: U256) -> 
 
 #[cfg(test)]
 mod tests {
+    use alloy::{
+        primitives::{Bytes, Log as PrimitiveLog},
+        sol_types::SolEvent,
+    };
+
     use super::*;
+    use crate::decoder::test_utils::{addr, make_transfer_log};
+
+    #[test]
+    fn match_veto_flags_bridge_orders_only() {
+        let primitive = PrimitiveLog::new_unchecked(
+            addr(70),
+            vec![lifi::LiFiTransferStarted::SIGNATURE_HASH],
+            Bytes::default(),
+        );
+        let bridge_logs = vec![Log { inner: primitive, ..Default::default() }];
+        assert_eq!(match_veto(&bridge_logs), Some("cross-chain bridge order"));
+
+        let swap_logs = vec![make_transfer_log(addr(10), addr(1), addr(2), U256::from(1000))];
+        assert_eq!(match_veto(&swap_logs), None);
+    }
 
     #[test]
     fn plausible_quote_accepts_slippage_and_rejects_unit_mismatch() {

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -30,12 +30,17 @@ pub(crate) struct SolverQuote {
     pub timestamp: Option<u64>,
 }
 
-/// Match-time veto: order shapes a solver's own logs mark as not same-chain swaps, checked
-/// before the transaction costs a trace. Netting such a transaction would pair its input with a
-/// leftover refund as a phantom trade. Adding a solver's veto is one check here — the matching
-/// in `strategy` stays solver-agnostic.
+/// The reason a matched transaction must be skipped instead of decoded, if any.
+///
+/// Some solver routers also settle orders that are not same-chain swaps; decoding those would
+/// fabricate phantom trades, so they are vetoed from their logs before the transaction costs a
+/// trace. Each solver contributes one check here, keeping the matching in `strategy`
+/// solver-agnostic.
 pub(crate) fn match_veto(logs: &[Log]) -> Option<&'static str> {
-    lifi::started_bridge_order(logs).then_some("cross-chain bridge order")
+    if lifi::started_bridge_order(logs) {
+        return Some("cross-chain bridge order");
+    }
+    None
 }
 
 /// The solver's off-chain quote declared in the transaction's calldata, when the attributed

--- a/tools/hindsight/src/decoder/solvers/paraswap.rs
+++ b/tools/hindsight/src/decoder/solvers/paraswap.rs
@@ -1,11 +1,12 @@
 //! ParaSwap-specific calldata extraction.
 //!
-//! Augustus v6 swap methods carry the trade parameters as consecutive 32-byte words —
-//! `…, fromAmount, toAmount, quotedAmount, …` — where `toAmount` is the slippage floor and
+//! Augustus v6 swap methods carry the trade parameters as consecutive 32-byte words:
+//! `…, fromAmount, toAmount, quotedAmount, …`. `toAmount` is the slippage floor and
 //! `quotedAmount` the off-chain quoted output, kept on-chain for `ParaSwap`'s surplus accounting
-//! (the user is capped at the quote, so settled often equals it exactly). The triple's offset
-//! differs per method selector, so it is located by value rather than per-selector ABI: the word
-//! equal to the trade's decoded input amount, followed by a floor-and-quote pair.
+//! (the user is capped at the quote, so settled often equals it exactly). The triple sits at a
+//! different offset per method selector, so instead of per-selector ABI decoding it is located
+//! by value: find the word equal to the trade's decoded input amount, then read the
+//! floor-and-quote pair that follows it.
 
 use alloy::primitives::U256;
 

--- a/tools/hindsight/src/decoder/strategy.rs
+++ b/tools/hindsight/src/decoder/strategy.rs
@@ -18,8 +18,7 @@ use crate::decoder::{
     intent,
     ledger::{NetSwap, TransferLedger},
     registry::Registry,
-    solvers::lifi,
-    venues,
+    solvers, venues,
 };
 
 /// Everything a decode strategy may need from one matched transaction, so every strategy is
@@ -131,18 +130,19 @@ impl Flow {
 /// A transaction qualifies two ways: its entry point (`tx.to`) is a known
 /// venue or solver, or one of its logs was emitted by a known solver
 /// (filler-initiated intent fills, where `tx.to` is a rotating filler).
-/// Matched transactions that start a cross-chain bridge order are vetoed here
-/// (see [`lifi::started_bridge_order`]), before they cost a trace.
+/// Matched transactions whose logs mark a non-swap order shape are vetoed
+/// here (see [`solvers::match_veto`]), before they cost a trace.
 pub(crate) fn select<'a>(
     receipt: &'a TransactionReceipt,
     registry: &Registry,
 ) -> Option<Matched<'a>> {
     let matched = match_entry(receipt, registry)?;
-    if lifi::started_bridge_order(matched.receipt.logs()) {
+    if let Some(reason) = solvers::match_veto(matched.receipt.logs()) {
         debug!(
             tx = %matched.receipt.transaction_hash,
             venue = %registry.label(matched.entry_point),
-            "cross-chain bridge order; skipping"
+            reason,
+            "matched transaction is not a same-chain swap; skipping"
         );
         return None;
     }

--- a/tools/hindsight/src/decoder/test_utils.rs
+++ b/tools/hindsight/src/decoder/test_utils.rs
@@ -1,11 +1,14 @@
 use alloy::{
     consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom},
-    primitives::{Address, Bloom, Bytes, Log as PrimitiveLog, TxHash, B256, U256},
+    primitives::{address, Address, Bloom, Bytes, Log as PrimitiveLog, TxHash, B256, U256},
     rpc::types::{trace::geth::CallFrame, Log, TransactionReceipt},
     sol_types::SolEvent,
 };
 
 use crate::decoder::ledger::{NetSwap, Transfer};
+
+/// The canonical Permit2 deployment, for fixtures exercising the registry's infrastructure set.
+pub(crate) const PERMIT2: Address = address!("0x000000000022d473030f116ddee9f6b43ac78ba3");
 
 /// An address with `n` in its last byte, for readable test fixtures.
 pub(crate) fn addr(n: u8) -> Address {

--- a/tools/hindsight/src/decoder/trace.rs
+++ b/tools/hindsight/src/decoder/trace.rs
@@ -1,15 +1,11 @@
 use alloy::{
-    primitives::{address, Address, TxHash, U256},
+    primitives::{Address, TxHash, U256},
     providers::{ext::DebugApi, Provider},
     rpc::types::trace::geth::{CallConfig, CallFrame, GethDebugTracingOptions, GethTrace},
 };
 use anyhow::Context;
 
 use crate::decoder::registry::Registry;
-
-/// The canonical Permit2 deployment (same address on every chain) — token-pull infrastructure
-/// that routers call first, never the venue settling a swap.
-pub(crate) const PERMIT2: Address = address!("0x000000000022d473030f116ddee9f6b43ac78ba3");
 
 /// Fetch the callTracer root frame for a transaction.
 ///
@@ -108,8 +104,8 @@ pub(crate) fn find_solver_frame<'a>(
 }
 
 /// The client's direct child call that moved the most native value, excluding
-/// self-calls, refunds to the sender, Permit2, and the wrapped-native contract. Best guess at
-/// an unknown router.
+/// self-calls, refunds to the sender, and the registry's infrastructure addresses (Permit2, the
+/// wrapped-native contract). Best guess at an unknown router.
 ///
 /// The wrapped-native exclusion matters most: on an ETH-input swap through an unknown router,
 /// the highest-value call is typically the `WETH.deposit()` wrapping the input — infrastructure,
@@ -130,7 +126,7 @@ pub(crate) fn largest_external_call(
             continue;
         }
         let Some(to) = child.to else { continue };
-        if to == entry_point || to == sender || to == PERMIT2 || to == registry.wrapped_native() {
+        if to == entry_point || to == sender || registry.is_infrastructure(to) {
             continue;
         }
         let value = child.value.unwrap_or_default();

--- a/tools/hindsight/src/decoder/trace.rs
+++ b/tools/hindsight/src/decoder/trace.rs
@@ -57,15 +57,16 @@ fn transfers_value(call_type: &str) -> bool {
     matches!(call_type, "CALL" | "CALLCODE" | "CREATE" | "CREATE2" | "SELFDESTRUCT")
 }
 
-/// Gas consumed by the settled route inside a client-wrapped transaction (Relay, `MetaMask`), in
+/// Gas consumed by the settled route inside a venue-wrapped transaction (Relay, `MetaMask`), in
 /// gas units.
 ///
-/// The wrapper's own gas — fee skim, forwarding, the base transaction cost — is charged whichever
-/// router the client picks, so like the client fee it is excluded from the comparison. Each trace
-/// frame's `gas_used` includes its whole subtree, so the call into the venue carries the full
+/// The venue's own gas — fee skim, forwarding, the base transaction cost — is charged whichever
+/// router the venue picks, so like the venue fee it is excluded from the comparison. Each trace
+/// frame's `gas_used` includes its whole subtree, so the call into the solver carries the full
 /// routing cost. Prefers the first call into a known solver; falls back to the most
-/// gas-consuming direct child (in a wrapper transaction the routing work dwarfs the bookkeeping
-/// calls). `None` when no usable frame exists — the caller skips the deduction rather than guess.
+/// gas-consuming direct child, since in a wrapped transaction the routing work dwarfs the
+/// bookkeeping calls. `None` when no usable frame exists — the caller then skips the gas
+/// deduction rather than guess.
 pub(crate) fn route_gas(root: &CallFrame, registry: &Registry) -> Option<U256> {
     if let Some(frame) = find_solver_frame(root, registry) {
         return Some(frame.gas_used);
@@ -103,9 +104,9 @@ pub(crate) fn find_solver_frame<'a>(
         .find_map(|child| find_solver_frame(child, registry))
 }
 
-/// The client's direct child call that moved the most native value, excluding
-/// self-calls, refunds to the sender, and the registry's infrastructure addresses (Permit2, the
-/// wrapped-native contract). Best guess at an unknown router.
+/// Best guess at an unknown router: the entry point's direct child call that moved the most
+/// native value, excluding self-calls, refunds to the sender, and the registry's infrastructure
+/// addresses (Permit2, the wrapped-native contract).
 ///
 /// The wrapped-native exclusion matters most: on an ETH-input swap through an unknown router,
 /// the highest-value call is typically the `WETH.deposit()` wrapping the input — infrastructure,

--- a/tools/hindsight/src/decoder/venues/metamask.rs
+++ b/tools/hindsight/src/decoder/venues/metamask.rs
@@ -22,8 +22,8 @@ sol! {
     function swap(string aggregatorId, address tokenFrom, uint256 amount, bytes data);
 }
 
-/// The solver label declared in the router calldata's `aggregatorId`, normalized to the book's
-/// solver names via the `[venues.metamask.solver_aliases]` section.
+/// The solver label declared in the router calldata's `aggregatorId`, normalized to the address
+/// book's solver names via the `[venues.metamask.solver_aliases]` section.
 ///
 /// `MetaMask` states which solver API it routed through (e.g. "oneInchV6FeeDynamic",
 /// "uniswapPermit2FeeDynamic"). Trace attribution often cannot resolve these — a token→token

--- a/tools/hindsight/src/decoder/venues/metamask.rs
+++ b/tools/hindsight/src/decoder/venues/metamask.rs
@@ -10,7 +10,10 @@
 use alloy::{primitives::Address, sol, sol_types::SolCall};
 
 use crate::decoder::{
-    ledger::TransferLedger, registry::Registry, strategy::Flow, venues::venue_fee_flow,
+    ledger::TransferLedger,
+    registry::{Registry, VenueAddresses},
+    strategy::Flow,
+    venues::venue_fee_flow,
 };
 
 sol! {
@@ -19,38 +22,16 @@ sol! {
     function swap(string aggregatorId, address tokenFrom, uint256 amount, bytes data);
 }
 
-/// The solver label declared in the router calldata's `aggregatorId`, normalized to the
-/// registry's solver names.
+/// The solver label declared in the router calldata's `aggregatorId`, normalized to the book's
+/// solver names via the `[venues.metamask.solver_aliases]` section.
 ///
 /// `MetaMask` states which solver API it routed through (e.g. "oneInchV6FeeDynamic",
 /// "uniswapPermit2FeeDynamic"). Trace attribution often cannot resolve these — a token→token
 /// route moves no native value and enters through Permit2 — so the calldata declaration is the
-/// authoritative source. Unrecognized ids pass through as-is: "airswapV4" is still more
-/// informative than a raw executor address.
-fn solver_from_calldata(input: &[u8]) -> Option<String> {
+/// authoritative source.
+fn solver_from_calldata(input: &[u8], metamask: &VenueAddresses) -> Option<String> {
     let call = swapCall::abi_decode(input).ok()?;
-    Some(normalize(&call.aggregatorId))
-}
-
-fn normalize(id: &str) -> String {
-    let lower = id.to_lowercase();
-    let names = [
-        ("oneinch", "1inch"),
-        ("zeroex", "0x"),
-        ("uniswap", "uniswap"),
-        ("okx", "okx"),
-        ("kyber", "kyberswap"),
-        ("paraswap", "paraswap"),
-        ("airswap", "airswap"),
-        ("openocean", "openocean"),
-        ("hashflow", "hashflow"),
-    ];
-    for (needle, name) in names {
-        if lower.contains(needle) {
-            return name.to_string();
-        }
-    }
-    id.to_string()
+    Some(metamask.normalize_solver(&call.aggregatorId))
 }
 
 /// Decode a MetaMask-entered transaction: net the sender's flow, back the venue fee out of it,
@@ -64,7 +45,7 @@ pub(crate) fn decode(
 ) -> Option<Flow> {
     let metamask = registry.venue("metamask")?;
     let mut flow = venue_fee_flow(ledger, sender, entry_point, &metamask.fee_collectors)?;
-    flow.solver_override = solver_from_calldata(input);
+    flow.solver_override = solver_from_calldata(input, metamask);
     Some(flow)
 }
 
@@ -103,6 +84,8 @@ mod tests {
 
     #[test]
     fn solver_from_calldata_normalizes_known_ids() {
+        let registry = Registry::ethereum();
+        let metamask = registry.venue("metamask").unwrap();
         for (id, want) in [
             ("oneInchV6FeeDynamic", "1inch"),
             ("uniswapPermit2FeeDynamic", "uniswap"),
@@ -115,14 +98,16 @@ mod tests {
                 amount: U256::from(1000),
                 data: Bytes::default(),
             };
-            assert_eq!(solver_from_calldata(&call.abi_encode()).as_deref(), Some(want));
+            assert_eq!(solver_from_calldata(&call.abi_encode(), metamask).as_deref(), Some(want));
         }
     }
 
     #[test]
     fn solver_from_calldata_declines_other_selectors() {
-        assert_eq!(solver_from_calldata(&[0xde, 0xad, 0xbe, 0xef, 0x00]), None);
-        assert_eq!(solver_from_calldata(&[]), None);
+        let registry = Registry::ethereum();
+        let metamask = registry.venue("metamask").unwrap();
+        assert_eq!(solver_from_calldata(&[0xde, 0xad, 0xbe, 0xef, 0x00], metamask), None);
+        assert_eq!(solver_from_calldata(&[], metamask), None);
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/venues/metamask.rs
+++ b/tools/hindsight/src/decoder/venues/metamask.rs
@@ -2,10 +2,10 @@
 //!
 //! `MetaMask`'s Swap Router routes through a real solver and skims its fee (~87.5 bps, plus a gas
 //! recoup on gasless "smart swaps") to a fee wallet — from the input token before swapping or
-//! from the output after. Without backing that skim out, every comparison credits Fynd with
-//! `MetaMask`'s own fee: the skim is charged whichever router `MetaMask` plugs in, so it is not
-//! value better routing can recover. On dust trades the skim dominates and fabricated
-//! extreme "wins".
+//! from the output after. The skim is charged whichever router `MetaMask` plugs in, so it is not
+//! value better routing can recover; without backing it out, every comparison credits Fynd with
+//! `MetaMask`'s own fee, and on dust trades — where the skim dominates — that fabricates extreme
+//! "wins".
 
 use alloy::{primitives::Address, sol, sol_types::SolCall};
 

--- a/tools/hindsight/src/decoder/venues/mod.rs
+++ b/tools/hindsight/src/decoder/venues/mod.rs
@@ -28,9 +28,9 @@ pub(crate) enum Venue {
 impl Venue {
     /// The venue bound to a name from the address book.
     ///
-    /// A `[venues.<name>]` section in the book only carries addresses; this is where its name
-    /// gets behavior. The registry validates every configured venue name against this binding
-    /// at load time, so a typo'd section fails fast instead of silently never matching.
+    /// A `[venues.<name>]` section in the address book only carries addresses; this is where
+    /// its name gets behavior. The registry validates every configured venue name against this
+    /// binding at load time, so a typo'd section fails fast instead of silently never matching.
     pub(crate) fn from_name(name: &str) -> Option<Self> {
         match name {
             "relay" => Some(Self::Relay),

--- a/tools/hindsight/src/decoder/venues/relay.rs
+++ b/tools/hindsight/src/decoder/venues/relay.rs
@@ -40,13 +40,14 @@ pub(crate) fn decode(
 /// no net flow (so sender netting finds nothing) and the swap moves Relay's own liquidity.
 ///
 /// Anchors on the fee collector, which always funds the input: `token_in` is the single token it
-/// net-sends. The output is either the token that returns to the collector (an **internal**
-/// inventory rebalance) or the asset received by the single external **pure-sink** recipient —
-/// see [`TransferLedger::sink_receipts`] — for a cross-chain order fill.
+/// net-sends. The output is one of two shapes — the token that comes back to the collector (an
+/// internal inventory rebalance), or the asset received by the single external recipient that
+/// only receives and never sends (a cross-chain order fill; see
+/// [`TransferLedger::sink_receipts`]).
 ///
-/// Returns `None` (declines) when the shape is ambiguous: not exactly one input token, a same-token
-/// "swap", more than one token back to the collector, or more than one external recipient/output
-/// (a batched multi-order fill, like the multi-leg netting guard).
+/// Declines (returns `None`) when the shape is ambiguous: not exactly one input token, a
+/// same-token "swap", more than one token back to the collector, or more than one external
+/// recipient or output (a batched multi-order fill, like the multi-leg netting guard).
 fn decode_rebalance(
     ledger: &TransferLedger,
     fee_collectors: &HashSet<Address>,

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -33,9 +33,13 @@ enum Command {
 /// Chain access shared by every subcommand: the RPC endpoint and the decoder's address book.
 #[derive(Args)]
 pub(crate) struct RpcArgs {
-    /// Ethereum RPC URL
+    /// Chain RPC URL
     #[arg(long, env = "RPC_URL")]
     pub rpc_url: String,
+
+    /// Chain to operate on — selects the decoder's address book (only ethereum is built in)
+    #[arg(long, default_value = "ethereum")]
+    pub chain: String,
 
     /// Decoder address-book TOML (defaults to the chain's built-in book)
     #[arg(long, env = "HINDSIGHT_REGISTRY")]
@@ -129,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
 async fn run_decode(args: DecodeArgs) -> anyhow::Result<()> {
     let provider = provider_from(&args.rpc.rpc_url)?;
     let blocks = resolve_blocks(&provider, args.blocks.block, args.blocks.range.as_deref()).await?;
-    let registry = decoder::Registry::load("ethereum", args.rpc.registry.as_deref())?;
+    let registry = decoder::Registry::load(&args.rpc.chain, args.rpc.registry.as_deref())?;
     let mut decoder = decoder::Decoder::new(provider, registry);
 
     let mut all_trades = Vec::new();
@@ -169,7 +173,7 @@ async fn run_verify(args: VerifyArgs) -> anyhow::Result<()> {
     let provider = provider_from(&args.rpc.rpc_url)?;
     let blocks = resolve_blocks(&provider, args.blocks.block, args.blocks.range.as_deref()).await?;
     let allium = verify::allium::AlliumClient::new(args.allium_key, args.allium_query_id);
-    let registry = decoder::Registry::load("ethereum", args.rpc.registry.as_deref())?;
+    let registry = decoder::Registry::load(&args.rpc.chain, args.rpc.registry.as_deref())?;
     let mut decoder = decoder::Decoder::new(provider, registry);
 
     info!(blocks = blocks.len(), "verifying decoded trades against Allium");

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -30,16 +30,17 @@ enum Command {
     Monitor(resolve::monitor::MonitorArgs),
 }
 
-/// Chain access shared by every subcommand: the RPC endpoint and the decoder's address book.
+/// Chain selection shared by every subcommand: which chain to operate on and how to reach it.
+/// Chain-specific configuration beyond the RPC endpoint and address book belongs here too.
 #[derive(Args)]
-pub(crate) struct RpcArgs {
+pub(crate) struct ChainArgs {
+    /// Chain to operate on — selects the decoder's address book (only ethereum is built in)
+    #[arg(long = "chain", value_name = "CHAIN", default_value = "ethereum")]
+    pub name: String,
+
     /// Chain RPC URL
     #[arg(long, env = "RPC_URL")]
     pub rpc_url: String,
-
-    /// Chain to operate on — selects the decoder's address book (only ethereum is built in)
-    #[arg(long, default_value = "ethereum")]
-    pub chain: String,
 
     /// Decoder address-book TOML (defaults to the chain's built-in book)
     #[arg(long, env = "HINDSIGHT_REGISTRY")]
@@ -61,7 +62,7 @@ struct BlockArgs {
 #[derive(Args)]
 struct DecodeArgs {
     #[command(flatten)]
-    rpc: RpcArgs,
+    chain: ChainArgs,
 
     #[command(flatten)]
     blocks: BlockArgs,
@@ -74,7 +75,7 @@ struct DecodeArgs {
 #[derive(Args)]
 struct VerifyArgs {
     #[command(flatten)]
-    rpc: RpcArgs,
+    chain: ChainArgs,
 
     #[command(flatten)]
     blocks: BlockArgs,
@@ -131,9 +132,9 @@ async fn main() -> anyhow::Result<()> {
 
 #[expect(clippy::print_stdout)]
 async fn run_decode(args: DecodeArgs) -> anyhow::Result<()> {
-    let provider = provider_from(&args.rpc.rpc_url)?;
+    let provider = provider_from(&args.chain.rpc_url)?;
     let blocks = resolve_blocks(&provider, args.blocks.block, args.blocks.range.as_deref()).await?;
-    let registry = decoder::Registry::load(&args.rpc.chain, args.rpc.registry.as_deref())?;
+    let registry = decoder::Registry::load(&args.chain.name, args.chain.registry.as_deref())?;
     let mut decoder = decoder::Decoder::new(provider, registry);
 
     let mut all_trades = Vec::new();
@@ -170,10 +171,10 @@ async fn run_decode(args: DecodeArgs) -> anyhow::Result<()> {
 
 #[expect(clippy::print_stdout)]
 async fn run_verify(args: VerifyArgs) -> anyhow::Result<()> {
-    let provider = provider_from(&args.rpc.rpc_url)?;
+    let provider = provider_from(&args.chain.rpc_url)?;
     let blocks = resolve_blocks(&provider, args.blocks.block, args.blocks.range.as_deref()).await?;
     let allium = verify::allium::AlliumClient::new(args.allium_key, args.allium_query_id);
-    let registry = decoder::Registry::load(&args.rpc.chain, args.rpc.registry.as_deref())?;
+    let registry = decoder::Registry::load(&args.chain.name, args.chain.registry.as_deref())?;
     let mut decoder = decoder::Decoder::new(provider, registry);
 
     info!(blocks = blocks.len(), "verifying decoded trades against Allium");

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -50,9 +50,9 @@ pub(crate) enum Verdict {
 }
 
 /// Minimum fraction of the settled output Fynd must produce for the result to count as a real
-/// comparison. Below this, Fynd could not serve the trade's size — because liquidity was too thin
-/// it returned a route covering only part of it — so the result is a coverage miss rather than a
-/// near-total loss; otherwise a single un-fillable whale dominates the USD aggregate.
+/// comparison. Below this, Fynd could not serve the trade's size (thin liquidity made it return
+/// a route covering only part of it), so the result is a coverage miss rather than a near-total
+/// loss. Without this cut, a single un-fillable whale trade dominates the USD aggregate.
 const MIN_FILL_RATIO: f64 = 0.5;
 
 /// Reclassify a Fynd quote that covers far less than the settled amount as a coverage miss.

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -121,8 +121,8 @@ fn date_from_unix(secs: u64) -> String {
 pub(super) fn write_comparisons<W: std::io::Write>(
     writer: &mut W,
     ranges: &[RangeComparison],
-    prices_top: &usd::PriceMap,
-    prices_back: &usd::PriceMap,
+    prices_top: &usd::Prices,
+    prices_back: &usd::Prices,
 ) {
     for range in ranges {
         let Ok(line) = serde_json::to_string(&comparison_record(range, prices_top, prices_back))
@@ -144,8 +144,8 @@ pub(super) fn write_comparisons<W: std::io::Write>(
 /// reason). Top is valued at N-1 prices, back at N prices, matching the state each was solved at.
 fn comparison_record(
     range: &RangeComparison,
-    prices_top: &usd::PriceMap,
-    prices_back: &usd::PriceMap,
+    prices_top: &usd::Prices,
+    prices_back: &usd::Prices,
 ) -> serde_json::Value {
     serde_json::json!({
         "block": range.block_number,
@@ -176,7 +176,7 @@ fn comparison_record(
 fn state_record(
     state: &StateResult,
     range: &RangeComparison,
-    prices: &usd::PriceMap,
+    prices: &usd::Prices,
 ) -> serde_json::Value {
     let token_out = range.token_out;
     let solved = match &state.outcome {
@@ -189,9 +189,9 @@ fn state_record(
         Outcome::Unsolvable(reason) | Outcome::Partial(reason) => Some(reason.as_str()),
         Outcome::Solved(_) => None,
     };
-    let improvement_usd = solved
-        .and_then(|s| usd::savings_usd(token_out, s.amount_out, range.settled_amount_out, prices));
-    let fynd_value_usd = solved.and_then(|s| usd::value_usd(token_out, s.amount_out, prices));
+    let improvement_usd =
+        solved.and_then(|s| prices.savings_usd(token_out, s.amount_out, range.settled_amount_out));
+    let fynd_value_usd = solved.and_then(|s| prices.value_usd(token_out, s.amount_out));
     serde_json::json!({
         "verdict": state.verdict,
         "net_bps": state.deltas.net_bps,
@@ -201,7 +201,7 @@ fn state_record(
         "gas_estimate": solved.map(|s| s.gas_estimate.to_string()),
         "improvement_usd": improvement_usd,
         "fynd_value_usd": fynd_value_usd,
-        "settled_value_usd": usd::value_usd(token_out, range.settled_amount_out, prices),
+        "settled_value_usd": prices.value_usd(token_out, range.settled_amount_out),
         "unsolvable_reason": unsolvable_reason,
         "quote": solved
             .and_then(|s| s.quote_json.as_deref())
@@ -262,9 +262,13 @@ mod tests {
 
     use super::*;
     use crate::{
-        decoder::{AttributionSource, DecodedTrade, SandwichEvidence, SolverQuote},
+        decoder::{AttributionSource, DecodedTrade, Registry, SandwichEvidence, SolverQuote},
         resolve::{build_range, SolvedAmount},
     };
+
+    fn empty_prices() -> usd::Prices {
+        usd::Prices::new(&Registry::ethereum())
+    }
 
     #[test]
     fn date_from_unix_matches_utc_calendar() {
@@ -328,11 +332,11 @@ mod tests {
         };
         let range = build_range(
             &trade,
-            &usd::PriceMap::new(),
+            &empty_prices(),
             Outcome::Unsolvable("x".into()),
             Outcome::Unsolvable("x".into()),
         );
-        let rec = comparison_record(&range, &usd::PriceMap::new(), &usd::PriceMap::new());
+        let rec = comparison_record(&range, &empty_prices(), &empty_prices());
         assert_eq!(rec.pointer("/tx_index").unwrap(), 3);
         assert_eq!(
             rec.pointer("/quoted_amount_out")
@@ -376,7 +380,9 @@ mod tests {
             .parse()
             .unwrap();
         // ETH=$2000: USDC (6dp) = 2e-9 native units/wei, WETH (18dp) = 1.0.
-        let prices = usd::PriceMap::from([(usdc, 2e-9), (weth, 1.0)]);
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
+        prices.insert(weth, 1.0);
 
         let trade = DecodedTrade {
             tx_hash: TxHash::default(),
@@ -480,11 +486,11 @@ mod tests {
         // A coverage gap: Fynd could not solve at either state.
         let range = build_range(
             &trade,
-            &usd::PriceMap::new(),
+            &empty_prices(),
             Outcome::Unsolvable("missing token in Tycho".into()),
             Outcome::Unsolvable("missing token in Tycho".into()),
         );
-        let rec = comparison_record(&range, &usd::PriceMap::new(), &usd::PriceMap::new());
+        let rec = comparison_record(&range, &empty_prices(), &empty_prices());
         assert_eq!(rec.pointer("/top/verdict").unwrap(), "unsolvable");
         assert_eq!(
             rec.pointer("/top/unsolvable_reason")
@@ -533,8 +539,8 @@ mod tests {
                 quote_json: None,
             })
         };
-        let range = build_range(&trade, &usd::PriceMap::new(), solved(1_100), solved(1_050));
-        let rec = comparison_record(&range, &usd::PriceMap::new(), &usd::PriceMap::new());
+        let range = build_range(&trade, &empty_prices(), solved(1_100), solved(1_050));
+        let rec = comparison_record(&range, &empty_prices(), &empty_prices());
 
         assert_eq!(rec.pointer("/tx_index").unwrap(), 42);
         assert_eq!(rec.pointer("/top/verdict").unwrap(), "sandwiched");

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -98,7 +98,8 @@ pub(crate) struct RangeComparison {
 
 /// Solves a sell order at the current block state and steps to the next block. The production
 /// implementation ([`monitor`]) drives an in-process `fynd-core` solver via
-/// [`BlockStepController`]; tests use a mock returning a top- then back-of-block outcome.
+/// [`fynd_core::BlockStepController`]; tests use a mock returning a top- then back-of-block
+/// outcome.
 #[async_trait]
 pub(crate) trait SteppingSolver {
     /// Solve a sell order at the solver's current block state.

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -122,13 +122,13 @@ pub(crate) trait SteppingSolver {
 /// stays studyable offline.
 pub(crate) fn build_range(
     trade: &DecodedTrade,
-    prices: &usd::PriceMap,
+    prices: &usd::Prices,
     top: Outcome,
     back: Outcome,
 ) -> RangeComparison {
     let settled_net_gas = trade
         .settled_gas
-        .and_then(|gas| usd::gas_in_token(gas, trade.token_out, prices))
+        .and_then(|gas| prices.gas_in_token(gas, trade.token_out))
         .map_or(trade.amount_out, |gas_out| trade.amount_out.saturating_sub(gas_out));
     let mut top = StateResult::new(top, trade.amount_out, settled_net_gas);
     let mut back = StateResult::new(back, trade.amount_out, settled_net_gas);
@@ -167,7 +167,7 @@ pub(crate) fn build_range(
 pub(crate) async fn resolve_block_range<S: SteppingSolver + ?Sized>(
     solver: &S,
     trades: &[DecodedTrade],
-    prices: &usd::PriceMap,
+    prices: &usd::Prices,
 ) -> anyhow::Result<Vec<RangeComparison>> {
     let mut tops = Vec::with_capacity(trades.len());
     for trade in trades {
@@ -195,6 +195,11 @@ mod tests {
     use alloy::primitives::TxHash;
 
     use super::*;
+    use crate::decoder::Registry;
+
+    fn empty_prices() -> usd::Prices {
+        usd::Prices::new(&Registry::ethereum())
+    }
 
     fn trade(settled: u64) -> DecodedTrade {
         DecodedTrade {
@@ -257,7 +262,7 @@ mod tests {
     fn build_range_headline_is_top() {
         let range = build_range(
             &trade(10_000),
-            &usd::PriceMap::new(),
+            &empty_prices(),
             solved(10_200, 10_100),
             solved(10_010, 9_990),
         );
@@ -268,12 +273,8 @@ mod tests {
     #[test]
     fn build_range_partial_fill_is_coverage_miss() {
         // Fynd fills only 10% of a 10_000 settled trade → reclassified as a coverage miss.
-        let range = build_range(
-            &trade(10_000),
-            &usd::PriceMap::new(),
-            solved(1_000, 990),
-            solved(1_000, 990),
-        );
+        let range =
+            build_range(&trade(10_000), &empty_prices(), solved(1_000, 990), solved(1_000, 990));
         assert_eq!(range.verdict, Verdict::CoverageMiss);
         assert_eq!(range.top.deltas, Deltas { raw_bps: None, net_bps: None });
         assert!(matches!(range.top.outcome, Outcome::Partial(_)));
@@ -288,12 +289,8 @@ mod tests {
             attacker: Address::repeat_byte(0xcc),
             pools: vec![Address::repeat_byte(0xdd)],
         });
-        let range = build_range(
-            &sandwiched,
-            &usd::PriceMap::new(),
-            solved(10_200, 10_100),
-            solved(9_800, 9_700),
-        );
+        let range =
+            build_range(&sandwiched, &empty_prices(), solved(10_200, 10_100), solved(9_800, 9_700));
 
         assert_eq!(range.verdict, Verdict::Sandwiched);
         assert_eq!(range.top.verdict, Verdict::Sandwiched);
@@ -316,7 +313,7 @@ mod tests {
         });
         let range = build_range(
             &sandwiched,
-            &usd::PriceMap::new(),
+            &empty_prices(),
             solved(10_200, 10_100),
             Outcome::Unsolvable("missing token in Tycho".into()),
         );
@@ -332,7 +329,8 @@ mod tests {
         // the secondary net column carries the deduction; the verdict stays gross vs gross.
         let mut with_gas = trade(10_000);
         with_gas.settled_gas = Some(U256::from(100u64));
-        let prices = usd::PriceMap::from([(with_gas.token_out, 2.0)]);
+        let mut prices = empty_prices();
+        prices.insert(with_gas.token_out, 2.0);
 
         let range = build_range(&with_gas, &prices, solved(10_050, 9_990), solved(10_050, 9_990));
         assert_eq!(range.settled_amount_out_net_gas, U256::from(9_800u64));
@@ -347,12 +345,8 @@ mod tests {
         let mut with_gas = trade(10_000);
         with_gas.settled_gas = Some(U256::from(100u64));
 
-        let range = build_range(
-            &with_gas,
-            &usd::PriceMap::new(),
-            solved(10_050, 9_990),
-            solved(10_050, 9_990),
-        );
+        let range =
+            build_range(&with_gas, &empty_prices(), solved(10_050, 9_990), solved(10_050, 9_990));
         assert_eq!(range.settled_amount_out_net_gas, U256::from(10_000u64));
         assert_eq!(range.verdict, Verdict::Win);
     }
@@ -366,7 +360,7 @@ mod tests {
             back: solved(9_900, 9_800),
         };
         let trades = [trade(10_000), trade(10_000)];
-        let ranges = resolve_block_range(&solver, &trades, &usd::PriceMap::new())
+        let ranges = resolve_block_range(&solver, &trades, &empty_prices())
             .await
             .unwrap();
 

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -462,14 +462,14 @@ async fn run_session<P: Provider>(
         let start = Instant::now();
         // Snapshot token prices at top-of-block (N-1) for the headline metric and the top-of-block
         // USD valuation.
-        let prices_top = snapshot_prices(adapter.solver).await;
+        let prices_top = snapshot_prices(adapter.solver, decoder.registry()).await;
         let ranges = match resolve_block_range(adapter, &trades, &prices_top).await {
             Ok(ranges) => ranges,
             Err(e) => return SessionEnd::Unhealthy(e.to_string()),
         };
         // resolve_block_range advanced the solver to back-of-block (N); snapshot again so the
         // back-of-block improvement is valued against the state it was solved at.
-        let prices_back = snapshot_prices(adapter.solver).await;
+        let prices_back = snapshot_prices(adapter.solver, decoder.registry()).await;
         // The back-of-block solve should land on `target`. On a reorg/gap/resync the stream can
         // apply a different block, silently pairing the back state with another block's trades.
         // The top-of-block (N-1) headline is unaffected; warn so the mispaired back state is
@@ -510,16 +510,16 @@ async fn run_session<P: Provider>(
     }
 }
 
-/// Snapshot the solver's current token prices as a [`usd::PriceMap`] (token native-units per
-/// ETH-wei). Empty until the first derived-data computation completes; tokens with an
-/// unconvertible price are skipped.
-async fn snapshot_prices(solver: &Solver) -> usd::PriceMap {
+/// Snapshot the solver's current token prices as [`usd::Prices`] (token native-units per
+/// ETH-wei), anchored by `registry`'s USD anchor tokens. Empty until the first derived-data
+/// computation completes; tokens with an unconvertible price are skipped.
+async fn snapshot_prices(solver: &Solver, registry: &Registry) -> usd::Prices {
+    let mut prices = usd::Prices::new(registry);
     let derived = solver.derived_data();
     let guard = derived.read().await;
     let Some(token_prices) = guard.token_prices() else {
-        return usd::PriceMap::new();
+        return prices;
     };
-    let mut prices = usd::PriceMap::with_capacity(token_prices.len());
     for (token, price) in token_prices {
         let (Ok(numerator), Ok(denominator)) = (
             price

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -63,7 +63,7 @@ const MAX_LAG_BLOCKS: u64 = 100;
 #[derive(clap::Args)]
 pub(crate) struct MonitorArgs {
     #[command(flatten)]
-    pub rpc: crate::RpcArgs,
+    pub chain: crate::ChainArgs,
 
     /// Tycho WebSocket URL feeding the in-process solver
     #[arg(long, env = "TYCHO_URL")]
@@ -287,12 +287,17 @@ async fn build_solver(
     pools_config: &fynd_rpc::config::WorkerPoolsConfig,
 ) -> anyhow::Result<(Solver, BlockStepController)> {
     info!(
-        chain = cfg.rpc.chain,
+        chain = cfg.chain.name,
         protocols = protocols.len(),
         "building in-process solver (loading tokens may take minutes)…"
     );
-    let mut builder =
-        FyndBuilder::new(chain, &cfg.tycho_url, &cfg.rpc.rpc_url, protocols.to_vec(), cfg.min_tvl);
+    let mut builder = FyndBuilder::new(
+        chain,
+        &cfg.tycho_url,
+        &cfg.chain.rpc_url,
+        protocols.to_vec(),
+        cfg.min_tvl,
+    );
     if let Some(key) = cfg.tycho_api_key.as_deref() {
         builder = builder.tycho_api_key(key);
     }
@@ -312,8 +317,8 @@ async fn build_solver(
 /// [`FEED_DEAD_TIMEOUT`]), the solver is torn down and rebuilt in place — fresh subscriptions,
 /// same decoder cache and comparisons file — so a long unattended run survives feed failures.
 pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
-    let chain = parse_chain(&cfg.rpc.chain)
-        .map_err(|e| anyhow::anyhow!("invalid --chain '{}': {e}", cfg.rpc.chain))?;
+    let chain = parse_chain(&cfg.chain.name)
+        .map_err(|e| anyhow::anyhow!("invalid --chain '{}': {e}", cfg.chain.name))?;
 
     // Expand protocol tokens (e.g. `native_onchain`/`all_onchain`) against Tycho, like serve/scale.
     let protocols = fynd_rpc::protocols::resolve_protocols(
@@ -345,8 +350,8 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
         };
 
     let mut decoder = Decoder::new(
-        provider_from(&cfg.rpc.rpc_url)?,
-        Registry::load(&cfg.rpc.chain, cfg.rpc.registry.as_deref())?,
+        provider_from(&cfg.chain.rpc_url)?,
+        Registry::load(&cfg.chain.name, cfg.chain.registry.as_deref())?,
     );
 
     if let Some(port) = cfg.metrics_port {
@@ -481,7 +486,7 @@ async fn run_session<P: Provider>(
         for range in &ranges {
             telemetry::record_range(
                 range,
-                &cfg.rpc.chain,
+                &cfg.chain.name,
                 &prices_top,
                 &prices_back,
                 decoder.registry(),
@@ -561,7 +566,7 @@ mod tests {
         let tycho_url = std::env::var("TYCHO_URL").expect("set TYCHO_URL");
         let api_key = std::env::var("TYCHO_API_KEY").ok();
         run(MonitorArgs {
-            rpc: crate::RpcArgs { rpc_url, chain: "ethereum".to_string(), registry: None },
+            chain: crate::ChainArgs { name: "ethereum".to_string(), rpc_url, registry: None },
             tycho_url,
             protocols: vec!["uniswap_v2".to_string(), "uniswap_v3".to_string()],
             // High TVL floor → fewer pools → faster load for a smoke test.

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -69,10 +69,6 @@ pub(crate) struct MonitorArgs {
     #[arg(long, env = "TYCHO_URL")]
     pub tycho_url: String,
 
-    /// Chain to monitor (the decoder is Ethereum-only for now)
-    #[arg(long, default_value = "ethereum")]
-    pub chain: String,
-
     /// Protocols to index, comma-separated. Defaults to every native on-chain protocol; use
     /// `all_onchain` to include VM-simulated ones too (see `fynd serve --protocols`)
     #[arg(long, value_delimiter = ',', default_value = "native_onchain")]
@@ -291,7 +287,7 @@ async fn build_solver(
     pools_config: &fynd_rpc::config::WorkerPoolsConfig,
 ) -> anyhow::Result<(Solver, BlockStepController)> {
     info!(
-        chain = cfg.chain,
+        chain = cfg.rpc.chain,
         protocols = protocols.len(),
         "building in-process solver (loading tokens may take minutes)…"
     );
@@ -316,8 +312,8 @@ async fn build_solver(
 /// [`FEED_DEAD_TIMEOUT`]), the solver is torn down and rebuilt in place — fresh subscriptions,
 /// same decoder cache and comparisons file — so a long unattended run survives feed failures.
 pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
-    let chain = parse_chain(&cfg.chain)
-        .map_err(|e| anyhow::anyhow!("invalid --chain '{}': {e}", cfg.chain))?;
+    let chain = parse_chain(&cfg.rpc.chain)
+        .map_err(|e| anyhow::anyhow!("invalid --chain '{}': {e}", cfg.rpc.chain))?;
 
     // Expand protocol tokens (e.g. `native_onchain`/`all_onchain`) against Tycho, like serve/scale.
     let protocols = fynd_rpc::protocols::resolve_protocols(
@@ -350,7 +346,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
 
     let mut decoder = Decoder::new(
         provider_from(&cfg.rpc.rpc_url)?,
-        Registry::load(&cfg.chain, cfg.rpc.registry.as_deref())?,
+        Registry::load(&cfg.rpc.chain, cfg.rpc.registry.as_deref())?,
     );
 
     if let Some(port) = cfg.metrics_port {
@@ -485,7 +481,7 @@ async fn run_session<P: Provider>(
         for range in &ranges {
             telemetry::record_range(
                 range,
-                &cfg.chain,
+                &cfg.rpc.chain,
                 &prices_top,
                 &prices_back,
                 decoder.registry(),
@@ -565,9 +561,8 @@ mod tests {
         let tycho_url = std::env::var("TYCHO_URL").expect("set TYCHO_URL");
         let api_key = std::env::var("TYCHO_API_KEY").ok();
         run(MonitorArgs {
-            rpc: crate::RpcArgs { rpc_url, registry: None },
+            rpc: crate::RpcArgs { rpc_url, chain: "ethereum".to_string(), registry: None },
             tycho_url,
-            chain: "ethereum".to_string(),
             protocols: vec!["uniswap_v2".to_string(), "uniswap_v3".to_string()],
             // High TVL floor → fewer pools → faster load for a smoke test.
             min_tvl: 10_000.0,

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -511,9 +511,9 @@ async fn run_session<P: Provider>(
     }
 }
 
-/// Snapshot the solver's current token prices as [`usd::Prices`] (token native-units per
-/// ETH-wei), anchored by `registry`'s USD anchor tokens. Empty until the first derived-data
-/// computation completes; tokens with an unconvertible price are skipped.
+/// Snapshot the solver's current token prices as [`usd::Prices`] (token native-units per wei of
+/// the gas token), anchored by `registry`'s USD anchor tokens. Empty until the first
+/// derived-data computation completes; tokens with an unconvertible price are skipped.
 async fn snapshot_prices(solver: &Solver, registry: &Registry) -> usd::Prices {
     let mut prices = usd::Prices::new(registry);
     let derived = solver.derived_data();

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -33,11 +33,10 @@ fn is_usd_outlier(usd: f64) -> bool {
     usd.abs() >= USD_OUTLIER_THRESHOLD
 }
 
-/// Metric label for a range's venue: registered venues (the registry's `[venues.*]` sections
-/// — the integrator front-ends the comparison is pitched at) keep their name; everything else —
-/// direct router entries, bots, unregistered addresses — collapses to "other". Keeps the
-/// dashboard's venue filter to the registered names plus "other"; full venue detail stays in
-/// the JSONL records.
+/// Metric label for a range's venue. Venues registered in the address book — the integrator
+/// front-ends the comparison is pitched at — keep their name; everything else (direct router
+/// entries, bots, unregistered addresses) collapses to "other". This keeps the dashboard's
+/// venue filter bounded; full venue detail stays in the JSONL records.
 fn venue_label<'a>(venue: &'a str, registry: &Registry) -> &'a str {
     if registry.venue(venue).is_some() {
         venue
@@ -46,12 +45,11 @@ fn venue_label<'a>(venue: &'a str, registry: &Registry) -> &'a str {
     }
 }
 
-/// Metric label for a range's settling solver: registered solver names pass through, everything
-/// else collapses to "unknown". Attribution can also produce raw addresses (largest-call guess),
-/// venue names (fallback tier), and calldata-declared names from a venue's own vocabulary
-/// (`MetaMask` aggregator ids like "pancakeSwapRouterFeeDynamic") — none belong in the bounded
+/// Metric label for a range's settling solver. Registered solver names pass through; everything
+/// else collapses to "unknown". Attribution can also produce raw addresses, venue names, and
+/// venue-declared ids like "pancakeSwapRouterFeeDynamic" — none of which belong in a bounded
 /// metric vocabulary. The original label stays in the JSONL records, where it serves as the
-/// registry-expansion worklist.
+/// worklist for expanding the address book.
 fn solver_label<'a>(solver: &'a str, registry: &Registry) -> &'a str {
     if registry.is_solver_name(solver) {
         solver
@@ -194,10 +192,10 @@ pub(crate) fn record_range(
 /// metrics compare gross vs gross, matching the headline verdict.
 ///
 /// A sandwiched state's output was moved by MEV, not by Fynd's own routing, so it skips the
-/// `SAVINGS_BPS`/`SAVINGS_USD`/`IMPROVEMENT_USD` histograms — the USD pair carry no outcome
-/// label, so skipping is the only way to keep the "value of adding Fynd" aggregates clean. The
-/// USD value is still computed and returned so the per-trade Loki line (in [`record_range`])
-/// keeps logging.
+/// `SAVINGS_BPS`/`SAVINGS_USD`/`IMPROVEMENT_USD` histograms — the USD histograms carry no
+/// outcome label, so skipping is the only way to keep the "value of adding Fynd" aggregates
+/// clean. The USD value is still computed and returned so the per-trade Loki line (in
+/// [`record_range`]) keeps logging.
 ///
 /// Returns the signed USD savings it computed, `None` when the state is unsolved or unpriced.
 fn record_state(

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -127,8 +127,8 @@ pub(crate) fn describe() {
 pub(crate) fn record_range(
     range: &RangeComparison,
     chain: &str,
-    prices_top: &usd::PriceMap,
-    prices_back: &usd::PriceMap,
+    prices_top: &usd::Prices,
+    prices_back: &usd::Prices,
     registry: &Registry,
 ) {
     let labels = MetricLabels {
@@ -143,8 +143,9 @@ pub(crate) fn record_range(
     // and the output leg is unpriced exactly when the trade is unsolvable (a long-tail token
     // outside the solver's graph) — without the fallback, unsolvable volume would be
     // systematically undercounted.
-    let volume = usd::value_usd(range.token_out, range.settled_amount_out, prices_top)
-        .or_else(|| usd::value_usd(range.token_in, range.amount_in, prices_top));
+    let volume = prices_top
+        .value_usd(range.token_out, range.settled_amount_out)
+        .or_else(|| prices_top.value_usd(range.token_in, range.amount_in));
     if let Some(volume) = volume {
         histogram!(
             VOLUME_USD,
@@ -164,7 +165,11 @@ pub(crate) fn record_range(
     // message and field names stable — the LogQL query extracts them by regexp. Zero means
     // "unpriced" (or, for quoted_usd, "the solver declared no quote").
     if let (Some(savings_usd), Outcome::Solved(solved)) = (savings_top, &range.top.outcome) {
-        let priced = |amount| usd::value_usd(range.token_out, amount, prices_top).unwrap_or(0.0);
+        let priced = |amount| {
+            prices_top
+                .value_usd(range.token_out, amount)
+                .unwrap_or(0.0)
+        };
         info!(
             tx = %range.tx_hash,
             block = range.block_number,
@@ -200,7 +205,7 @@ fn record_state(
     state: &StateResult,
     state_label: &'static str,
     labels: &MetricLabels<'_>,
-    prices: &usd::PriceMap,
+    prices: &usd::Prices,
 ) -> Option<f64> {
     counter!(
         TRADES_TOTAL,
@@ -231,8 +236,7 @@ fn record_state(
     let Outcome::Solved(solved) = &state.outcome else {
         return None;
     };
-    let usd =
-        usd::savings_usd(range.token_out, solved.amount_out, range.settled_amount_out, prices)?;
+    let usd = prices.savings_usd(range.token_out, solved.amount_out, range.settled_amount_out)?;
     if sandwiched {
         return Some(usd);
     }
@@ -249,7 +253,7 @@ fn record_state(
             amount_in = %range.amount_in,
             settled_out = %range.settled_amount_out,
             fynd_out = %solved.amount_out,
-            token_out_price = ?prices.get(&range.token_out),
+            token_out_price = ?prices.get(range.token_out),
             usd,
             "USD outlier — inspect for token mispricing vs genuinely large trade"
         );
@@ -369,6 +373,10 @@ mod tests {
         resolve::{build_range, SolvedAmount},
     };
 
+    fn empty_prices() -> usd::Prices {
+        usd::Prices::new(&Registry::ethereum())
+    }
+
     fn trade(token_out: Address, settled: u64) -> DecodedTrade {
         DecodedTrade {
             tx_hash: TxHash::default(),
@@ -423,12 +431,13 @@ mod tests {
         // Top wins (net 1005 USDC vs 1000 settled); back loses (net 995).
         let range = build_range(
             &trade(usdc, 1_000_000_000),
-            &usd::PriceMap::new(),
+            &empty_prices(),
             solved(1_010_000_000, 1_005_000_000),
             solved(998_000_000, 995_000_000),
         );
         // USDC priced at 2e-9 native-units per ETH-wei (ETH = $2000) anchors ETH→USD.
-        let prices = usd::PriceMap::from([(usdc, 2e-9)]);
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
 
         let recorder = configure_buckets(PrometheusBuilder::new())
             .unwrap()
@@ -497,8 +506,7 @@ mod tests {
         let mut t = trade(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 1_000);
         t.venue = "0xD720183DdA64a8CDb424B5c13aF73baf713521f8".to_string();
         t.solver = "0xB6F54cAed61C318027c022c47B94BAF139a99Dab".to_string();
-        let range =
-            build_range(&t, &usd::PriceMap::new(), solved(1_100, 1_050), solved(1_100, 1_050));
+        let range = build_range(&t, &empty_prices(), solved(1_100, 1_050), solved(1_100, 1_050));
 
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
@@ -506,8 +514,8 @@ mod tests {
             record_range(
                 &range,
                 "ethereum",
-                &usd::PriceMap::new(),
-                &usd::PriceMap::new(),
+                &empty_prices(),
+                &empty_prices(),
                 &Registry::ethereum(),
             );
         });
@@ -525,8 +533,7 @@ mod tests {
         let mut t = trade(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 1_000);
         t.solver = "relay".to_string();
         t.solver_source = AttributionSource::Fallback;
-        let range =
-            build_range(&t, &usd::PriceMap::new(), solved(1_100, 1_050), solved(1_100, 1_050));
+        let range = build_range(&t, &empty_prices(), solved(1_100, 1_050), solved(1_100, 1_050));
 
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
@@ -534,8 +541,8 @@ mod tests {
             record_range(
                 &range,
                 "ethereum",
-                &usd::PriceMap::new(),
-                &usd::PriceMap::new(),
+                &empty_prices(),
+                &empty_prices(),
                 &Registry::ethereum(),
             );
         });
@@ -555,11 +562,12 @@ mod tests {
         t.amount_in = U256::from(1_000_000_000u64); // 1000 USDC
         let range = build_range(
             &t,
-            &usd::PriceMap::new(),
+            &empty_prices(),
             Outcome::Unsolvable("no route".into()),
             Outcome::Unsolvable("no route".into()),
         );
-        let prices = usd::PriceMap::from([(usdc, 2e-9)]);
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
 
         let recorder = configure_buckets(PrometheusBuilder::new())
             .unwrap()
@@ -580,7 +588,7 @@ mod tests {
     fn record_range_skips_savings_when_unsolvable() {
         let range = build_range(
             &trade(Address::repeat_byte(0x22), 1_000),
-            &usd::PriceMap::new(),
+            &empty_prices(),
             Outcome::Unsolvable("x".into()),
             Outcome::Unsolvable("x".into()),
         );
@@ -590,8 +598,8 @@ mod tests {
             record_range(
                 &range,
                 "ethereum",
-                &usd::PriceMap::new(),
-                &usd::PriceMap::new(),
+                &empty_prices(),
+                &empty_prices(),
                 &Registry::ethereum(),
             );
         });
@@ -612,7 +620,8 @@ mod tests {
             attacker: Address::repeat_byte(0xcc),
             pools: vec![Address::repeat_byte(0xdd)],
         });
-        let prices = usd::PriceMap::from([(usdc, 2e-9)]);
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
         let range = build_range(
             &sandwiched,
             &prices,

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -25,7 +25,7 @@ const FEED_REBUILDS: &str = "hindsight_feed_rebuilds_total";
 
 /// Absolute USD savings beyond which a comparison is logged with full per-trade context, so large
 /// outliers can be traced and classified (a genuinely large trade vs a token-mispricing artifact
-/// from the ETH-anchored valuation).
+/// from the gas-token-anchored valuation).
 const USD_OUTLIER_THRESHOLD: f64 = 1_000.0;
 
 /// Whether a USD savings value is large enough to log for inspection.

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -1,9 +1,9 @@
 //! USD valuation from Fynd's own token prices.
 //!
-//! The in-process solver prices every token it knows relative to the gas token (ETH):
-//! `price[token]` is the token's native-unit amount per 1 ETH-wei (tycho's best-spread
-//! mid-price). Those prices are ETH-denominated, not USD, so ETH itself is anchored to USD via
-//! the stablecoins' own entries in the same price map — a stablecoin is worth ~$1 per
+//! The in-process solver prices every token it knows relative to the chain's gas token (ETH on
+//! mainnet): `price[token]` is the token's native-unit amount per 1 wei of gas token (tycho's
+//! best-spread mid-price). Those prices are not USD, so the gas token itself is anchored to USD
+//! via the stablecoins' own entries in the same price map — a stablecoin is worth ~$1 per
 //! `10^decimals` native units. Which stablecoins anchor, and which wrapped-native token is
 //! interchangeable with the gas token, comes from the chain's address book, so valuation carries
 //! no chain knowledge of its own. Any trade whose output token Fynd has priced can be valued
@@ -17,14 +17,15 @@ use alloy::primitives::{Address, U256};
 use crate::decoder::Registry;
 
 /// Token-price snapshot from the solver's derived data, bundled with the chain's USD anchors:
-/// `price[token]` is the token's native-unit amount per 1 ETH-wei. Native ETH is the zero address.
+/// `price[token]` is the token's native-unit amount per 1 wei of the gas token. The native token
+/// is the zero address.
 pub(crate) struct Prices {
     map: HashMap<Address, f64>,
     /// The chain's wrapped-native token. Interchangeable with native (the zero address) for
     /// pricing, since only one of the two may carry a derived price depending on the solver's
     /// gas-token configuration.
     wrapped_native: Address,
-    /// `(stablecoin, decimals)` anchors for ETH→USD, from the address book.
+    /// `(stablecoin, decimals)` anchors pinning the gas token to USD, from the address book.
     stablecoins: Vec<(Address, u32)>,
 }
 
@@ -47,7 +48,7 @@ impl Prices {
         self.map.get(&token).copied()
     }
 
-    /// Positive, finite price of `token`, treating native ETH and the wrapped-native token as
+    /// Positive, finite price of `token`, treating the native token and its wrapped form as
     /// interchangeable.
     fn price_of(&self, token: Address) -> Option<f64> {
         let direct = self.map.get(&token).copied();
@@ -64,12 +65,13 @@ impl Prices {
             .filter(|p| *p > 0.0 && p.is_finite())
     }
 
-    /// USD value of one ETH-wei, averaged over whichever anchor stablecoins are priced.
+    /// USD value of one wei of the gas token, averaged over whichever anchor stablecoins are
+    /// priced.
     ///
-    /// For a stablecoin with `d` decimals, `price[stable]` is its native-unit amount per ETH-wei,
-    /// so `price[stable] / 10^d` is USD per ETH-wei (one native unit ≈ `1/10^d` USD). Returns
-    /// `None` when no anchor stablecoin is priced.
-    fn usd_per_eth_wei(&self) -> Option<f64> {
+    /// For a stablecoin with `d` decimals, `price[stable]` is its native-unit amount per wei, so
+    /// `price[stable] / 10^d` is USD per wei (one native unit ≈ `1/10^d` USD). Returns `None`
+    /// when no anchor stablecoin is priced.
+    fn usd_per_native_wei(&self) -> Option<f64> {
         let mut sum = 0.0;
         let mut count = 0u32;
         for &(stable, decimals) in &self.stablecoins {
@@ -81,21 +83,22 @@ impl Prices {
         (count > 0).then(|| sum / f64::from(count))
     }
 
-    /// USD value of `amount` native units of `token`: `amount / price[token] * usd_per_eth_wei`.
+    /// USD value of `amount` native units of `token`: `amount / price[token] * usd_per_native_wei`.
     ///
     /// Returns `None` when `token` is not priced, no anchor stablecoin is available, or the result
     /// is not finite (e.g. an amount that overflows f64).
     pub(crate) fn value_usd(&self, token: Address, amount: U256) -> Option<f64> {
-        let usd_per_eth_wei = self.usd_per_eth_wei()?;
+        let usd_per_native_wei = self.usd_per_native_wei()?;
         let price = self.price_of(token)?;
         let amount = u256_to_f64(amount);
-        let usd = amount * usd_per_eth_wei / price;
+        let usd = amount * usd_per_native_wei / price;
         usd.is_finite().then_some(usd)
     }
 
-    /// Convert a native gas cost (ETH-wei) into `token` native units at the snapshot price.
+    /// Convert a native gas cost (wei of the gas token) into `token` native units at the
+    /// snapshot price.
     ///
-    /// `price[token]` is the token's native-unit amount per ETH-wei, so the conversion is one
+    /// `price[token]` is the token's native-unit amount per wei, so the conversion is one
     /// multiplication. Returns `None` when `token` is not priced. The f64 round-trip loses
     /// wei-level precision, which is acceptable for a gas deduction — the cost itself is exact but
     /// its value in the output token is an estimate by nature.

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -1,14 +1,14 @@
 //! USD valuation from Fynd's own token prices.
 //!
-//! The in-process solver exposes, via its derived data, each token's mid-price relative to the gas
-//! token (ETH): `price[token]` is the token's native-unit amount per 1 ETH-wei (tycho's
-//! best-spread mid-price). Those prices are ETH-denominated, not USD, so to report USD we anchor
-//! ETH→USD using the stablecoins' own entries in the same price map (a stablecoin is worth ~$1 per
-//! `10^decimals` native units). Which stablecoins anchor — and which wrapped-native token is
-//! interchangeable with the gas token — comes from the chain's address book, so valuation carries
-//! no chain knowledge of its own. This values any trade whose output token Fynd has priced, using
-//! the solver's self-consistent price view. The prices are f64 approximations suitable for a USD
-//! estimate, not execution.
+//! The in-process solver prices every token it knows relative to the gas token (ETH):
+//! `price[token]` is the token's native-unit amount per 1 ETH-wei (tycho's best-spread
+//! mid-price). Those prices are ETH-denominated, not USD, so ETH itself is anchored to USD via
+//! the stablecoins' own entries in the same price map — a stablecoin is worth ~$1 per
+//! `10^decimals` native units. Which stablecoins anchor, and which wrapped-native token is
+//! interchangeable with the gas token, comes from the chain's address book, so valuation carries
+//! no chain knowledge of its own. Any trade whose output token Fynd has priced can be valued
+//! this way, using the solver's self-consistent price view. The prices are f64 approximations —
+//! fine for a USD estimate, not for execution.
 
 use std::collections::HashMap;
 

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -173,8 +173,8 @@ mod tests {
 
     #[test]
     fn anchors_come_from_the_address_book() {
-        // USDC and WETH are anchors because the ethereum book registers them, not because this
-        // module knows them.
+        // USDC and WETH are anchors because the ethereum address book registers them, not
+        // because this module knows them.
         let registry = Registry::ethereum();
         assert!(registry
             .stablecoin_anchors()

--- a/tools/hindsight/src/usd.rs
+++ b/tools/hindsight/src/usd.rs
@@ -4,30 +4,128 @@
 //! token (ETH): `price[token]` is the token's native-unit amount per 1 ETH-wei (tycho's
 //! best-spread mid-price). Those prices are ETH-denominated, not USD, so to report USD we anchor
 //! ETH→USD using the stablecoins' own entries in the same price map (a stablecoin is worth ~$1 per
-//! `10^decimals` native units). This values any trade whose output token Fynd has priced — far
-//! broader than the previous stablecoin-leg-only valuation — using the solver's self-consistent
-//! price view. The prices are f64 approximations suitable for a USD estimate, not execution.
+//! `10^decimals` native units). Which stablecoins anchor — and which wrapped-native token is
+//! interchangeable with the gas token — comes from the chain's address book, so valuation carries
+//! no chain knowledge of its own. This values any trade whose output token Fynd has priced, using
+//! the solver's self-consistent price view. The prices are f64 approximations suitable for a USD
+//! estimate, not execution.
 
 use std::collections::HashMap;
 
-use alloy::primitives::{address, Address, U256};
+use alloy::primitives::{Address, U256};
 
-/// Token prices snapshot from the solver's derived data: `price[token]` = token native-unit amount
-/// per 1 ETH-wei. Native ETH is the zero address.
-pub(crate) type PriceMap = HashMap<Address, f64>;
+use crate::decoder::Registry;
 
-/// Wrapped ETH. Interchangeable with native ETH (the zero address) for pricing, since only one of
-/// the two may carry a derived price depending on the solver's gas-token configuration.
-const WETH: Address = address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
+/// Token-price snapshot from the solver's derived data, bundled with the chain's USD anchors:
+/// `price[token]` is the token's native-unit amount per 1 ETH-wei. Native ETH is the zero address.
+pub(crate) struct Prices {
+    map: HashMap<Address, f64>,
+    /// The chain's wrapped-native token. Interchangeable with native (the zero address) for
+    /// pricing, since only one of the two may carry a derived price depending on the solver's
+    /// gas-token configuration.
+    wrapped_native: Address,
+    /// `(stablecoin, decimals)` anchors for ETH→USD, from the address book.
+    stablecoins: Vec<(Address, u32)>,
+}
 
-/// `(stablecoin address, decimals)` on Ethereum mainnet, used only to anchor ETH→USD.
-const STABLECOINS: &[(Address, u32)] = &[
-    (address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 6), // USDC
-    (address!("0xdac17f958d2ee523a2206206994597c13d831ec7"), 6), // USDT
-    (address!("0x6b175474e89094c44da98b954eedeac495271d0f"), 18), // DAI
-    (address!("0x4c9edd5852cd905f086c759e8383e09bff1e68b3"), 18), // USDe
-    (address!("0xdc035d45d973e3ec169d2276ddab16f1e407384f"), 18), // USDS
-];
+impl Prices {
+    /// An empty snapshot carrying `registry`'s USD anchors; fill it with [`Prices::insert`].
+    pub(crate) fn new(registry: &Registry) -> Self {
+        Self {
+            map: HashMap::new(),
+            wrapped_native: registry.wrapped_native(),
+            stablecoins: registry.stablecoin_anchors().to_vec(),
+        }
+    }
+
+    pub(crate) fn insert(&mut self, token: Address, price: f64) {
+        self.map.insert(token, price);
+    }
+
+    /// The raw derived price of `token`, without the wrapped-native fallback (for logging).
+    pub(crate) fn get(&self, token: Address) -> Option<f64> {
+        self.map.get(&token).copied()
+    }
+
+    /// Positive, finite price of `token`, treating native ETH and the wrapped-native token as
+    /// interchangeable.
+    fn price_of(&self, token: Address) -> Option<f64> {
+        let direct = self.map.get(&token).copied();
+        let fallback = match token {
+            t if t == Address::ZERO => self
+                .map
+                .get(&self.wrapped_native)
+                .copied(),
+            t if t == self.wrapped_native => self.map.get(&Address::ZERO).copied(),
+            _ => None,
+        };
+        direct
+            .or(fallback)
+            .filter(|p| *p > 0.0 && p.is_finite())
+    }
+
+    /// USD value of one ETH-wei, averaged over whichever anchor stablecoins are priced.
+    ///
+    /// For a stablecoin with `d` decimals, `price[stable]` is its native-unit amount per ETH-wei,
+    /// so `price[stable] / 10^d` is USD per ETH-wei (one native unit ≈ `1/10^d` USD). Returns
+    /// `None` when no anchor stablecoin is priced.
+    fn usd_per_eth_wei(&self) -> Option<f64> {
+        let mut sum = 0.0;
+        let mut count = 0u32;
+        for &(stable, decimals) in &self.stablecoins {
+            if let Some(price) = self.price_of(stable) {
+                sum += price / 10f64.powi(decimals.cast_signed());
+                count += 1;
+            }
+        }
+        (count > 0).then(|| sum / f64::from(count))
+    }
+
+    /// USD value of `amount` native units of `token`: `amount / price[token] * usd_per_eth_wei`.
+    ///
+    /// Returns `None` when `token` is not priced, no anchor stablecoin is available, or the result
+    /// is not finite (e.g. an amount that overflows f64).
+    pub(crate) fn value_usd(&self, token: Address, amount: U256) -> Option<f64> {
+        let usd_per_eth_wei = self.usd_per_eth_wei()?;
+        let price = self.price_of(token)?;
+        let amount = u256_to_f64(amount);
+        let usd = amount * usd_per_eth_wei / price;
+        usd.is_finite().then_some(usd)
+    }
+
+    /// Convert a native gas cost (ETH-wei) into `token` native units at the snapshot price.
+    ///
+    /// `price[token]` is the token's native-unit amount per ETH-wei, so the conversion is one
+    /// multiplication. Returns `None` when `token` is not priced. The f64 round-trip loses
+    /// wei-level precision, which is acceptable for a gas deduction — the cost itself is exact but
+    /// its value in the output token is an estimate by nature.
+    // Truncation is intentional: whole token units are sufficient for a gas estimate.
+    // Sign loss is impossible: gas_wei is from a U256 and price_of only returns positive values.
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    pub(crate) fn gas_in_token(&self, gas_wei: U256, token: Address) -> Option<U256> {
+        let price = self.price_of(token)?;
+        let units = u256_to_f64(gas_wei) * price;
+        units
+            .is_finite()
+            .then(|| U256::from(units as u128))
+    }
+
+    /// Signed USD savings of Fynd's output vs the settled amount (positive = Fynd better).
+    ///
+    /// Both amounts are `token_out` native units, valued in USD via [`Prices::value_usd`]; the
+    /// savings is their difference. Returns `None` when `token_out` is not priced or no anchor
+    /// stablecoin is available.
+    pub(crate) fn savings_usd(
+        &self,
+        token_out: Address,
+        fynd_amount_out: U256,
+        settled_amount_out: U256,
+    ) -> Option<f64> {
+        let fynd_usd = self.value_usd(token_out, fynd_amount_out)?;
+        let settled_usd = self.value_usd(token_out, settled_amount_out)?;
+        Some(fynd_usd - settled_usd)
+    }
+}
 
 /// Convert a `U256` token amount to `f64` via its four 64-bit limbs (little-endian).
 ///
@@ -44,85 +142,14 @@ pub(crate) fn u256_to_f64(amount: U256) -> f64 {
         (*d as f64) * 2f64.powi(192)
 }
 
-/// Positive, finite price of `token`, treating native ETH and WETH as interchangeable.
-fn price_of(prices: &PriceMap, token: Address) -> Option<f64> {
-    let direct = prices.get(&token).copied();
-    let fallback = match token {
-        t if t == Address::ZERO => prices.get(&WETH).copied(),
-        t if t == WETH => prices.get(&Address::ZERO).copied(),
-        _ => None,
-    };
-    direct
-        .or(fallback)
-        .filter(|p| *p > 0.0 && p.is_finite())
-}
-
-/// USD value of one ETH-wei, averaged over whichever anchor stablecoins are priced.
-///
-/// For a stablecoin with `d` decimals, `price[stable]` is its native-unit amount per ETH-wei, so
-/// `price[stable] / 10^d` is USD per ETH-wei (one native unit ≈ `1/10^d` USD). Returns `None` when
-/// no anchor stablecoin is priced.
-fn usd_per_eth_wei(prices: &PriceMap) -> Option<f64> {
-    let mut sum = 0.0;
-    let mut count = 0u32;
-    for &(stable, decimals) in STABLECOINS {
-        if let Some(price) = price_of(prices, stable) {
-            sum += price / 10f64.powi(decimals.cast_signed());
-            count += 1;
-        }
-    }
-    (count > 0).then(|| sum / f64::from(count))
-}
-
-/// USD value of `amount` native units of `token`: `amount / price[token] * usd_per_eth_wei`.
-///
-/// Returns `None` when `token` is not priced, no anchor stablecoin is available, or the result is
-/// not finite (e.g. an amount that overflows f64).
-pub(crate) fn value_usd(token: Address, amount: U256, prices: &PriceMap) -> Option<f64> {
-    let usd_per_eth_wei = usd_per_eth_wei(prices)?;
-    let price = price_of(prices, token)?;
-    let amount = u256_to_f64(amount);
-    let usd = amount * usd_per_eth_wei / price;
-    usd.is_finite().then_some(usd)
-}
-
-/// Convert a native gas cost (ETH-wei) into `token` native units at the snapshot price.
-///
-/// `price[token]` is the token's native-unit amount per ETH-wei, so the conversion is one
-/// multiplication. Returns `None` when `token` is not priced. The f64 round-trip loses wei-level
-/// precision, which is acceptable for a gas deduction — the cost itself is exact but its value in
-/// the output token is an estimate by nature.
-// Truncation is intentional: whole token units are sufficient for a gas estimate.
-// Sign loss is impossible: gas_wei is from a U256 and price_of only returns positive values.
-#[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-pub(crate) fn gas_in_token(gas_wei: U256, token: Address, prices: &PriceMap) -> Option<U256> {
-    let price = price_of(prices, token)?;
-    let units = u256_to_f64(gas_wei) * price;
-    units
-        .is_finite()
-        .then(|| U256::from(units as u128))
-}
-
-/// Signed USD savings of Fynd's output vs the settled amount (positive = Fynd better).
-///
-/// Both amounts are `token_out` native units, valued in USD via [`value_usd`]; the savings is their
-/// difference. Returns `None` when `token_out` is not priced or no anchor stablecoin is available.
-pub(crate) fn savings_usd(
-    token_out: Address,
-    fynd_amount_out: U256,
-    settled_amount_out: U256,
-    prices: &PriceMap,
-) -> Option<f64> {
-    let fynd_usd = value_usd(token_out, fynd_amount_out, prices)?;
-    let settled_usd = value_usd(token_out, settled_amount_out, prices)?;
-    Some(fynd_usd - settled_usd)
-}
-
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::address;
+
     use super::*;
 
     const USDC: Address = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+    const WETH: Address = address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");
 
     /// ETH = $2000. price[token] = token native-units per ETH-wei.
     /// USDC (6 dp): 2000 USDC per ETH = 2000 * 1e6 native units / 1e18 wei = 2e-9.
@@ -130,28 +157,42 @@ mod tests {
     /// WETH (18 dp): ~1:1 with ETH → 1e18 native units / 1e18 wei = 1.0.
     const WETH_PRICE: f64 = 1.0;
 
-    fn prices() -> PriceMap {
-        PriceMap::from([(USDC, USDC_PRICE), (WETH, WETH_PRICE)])
+    fn empty_prices() -> Prices {
+        Prices::new(&Registry::ethereum())
+    }
+
+    fn prices() -> Prices {
+        let mut prices = empty_prices();
+        prices.insert(USDC, USDC_PRICE);
+        prices.insert(WETH, WETH_PRICE);
+        prices
+    }
+
+    #[test]
+    fn anchors_come_from_the_address_book() {
+        // USDC and WETH are anchors because the ethereum book registers them, not because this
+        // module knows them.
+        let registry = Registry::ethereum();
+        assert!(registry
+            .stablecoin_anchors()
+            .contains(&(USDC, 6)));
+        assert_eq!(registry.wrapped_native(), WETH);
     }
 
     #[test]
     fn output_leg_stable_positive_when_fynd_better() {
         // WETH→USDC: Fynd 1010 USDC vs settled 1000 USDC → +$10.
-        let s = savings_usd(
-            USDC,
-            U256::from(1_010_000_000u64),
-            U256::from(1_000_000_000u64),
-            &prices(),
-        )
-        .unwrap();
+        let s = prices()
+            .savings_usd(USDC, U256::from(1_010_000_000u64), U256::from(1_000_000_000u64))
+            .unwrap();
         assert!((s - 10.0).abs() < 1e-6, "expected +10, got {s}");
     }
 
     #[test]
     fn output_leg_negative_when_fynd_worse() {
-        let s =
-            savings_usd(USDC, U256::from(990_000_000u64), U256::from(1_000_000_000u64), &prices())
-                .unwrap();
+        let s = prices()
+            .savings_usd(USDC, U256::from(990_000_000u64), U256::from(1_000_000_000u64))
+            .unwrap();
         assert!((s + 10.0).abs() < 1e-6, "expected -10, got {s}");
     }
 
@@ -160,7 +201,9 @@ mod tests {
         // USDC→WETH: Fynd 1.01 WETH vs settled 1.00 WETH → +0.01 ETH = +$20 (ETH = $2000).
         let one_weth = U256::from(10u64).pow(U256::from(18u64));
         let fynd_weth = one_weth * U256::from(101u64) / U256::from(100u64);
-        let s = savings_usd(WETH, fynd_weth, one_weth, &prices()).unwrap();
+        let s = prices()
+            .savings_usd(WETH, fynd_weth, one_weth)
+            .unwrap();
         assert!((s - 20.0).abs() < 1e-3, "expected ~+20, got {s}");
     }
 
@@ -169,31 +212,33 @@ mod tests {
         // token_out is native ETH (zero address); only WETH is priced → use WETH's price.
         let one_eth = U256::from(10u64).pow(U256::from(18u64));
         let fynd_eth = one_eth * U256::from(101u64) / U256::from(100u64);
-        let s = savings_usd(Address::ZERO, fynd_eth, one_eth, &prices()).unwrap();
+        let s = prices()
+            .savings_usd(Address::ZERO, fynd_eth, one_eth)
+            .unwrap();
         assert!((s - 20.0).abs() < 1e-3, "expected ~+20, got {s}");
     }
 
     #[test]
     fn large_gain_not_capped() {
         // Fynd 1500 USDC vs settled 1000 USDC → +$500, no plausibility cap.
-        let s = savings_usd(
-            USDC,
-            U256::from(1_500_000_000u64),
-            U256::from(1_000_000_000u64),
-            &prices(),
-        )
-        .unwrap();
+        let s = prices()
+            .savings_usd(USDC, U256::from(1_500_000_000u64), U256::from(1_000_000_000u64))
+            .unwrap();
         assert!((s - 500.0).abs() < 1e-6, "expected +500, got {s}");
     }
 
     #[test]
     fn value_usd_scales_amount_by_price_and_anchor() {
         // 1000 USDC (6 dp) → $1000.
-        let v = value_usd(USDC, U256::from(1_000_000_000u64), &prices()).unwrap();
+        let v = prices()
+            .value_usd(USDC, U256::from(1_000_000_000u64))
+            .unwrap();
         assert!((v - 1_000.0).abs() < 1e-6, "expected $1000, got {v}");
         // 1 WETH → $2000 (ETH = $2000).
         let one_weth = U256::from(10u64).pow(U256::from(18u64));
-        let v = value_usd(WETH, one_weth, &prices()).unwrap();
+        let v = prices()
+            .value_usd(WETH, one_weth)
+            .unwrap();
         assert!((v - 2_000.0).abs() < 1e-3, "expected $2000, got {v}");
     }
 
@@ -201,37 +246,40 @@ mod tests {
     fn gas_in_token_converts_wei_at_snapshot_price() {
         // 0.001 ETH of gas, USDC at 2e-9 native units per wei (ETH = $2000) → 2 USDC.
         let gas_wei = U256::from(10u64).pow(U256::from(15u64));
-        let got = gas_in_token(gas_wei, USDC, &prices()).unwrap();
+        let got = prices()
+            .gas_in_token(gas_wei, USDC)
+            .unwrap();
         assert_eq!(got, U256::from(2_000_000u64));
     }
 
     #[test]
     fn gas_in_token_unpriced_token_is_none() {
-        assert_eq!(gas_in_token(U256::from(1u64), Address::repeat_byte(0x42), &prices()), None);
+        assert_eq!(prices().gas_in_token(U256::from(1u64), Address::repeat_byte(0x42)), None);
     }
 
     #[test]
     fn value_usd_unpriced_or_no_anchor_is_none() {
-        assert_eq!(value_usd(Address::repeat_byte(0x42), U256::from(1u64), &prices()), None);
-        assert_eq!(value_usd(USDC, U256::from(1u64), &PriceMap::new()), None);
+        assert_eq!(prices().value_usd(Address::repeat_byte(0x42), U256::from(1u64)), None);
+        assert_eq!(empty_prices().value_usd(USDC, U256::from(1u64)), None);
     }
 
     #[test]
     fn unpriced_output_token_is_none() {
         let unknown = Address::repeat_byte(0x42);
-        assert_eq!(savings_usd(unknown, U256::from(2u64), U256::from(1u64), &prices()), None);
+        assert_eq!(prices().savings_usd(unknown, U256::from(2u64), U256::from(1u64)), None);
     }
 
     #[test]
     fn no_anchor_stablecoin_is_none() {
         // WETH priced but no stablecoin → cannot anchor ETH→USD.
-        let prices = PriceMap::from([(WETH, WETH_PRICE)]);
+        let mut prices = empty_prices();
+        prices.insert(WETH, WETH_PRICE);
         let one_weth = U256::from(10u64).pow(U256::from(18u64));
-        assert_eq!(savings_usd(WETH, one_weth, one_weth, &prices), None);
+        assert_eq!(prices.savings_usd(WETH, one_weth, one_weth), None);
     }
 
     #[test]
     fn empty_prices_is_none() {
-        assert_eq!(savings_usd(USDC, U256::from(2u64), U256::from(1u64), &PriceMap::new()), None);
+        assert_eq!(empty_prices().savings_usd(USDC, U256::from(2u64), U256::from(1u64)), None);
     }
 }


### PR DESCRIPTION
Preparation for integrating new venues, solvers, and chains: everything the decoder knows about a specific chain or protocol now lives either in the per-chain address book (TOML) or in that protocol's own module. No behavior changes.

Review by commit.

Custom `--registry` files need the new sections and fail loudly at load if they are missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)