### PR TITLE
fix: restore native CurveState using upstream curve_filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -6699,6 +6702,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7756,9 +7772,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.331.0"
+version = "0.338.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0016d3b1320e456d9d82690425fd1d32bb1b6ba59d8e2c17466a95bb7ef8171"
+checksum = "7392875f725fa1464eaeb6b572885355beef6240be446854cfb786c42b7901fd"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7786,11 +7802,12 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.331.0"
+version = "0.338.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c005588841e242b212d2b111bb2283cda4e49e5589f72281ae5a03ea248031f"
+checksum = "1aecc6a429b69976747c5fd3a1a30f580d391efb1bb6ffedd4bc2551545374b6"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "async-trait",
  "bytes",
  "chrono",
@@ -7801,6 +7818,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
+ "serde_yaml",
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "thiserror 1.0.69",
@@ -7813,9 +7831,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.331.0"
+version = "0.338.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d25adf4f79dbcb37e87231815055a5ec6f171ff33355a407434b2368eddbc5e"
+checksum = "b2c0e9dd474bf4180a4a78305480291febacc7bc683107156f6390cfa26e4481"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7835,9 +7853,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.331.0"
+version = "0.338.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2122ffa88b5bcf90984e7d03c1ace245a6a14be08372eef45bb2fd18400253b3"
+checksum = "709a4ccd33621c819d2caae7dc0fe4cd91ed1324100f258f12096ce747abad5b"
 dependencies = [
  "alloy",
  "chrono",
@@ -7856,9 +7874,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.331.0"
+version = "0.338.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7551b85e258e0dd0d71807a26d3532d91f30cf05c45353cf273545994dacdee5"
+checksum = "0d2228d44660867c09a004561aa7dca8bc5e08ecd613ae8c909b7c781f892dc4"
 dependencies = [
  "alloy",
  "alloy-chains",
@@ -8001,6 +8019,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,8 @@ metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
 
 # Tycho
-tycho-execution = ">=0.331.0"
-tycho-simulation = ">=0.331.0"
+tycho-execution = ">=0.338.0"
+tycho-simulation = ">=0.338.0"
 typetag = "0.2"
 
 # Compression

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -6,10 +6,13 @@ use tycho_simulation::{
         engine_db::tycho_db::PreCachedDB,
         protocol::{
             aerodrome_slipstreams::state::AerodromeSlipstreamsState,
+            curve::CurveState,
             ekubo::state::EkuboState,
             ekubo_v3::{self, state::EkuboV3State},
             erc4626::state::ERC4626State,
-            filters::{balancer_v2_pool_filter, erc4626_filter, fluid_v1_paused_pools_filter},
+            filters::{
+                balancer_v2_pool_filter, curve_filter, erc4626_filter, fluid_v1_paused_pools_filter,
+            },
             fluid::FluidV1,
             pancakeswap_v2::state::PancakeswapV2State,
             uniswap_v2::state::UniswapV2State,
@@ -92,15 +95,14 @@ pub(crate) fn register_exchanges(
                 builder = builder.exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None);
             }
             "vm:curve" => {
-                // Deliberately the VM adapter, not the native CurveState (tycho-simulation
-                // 0.324.0, switched in fba3c223): under CurveState, hindsight shows curve-routed
-                // quotes systematically overestimating output vs settlement (median +43 bps,
-                // 93% "win" rate vs 53% elsewhere). Full-EVM simulation until the mispricing —
-                // in CurveState's math or in the indexed curve state — is found and fixed.
-                builder = builder.exchange::<EVMPoolState<PreCachedDB>>(
+                // The hybrid CurveState with tycho-simulation's own curve_filter, which drops
+                // the pools CurveState cannot quote correctly (oracle/rate-bearing/rebasing
+                // coins) — the source of the overestimation that forced the temporary
+                // full-EVM fallback (see #318); fixed upstream in tycho-simulation 0.338.0.
+                builder = builder.exchange::<CurveState>(
                     "vm:curve",
                     tvl_filter.clone(),
-                    None,
+                    Some(curve_filter),
                 );
             }
             "uniswap_v4_hooks" => {

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -11,7 +11,7 @@ use fynd_core::{
 };
 use tokio::task::JoinHandle;
 use tracing::{error, info, warn};
-use tycho_simulation::tycho_common::models::{Chain, TvlThresholdTier};
+use tycho_simulation::tycho_common::models::{chain_config::TvlThresholdTier, Chain};
 
 use crate::{
     api::{configure_app, AppState, HealthTracker},

--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -8,7 +8,7 @@ use fynd_core::{
 };
 use fynd_rpc::parse_chain;
 use tracing::info;
-use tycho_simulation::tycho_common::models::{Address, TvlThresholdTier};
+use tycho_simulation::tycho_common::models::{chain_config::TvlThresholdTier, Address};
 
 /// Derives recommended connector tokens from live Tycho market data.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,9 @@ use tokio::{
 };
 use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-use tycho_simulation::{tycho_common::models::TvlThresholdTier, utils::default_blocklist};
+use tycho_simulation::{
+    tycho_common::models::chain_config::TvlThresholdTier, utils::default_blocklist,
+};
 
 fn main() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();


### PR DESCRIPTION
## What

- Bump `tycho-simulation` / `tycho-execution` to `>=0.338.0` (lockfile updated in place; `TvlThresholdTier` import path updated for its move to `tycho_common::models::chain_config`).
- Revert the `vm:curve` registration from the temporary full-EVM fallback (#318) back to the native `CurveState`, registered with tycho-simulation's `curve_filter`.

## Why

The curve-routed overestimation that motivated #318 (median +43 bps, 93% win rate in hindsight data) came from pools with oracle/rate-bearing/rebasing coins that the hybrid `CurveState` cannot quote. tycho-simulation 0.338.0 fixes the quoting and ships `curve_filter` to drop exactly those pools, so the native state is safe to use again — with the filter registered as upstream intends.

## Notes

- The interim #318 release (0.90.2) was never deployed to the hindsight monitor (prod runs 0.90.0), so live comparison data has carried the CurveState artifact throughout; after this releases, prod hindsight needs a versions.yml bump before the data cleans up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)