### PR TITLE
feat: add fynd-benchmark generate-requests subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,6 +3386,7 @@ dependencies = [
  "fynd-rpc",
  "fynd-tools-common",
  "num-bigint",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -9,7 +9,7 @@ infrastructure.
 |---|---|
 | `builder.rs` | `FyndRPCBuilder` wraps `FyndBuilder`, adds HTTP server config. `FyndRPC` struct runs the server with graceful shutdown |
 | `config.rs` | `WorkerPoolsConfig` (TOML loader), `BlocklistConfig`, `defaults` module re-exporting `fynd-core` defaults + HTTP-specific ones |
-| `protocols.rs` | `fetch_protocol_systems()` — paginated Tycho RPC call to discover available protocols; `resolve_protocols()` — higher-level wrapper used by `serve` and `scale` that expands `all_onchain`/`native_onchain` tokens and applies min-TVL filtering |
+| `protocols.rs` | `fetch_protocol_systems()` — paginated Tycho RPC call to discover available protocols; `resolve_protocols()` — higher-level wrapper used by `serve` and `scale` that expands `all_onchain`/`native_onchain` tokens and applies min-TVL filtering; `fetch_token_pool_stats()` — per-token pool counts and decimals (used by the benchmark `generate-requests` subcommand) |
 | `api/` | HTTP endpoint handlers and OpenAPI documentation |
 
 ## Features

--- a/fynd-rpc/src/protocols.rs
+++ b/fynd-rpc/src/protocols.rs
@@ -1,11 +1,21 @@
 //! Tycho protocol system discovery.
 
+use std::collections::HashMap;
+
 use anyhow::{bail, Result};
 use tracing::info;
 use tycho_simulation::{
-    tycho_client::rpc::{HttpRPCClient, HttpRPCClientOptions, ProtocolSystemsParams, RPCClient},
+    tycho_client::rpc::{
+        AllTokensParams, HttpRPCClient, HttpRPCClientOptions, ProtocolComponentsPaginatedParams,
+        ProtocolSystemsParams, RPCClient,
+    },
     tycho_common::models::Chain,
 };
+
+use crate::config::defaults::MIN_TOKEN_QUALITY;
+
+/// Concurrency for the paginated Tycho component/token fetches in [`fetch_token_pool_stats`].
+const FETCH_CONCURRENCY: usize = 8;
 
 /// Expansion token: fetch every on-chain protocol system from Tycho.
 const ALL_ONCHAIN: &str = "all_onchain";
@@ -84,4 +94,95 @@ pub async fn resolve_protocols(
         bail!("no supported protocols found. Provide --protocols or check Tycho connectivity.");
     }
     Ok(protocols)
+}
+
+/// Per-token liquidity statistics derived from Tycho protocol components.
+///
+/// `pool_count` mirrors the connector-token score in the `derive-connector-tokens` command: the
+/// number of pools a token appears in, a proxy for how much traffic it attracts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenPoolStats {
+    /// 0x-prefixed lowercase hex address.
+    pub address: String,
+    /// Token symbol as reported by Tycho (may be empty for exotic tokens).
+    pub symbol: String,
+    /// Number of decimals; used to scale synthetic amounts into raw units.
+    pub decimals: u32,
+    /// Number of pools the token appears in across the queried protocol systems.
+    pub pool_count: usize,
+}
+
+/// Fetches per-token pool counts and metadata from the Tycho RPC.
+///
+/// Queries every protocol system in `protocols` for its components (paginated), counts how many
+/// pools each token appears in, then joins against Tycho's token list for symbols and decimals.
+/// Tokens that appear in a pool but have no metadata (or fail the quality filter) are dropped, as
+/// their decimals are needed to scale amounts.
+///
+/// The result is sorted by descending pool count then address so callers get a deterministic order
+/// regardless of RPC page ordering.
+pub async fn fetch_token_pool_stats(
+    tycho_url: &str,
+    auth_key: Option<&str>,
+    use_tls: bool,
+    chain: Chain,
+    protocols: &[String],
+) -> Result<Vec<TokenPoolStats>> {
+    let rpc_url =
+        if use_tls { format!("https://{tycho_url}") } else { format!("http://{tycho_url}") };
+    let rpc_options = HttpRPCClientOptions::new().with_auth_key(auth_key.map(|s| s.to_string()));
+    let rpc_client = HttpRPCClient::new(&rpc_url, rpc_options)?;
+
+    // Count pool appearances per token across every requested protocol system.
+    let mut pool_count: HashMap<String, usize> = HashMap::new();
+    for protocol in protocols {
+        info!("Fetching components for protocol system '{protocol}'...");
+        let params = ProtocolComponentsPaginatedParams::new(chain, protocol, FETCH_CONCURRENCY);
+        let components = rpc_client
+            .get_protocol_components_paginated(params)
+            .await?;
+        for component in &components {
+            for token in &component.tokens {
+                *pool_count
+                    .entry(token.to_string())
+                    .or_insert(0) += 1;
+            }
+        }
+    }
+
+    info!("Fetching token metadata from Tycho RPC...");
+    let token_params =
+        AllTokensParams::new(chain, FETCH_CONCURRENCY).with_min_quality(MIN_TOKEN_QUALITY);
+    let tokens = rpc_client
+        .get_all_tokens(token_params)
+        .await?;
+
+    let mut stats: Vec<TokenPoolStats> = Vec::new();
+    for token in &tokens {
+        let address = token.address.to_string();
+        let Some(&count) = pool_count.get(&address) else {
+            continue;
+        };
+        stats.push(TokenPoolStats {
+            address,
+            symbol: token.symbol.clone(),
+            decimals: token.decimals,
+            pool_count: count,
+        });
+    }
+
+    stats.sort_by(|a, b| {
+        b.pool_count
+            .cmp(&a.pool_count)
+            .then_with(|| a.address.cmp(&b.address))
+    });
+
+    if stats.is_empty() {
+        bail!(
+            "no tokens with both pool membership and metadata found for the requested protocols; \
+             check Tycho connectivity and the --protocols / --chain arguments"
+        );
+    }
+    info!("Derived pool stats for {} token(s)", stats.len());
+    Ok(stats)
 }

--- a/fynd-rpc/src/protocols.rs
+++ b/fynd-rpc/src/protocols.rs
@@ -1,8 +1,9 @@
 //! Tycho protocol system discovery.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, future::Future, time::Duration};
 
 use anyhow::{bail, Result};
+use tokio::time::timeout;
 use tracing::info;
 use tycho_simulation::{
     tycho_client::rpc::{
@@ -112,6 +113,51 @@ pub struct TokenPoolStats {
     pub pool_count: usize,
 }
 
+/// Inputs to [`fetch_token_pool_stats`].
+///
+/// Bundles the Tycho connection parameters with the two capacity-testing knobs: a per-fetch
+/// client-side `fetch_timeout` so a degraded indexer fails fast instead of hanging, and an optional
+/// `min_tvl` passed to Tycho as `tvl_gt`. The dedicated `tycho-fynd-*` indexer endpoints plan-gate
+/// component queries and reject them unless `min_tvl` is set.
+pub struct TokenPoolStatsParams<'a> {
+    /// Tycho RPC host:port (no scheme).
+    pub tycho_url: &'a str,
+    /// Optional Tycho auth key.
+    pub auth_key: Option<&'a str>,
+    /// Connect over HTTPS when true, HTTP otherwise.
+    pub use_tls: bool,
+    /// Target chain.
+    pub chain: Chain,
+    /// Protocol systems to query for components.
+    pub protocols: &'a [String],
+    /// When set, only pools whose TVL exceeds this value (native-token units) are counted, passed
+    /// as `tvl_gt`. Required by the `tycho-fynd-*` endpoints, which plan-gate component queries.
+    pub min_tvl: Option<f64>,
+    /// Client-side deadline applied to each per-protocol component fetch and the token-metadata
+    /// fetch.
+    pub fetch_timeout: Duration,
+}
+
+/// Awaits a single Tycho fetch under a client-side deadline.
+///
+/// On completion the inner RPC error is surfaced unchanged; on a timeout the `on_timeout` message
+/// is returned instead. Without this a degraded indexer leaves the fetch hanging indefinitely
+/// (observed byte-flat stalls exceeding 18 minutes against `tycho-base-beta`).
+async fn await_with_timeout<T, E, Fut>(
+    fetch: Fut,
+    timeout_after: Duration,
+    on_timeout: impl FnOnce() -> String,
+) -> Result<T>
+where
+    Fut: Future<Output = std::result::Result<T, E>>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    match timeout(timeout_after, fetch).await {
+        Ok(result) => result.map_err(anyhow::Error::from),
+        Err(_elapsed) => Err(anyhow::anyhow!(on_timeout())),
+    }
+}
+
 /// Fetches per-token pool counts and metadata from the Tycho RPC.
 ///
 /// Queries every protocol system in `protocols` for its components (paginated), counts how many
@@ -122,25 +168,39 @@ pub struct TokenPoolStats {
 /// The result is sorted by descending pool count then address so callers get a deterministic order
 /// regardless of RPC page ordering.
 pub async fn fetch_token_pool_stats(
-    tycho_url: &str,
-    auth_key: Option<&str>,
-    use_tls: bool,
-    chain: Chain,
-    protocols: &[String],
+    params: &TokenPoolStatsParams<'_>,
 ) -> Result<Vec<TokenPoolStats>> {
-    let rpc_url =
-        if use_tls { format!("https://{tycho_url}") } else { format!("http://{tycho_url}") };
-    let rpc_options = HttpRPCClientOptions::new().with_auth_key(auth_key.map(|s| s.to_string()));
+    let rpc_url = if params.use_tls {
+        format!("https://{}", params.tycho_url)
+    } else {
+        format!("http://{}", params.tycho_url)
+    };
+    let rpc_options =
+        HttpRPCClientOptions::new().with_auth_key(params.auth_key.map(|s| s.to_string()));
     let rpc_client = HttpRPCClient::new(&rpc_url, rpc_options)?;
 
     // Count pool appearances per token across every requested protocol system.
     let mut pool_count: HashMap<String, usize> = HashMap::new();
-    for protocol in protocols {
+    for protocol in params.protocols {
         info!("Fetching components for protocol system '{protocol}'...");
-        let params = ProtocolComponentsPaginatedParams::new(chain, protocol, FETCH_CONCURRENCY);
-        let components = rpc_client
-            .get_protocol_components_paginated(params)
-            .await?;
+        let mut component_params =
+            ProtocolComponentsPaginatedParams::new(params.chain, protocol, FETCH_CONCURRENCY);
+        if let Some(min_tvl) = params.min_tvl {
+            component_params = component_params.with_tvl_gt(min_tvl);
+        }
+        let components = await_with_timeout(
+            rpc_client.get_protocol_components_paginated(component_params),
+            params.fetch_timeout,
+            || {
+                format!(
+                    "timed out after {}s fetching components for protocol system '{protocol}'; \
+                     the Tycho indexer may be degraded. Exclude it via --protocols or raise \
+                     --fetch-timeout-secs.",
+                    params.fetch_timeout.as_secs()
+                )
+            },
+        )
+        .await?;
         for component in &components {
             for token in &component.tokens {
                 *pool_count
@@ -152,9 +212,15 @@ pub async fn fetch_token_pool_stats(
 
     info!("Fetching token metadata from Tycho RPC...");
     let token_params =
-        AllTokensParams::new(chain, FETCH_CONCURRENCY).with_min_quality(MIN_TOKEN_QUALITY);
-    let tokens = rpc_client
-        .get_all_tokens(token_params)
+        AllTokensParams::new(params.chain, FETCH_CONCURRENCY).with_min_quality(MIN_TOKEN_QUALITY);
+    let tokens =
+        await_with_timeout(rpc_client.get_all_tokens(token_params), params.fetch_timeout, || {
+            format!(
+                "timed out after {}s fetching token metadata from Tycho; the indexer may be \
+                 degraded. Raise --fetch-timeout-secs or retry.",
+                params.fetch_timeout.as_secs()
+            )
+        })
         .await?;
 
     let mut stats: Vec<TokenPoolStats> = Vec::new();
@@ -185,4 +251,49 @@ pub async fn fetch_token_pool_stats(
     }
     info!("Derived pool stats for {} token(s)", stats.len());
     Ok(stats)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn await_with_timeout_reports_deadline() {
+        let fetch = std::future::pending::<std::result::Result<(), io::Error>>();
+        let err = await_with_timeout(fetch, Duration::from_millis(10), || {
+            "timed out fetching components for protocol system 'uniswap_v3'".to_string()
+        })
+        .await
+        .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("protocol system 'uniswap_v3'"));
+    }
+
+    #[tokio::test]
+    async fn await_with_timeout_passes_through_success() {
+        let value =
+            await_with_timeout(async { Ok::<u32, io::Error>(7) }, Duration::from_secs(30), || {
+                "unused".to_string()
+            })
+            .await
+            .unwrap();
+        assert_eq!(value, 7);
+    }
+
+    #[tokio::test]
+    async fn await_with_timeout_surfaces_inner_error() {
+        let fetch =
+            async { std::result::Result::<u32, io::Error>::Err(io::Error::other("rpc exploded")) };
+        let err =
+            await_with_timeout(fetch, Duration::from_secs(30), || "should not be used".to_string())
+                .await
+                .unwrap_err();
+        assert!(err.to_string().contains("rpc exploded"));
+        assert!(!err
+            .to_string()
+            .contains("should not be used"));
+    }
 }

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -15,13 +15,14 @@ Developer and operational tooling for the Fynd solver.
 
 See [`tools/benchmark/CLAUDE.md`](benchmark/CLAUDE.md) for the full module overview.
 
-Five subcommands via `cargo run -p fynd-benchmark --release --`:
+Six subcommands via `cargo run -p fynd-benchmark --release --`:
 
 - **`load`** — Load-test a single solver (latency, throughput, histograms)
 - **`compare`** — Compare output quality between two solver instances (amount out diff in bps)
 - **`scale`** — Measure how solver throughput scales with worker thread count (in-process, no external solver needed)
 - **`download-trades`** — Download the full 10k aggregator trade dataset from GitHub Releases
 - **`audit`** — Compare Fynd quote quality against external aggregators (Nordstern, KyberSwap, 0x); writes a JSON report
+- **`generate-requests`** — Generate a synthetic per-chain request dataset (weighted by Tycho pool counts) for capacity testing on non-Ethereum chains
 
 ---
 

--- a/tools/benchmark/CLAUDE.md
+++ b/tools/benchmark/CLAUDE.md
@@ -4,7 +4,7 @@ Benchmark and comparison tooling for Fynd solvers. Requires one or more running 
 
 ## Commands
 
-Five subcommands available via `cargo run -p fynd-benchmark --release --`:
+Six subcommands available via `cargo run -p fynd-benchmark --release --`:
 
 - **`load`** — Load-test a single solver. Measures latency (round-trip, solve time, overhead) and throughput. Supports sequential, fixed-concurrency, and rate-based parallelization modes. Prints statistics and ASCII histograms to stdout; optionally exports results to JSON.
 
@@ -15,6 +15,8 @@ Five subcommands available via `cargo run -p fynd-benchmark --release --`:
 - **`download-trades`** — Download the full 10k aggregator trade dataset from GitHub Releases for use with `--requests-file`.
 
 - **`audit`** — Compare Fynd quote quality against external aggregators (Nordstern, KyberSwap, 0x). Runs over a trade dataset, records per-trade participant results (amount out, gas, protocols, route, eth_call on-chain validation), and writes a JSON report.
+
+- **`generate-requests`** — Generate a synthetic per-chain request dataset (JSON) for capacity load testing, for chains the Ethereum-only `download-trades` set does not cover. Fetches token/pool-count data from Tycho (via `fynd_rpc::protocols::fetch_token_pool_stats`, the same pool-count query as `derive-connector-tokens`), samples token pairs weighted by pool count, and log-spaces amounts around one whole token. Deterministic for a fixed `--seed`. Output is loadable via `--requests-file`. Accepts `--chain` values `ethereum`, `base`, `unichain`, `bsc`, `arbitrum`, `polygon` (case-insensitive); `zksync` parses but needs an explicit `--tycho-url`.
 
 Run `--help` on any subcommand for detailed options.
 
@@ -118,6 +120,7 @@ Key fields per participant:
 | `exporter.rs` | Statistics calculation (`TimingStats::from_measurements` — min/max/mean/median/p95/p99/stddev), ASCII histogram rendering, and JSON export of `BenchmarkResults`. |
 | `requests.rs` | Request generation and loading. Provides a default WETH→USDC request, loads embedded aggregator trades, downloads the full 10k dataset, and loads custom requests from a JSON file. |
 | `scale.rs` | `scale` subcommand handler. Resolves protocols once via `resolve_protocols` (`all_onchain`/`native_onchain` expansion), then builds and tears down an in-process Fynd instance for each worker-count iteration (applying `--min-tvl`), runs load tests via `runner`, and exports scaling results to JSON. |
+| `generate_requests.rs` | `generate-requests` subcommand handler. Fetches per-token pool counts and decimals from Tycho via `fynd_rpc::protocols::fetch_token_pool_stats`, samples token pairs weighted by pool count (seeded `StdRng`, no self-pairs), log-spaces amounts around one whole token, and writes a `--requests-file`-compatible JSON array. |
 | `aggregator.rs` | Aggregator API clients (Nordstern, KyberSwap, 0x) used by the `audit` subcommand. |
 | `pair_selector.rs` | Trade pair selection logic for `audit` runs. |
 | `audit/` | `audit` subcommand handler: per-trade result collection, on-chain validation via `eth_call`, JSON report writing. |

--- a/tools/benchmark/Cargo.toml
+++ b/tools/benchmark/Cargo.toml
@@ -20,6 +20,7 @@ alloy = { workspace = true }
 bytes = { workspace = true }
 num-bigint = { workspace = true }
 fastrand = "2.3"
+rand = "0.9"
 reqwest = { workspace = true }
 async-trait = { workspace = true }
 futures = { workspace = true }

--- a/tools/benchmark/src/generate_requests.rs
+++ b/tools/benchmark/src/generate_requests.rs
@@ -8,14 +8,14 @@
 //! Token and pool-count data comes from the same Tycho query the `derive-connector-tokens` command
 //! uses, exposed as `fynd_rpc::protocols::fetch_token_pool_stats`.
 
-use std::{collections::HashSet, path::PathBuf};
+use std::{collections::HashSet, path::PathBuf, time::Duration};
 
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use fynd_rpc::{
     config::defaults::default_tycho_url,
     parse_chain,
-    protocols::{fetch_token_pool_stats, resolve_protocols, TokenPoolStats},
+    protocols::{fetch_token_pool_stats, resolve_protocols, TokenPoolStats, TokenPoolStatsParams},
 };
 use num_bigint::BigUint;
 use rand::{
@@ -64,6 +64,18 @@ pub struct Args {
     /// `native_onchain` expansion tokens.
     #[arg(long, value_delimiter = ',', default_value = "all_onchain")]
     pub protocols: Vec<String>,
+
+    /// Minimum pool TVL (in the chain's native token) for a pool to be counted, passed to Tycho as
+    /// `tvl_gt`. Leave unset to count all pools. The dedicated `tycho-fynd-*` indexer endpoints
+    /// plan-gate component queries and reject them unless this is set.
+    #[arg(long)]
+    pub min_tvl: Option<f64>,
+
+    /// Client-side timeout, in seconds, for each per-protocol Tycho fetch. A degraded indexer can
+    /// otherwise hang the fetch indefinitely; on timeout the run fails fast, naming the protocol
+    /// system so it can be excluded with --protocols.
+    #[arg(long, default_value_t = 300)]
+    pub fetch_timeout_secs: u64,
 
     /// Number of most-connected tokens to sample pairs from.
     #[arg(long, default_value_t = 50)]
@@ -235,14 +247,16 @@ pub async fn run(args: Args) -> Result<()> {
     .await?;
     info!("Resolved {} protocol system(s)", protocols.len());
 
-    let mut tokens = fetch_token_pool_stats(
-        &tycho_url,
-        args.tycho_api_key.as_deref(),
-        !args.disable_tls,
+    let stats_params = TokenPoolStatsParams {
+        tycho_url: &tycho_url,
+        auth_key: args.tycho_api_key.as_deref(),
+        use_tls: !args.disable_tls,
         chain,
-        &protocols,
-    )
-    .await?;
+        protocols: &protocols,
+        min_tvl: args.min_tvl,
+        fetch_timeout: Duration::from_secs(args.fetch_timeout_secs),
+    };
+    let mut tokens = fetch_token_pool_stats(&stats_params).await?;
     tokens.truncate(args.top_n_tokens);
     info!("Sampling {} request(s) from top {} token(s)", args.num_requests, tokens.len());
 
@@ -333,6 +347,38 @@ mod tests {
         assert_eq!(amounts(&first), amounts(&second));
         let different = sample_requests(&tokens, 100, 43, 5000).unwrap();
         assert_ne!(amounts(&first), amounts(&different));
+    }
+
+    #[test]
+    fn args_parse_min_tvl_and_fetch_timeout() {
+        let args = Args::try_parse_from([
+            "generate-requests",
+            "--chain",
+            "ethereum",
+            "--output",
+            "out.json",
+            "--min-tvl",
+            "250.5",
+            "--fetch-timeout-secs",
+            "45",
+        ])
+        .unwrap();
+        assert_eq!(args.min_tvl, Some(250.5));
+        assert_eq!(args.fetch_timeout_secs, 45);
+    }
+
+    #[test]
+    fn args_default_fetch_timeout_and_no_min_tvl() {
+        let args = Args::try_parse_from([
+            "generate-requests",
+            "--chain",
+            "ethereum",
+            "--output",
+            "out.json",
+        ])
+        .unwrap();
+        assert_eq!(args.min_tvl, None);
+        assert_eq!(args.fetch_timeout_secs, 300);
     }
 
     #[test]

--- a/tools/benchmark/src/generate_requests.rs
+++ b/tools/benchmark/src/generate_requests.rs
@@ -1,0 +1,365 @@
+//! `generate-requests` subcommand.
+//!
+//! Generates a per-chain synthetic swap-request dataset for capacity load testing. Token pairs are
+//! sampled weighted by pool count (mimicking real traffic skew) and amounts are log-spaced around
+//! one whole token, so the dataset spans the amount range a solver sees in production. The output
+//! is a JSON array loadable via `--requests-file`.
+//!
+//! Token and pool-count data comes from the same Tycho query the `derive-connector-tokens` command
+//! uses, exposed as `fynd_rpc::protocols::fetch_token_pool_stats`.
+
+use std::{collections::HashSet, path::PathBuf};
+
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use fynd_rpc::{
+    config::defaults::default_tycho_url,
+    parse_chain,
+    protocols::{fetch_token_pool_stats, resolve_protocols, TokenPoolStats},
+};
+use num_bigint::BigUint;
+use rand::{
+    distr::{weighted::WeightedIndex, Distribution},
+    rngs::StdRng,
+    Rng, SeedableRng,
+};
+use serde::Serialize;
+use tracing::info;
+
+/// Placeholder sender used for every generated order (matches the aggregator-trade datasets).
+const SENDER: &str = "0x0000000000000000000000000000000000000001";
+
+/// Orders of magnitude spanned around one whole token, in each direction. A spread of 2 covers a
+/// ~4-order-of-magnitude range (0.01 to 100 whole tokens).
+const AMOUNT_LOG_SPREAD: f64 = 2.0;
+
+/// Generate a synthetic per-chain request dataset for capacity testing.
+#[derive(Parser, Debug)]
+#[command(
+    about = "Generate a synthetic per-chain request dataset for capacity testing",
+    long_about = "Generate a synthetic per-chain request dataset for capacity testing.\n\n\
+        Fetches token and pool-count data from Tycho, samples token pairs weighted by pool count, \
+        and writes a JSON array of requests loadable via --requests-file.\n\n\
+        Accepted --chain values: ethereum, base, unichain, bsc, arbitrum, polygon (case-insensitive). \
+        zksync also parses but has no default Tycho URL, so pass --tycho-url for it."
+)]
+pub struct Args {
+    /// Target chain: ethereum, base, unichain, bsc, arbitrum, or polygon.
+    #[arg(long)]
+    pub chain: String,
+
+    /// Tycho URL. Defaults to the Fynd endpoint for the selected chain.
+    #[arg(long)]
+    pub tycho_url: Option<String>,
+
+    /// Tycho API key (defaults to the TYCHO_API_KEY environment variable).
+    #[arg(long, env = "TYCHO_API_KEY")]
+    pub tycho_api_key: Option<String>,
+
+    /// Disable TLS for the Tycho connection.
+    #[arg(long)]
+    pub disable_tls: bool,
+
+    /// Protocol systems to query (comma-separated). Supports the `all_onchain` and
+    /// `native_onchain` expansion tokens.
+    #[arg(long, value_delimiter = ',', default_value = "all_onchain")]
+    pub protocols: Vec<String>,
+
+    /// Number of most-connected tokens to sample pairs from.
+    #[arg(long, default_value_t = 50)]
+    pub top_n_tokens: usize,
+
+    /// Number of requests to generate.
+    #[arg(long, default_value_t = 2000)]
+    pub num_requests: usize,
+
+    /// RNG seed. The output is deterministic for a fixed seed and token set.
+    #[arg(long, default_value_t = 42)]
+    pub seed: u64,
+
+    /// Per-request quote timeout written into each request's options.
+    #[arg(long, default_value_t = 5000)]
+    pub timeout_ms: u64,
+
+    /// Output JSON file path.
+    #[arg(long)]
+    pub output: PathBuf,
+}
+
+#[derive(Serialize)]
+struct GeneratedRequest {
+    orders: Vec<GeneratedOrder>,
+    options: RequestOptions,
+}
+
+#[derive(Serialize)]
+struct GeneratedOrder {
+    id: String,
+    token_in: String,
+    token_out: String,
+    amount: String,
+    side: String,
+    sender: String,
+    receiver: Option<String>,
+}
+
+#[derive(Serialize)]
+struct RequestOptions {
+    timeout_ms: u64,
+    min_responses: Option<u64>,
+    max_gas: Option<u64>,
+}
+
+/// Converts a log-spaced magnitude into a raw integer amount for a token with `decimals`.
+///
+/// The amount is centered at one whole token (`10^decimals` raw units) and shifted by `log_offset`
+/// orders of magnitude. The value is split into a seven-significant-digit leading part and a power
+/// of ten so the result stays an exact integer even for large `decimals`.
+fn raw_amount(decimals: u32, log_offset: f64) -> BigUint {
+    let magnitude = f64::from(decimals) + log_offset;
+    let whole = magnitude.floor();
+    let frac = magnitude - whole;
+    // 10^frac is in [1, 10); scaling by 1e6 yields a 7-digit leading value in [1_000_000,
+    // 10_000_000].
+    let leading = (10f64.powf(frac) * 1e6).round() as u64;
+    let whole = whole as i64;
+    let ten = BigUint::from(10u32);
+
+    if whole >= 6 {
+        BigUint::from(leading) * ten.pow((whole - 6) as u32)
+    } else if whole >= 0 {
+        let scaled = BigUint::from(leading) / ten.pow((6 - whole) as u32);
+        scaled.max(BigUint::from(1u32))
+    } else {
+        // Sub-unit magnitudes floor to the smallest representable amount.
+        BigUint::from(1u32)
+    }
+}
+
+/// Samples `num_requests` orders, drawing both tokens weighted by pool count and excluding
+/// self-pairs. Deterministic for a fixed `seed` and token slice.
+fn sample_requests(
+    tokens: &[TokenPoolStats],
+    num_requests: usize,
+    seed: u64,
+    timeout_ms: u64,
+) -> Result<Vec<GeneratedRequest>> {
+    if tokens.len() < 2 {
+        bail!("need at least 2 tokens to sample distinct pairs, got {}", tokens.len());
+    }
+
+    let weights: Vec<u64> = tokens
+        .iter()
+        .map(|t| t.pool_count as u64)
+        .collect();
+    let distribution = WeightedIndex::new(&weights)
+        .context("failed to build weighted token distribution (are all pool counts zero?)")?;
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    let mut requests = Vec::with_capacity(num_requests);
+    for _ in 0..num_requests {
+        let in_idx = distribution.sample(&mut rng);
+        let mut out_idx = distribution.sample(&mut rng);
+        // Reject self-pairs; after a few draws fall back to a neighbour so a token that dominates
+        // the weight distribution cannot loop forever.
+        let mut attempts = 0;
+        while out_idx == in_idx && attempts < 16 {
+            out_idx = distribution.sample(&mut rng);
+            attempts += 1;
+        }
+        if out_idx == in_idx {
+            out_idx = (in_idx + 1) % tokens.len();
+        }
+
+        let token_in = &tokens[in_idx];
+        let token_out = &tokens[out_idx];
+        let log_offset = rng.random_range(-AMOUNT_LOG_SPREAD..=AMOUNT_LOG_SPREAD);
+        let amount = raw_amount(token_in.decimals, log_offset).to_string();
+
+        requests.push(GeneratedRequest {
+            orders: vec![GeneratedOrder {
+                id: String::new(),
+                token_in: token_in.address.clone(),
+                token_out: token_out.address.clone(),
+                amount,
+                side: "sell".to_string(),
+                sender: SENDER.to_string(),
+                receiver: None,
+            }],
+            options: RequestOptions { timeout_ms, min_responses: None, max_gas: None },
+        });
+    }
+
+    Ok(requests)
+}
+
+fn print_summary(args: &Args, tokens: &[TokenPoolStats], requests: &[GeneratedRequest]) {
+    let unique_pairs: HashSet<(&str, &str)> = requests
+        .iter()
+        .filter_map(|r| r.orders.first())
+        .map(|o| (o.token_in.as_str(), o.token_out.as_str()))
+        .collect();
+
+    println!("\n=== generate-requests summary ===");
+    println!("Chain:            {}", args.chain);
+    println!("Tokens sampled:   {}", tokens.len());
+    println!("Requests written: {}", requests.len());
+    println!("Unique pairs:     {}", unique_pairs.len());
+    println!("Output:           {}", args.output.display());
+    if let Some(order) = requests
+        .first()
+        .and_then(|r| r.orders.first())
+    {
+        println!("Sample order:     {} of {} -> {}", order.amount, order.token_in, order.token_out);
+    }
+}
+
+pub async fn run(args: Args) -> Result<()> {
+    let chain =
+        parse_chain(&args.chain).with_context(|| format!("invalid --chain '{}'", args.chain))?;
+
+    let tycho_url = match args.tycho_url.clone() {
+        Some(url) => url,
+        None => default_tycho_url(&args.chain)
+            .map_err(|e| anyhow::anyhow!("{e}"))?
+            .to_string(),
+    };
+
+    let protocols = resolve_protocols(
+        &tycho_url,
+        args.tycho_api_key.as_deref(),
+        !args.disable_tls,
+        chain,
+        &args.protocols,
+    )
+    .await?;
+    info!("Resolved {} protocol system(s)", protocols.len());
+
+    let mut tokens = fetch_token_pool_stats(
+        &tycho_url,
+        args.tycho_api_key.as_deref(),
+        !args.disable_tls,
+        chain,
+        &protocols,
+    )
+    .await?;
+    tokens.truncate(args.top_n_tokens);
+    info!("Sampling {} request(s) from top {} token(s)", args.num_requests, tokens.len());
+
+    let requests = sample_requests(&tokens, args.num_requests, args.seed, args.timeout_ms)?;
+    let json = serde_json::to_string_pretty(&requests)?;
+    std::fs::write(&args.output, json)
+        .with_context(|| format!("failed to write {}", args.output.display()))?;
+
+    print_summary(&args, &tokens, &requests);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::requests::load_request_templates;
+
+    fn fixture_tokens() -> Vec<TokenPoolStats> {
+        vec![
+            TokenPoolStats {
+                address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2".to_string(),
+                symbol: "WETH".to_string(),
+                decimals: 18,
+                pool_count: 500,
+            },
+            TokenPoolStats {
+                address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string(),
+                symbol: "USDC".to_string(),
+                decimals: 6,
+                pool_count: 300,
+            },
+            TokenPoolStats {
+                address: "0xdac17f958d2ee523a2206206994597c13d831ec7".to_string(),
+                symbol: "USDT".to_string(),
+                decimals: 6,
+                pool_count: 200,
+            },
+            TokenPoolStats {
+                address: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599".to_string(),
+                symbol: "WBTC".to_string(),
+                decimals: 8,
+                pool_count: 50,
+            },
+        ]
+    }
+
+    fn amounts(requests: &[GeneratedRequest]) -> Vec<String> {
+        requests
+            .iter()
+            .map(|r| r.orders[0].amount.clone())
+            .collect()
+    }
+
+    #[test]
+    fn raw_amount_centers_on_one_whole_token() {
+        assert_eq!(raw_amount(18, 0.0).to_string(), "1000000000000000000");
+        assert_eq!(raw_amount(6, 0.0).to_string(), "1000000");
+    }
+
+    #[test]
+    fn raw_amount_spans_orders_of_magnitude() {
+        // 0.01 and 100 whole USDC (6 decimals) at the spread bounds.
+        assert_eq!(raw_amount(6, -2.0).to_string(), "10000");
+        assert_eq!(raw_amount(6, 2.0).to_string(), "100000000");
+    }
+
+    #[test]
+    fn raw_amount_low_decimals_floor_to_one() {
+        assert_eq!(raw_amount(2, -2.0).to_string(), "1");
+    }
+
+    #[test]
+    fn sample_requests_rejects_self_pairs() {
+        let tokens = fixture_tokens();
+        let requests = sample_requests(&tokens, 500, 7, 5000).unwrap();
+        assert_eq!(requests.len(), 500);
+        for request in &requests {
+            let order = &request.orders[0];
+            assert_ne!(order.token_in, order.token_out);
+        }
+    }
+
+    #[test]
+    fn sample_requests_is_seed_deterministic() {
+        let tokens = fixture_tokens();
+        let first = sample_requests(&tokens, 100, 42, 5000).unwrap();
+        let second = sample_requests(&tokens, 100, 42, 5000).unwrap();
+        assert_eq!(amounts(&first), amounts(&second));
+        let different = sample_requests(&tokens, 100, 43, 5000).unwrap();
+        assert_ne!(amounts(&first), amounts(&different));
+    }
+
+    #[test]
+    fn sample_requests_needs_two_tokens() {
+        let tokens = vec![fixture_tokens()[0].clone()];
+        assert!(sample_requests(&tokens, 10, 42, 5000).is_err());
+    }
+
+    #[test]
+    fn generated_dataset_round_trips_through_loader() {
+        let tokens = fixture_tokens();
+        let requests = sample_requests(&tokens, 250, 42, 5000).unwrap();
+        let json = serde_json::to_string_pretty(&requests).unwrap();
+
+        let path = std::env::temp_dir().join("generate_requests_round_trip.json");
+        std::fs::write(&path, json).unwrap();
+        let loaded = load_request_templates(path.to_str().unwrap(), 5000);
+        std::fs::remove_file(&path).ok();
+
+        let loaded = loaded.unwrap();
+        assert_eq!(loaded.len(), 250);
+        for request in &loaded {
+            assert_ne!(request.token_in_addr(), request.token_out_addr());
+            assert!(request
+                .token_in_addr()
+                .starts_with("0x"));
+            assert!(!request.raw_amount().is_empty());
+        }
+    }
+}

--- a/tools/benchmark/src/main.rs
+++ b/tools/benchmark/src/main.rs
@@ -9,6 +9,7 @@ mod benchmark;
 mod compare;
 mod config;
 mod exporter;
+mod generate_requests;
 mod pair_selector;
 mod requests;
 mod runner;
@@ -41,6 +42,8 @@ enum Command {
     Scale(scale::Args),
     /// Compare Fynd quote performance against external DEX aggregators
     Audit(audit::Args),
+    /// Generate a synthetic per-chain request dataset for capacity testing
+    GenerateRequests(generate_requests::Args),
 }
 
 /// Download the full 10k aggregator trade dataset for benchmarking.
@@ -67,6 +70,7 @@ async fn main() -> anyhow::Result<()> {
             .map_err(|e| anyhow::anyhow!("{e}")),
         Command::Scale(args) => scale::run(args).await,
         Command::Audit(args) => audit::run(args).await,
+        Command::GenerateRequests(args) => generate_requests::run(args).await,
     }
 }
 


### PR DESCRIPTION
Adds a `generate-requests` subcommand to `fynd-benchmark` that produces a per-chain synthetic swap-request dataset (JSON) for capacity load testing. The existing `download-trades` dataset is Ethereum-only; this covers other chains.

## What it does

- Fetches token and pool-count data from Tycho via the new `fynd_rpc::protocols::fetch_token_pool_stats`, which reuses the pool-count query behind `derive-connector-tokens` (counts pools per token, joins Tycho token metadata for symbols and decimals).
- Samples token pairs weighted by pool count, excluding same-token pairs, using a seeded `StdRng` so output is deterministic for a given `--seed` and token set.
- Log-spaces amounts across ~4 orders of magnitude around one whole token, scaled by each token's decimals.
- Writes a JSON array loadable by the existing `--requests-file` loaders (`load_request_templates` / `load_requests_from_file`).

## CLI

```
fynd-benchmark generate-requests --chain base [--tycho-url <url>] \
  --top-n-tokens 50 --num-requests 2000 --seed 42 --output trades.json
```

Accepted `--chain` values: `ethereum`, `base`, `unichain`, `bsc`, `arbitrum`, `polygon` (case-insensitive). `zksync` parses but has no default Tycho URL, so pass `--tycho-url`. The Tycho URL defaults to the chain's Fynd endpoint; auth uses `TYCHO_API_KEY`.

## Tests and validation

Sampling and serialization are covered with fixture token data (no network): amount scaling, weighted pair sampling with no self-pairs, seed determinism, minimum-token guard, and a round-trip that loads the generated dataset back through `load_request_templates`.

The Tycho fetch is a thin network layer. Against a hosted endpoint it was exercised only up to the authentication boundary (the RPC call is made and auth is enforced). Live end-to-end generation against ethereum and base is validated in-cluster, where a one-off Job in the `staging-fynd` namespace runs the command with `TYCHO_API_KEY` mounted from the existing secret, so the key never leaves the cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)