### PR TITLE
fix(hindsight): honor BLOCKLIST_CONFIG in the monitor

### DIFF
--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -28,6 +28,7 @@ Three subcommands via `cargo run -p hindsight --release --`:
 | `ALLIUM_API_KEY` | Allium API key (`verify` only) |
 | `ALLIUM_QUERY_ID` | Saved Allium query ID (`verify` only) |
 | `HINDSIGHT_REGISTRY` | Override path for the decoder address-book TOML |
+| `BLOCKLIST_CONFIG` | Blocklist TOML of component IDs excluded from the Tycho stream (`monitor` only; falls back to tycho-simulation's default blocklist) |
 
 ## Architecture
 

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -88,6 +88,12 @@ pub(crate) struct MonitorArgs {
     #[arg(long, env = "WORKER_POOLS_CONFIG", default_value = "worker_pools.toml")]
     pub worker_pools_config: std::path::PathBuf,
 
+    /// Blocklist TOML of component IDs to exclude from the Tycho stream, same semantics as
+    /// `fynd serve --blocklist-config`. Falls back to tycho-simulation's embedded default
+    /// blocklist when unset
+    #[arg(long, env = "BLOCKLIST_CONFIG")]
+    pub blocklist_config: Option<std::path::PathBuf>,
+
     /// Per-quote timeout in milliseconds
     #[arg(long, default_value_t = 10_000)]
     pub timeout_ms: u64,
@@ -301,6 +307,13 @@ async fn build_solver(
     if let Some(key) = cfg.tycho_api_key.as_deref() {
         builder = builder.tycho_api_key(key);
     }
+    let blocklist = match &cfg.blocklist_config {
+        Some(path) => fynd_rpc::config::BlocklistConfig::load_from_file(path)
+            .map_err(|e| anyhow::anyhow!("failed to load blocklist config: {e}"))?
+            .into_components(),
+        None => tycho_simulation::utils::default_blocklist(),
+    };
+    builder = builder.blocklisted_components(blocklist);
     for (name, pool) in pools_config.pools() {
         builder = builder
             .add_pool(name, pool)
@@ -573,6 +586,7 @@ mod tests {
             min_tvl: 10_000.0,
             tycho_api_key: api_key,
             worker_pools_config: std::path::PathBuf::from("worker_pools.toml"),
+            blocklist_config: None,
             timeout_ms: 10_000,
             metrics_port: None,
             max_blocks: Some(1),


### PR DESCRIPTION
The hindsight monitor never read the blocklist. `fynd serve` declares `--blocklist-config` (env `BLOCKLIST_CONFIG`) and wires it into the feed, but `MonitorArgs` had no such flag — clap only binds declared env vars, so the prod deployment's mounted `/app/blocklist.toml` and `BLOCKLIST_CONFIG` env var were silently ignored. Observed live: blocklisted pools (curve tricrypto2 among them) streaming into the monitor's market and logging spot-price warnings.

This adds `--blocklist-config` to the monitor with the same semantics as serve: load the TOML when set, fall back to tycho-simulation's embedded default blocklist when unset. The existing prod helm config (env + ConfigMap mount) starts working with zero changes once this deploys.

Related: helm-configuration#783 removes the temp Curve entries from that blocklist (obsolete since 0.90.3's `curve_filter`); the remaining entries (AMPL, Fluid Lite, "Dollars" pools) only take effect with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)