### PR TITLE
fix: revert vm:curve to EVMPoolState VM simulation

### DIFF
--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -6,7 +6,6 @@ use tycho_simulation::{
         engine_db::tycho_db::PreCachedDB,
         protocol::{
             aerodrome_slipstreams::state::AerodromeSlipstreamsState,
-            curve::CurveState,
             ekubo::state::EkuboState,
             ekubo_v3::{self, state::EkuboV3State},
             erc4626::state::ERC4626State,
@@ -93,7 +92,15 @@ pub(crate) fn register_exchanges(
                 builder = builder.exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None);
             }
             "vm:curve" => {
-                builder = builder.exchange::<CurveState>("vm:curve", tvl_filter.clone(), None);
+                // Deliberately the VM adapter, not the native CurveState: the hybrid CurveState
+                // (tycho-simulation 0.324.0) produces wrong quotes on live state — hindsight's
+                // top/back comparisons show thousands-of-bps artifacts on curve-routed solutions
+                // since the switch (fba3c223). Full-EVM simulation until that is fixed upstream.
+                builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
+                    "vm:curve",
+                    tvl_filter.clone(),
+                    None,
+                );
             }
             "uniswap_v4_hooks" => {
                 builder = builder.exchange::<UniswapV4State>(

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -92,10 +92,11 @@ pub(crate) fn register_exchanges(
                 builder = builder.exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None);
             }
             "vm:curve" => {
-                // Deliberately the VM adapter, not the native CurveState: the hybrid CurveState
-                // (tycho-simulation 0.324.0) produces wrong quotes on live state — hindsight's
-                // top/back comparisons show thousands-of-bps artifacts on curve-routed solutions
-                // since the switch (fba3c223). Full-EVM simulation until that is fixed upstream.
+                // Deliberately the VM adapter, not the native CurveState (tycho-simulation
+                // 0.324.0, switched in fba3c223): under CurveState, hindsight shows curve-routed
+                // quotes systematically overestimating output vs settlement (median +43 bps,
+                // 93% "win" rate vs 53% elsewhere). Full-EVM simulation until the mispricing —
+                // in CurveState's math or in the indexed curve state — is found and fixed.
                 builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
                     "vm:curve",
                     tvl_filter.clone(),


### PR DESCRIPTION
## What

Register `vm:curve` with `EVMPoolState<PreCachedDB>` (full-EVM simulation) again instead of the native `CurveState` decoder. The `vm:bopamm`/`vm:fermiswap` registrations added alongside the original switch (fba3c223) are kept.

## Why

Curve-routed solutions in hindsight's comparison data are systematically overquoted relative to settlement (ground truth). Last 12h of Jul 13, both-state-solved trades:

| | non-curve (n=4268) | curve-routed (n=4524) |
|---|---|---|
| median quote vs settled | +0.12 bps | +43.3 bps |
| p10 quote vs settled | −21.3 bps | +12.5 bps |
| win rate | 53.1% | 93.3% |

~90% of curve-routed re-solves claim to beat what settled on-chain, with outliers in the thousands of bps — a one-directional overquote consistent with a pricing bug (fees or rates not applied), not stale state. This also inflates the hindsight win-rate metrics.

The monitor producing this data runs 0.90.0, which contains the `CurveState` switch; prod fynd (0.82.3) predates it.

## Caveat

The timeline cannot distinguish a bug in `CurveState`'s math from a bug in curve pool indexing (balances/rates from the Tycho stream), because curve pools entered the monitor's market at the same time as the decoder switch. This revert is the discriminating experiment: if the overquote disappears under `EVMPoolState`, the fault is in `CurveState`; if it persists, it is in the indexed state and this change should be reverted again.

## Testing

- `cargo check -p fynd-core --all-features`
- `cargo +nightly clippy -p fynd-core --all-features --all-targets -- -D warnings`
- `cargo +nightly fmt -- --check`
- Pre-commit hook (full CI script) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)