### PR TITLE
feat(encoding): sign exclusive-swap quotes into Ekubo user_data

### DIFF
--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -35,7 +35,7 @@ typetag.workspace = true
 tycho-execution.workspace = true
 reqwest.workspace = true
 tokio-tungstenite.workspace = true
-alloy = { workspace = true, features = ["sol-types"] }
+alloy = { workspace = true, features = ["sol-types", "signer-local"] }
 
 [features]
 test-utils = []

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -23,7 +23,7 @@ use tycho_simulation::tycho_common::{models::Chain, Bytes};
 use crate::{
     encoding::{
         router_fees::{FeeRates, RouterFees, SharedRouterFees},
-        signed_quote::SignedSwapSigner,
+        exclusive_swap::ExclusiveSwapSigner,
     },
     EncodingOptions, FeeBreakdown, OrderQuote, QuoteStatus, SolveError, Transaction,
 };
@@ -45,8 +45,8 @@ pub struct Encoder {
     chain: Chain,
     router_address: Option<Bytes>,
     router_fees: SharedRouterFees,
-    /// Signs exclusive Ekubo legs. `None` disables signing (no controller key configured).
-    signed_swap_signer: Option<SignedSwapSigner>,
+    /// Signs exclusive legs. `None` disables signing (no controller key configured).
+    exclusive_swap_signer: Option<ExclusiveSwapSigner>,
 }
 
 impl TryFrom<&OrderQuote> for Solution {
@@ -143,20 +143,20 @@ impl Encoder {
                     .build()
             })
             .transpose()?;
-        let signed_swap_signer = SignedSwapSigner::from_env(chain.id())?;
+        let exclusive_swap_signer = ExclusiveSwapSigner::from_env(chain.id())?;
         Ok(Self {
             tycho_encoder,
             chain,
             router_address,
             router_fees: SharedRouterFees::default(),
-            signed_swap_signer,
+            exclusive_swap_signer,
         })
     }
 
-    /// Overrides the signed-swap signer, replacing whatever was read from the environment.
+    /// Overrides the exclusive-swap signer, replacing whatever was read from the environment.
     #[must_use]
-    pub fn with_signed_swap_signer(mut self, signer: SignedSwapSigner) -> Self {
-        self.signed_swap_signer = Some(signer);
+    pub fn with_exclusive_swap_signer(mut self, signer: ExclusiveSwapSigner) -> Self {
+        self.exclusive_swap_signer = Some(signer);
         self
     }
 
@@ -211,15 +211,15 @@ impl Encoder {
 
             let solution = Solution::try_from(quote)?
                 .with_user_transfer_type(encoding_options.transfer_type().clone());
-            let solution = match &self.signed_swap_signer {
-                Some(signer) => Self::stamp_signed_swaps(solution, quote, signer)?,
+            let solution = match &self.exclusive_swap_signer {
+                Some(signer) => Self::stamp_exclusive_swaps(solution, quote, signer)?,
                 None => {
                     // Fail fast rather than emit on-chain-invalid unsigned calldata for an
                     // exclusive leg: an exclusive route requires a signature.
                     if has_exclusive_leg(quote) {
                         return Err(SolveError::FailedEncoding(
                             "quote routes through an exclusive pool but no signing key is \
-                             configured (set SIGNED_SWAP_CONTROLLER_KEY)"
+                             configured (set EXCLUSIVE_SWAP_CONTROLLER_KEY)"
                                 .to_string(),
                         ));
                     }
@@ -256,24 +256,33 @@ impl Encoder {
 
     /// Stamps controller-signed `user_data` onto each exclusive leg of `solution`.
     ///
-    /// A leg is exclusive when its fynd swap carries a committed amount. Solution swaps are built
-    /// 1:1 with the route's swaps, so they are matched by index. Returns `solution` unchanged when
-    /// no leg is exclusive.
-    fn stamp_signed_swaps(
+    /// A leg is exclusive when its route swap carries a committed amount. The solution's swaps are
+    /// built 1:1 from the route's swaps, so they are matched by index. Returns `solution` unchanged
+    /// when no leg is exclusive.
+    fn stamp_exclusive_swaps(
         solution: Solution,
         quote: &OrderQuote,
-        signer: &SignedSwapSigner,
+        signer: &ExclusiveSwapSigner,
     ) -> Result<Solution, SolveError> {
-        if !has_exclusive_leg(quote) {
-            return Ok(solution);
-        }
-
         let route = quote.route().ok_or_else(|| {
             SolveError::FailedEncoding("successful quote must have a route".to_string())
         })?;
-        let fynd_swaps = route.swaps();
+        let route_swaps = route.swaps();
 
-        if fynd_swaps.len() != solution.swaps().len() {
+        // Nothing to sign unless a leg carries a committed amount; leave the solution untouched.
+        if !route_swaps
+            .iter()
+            .any(|s| s.committed_amount_out().is_some())
+        {
+            return Ok(solution);
+        }
+
+        // `route_swaps` carry `committed_amount_out` and the pool attributes; `solution_swaps` are
+        // built 1:1 from them by `Solution::try_from` and are what the router executes. We read the
+        // committed amount from the route swap but stamp `user_data` onto the matching solution
+        // swap, so the two lists must stay index-aligned. A length divergence means that 1:1
+        // mapping broke upstream; bail rather than risk signing the wrong leg.
+        if route_swaps.len() != solution.swaps().len() {
             return Err(SolveError::FailedEncoding(
                 "route and solution swap counts diverged".to_string(),
             ));
@@ -283,16 +292,18 @@ impl Encoder {
             .swaps()
             .iter()
             .cloned()
-            .zip(fynd_swaps.iter())
-            .map(|(tycho_swap, fynd_swap)| {
-                if fynd_swap
+            .zip(route_swaps.iter())
+            // Only the exclusive leg (the route swap carrying a committed amount) gets signed
+            // `user_data`; every other solution swap passes through unchanged.
+            .map(|(solution_swap, route_swap)| {
+                if route_swap
                     .committed_amount_out()
                     .is_some()
                 {
-                    let user_data = signer.build_user_data(fynd_swap)?;
-                    Ok(tycho_swap.with_user_data(user_data))
+                    let user_data = signer.build_user_data(route_swap)?;
+                    Ok(solution_swap.with_user_data(user_data))
                 } else {
-                    Ok(tycho_swap)
+                    Ok(solution_swap)
                 }
             })
             .collect::<Result<Vec<_>, SolveError>>()?;
@@ -696,7 +707,7 @@ mod tests {
             chain,
             router_address: Some(Bytes::from([0u8; 20].as_ref())),
             router_fees,
-            signed_swap_signer: None,
+            exclusive_swap_signer: None,
         }
     }
 
@@ -820,13 +831,13 @@ mod tests {
     #[rstest]
     #[case::exclusive_leg_signed(Some(990_000), true)]
     #[case::public_leg_untouched(None, false)]
-    fn test_stamp_signed_swaps(#[case] committed: Option<u64>, #[case] signed: bool) {
+    fn test_stamp_exclusive_swaps(#[case] committed: Option<u64>, #[case] signed: bool) {
         let quote =
             make_order_quote(990_000).with_route(single_swap_route(ekubo_signed_swap(committed)));
-        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, 0);
 
         let solution =
-            Encoder::stamp_signed_swaps(Solution::try_from(&quote).unwrap(), &quote, &signer)
+            Encoder::stamp_exclusive_swaps(Solution::try_from(&quote).unwrap(), &quote, &signer)
                 .unwrap();
 
         assert_eq!(
@@ -839,7 +850,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_encode_rejects_exclusive_leg_without_signer() {
-        // mock_encoder has no signed_swap_signer, so an exclusive leg must fail fast rather than
+        // mock_encoder has no exclusive_swap_signer, so an exclusive leg must fail fast rather than
         // produce unsigned (on-chain-invalid) calldata.
         let encoder = mock_encoder(Chain::Ethereum);
         let quote = make_order_quote(990_000)

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -277,17 +277,10 @@ impl Encoder {
             return Ok(solution);
         }
 
-        // `route_swaps` carry `committed_amount_out` and the pool attributes; `solution_swaps` are
+        // `route_swaps` carry `committed_amount_out` and the pool attributes; `solution.swaps()` are
         // built 1:1 from them by `Solution::try_from` and are what the router executes. We read the
         // committed amount from the route swap but stamp `user_data` onto the matching solution
-        // swap, so the two lists must stay index-aligned. A length divergence means that 1:1
-        // mapping broke upstream; bail rather than risk signing the wrong leg.
-        if route_swaps.len() != solution.swaps().len() {
-            return Err(SolveError::FailedEncoding(
-                "route and solution swap counts diverged".to_string(),
-            ));
-        }
-
+        // swap, matched by index via the zip below.
         let swaps = solution
             .swaps()
             .iter()

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -21,7 +21,10 @@ use tycho_execution::encoding::{
 use tycho_simulation::tycho_common::{models::Chain, Bytes};
 
 use crate::{
-    encoding::router_fees::{FeeRates, RouterFees, SharedRouterFees},
+    encoding::{
+        router_fees::{FeeRates, RouterFees, SharedRouterFees},
+        signed_quote::SignedSwapSigner,
+    },
     EncodingOptions, FeeBreakdown, OrderQuote, QuoteStatus, SolveError, Transaction,
 };
 
@@ -42,6 +45,8 @@ pub struct Encoder {
     chain: Chain,
     router_address: Option<Bytes>,
     router_fees: SharedRouterFees,
+    /// Signs exclusive Ekubo legs. `None` disables signing (no controller key configured).
+    signed_swap_signer: Option<SignedSwapSigner>,
 }
 
 impl TryFrom<&OrderQuote> for Solution {
@@ -58,12 +63,6 @@ impl TryFrom<&OrderQuote> for Solution {
         let route = quote.route().ok_or_else(|| {
             SolveError::FailedEncoding("successful quote must have a route".to_string())
         })?;
-
-        // TODO(ENG-6134): when a swap in this route is exclusive, read its
-        // `Swap::committed_amount_out` and carry it into the encoded `Solution` so the
-        // on-chain exclusive hook can be parameterised — the user is committed to that
-        // amount while the executed route yields the surplus. Hook calldata/signature
-        // encoding is a separate later extension, out of scope here.
 
         let token_in = route
             .input_token()
@@ -144,7 +143,21 @@ impl Encoder {
                     .build()
             })
             .transpose()?;
-        Ok(Self { tycho_encoder, chain, router_address, router_fees: SharedRouterFees::default() })
+        let signed_swap_signer = SignedSwapSigner::from_env(chain.id())?;
+        Ok(Self {
+            tycho_encoder,
+            chain,
+            router_address,
+            router_fees: SharedRouterFees::default(),
+            signed_swap_signer,
+        })
+    }
+
+    /// Overrides the signed-swap signer, replacing whatever was read from the environment.
+    #[must_use]
+    pub fn with_signed_swap_signer(mut self, signer: SignedSwapSigner) -> Self {
+        self.signed_swap_signer = Some(signer);
+        self
     }
 
     /// Returns the Tycho Router contract address for this chain, or `None` if encoding is
@@ -196,11 +209,24 @@ impl Encoder {
                 continue;
             }
 
-            to_encode.push((
-                i,
-                Solution::try_from(quote)?
-                    .with_user_transfer_type(encoding_options.transfer_type().clone()),
-            ));
+            let solution = Solution::try_from(quote)?
+                .with_user_transfer_type(encoding_options.transfer_type().clone());
+            let solution = match &self.signed_swap_signer {
+                Some(signer) => Self::stamp_signed_swaps(solution, quote, signer)?,
+                None => {
+                    // Fail fast rather than emit on-chain-invalid unsigned calldata for an
+                    // exclusive leg: an exclusive route requires a signature.
+                    if has_exclusive_leg(quote) {
+                        return Err(SolveError::FailedEncoding(
+                            "quote routes through an exclusive pool but no signing key is \
+                             configured (set SIGNED_SWAP_CONTROLLER_KEY)"
+                                .to_string(),
+                        ));
+                    }
+                    solution
+                }
+            };
+            to_encode.push((i, solution));
         }
 
         let solutions: Vec<Solution> = to_encode
@@ -226,6 +252,52 @@ impl Encoder {
         }
 
         Ok(quotes)
+    }
+
+    /// Stamps controller-signed `user_data` onto each exclusive leg of `solution`.
+    ///
+    /// A leg is exclusive when its fynd swap carries a committed amount. Solution swaps are built
+    /// 1:1 with the route's swaps, so they are matched by index. Returns `solution` unchanged when
+    /// no leg is exclusive.
+    fn stamp_signed_swaps(
+        solution: Solution,
+        quote: &OrderQuote,
+        signer: &SignedSwapSigner,
+    ) -> Result<Solution, SolveError> {
+        if !has_exclusive_leg(quote) {
+            return Ok(solution);
+        }
+
+        let route = quote.route().ok_or_else(|| {
+            SolveError::FailedEncoding("successful quote must have a route".to_string())
+        })?;
+        let fynd_swaps = route.swaps();
+
+        if fynd_swaps.len() != solution.swaps().len() {
+            return Err(SolveError::FailedEncoding(
+                "route and solution swap counts diverged".to_string(),
+            ));
+        }
+
+        let swaps = solution
+            .swaps()
+            .iter()
+            .cloned()
+            .zip(fynd_swaps.iter())
+            .map(|(tycho_swap, fynd_swap)| {
+                if fynd_swap
+                    .committed_amount_out()
+                    .is_some()
+                {
+                    let user_data = signer.build_user_data(fynd_swap)?;
+                    Ok(tycho_swap.with_user_data(user_data))
+                } else {
+                    Ok(tycho_swap)
+                }
+            })
+            .collect::<Result<Vec<_>, SolveError>>()?;
+
+        Ok(solution.with_swaps(swaps))
     }
 
     /// Encodes a call using one of the router's swap methods.
@@ -499,11 +571,23 @@ impl From<EncodingError> for SolveError {
     }
 }
 
+/// Returns whether the quote routes through an exclusive pool, i.e. any swap in its route carries
+/// a committed amount.
+fn has_exclusive_leg(quote: &OrderQuote) -> bool {
+    quote.route().is_some_and(|route| {
+        route
+            .swaps()
+            .iter()
+            .any(|s| s.committed_amount_out().is_some())
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
     use num_bigint::BigUint;
+    use rstest::rstest;
     use tycho_execution::encoding::{
         errors::EncodingError,
         models::{EncodedSolution, Solution},
@@ -612,6 +696,7 @@ mod tests {
             chain,
             router_address: Some(Bytes::from([0u8; 20].as_ref())),
             router_fees,
+            signed_swap_signer: None,
         }
     }
 
@@ -691,6 +776,80 @@ mod tests {
         assert_eq!(*solution.amount_in(), *quote.amount_in());
         assert_eq!(*solution.min_amount_out(), *quote.amount_out());
         assert_eq!(solution.swaps().len(), 1);
+    }
+
+    const CONTROLLER_KEY: &str =
+        "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+    fn ekubo_signed_swap(committed: Option<u64>) -> crate::types::Swap {
+        let token_in = make_address(0x11);
+        let token_out = make_address(0x22);
+        let mut comp = component("ekubo-signed-pool", &[]);
+        comp.static_attributes
+            .insert("extension".to_string(), Bytes::from([0x55u8; 20].as_ref()));
+        comp.static_attributes
+            .insert("fee".to_string(), Bytes::from(0u64));
+        comp.static_attributes
+            .insert("pool_type_config".to_string(), Bytes::from(0u32));
+
+        let mut swap = crate::types::Swap::new(
+            "ekubo-signed-pool".to_string(),
+            "ekubo_v3".to_string(),
+            token_in,
+            token_out,
+            BigUint::from(1_000_000u64),
+            BigUint::from(1_000_000u64),
+            BigUint::from(50_000u64),
+            comp,
+            Box::new(MockProtocolSim::default()),
+        );
+        if let Some(committed) = committed {
+            swap.set_committed_amount_out(BigUint::from(committed));
+        }
+        swap
+    }
+
+    fn single_swap_route(swap: crate::types::Swap) -> crate::types::Route {
+        let tokens = HashMap::from([
+            (swap.token_in().clone(), make_token(swap.token_in().clone())),
+            (swap.token_out().clone(), make_token(swap.token_out().clone())),
+        ]);
+        crate::types::Route::new(vec![swap], tokens).expect("non-empty route")
+    }
+
+    #[rstest]
+    #[case::exclusive_leg_signed(Some(990_000), true)]
+    #[case::public_leg_untouched(None, false)]
+    fn test_stamp_signed_swaps(#[case] committed: Option<u64>, #[case] signed: bool) {
+        let quote =
+            make_order_quote(990_000).with_route(single_swap_route(ekubo_signed_swap(committed)));
+        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+
+        let solution =
+            Encoder::stamp_signed_swaps(Solution::try_from(&quote).unwrap(), &quote, &signer)
+                .unwrap();
+
+        assert_eq!(
+            solution.swaps()[0]
+                .user_data()
+                .is_some(),
+            signed
+        );
+    }
+
+    #[tokio::test]
+    async fn test_encode_rejects_exclusive_leg_without_signer() {
+        // mock_encoder has no signed_swap_signer, so an exclusive leg must fail fast rather than
+        // produce unsigned (on-chain-invalid) calldata.
+        let encoder = mock_encoder(Chain::Ethereum);
+        let quote = make_order_quote(990_000)
+            .with_route(single_swap_route(ekubo_signed_swap(Some(990_000))));
+
+        let result = encoder
+            .encode(vec![quote], EncodingOptions::new(0.01))
+            .await;
+
+        assert!(result.is_err(), "expected fail-fast error for unsigned exclusive leg");
     }
 
     #[test]

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -22,8 +22,8 @@ use tycho_simulation::tycho_common::{models::Chain, Bytes};
 
 use crate::{
     encoding::{
-        router_fees::{FeeRates, RouterFees, SharedRouterFees},
         exclusive_swap::ExclusiveSwapSigner,
+        router_fees::{FeeRates, RouterFees, SharedRouterFees},
     },
     EncodingOptions, FeeBreakdown, OrderQuote, QuoteStatus, SolveError, Transaction,
 };
@@ -277,10 +277,10 @@ impl Encoder {
             return Ok(solution);
         }
 
-        // `route_swaps` carry `committed_amount_out` and the pool attributes; `solution.swaps()` are
-        // built 1:1 from them by `Solution::try_from` and are what the router executes. We read the
-        // committed amount from the route swap but stamp `user_data` onto the matching solution
-        // swap, matched by index via the zip below.
+        // `route_swaps` carry `committed_amount_out` and the pool attributes; `solution.swaps()`
+        // are built 1:1 from them by `Solution::try_from` and are what the router executes.
+        // We read the committed amount from the route swap but stamp `user_data` onto the
+        // matching solution swap, matched by index via the zip below.
         let swaps = solution
             .swaps()
             .iter()
@@ -827,7 +827,7 @@ mod tests {
     fn test_stamp_exclusive_swaps(#[case] committed: Option<u64>, #[case] signed: bool) {
         let quote =
             make_order_quote(990_000).with_route(single_swap_route(ekubo_signed_swap(committed)));
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, 0);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
 
         let solution =
             Encoder::stamp_exclusive_swaps(Solution::try_from(&quote).unwrap(), &quote, &signer)

--- a/fynd-core/src/encoding/exclusive_swap.rs
+++ b/fynd-core/src/encoding/exclusive_swap.rs
@@ -1,15 +1,16 @@
-//! Builds the controller-signed `user_data` payload for exclusive Ekubo swaps.
+//! Builds the controller-signed `user_data` payload for exclusive swaps.
 //!
 //! An exclusive leg (one carrying a committed amount, [`Swap::committed_amount_out`]) executes
-//! through the on-chain `SignedExclusiveSwap` extension, which charges a per-swap fee so the
-//! taker's output tracks the committed amount and the surplus goes to the pool's LPs. The
-//! committed amount is best-effort, not a hard floor — the ≥committed guarantee lives upstream in
-//! the quote/router and price-guard layer.
+//! through an on-chain extension that charges a per-swap fee so the taker's output tracks the
+//! committed amount and the surplus goes to the pool's LPs. The committed amount is best-effort,
+//! not a hard floor — the ≥committed guarantee lives upstream in the quote/router and price-guard
+//! layer.
 //!
-//! The payload is the tycho [`Swap::user_data`](tycho_execution) bytes
-//! `fee(8) | meta(32) | minBalanceUpdate(32) | signature(65)`, where `fee` is the pool's config
-//! fee (a big-endian u64) that `EkuboV3SwapEncoder` uses to rebuild the hop's poolConfig. The
-//! encoder appends the 2-byte `sigLen` before the signature, so this module does not.
+//! For Ekubo's `SignedExclusiveSwap` extension the payload is the tycho
+//! [`Swap::user_data`](tycho_execution) bytes `fee(8) | meta(32) | minBalanceUpdate(32) |
+//! signature(65)`, where `fee` is the pool's config fee (a big-endian u64) that
+//! `EkuboV3SwapEncoder` uses to rebuild the hop's poolConfig. The encoder appends the 2-byte
+//! `sigLen` before the signature, so this module does not.
 //!
 //! Requires the Ekubo `user_data` support added in `tycho-execution` 0.338.0 (the workspace pins
 //! `>= 0.338.0`). All byte layouts and the EIP-712 digest are mirrored from the Ekubo contracts.
@@ -24,31 +25,44 @@ use alloy::{
     signers::{local::PrivateKeySigner, SignerSync},
 };
 use num_bigint::BigUint;
-use tycho_simulation::tycho_common::Bytes;
+use tycho_simulation::tycho_common::{models::protocol::ProtocolComponent, Bytes};
 
 use crate::{SolveError, Swap};
 
 /// Environment variable holding the pool controller's private key (hex, with or without `0x`).
-const ENV_CONTROLLER_KEY: &str = "SIGNED_SWAP_CONTROLLER_KEY";
+const ENV_CONTROLLER_KEY: &str = "EXCLUSIVE_SWAP_CONTROLLER_KEY";
 
 /// Default validity window for a signed quote, in seconds. Well under the extension's 30-day cap.
 const DEFAULT_DEADLINE_WINDOW_SECS: u32 = 120;
 
-/// Produces controller-signed `user_data` payloads for exclusive Ekubo swaps.
+/// Environment variable setting the taker's price-improvement buffer, in basis points.
+const ENV_BUFFER_BPS: &str = "EXCLUSIVE_SWAP_BUFFER_BPS";
+
+/// Denominator for the buffer basis points (`10_000` bps = 100%).
+const BUFFER_BPS_DENOMINATOR: u32 = 10_000;
+
+/// Default taker buffer: 0 bps, so the realized output tracks the committed amount exactly.
+const DEFAULT_BUFFER_BPS: u32 = 0;
+
+/// Produces controller-signed `user_data` payloads for exclusive swaps.
 ///
 /// Holds the controller key, the chain id (bound into the EIP-712 domain), a monotonic nonce
-/// source, and the deadline window. Construct it from the environment with
-/// [`SignedSwapSigner::from_env`]; when the key variable is unset the encoder simply leaves
+/// source, the deadline window, and the taker buffer. Construct it from the environment with
+/// [`ExclusiveSwapSigner::from_env`]; when the key variable is unset the encoder simply leaves
 /// exclusive legs unsigned.
-pub struct SignedSwapSigner {
+pub struct ExclusiveSwapSigner {
     signer: PrivateKeySigner,
     chain_id: u64,
     nonce: AtomicU64,
     deadline_window_secs: u32,
+    /// Price-improvement buffer in basis points: raises the taker's output floor above the
+    /// committed amount, so the fee captures less surplus and the user's quote improves. `0` tracks
+    /// the committed amount exactly.
+    buffer_bps: u32,
 }
 
-impl SignedSwapSigner {
-    /// Builds a signer from the `SIGNED_SWAP_CONTROLLER_KEY` env var: `Ok(None)` when unset
+impl ExclusiveSwapSigner {
+    /// Builds a signer from the `EXCLUSIVE_SWAP_CONTROLLER_KEY` env var: `Ok(None)` when unset
     /// (signing disabled), an error when set but invalid.
     ///
     /// The nonce is seeded from wall-clock seconds so it stays ahead of already-consumed on-chain
@@ -63,20 +77,40 @@ impl SignedSwapSigner {
             .map_err(|e| {
                 SolveError::FailedEncoding(format!("invalid {ENV_CONTROLLER_KEY}: {e}"))
             })?;
-        Ok(Some(Self::new(signer, chain_id, now_unix_secs(), DEFAULT_DEADLINE_WINDOW_SECS)))
+        let buffer_bps = std::env::var(ENV_BUFFER_BPS)
+            .ok()
+            .map(|v| v.parse::<u32>())
+            .transpose()
+            .map_err(|e| SolveError::FailedEncoding(format!("invalid {ENV_BUFFER_BPS}: {e}")))?
+            .unwrap_or(DEFAULT_BUFFER_BPS);
+        Ok(Some(Self::new(
+            signer,
+            chain_id,
+            now_unix_secs(),
+            DEFAULT_DEADLINE_WINDOW_SECS,
+            buffer_bps,
+        )))
     }
 
     /// Creates a signer from explicit parts.
     ///
     /// `nonce_seed` is the first nonce handed out; `deadline_window_secs` is added to the
-    /// signing-time timestamp to form each payload's deadline.
+    /// signing-time timestamp to form each payload's deadline; `buffer_bps` raises the taker's
+    /// output floor above the committed amount (`0` tracks the committed amount exactly).
     pub fn new(
         signer: PrivateKeySigner,
         chain_id: u64,
         nonce_seed: u64,
         deadline_window_secs: u32,
+        buffer_bps: u32,
     ) -> Self {
-        Self { signer, chain_id, nonce: AtomicU64::new(nonce_seed), deadline_window_secs }
+        Self {
+            signer,
+            chain_id,
+            nonce: AtomicU64::new(nonce_seed),
+            deadline_window_secs,
+            buffer_bps,
+        }
     }
 
     /// Builds the signed `user_data` for one exclusive swap leg.
@@ -100,7 +134,7 @@ impl SignedSwapSigner {
                 )
             })?;
 
-        let fee = derive_fee_q32(swap.amount_out(), committed);
+        let fee = derive_fee_q32(swap.amount_out(), committed, self.buffer_bps);
         let nonce = self
             .nonce
             .fetch_add(1, Ordering::Relaxed);
@@ -160,17 +194,24 @@ fn min_balance_update_accept_any() -> B256 {
     B256::from(word)
 }
 
-/// Derives the extension's 0.32 fixed-point fee so the realized output tracks `committed`.
+/// Derives the extension's 0.32 fixed-point fee so the taker's realized output tracks a floor at
+/// or above `committed`.
 ///
-/// The extension takes `ceil(grossOutput · (fee << 32) / 2⁶⁴)` from the output, so the largest
-/// fee that never charges more than the surplus (`gross − committed`) is
-/// `floor((gross − committed) · 2³² / gross)`, clamped to `u32`. Rounding down biases toward
-/// under-capture, so the taker always receives at least `committed`.
-fn derive_fee_q32(gross: &BigUint, committed: &BigUint) -> u32 {
-    if gross <= committed {
+/// `buffer_bps` raises that floor above `committed` to hand the taker part of the surplus;
+/// `buffer_bps = 0` targets `committed` exactly. The fee is rounded down so the taker always
+/// receives at least the floor.
+fn derive_fee_q32(gross: &BigUint, committed: &BigUint, buffer_bps: u32) -> u32 {
+    // Lift the floor by `buffer_bps` of the committed amount, capped at the gross output.
+    let floor =
+        (committed + committed * BigUint::from(buffer_bps) / BigUint::from(BUFFER_BPS_DENOMINATOR))
+            .min(gross.clone());
+    if gross <= &floor {
         return 0;
     }
-    let surplus = gross - committed;
+    // The extension charges `ceil(gross · (fee << 32) / 2⁶⁴)`, so the largest fee that never takes
+    // more than the surplus above the floor is `floor((gross − floor) · 2³² / gross)`. Rounding
+    // down biases toward under-capture, keeping the taker at or above the floor.
+    let surplus = gross - &floor;
     let scaled = (surplus * BigUint::from(1u64 << 32)) / gross;
     scaled
         .min(BigUint::from(u32::MAX))
@@ -180,9 +221,7 @@ fn derive_fee_q32(gross: &BigUint, committed: &BigUint) -> u32 {
 }
 
 /// Reads the Ekubo extension address from a component's static attributes.
-fn pool_extension(
-    component: &tycho_simulation::tycho_common::models::protocol::ProtocolComponent,
-) -> Result<Address, SolveError> {
+fn pool_extension(component: &ProtocolComponent) -> Result<Address, SolveError> {
     let bytes = attribute(component, "extension")?;
     Address::try_from(bytes).map_err(|_| {
         SolveError::FailedEncoding("extension attribute is not a 20-byte address".to_string())
@@ -190,9 +229,7 @@ fn pool_extension(
 }
 
 /// Rebuilds the 32-byte `PoolConfig` word: `extension(20) ‖ fee(u64, 8) ‖ pool_type_config(4)`.
-fn pool_config_word(
-    component: &tycho_simulation::tycho_common::models::protocol::ProtocolComponent,
-) -> Result<B256, SolveError> {
+fn pool_config_word(component: &ProtocolComponent) -> Result<B256, SolveError> {
     let extension = attribute(component, "extension")?;
     let fee = attribute(component, "fee")?;
     let pool_type_config = attribute(component, "pool_type_config")?;
@@ -281,10 +318,7 @@ fn eip712_digest(
 }
 
 /// Reads a required static attribute as a byte slice.
-fn attribute<'a>(
-    component: &'a tycho_simulation::tycho_common::models::protocol::ProtocolComponent,
-    key: &str,
-) -> Result<&'a [u8], SolveError> {
+fn attribute<'a>(component: &'a ProtocolComponent, key: &str) -> Result<&'a [u8], SolveError> {
     component
         .static_attributes
         .get(key)
@@ -307,9 +341,7 @@ mod tests {
     use alloy::primitives::{Address as EvmAddress, Signature};
     use chrono::NaiveDateTime;
     use rstest::rstest;
-    use tycho_simulation::tycho_common::models::{
-        protocol::ProtocolComponent, Chain as CommonChain,
-    };
+    use tycho_simulation::tycho_common::models::Chain as CommonChain;
 
     use super::*;
     use crate::algorithm::test_utils::MockProtocolSim;
@@ -353,7 +385,7 @@ mod tests {
     #[case::committed_equals_gross(1000, 1000)]
     #[case::committed_exceeds_gross(1000, 2000)]
     fn test_derive_fee_q32_without_surplus(#[case] gross: u64, #[case] committed: u64) {
-        assert_eq!(derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed)), 0);
+        assert_eq!(derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 0), 0);
     }
 
     #[rstest]
@@ -362,11 +394,27 @@ mod tests {
     #[case::surplus_50_percent(1_000_000, 500_000)]
     #[case::near_total_surplus(1_000_000, 1)]
     fn test_derive_fee_q32_never_shorts_taker(#[case] gross: u128, #[case] committed: u128) {
-        let fee = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed));
+        let fee = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 0);
 
         let fee_amount = compute_fee(gross, u64::from(fee) << 32);
         assert!(fee_amount <= gross - committed, "capture exceeds surplus");
         assert!(gross - fee_amount >= committed, "taker receives less than committed");
+    }
+
+    #[test]
+    fn test_derive_fee_q32_buffer_raises_taker_floor() {
+        // A 100 bps (1%) buffer lifts the floor on committed 900_000 to 909_000, so the fee
+        // captures less surplus and the taker keeps more than the committed amount.
+        let gross = 1_000_000u128;
+        let committed = 900_000u128;
+        let floor = 909_000u128;
+
+        let no_buffer = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 0);
+        let buffered = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 100);
+
+        assert!(buffered < no_buffer, "buffer must lower the captured fee");
+        let fee_amount = compute_fee(gross, u64::from(buffered) << 32);
+        assert!(gross - fee_amount >= floor, "taker receives less than the buffered floor");
     }
 
     fn ekubo_component() -> ProtocolComponent {
@@ -483,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_build_user_data_layout() {
-        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, 0);
         let swap = signed_swap(Some(990_000));
 
         let user_data = signer.build_user_data(&swap).unwrap();
@@ -515,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_build_user_data_requires_committed_amount() {
-        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, 0);
         assert!(signer
             .build_user_data(&signed_swap(None))
             .is_err());
@@ -523,7 +571,7 @@ mod tests {
 
     #[test]
     fn test_nonce_increments_per_payload() {
-        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 0, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 0, 120, 0);
         let swap = signed_swap(Some(990_000));
 
         let first = signer.build_user_data(&swap).unwrap();

--- a/fynd-core/src/encoding/exclusive_swap.rs
+++ b/fynd-core/src/encoding/exclusive_swap.rs
@@ -35,19 +35,10 @@ const ENV_CONTROLLER_KEY: &str = "EXCLUSIVE_SWAP_CONTROLLER_KEY";
 /// Default validity window for a signed quote, in seconds. Well under the extension's 30-day cap.
 const DEFAULT_DEADLINE_WINDOW_SECS: u32 = 120;
 
-/// Environment variable setting the taker's price-improvement buffer, in basis points.
-const ENV_BUFFER_BPS: &str = "EXCLUSIVE_SWAP_BUFFER_BPS";
-
-/// Denominator for the buffer basis points (`10_000` bps = 100%).
-const BUFFER_BPS_DENOMINATOR: u32 = 10_000;
-
-/// Default taker buffer: 0 bps, so the realized output tracks the committed amount exactly.
-const DEFAULT_BUFFER_BPS: u32 = 0;
-
 /// Produces controller-signed `user_data` payloads for exclusive swaps.
 ///
 /// Holds the controller key, the chain id (bound into the EIP-712 domain), a monotonic nonce
-/// source, the deadline window, and the taker buffer. Construct it from the environment with
+/// source, and the deadline window. Construct it from the environment with
 /// [`ExclusiveSwapSigner::from_env`]; when the key variable is unset the encoder simply leaves
 /// exclusive legs unsigned.
 pub struct ExclusiveSwapSigner {
@@ -55,10 +46,6 @@ pub struct ExclusiveSwapSigner {
     chain_id: u64,
     nonce: AtomicU64,
     deadline_window_secs: u32,
-    /// Price-improvement buffer in basis points: raises the taker's output floor above the
-    /// committed amount, so the fee captures less surplus and the user's quote improves. `0` tracks
-    /// the committed amount exactly.
-    buffer_bps: u32,
 }
 
 impl ExclusiveSwapSigner {
@@ -77,40 +64,20 @@ impl ExclusiveSwapSigner {
             .map_err(|e| {
                 SolveError::FailedEncoding(format!("invalid {ENV_CONTROLLER_KEY}: {e}"))
             })?;
-        let buffer_bps = std::env::var(ENV_BUFFER_BPS)
-            .ok()
-            .map(|v| v.parse::<u32>())
-            .transpose()
-            .map_err(|e| SolveError::FailedEncoding(format!("invalid {ENV_BUFFER_BPS}: {e}")))?
-            .unwrap_or(DEFAULT_BUFFER_BPS);
-        Ok(Some(Self::new(
-            signer,
-            chain_id,
-            now_unix_secs(),
-            DEFAULT_DEADLINE_WINDOW_SECS,
-            buffer_bps,
-        )))
+        Ok(Some(Self::new(signer, chain_id, now_unix_secs(), DEFAULT_DEADLINE_WINDOW_SECS)))
     }
 
     /// Creates a signer from explicit parts.
     ///
     /// `nonce_seed` is the first nonce handed out; `deadline_window_secs` is added to the
-    /// signing-time timestamp to form each payload's deadline; `buffer_bps` raises the taker's
-    /// output floor above the committed amount (`0` tracks the committed amount exactly).
+    /// signing-time timestamp to form each payload's deadline.
     pub fn new(
         signer: PrivateKeySigner,
         chain_id: u64,
         nonce_seed: u64,
         deadline_window_secs: u32,
-        buffer_bps: u32,
     ) -> Self {
-        Self {
-            signer,
-            chain_id,
-            nonce: AtomicU64::new(nonce_seed),
-            deadline_window_secs,
-            buffer_bps,
-        }
+        Self { signer, chain_id, nonce: AtomicU64::new(nonce_seed), deadline_window_secs }
     }
 
     /// Builds the signed `user_data` for one exclusive swap leg.
@@ -134,7 +101,7 @@ impl ExclusiveSwapSigner {
                 )
             })?;
 
-        let fee = derive_fee_q32(swap.amount_out(), committed, self.buffer_bps);
+        let fee = derive_fee_q32(swap.amount_out(), committed);
         let nonce = self
             .nonce
             .fetch_add(1, Ordering::Relaxed);
@@ -194,24 +161,17 @@ fn min_balance_update_accept_any() -> B256 {
     B256::from(word)
 }
 
-/// Derives the extension's 0.32 fixed-point fee so the taker's realized output tracks a floor at
-/// or above `committed`.
+/// Derives the extension's 0.32 fixed-point fee so the taker's realized output tracks `committed`.
 ///
-/// `buffer_bps` raises that floor above `committed` to hand the taker part of the surplus;
-/// `buffer_bps = 0` targets `committed` exactly. The fee is rounded down so the taker always
-/// receives at least the floor.
-fn derive_fee_q32(gross: &BigUint, committed: &BigUint, buffer_bps: u32) -> u32 {
-    // Lift the floor by `buffer_bps` of the committed amount, capped at the gross output.
-    let floor =
-        (committed + committed * BigUint::from(buffer_bps) / BigUint::from(BUFFER_BPS_DENOMINATOR))
-            .min(gross.clone());
-    if gross <= &floor {
+/// The fee is rounded down so the taker always receives at least the committed amount.
+fn derive_fee_q32(gross: &BigUint, committed: &BigUint) -> u32 {
+    if gross <= committed {
         return 0;
     }
     // The extension charges `ceil(gross · (fee << 32) / 2⁶⁴)`, so the largest fee that never takes
-    // more than the surplus above the floor is `floor((gross − floor) · 2³² / gross)`. Rounding
-    // down biases toward under-capture, keeping the taker at or above the floor.
-    let surplus = gross - &floor;
+    // more than the surplus above the committed amount is `floor((gross − committed) · 2³² /
+    // gross)`. Rounding down biases toward under-capture, keeping the taker at or above it.
+    let surplus = gross - committed;
     let scaled = (surplus * BigUint::from(1u64 << 32)) / gross;
     scaled
         .min(BigUint::from(u32::MAX))
@@ -385,7 +345,7 @@ mod tests {
     #[case::committed_equals_gross(1000, 1000)]
     #[case::committed_exceeds_gross(1000, 2000)]
     fn test_derive_fee_q32_without_surplus(#[case] gross: u64, #[case] committed: u64) {
-        assert_eq!(derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 0), 0);
+        assert_eq!(derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed)), 0);
     }
 
     #[rstest]
@@ -394,27 +354,11 @@ mod tests {
     #[case::surplus_50_percent(1_000_000, 500_000)]
     #[case::near_total_surplus(1_000_000, 1)]
     fn test_derive_fee_q32_never_shorts_taker(#[case] gross: u128, #[case] committed: u128) {
-        let fee = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 0);
+        let fee = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed));
 
         let fee_amount = compute_fee(gross, u64::from(fee) << 32);
         assert!(fee_amount <= gross - committed, "capture exceeds surplus");
         assert!(gross - fee_amount >= committed, "taker receives less than committed");
-    }
-
-    #[test]
-    fn test_derive_fee_q32_buffer_raises_taker_floor() {
-        // A 100 bps (1%) buffer lifts the floor on committed 900_000 to 909_000, so the fee
-        // captures less surplus and the taker keeps more than the committed amount.
-        let gross = 1_000_000u128;
-        let committed = 900_000u128;
-        let floor = 909_000u128;
-
-        let no_buffer = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 0);
-        let buffered = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed), 100);
-
-        assert!(buffered < no_buffer, "buffer must lower the captured fee");
-        let fee_amount = compute_fee(gross, u64::from(buffered) << 32);
-        assert!(gross - fee_amount >= floor, "taker receives less than the buffered floor");
     }
 
     fn ekubo_component() -> ProtocolComponent {
@@ -531,7 +475,7 @@ mod tests {
 
     #[test]
     fn test_build_user_data_layout() {
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, 0);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
         let swap = signed_swap(Some(990_000));
 
         let user_data = signer.build_user_data(&swap).unwrap();
@@ -563,7 +507,7 @@ mod tests {
 
     #[test]
     fn test_build_user_data_requires_committed_amount() {
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, 0);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
         assert!(signer
             .build_user_data(&signed_swap(None))
             .is_err());
@@ -571,7 +515,7 @@ mod tests {
 
     #[test]
     fn test_nonce_increments_per_payload() {
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 0, 120, 0);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 0, 120);
         let swap = signed_swap(Some(990_000));
 
         let first = signer.build_user_data(&swap).unwrap();

--- a/fynd-core/src/encoding/mod.rs
+++ b/fynd-core/src/encoding/mod.rs
@@ -8,4 +8,4 @@
 pub mod encoder;
 pub mod fee_fetcher;
 pub mod router_fees;
-pub mod signed_quote;
+pub mod exclusive_swap;

--- a/fynd-core/src/encoding/mod.rs
+++ b/fynd-core/src/encoding/mod.rs
@@ -6,6 +6,6 @@
 /// the [Fynd encoding guide](https://docs.fynd.xyz/guides/encoding-options) for supported
 /// encoding options and how to configure them.
 pub mod encoder;
+pub mod exclusive_swap;
 pub mod fee_fetcher;
 pub mod router_fees;
-pub mod exclusive_swap;

--- a/fynd-core/src/encoding/mod.rs
+++ b/fynd-core/src/encoding/mod.rs
@@ -8,3 +8,4 @@
 pub mod encoder;
 pub mod fee_fetcher;
 pub mod router_fees;
+pub mod signed_quote;

--- a/fynd-core/src/encoding/signed_quote.rs
+++ b/fynd-core/src/encoding/signed_quote.rs
@@ -1,0 +1,535 @@
+//! Builds the controller-signed `user_data` payload for exclusive Ekubo swaps.
+//!
+//! An exclusive leg (one carrying a committed amount, [`Swap::committed_amount_out`]) executes
+//! through the on-chain `SignedExclusiveSwap` extension, which charges a per-swap fee so the
+//! taker's output tracks the committed amount and the surplus goes to the pool's LPs. The
+//! committed amount is best-effort, not a hard floor — the ≥committed guarantee lives upstream in
+//! the quote/router and price-guard layer.
+//!
+//! The payload is the tycho [`Swap::user_data`](tycho_execution) bytes
+//! `fee(8) | meta(32) | minBalanceUpdate(32) | signature(65)`, where `fee` is the pool's config
+//! fee (a big-endian u64) that `EkuboV3SwapEncoder` uses to rebuild the hop's poolConfig. The
+//! encoder appends the 2-byte `sigLen` before the signature, so this module does not.
+//!
+//! Requires the Ekubo `user_data` support added in `tycho-execution` 0.338.0 (the workspace pins
+//! `>= 0.338.0`). All byte layouts and the EIP-712 digest are mirrored from the Ekubo contracts.
+
+use std::{
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use alloy::{
+    primitives::{keccak256, Address, B256, U256},
+    signers::{local::PrivateKeySigner, SignerSync},
+};
+use num_bigint::BigUint;
+use tycho_simulation::tycho_common::Bytes;
+
+use crate::{SolveError, Swap};
+
+/// Environment variable holding the pool controller's private key (hex, with or without `0x`).
+const ENV_CONTROLLER_KEY: &str = "SIGNED_SWAP_CONTROLLER_KEY";
+
+/// Default validity window for a signed quote, in seconds. Well under the extension's 30-day cap.
+const DEFAULT_DEADLINE_WINDOW_SECS: u32 = 120;
+
+/// Produces controller-signed `user_data` payloads for exclusive Ekubo swaps.
+///
+/// Holds the controller key, the chain id (bound into the EIP-712 domain), a monotonic nonce
+/// source, and the deadline window. Construct it from the environment with
+/// [`SignedSwapSigner::from_env`]; when the key variable is unset the encoder simply leaves
+/// exclusive legs unsigned.
+pub struct SignedSwapSigner {
+    signer: PrivateKeySigner,
+    chain_id: u64,
+    nonce: AtomicU64,
+    deadline_window_secs: u32,
+}
+
+impl SignedSwapSigner {
+    /// Builds a signer from the `SIGNED_SWAP_CONTROLLER_KEY` env var: `Ok(None)` when unset
+    /// (signing disabled), an error when set but invalid.
+    ///
+    /// The nonce is seeded from wall-clock seconds so it stays ahead of already-consumed on-chain
+    /// nonces across restarts without persistence. This holds only below ~1 signature/second;
+    /// higher throughput or multiple replicas need a per-process offset or persisted nonces.
+    pub fn from_env(chain_id: u64) -> Result<Option<Self>, SolveError> {
+        let Ok(key) = std::env::var(ENV_CONTROLLER_KEY) else {
+            return Ok(None);
+        };
+        let signer = key
+            .parse::<PrivateKeySigner>()
+            .map_err(|e| {
+                SolveError::FailedEncoding(format!("invalid {ENV_CONTROLLER_KEY}: {e}"))
+            })?;
+        Ok(Some(Self::new(signer, chain_id, now_unix_secs(), DEFAULT_DEADLINE_WINDOW_SECS)))
+    }
+
+    /// Creates a signer from explicit parts.
+    ///
+    /// `nonce_seed` is the first nonce handed out; `deadline_window_secs` is added to the
+    /// signing-time timestamp to form each payload's deadline.
+    pub fn new(
+        signer: PrivateKeySigner,
+        chain_id: u64,
+        nonce_seed: u64,
+        deadline_window_secs: u32,
+    ) -> Self {
+        Self { signer, chain_id, nonce: AtomicU64::new(nonce_seed), deadline_window_secs }
+    }
+
+    /// Builds the signed `user_data` for one exclusive swap leg.
+    ///
+    /// The leg must carry a committed amount ([`Swap::committed_amount_out`]); the fee is derived
+    /// from the quoted output so the realized output tracks it (best-effort — see the module docs).
+    ///
+    /// v1 supports only standard ERC-20 pools: `poolId` is rebuilt from the swap's token addresses,
+    /// so a native-ETH pool (whose on-chain `PoolKey` uses `address(0)`) would yield a mismatched
+    /// signature and revert.
+    ///
+    /// # Errors
+    /// Errors if the leg lacks a committed amount, the component is missing Ekubo pool attributes,
+    /// a token address exceeds 32 bytes, the deadline overflows `u32`, or signing fails.
+    pub fn build_user_data(&self, swap: &Swap) -> Result<Bytes, SolveError> {
+        let committed = swap
+            .committed_amount_out()
+            .ok_or_else(|| {
+                SolveError::FailedEncoding(
+                    "signed swap leg is missing committed_amount_out".to_string(),
+                )
+            })?;
+
+        let fee = derive_fee_q32(swap.amount_out(), committed);
+        let nonce = self
+            .nonce
+            .fetch_add(1, Ordering::Relaxed);
+        let deadline = now_unix_secs().saturating_add(u64::from(self.deadline_window_secs));
+        let deadline = u32::try_from(deadline).map_err(|_| {
+            SolveError::FailedEncoding("signed swap deadline overflows u32".to_string())
+        })?;
+
+        // No authorized locker: address(0) leaves the swap usable by any locker (see the
+        // extension's `isAuthorized`), matching the reference wiring.
+        let meta = signed_swap_meta(deadline, fee, nonce, Address::ZERO);
+        let min_balance_update = min_balance_update_accept_any();
+
+        let component = swap.protocol_component();
+        let extension = pool_extension(component)?;
+        let config = pool_config_word(component)?;
+        let (token0, token1) = sorted_tokens(swap.token_in(), swap.token_out());
+        let pool_id = pool_id(token0, token1, config)?;
+
+        let digest = eip712_digest(self.chain_id, extension, pool_id, meta, min_balance_update);
+        let signature = self
+            .signer
+            .sign_hash_sync(&digest)
+            .map_err(|e| SolveError::FailedEncoding(format!("signed swap signing failed: {e}")))?;
+
+        // `EkuboV3SwapEncoder` reads the leading fee(8) as the pool's config fee to rebuild the
+        // hop's poolConfig. Take it from the same `config` word the poolId is derived from (bytes
+        // [20..28]) so the executor resolves the pool the signature was made over.
+        let config_fee = &config.as_slice()[20..28];
+
+        let mut user_data = Vec::with_capacity(8 + 32 + 32 + 65);
+        user_data.extend_from_slice(config_fee);
+        user_data.extend_from_slice(meta.as_slice());
+        user_data.extend_from_slice(min_balance_update.as_slice());
+        user_data.extend_from_slice(&signature.as_bytes());
+        Ok(Bytes::from(user_data))
+    }
+}
+
+/// Packs a `SignedSwapMeta` word: `[255..224]` deadline(u32), `[223..192]` fee(u32, 0.32 fixed
+/// point), `[191..128]` nonce(u64), `[127..0]` authorized-locker low 128 bits.
+fn signed_swap_meta(deadline: u32, fee: u32, nonce: u64, authorized_locker: Address) -> B256 {
+    let mut word = [0u8; 32];
+    word[0..4].copy_from_slice(&deadline.to_be_bytes());
+    word[4..8].copy_from_slice(&fee.to_be_bytes());
+    word[8..16].copy_from_slice(&nonce.to_be_bytes());
+    // Low 128 bits of the 20-byte locker address = its least-significant 16 bytes.
+    word[16..32].copy_from_slice(&authorized_locker.as_slice()[4..20]);
+    B256::from(word)
+}
+
+/// Returns the `PoolBalanceUpdate` that accepts any swap output (`delta0 = delta1 = i128::MIN`).
+fn min_balance_update_accept_any() -> B256 {
+    let mut word = [0u8; 32];
+    word[0] = 0x80;
+    word[16] = 0x80;
+    B256::from(word)
+}
+
+/// Derives the extension's 0.32 fixed-point fee so the realized output tracks `committed`.
+///
+/// The extension takes `ceil(grossOutput · (fee << 32) / 2⁶⁴)` from the output, so the largest
+/// fee that never charges more than the surplus (`gross − committed`) is
+/// `floor((gross − committed) · 2³² / gross)`, clamped to `u32`. Rounding down biases toward
+/// under-capture, so the taker always receives at least `committed`.
+fn derive_fee_q32(gross: &BigUint, committed: &BigUint) -> u32 {
+    if gross <= committed {
+        return 0;
+    }
+    let surplus = gross - committed;
+    let scaled = (surplus * BigUint::from(1u64 << 32)) / gross;
+    scaled
+        .min(BigUint::from(u32::MAX))
+        .iter_u32_digits()
+        .next()
+        .unwrap_or(0)
+}
+
+/// Reads the Ekubo extension address from a component's static attributes.
+fn pool_extension(
+    component: &tycho_simulation::tycho_common::models::protocol::ProtocolComponent,
+) -> Result<Address, SolveError> {
+    let bytes = attribute(component, "extension")?;
+    Address::try_from(bytes).map_err(|_| {
+        SolveError::FailedEncoding("extension attribute is not a 20-byte address".to_string())
+    })
+}
+
+/// Rebuilds the 32-byte `PoolConfig` word: `extension(20) ‖ fee(u64, 8) ‖ pool_type_config(4)`.
+fn pool_config_word(
+    component: &tycho_simulation::tycho_common::models::protocol::ProtocolComponent,
+) -> Result<B256, SolveError> {
+    let extension = attribute(component, "extension")?;
+    let fee = attribute(component, "fee")?;
+    let pool_type_config = attribute(component, "pool_type_config")?;
+
+    if extension.len() != 20 {
+        return Err(SolveError::FailedEncoding("extension attribute must be 20 bytes".to_string()));
+    }
+    if fee.len() != 8 {
+        return Err(SolveError::FailedEncoding("fee attribute must be 8 bytes".to_string()));
+    }
+    if pool_type_config.len() != 4 {
+        return Err(SolveError::FailedEncoding(
+            "pool_type_config attribute must be 4 bytes".to_string(),
+        ));
+    }
+
+    let mut word = [0u8; 32];
+    word[0..20].copy_from_slice(extension);
+    word[20..28].copy_from_slice(fee);
+    word[28..32].copy_from_slice(pool_type_config);
+    Ok(B256::from(word))
+}
+
+/// Computes `poolId = keccak256(token0₃₂ ‖ token1₃₂ ‖ poolConfig₃₂)`.
+///
+/// Each token is left-padded into a 32-byte word, so a token longer than 32 bytes is rejected
+/// rather than panicking on the slice index.
+fn pool_id(token0: &[u8], token1: &[u8], config: B256) -> Result<B256, SolveError> {
+    if token0.len() > 32 || token1.len() > 32 {
+        return Err(SolveError::FailedEncoding(
+            "token address exceeds 32 bytes; cannot build poolId".to_string(),
+        ));
+    }
+    let mut buf = [0u8; 96];
+    buf[32 - token0.len()..32].copy_from_slice(token0);
+    buf[64 - token1.len()..64].copy_from_slice(token1);
+    buf[64..96].copy_from_slice(config.as_slice());
+    Ok(keccak256(buf))
+}
+
+/// Orders two token addresses so `token0 < token1`, matching the on-chain `PoolKey`.
+fn sorted_tokens<'a>(token_in: &'a [u8], token_out: &'a [u8]) -> (&'a [u8], &'a [u8]) {
+    if token_in <= token_out {
+        (token_in, token_out)
+    } else {
+        (token_out, token_in)
+    }
+}
+
+/// Computes the EIP-712 digest the `SignedExclusiveSwap` extension recovers the signer from.
+fn eip712_digest(
+    chain_id: u64,
+    extension: Address,
+    pool_id: B256,
+    meta: B256,
+    min_balance_update: B256,
+) -> B256 {
+    let domain_typehash = keccak256(
+        b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+    );
+    let name_hash = keccak256(b"Ekubo SignedExclusiveSwap");
+    let version_hash = keccak256(b"1");
+
+    let mut domain = Vec::with_capacity(32 * 5);
+    domain.extend_from_slice(domain_typehash.as_slice());
+    domain.extend_from_slice(name_hash.as_slice());
+    domain.extend_from_slice(version_hash.as_slice());
+    domain.extend_from_slice(&U256::from(chain_id).to_be_bytes::<32>());
+    domain.extend_from_slice(B256::left_padding_from(extension.as_slice()).as_slice());
+    let domain_separator = keccak256(&domain);
+
+    let struct_typehash =
+        keccak256(b"SignedSwap(bytes32 poolId,uint256 meta,bytes32 minBalanceUpdate)");
+    let mut struct_input = Vec::with_capacity(32 * 4);
+    struct_input.extend_from_slice(struct_typehash.as_slice());
+    struct_input.extend_from_slice(pool_id.as_slice());
+    struct_input.extend_from_slice(meta.as_slice());
+    struct_input.extend_from_slice(min_balance_update.as_slice());
+    let struct_hash = keccak256(&struct_input);
+
+    let mut digest_input = Vec::with_capacity(2 + 64);
+    digest_input.extend_from_slice(&[0x19, 0x01]);
+    digest_input.extend_from_slice(domain_separator.as_slice());
+    digest_input.extend_from_slice(struct_hash.as_slice());
+    keccak256(&digest_input)
+}
+
+/// Reads a required static attribute as a byte slice.
+fn attribute<'a>(
+    component: &'a tycho_simulation::tycho_common::models::protocol::ProtocolComponent,
+    key: &str,
+) -> Result<&'a [u8], SolveError> {
+    component
+        .static_attributes
+        .get(key)
+        .map(AsRef::as_ref)
+        .ok_or_else(|| SolveError::FailedEncoding(format!("component missing `{key}` attribute")))
+}
+
+/// Current Unix time in seconds, or 0 if the clock is before the epoch.
+fn now_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, str::FromStr};
+
+    use alloy::primitives::{Address as EvmAddress, Signature};
+    use chrono::NaiveDateTime;
+    use rstest::rstest;
+    use tycho_simulation::tycho_common::models::{
+        protocol::ProtocolComponent, Chain as CommonChain,
+    };
+
+    use super::*;
+    use crate::algorithm::test_utils::MockProtocolSim;
+
+    const CONTROLLER_KEY: &str =
+        "0x1111111111111111111111111111111111111111111111111111111111111111";
+    // SignedExclusiveSwap extension placeholder used by the tycho reference PR.
+    const EXTENSION: &str = "0x5519ed5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e";
+
+    // Reimplements the extension's `computeFee` (ceil(amount * fee / 2^64)) to check the taker is
+    // never charged more than the surplus.
+    fn compute_fee(amount: u128, fee_x64: u64) -> u128 {
+        let numerator = U256::from(amount) * U256::from(fee_x64) + U256::from(u64::MAX);
+        u128::try_from(numerator >> 64).expect("fee fits in u128")
+    }
+
+    #[test]
+    fn test_signed_swap_meta_packs_fields_in_order() {
+        let deadline = 0x1122_3344u32;
+        let fee = 0x5566_7788u32;
+        let nonce = 0x99AA_BBCC_DDEE_FF00u64;
+        let locker = EvmAddress::from([0xAB; 20]);
+
+        let meta = signed_swap_meta(deadline, fee, nonce, locker);
+        let bytes = meta.as_slice();
+
+        assert_eq!(&bytes[0..4], &deadline.to_be_bytes());
+        assert_eq!(&bytes[4..8], &fee.to_be_bytes());
+        assert_eq!(&bytes[8..16], &nonce.to_be_bytes());
+        // Low 128 bits of the locker = its last 16 bytes.
+        assert_eq!(&bytes[16..32], &[0xABu8; 16]);
+    }
+
+    #[test]
+    fn test_min_balance_update_accepts_any_output() {
+        let expected = "8000000000000000000000000000000080000000000000000000000000000000";
+        assert_eq!(alloy::hex::encode(min_balance_update_accept_any()), expected);
+    }
+
+    #[rstest]
+    #[case::committed_equals_gross(1000, 1000)]
+    #[case::committed_exceeds_gross(1000, 2000)]
+    fn test_derive_fee_q32_without_surplus(#[case] gross: u64, #[case] committed: u64) {
+        assert_eq!(derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed)), 0);
+    }
+
+    #[rstest]
+    #[case::no_surplus(1_000_000, 1_000_000)]
+    #[case::surplus_1_percent(1_000_000, 990_000)]
+    #[case::surplus_50_percent(1_000_000, 500_000)]
+    #[case::near_total_surplus(1_000_000, 1)]
+    fn test_derive_fee_q32_never_shorts_taker(#[case] gross: u128, #[case] committed: u128) {
+        let fee = derive_fee_q32(&BigUint::from(gross), &BigUint::from(committed));
+
+        let fee_amount = compute_fee(gross, u64::from(fee) << 32);
+        assert!(fee_amount <= gross - committed, "capture exceeds surplus");
+        assert!(gross - fee_amount >= committed, "taker receives less than committed");
+    }
+
+    fn ekubo_component() -> ProtocolComponent {
+        let static_attributes = HashMap::from([
+            ("extension".to_string(), Bytes::from_str(EXTENSION).unwrap()),
+            ("fee".to_string(), Bytes::from(0u64)),
+            ("pool_type_config".to_string(), Bytes::from(0u32)),
+        ]);
+        ProtocolComponent::new(
+            "ekubo-signed-pool",
+            "ekubo_v3",
+            "swap",
+            CommonChain::Ethereum,
+            vec![],
+            vec![],
+            static_attributes,
+            Default::default(),
+            Default::default(),
+            NaiveDateTime::default(),
+        )
+    }
+
+    #[test]
+    fn test_pool_config_word_matches_packed_layout() {
+        let config = pool_config_word(&ekubo_component()).unwrap();
+        let expected = format!("{}{}", &EXTENSION[2..], "0".repeat(24));
+        assert_eq!(alloy::hex::encode(config), expected);
+    }
+
+    #[test]
+    fn test_sorted_tokens_orders_ascending() {
+        let low: &[u8] = &[0x11u8; 20];
+        let high: &[u8] = &[0x22u8; 20];
+        assert_eq!(sorted_tokens(low, high), (low, high));
+        assert_eq!(sorted_tokens(high, low), (low, high));
+    }
+
+    #[test]
+    fn test_pool_id_independent_of_swap_direction() {
+        let config = B256::ZERO;
+        let low: &[u8] = &[0x11u8; 20];
+        let high: &[u8] = &[0x22u8; 20];
+        // Swapping token_in/token_out yields the same pool once sorted.
+        let (a0, a1) = sorted_tokens(low, high);
+        let (b0, b1) = sorted_tokens(high, low);
+        assert_eq!(pool_id(a0, a1, config).unwrap(), pool_id(b0, b1, config).unwrap());
+    }
+
+    #[test]
+    fn test_pool_id_rejects_over_long_token() {
+        assert!(pool_id(&[0u8; 33], &[0x22u8; 20], B256::ZERO).is_err());
+    }
+
+    #[test]
+    fn test_eip712_digest_signature_recovers_signer() {
+        let signer: PrivateKeySigner = CONTROLLER_KEY.parse().unwrap();
+        let extension = EvmAddress::from_str(EXTENSION).unwrap();
+        let digest = eip712_digest(
+            1,
+            extension,
+            keccak256(b"pool"),
+            signed_swap_meta(1_000, 42, 7, EvmAddress::ZERO),
+            min_balance_update_accept_any(),
+        );
+
+        let signature = signer.sign_hash_sync(&digest).unwrap();
+        let recovered = signature
+            .recover_address_from_prehash(&digest)
+            .unwrap();
+        assert_eq!(recovered, signer.address());
+        // v byte is normalized to 27/28, matching the on-chain `abi.encodePacked(r, s, v)`.
+        assert!(matches!(signature.as_bytes()[64], 27 | 28));
+    }
+
+    #[test]
+    fn test_eip712_digest_matches_independent_oracle() {
+        // Known-answer vector: the expected digest was computed independently with `cast keccak`
+        // (foundry) from the Ekubo domain/struct definitions, pinning the domain strings, type
+        // hashes, field ordering, and the meta packing against a non-alloy Keccak implementation.
+        // Inputs: chainId=1, extension=EXTENSION, poolId=0x11..11, deadline=1000, fee=42, nonce=7,
+        // locker=0, minBalanceUpdate=accept-any.
+        let extension = EvmAddress::from_str(EXTENSION).unwrap();
+        let pool_id = B256::from([0x11u8; 32]);
+        let meta = signed_swap_meta(1_000, 42, 7, EvmAddress::ZERO);
+        let min_bu = min_balance_update_accept_any();
+
+        let digest = eip712_digest(1, extension, pool_id, meta, min_bu);
+
+        let expected =
+            B256::from_str("0xd47eb1b9f473ba6fa851d6dee23ab3ae57ee989187256835206411cea3baa0e0")
+                .unwrap();
+        assert_eq!(digest, expected);
+    }
+
+    fn signed_swap(committed: Option<u64>) -> Swap {
+        let token_in = tycho_simulation::tycho_common::Bytes::from([0x11u8; 20].as_ref());
+        let token_out = tycho_simulation::tycho_common::Bytes::from([0x22u8; 20].as_ref());
+        let mut swap = Swap::new(
+            "ekubo-signed-pool".to_string(),
+            "ekubo_v3".to_string(),
+            token_in,
+            token_out,
+            BigUint::from(1_000_000u64),
+            BigUint::from(1_000_000u64),
+            BigUint::from(50_000u64),
+            ekubo_component(),
+            Box::new(MockProtocolSim::default()),
+        );
+        if let Some(committed) = committed {
+            swap.set_committed_amount_out(BigUint::from(committed));
+        }
+        swap
+    }
+
+    #[test]
+    fn test_build_user_data_layout() {
+        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        let swap = signed_swap(Some(990_000));
+
+        let user_data = signer.build_user_data(&swap).unwrap();
+        let bytes = user_data.as_ref();
+
+        // Offsets mirror tycho `EkuboV3SwapEncoder::parse_signed_user_data`:
+        // fee(8) | meta(32) | minBalanceUpdate(32) | signature(65).
+        assert_eq!(bytes.len(), 8 + 32 + 32 + 65);
+        let config = pool_config_word(swap.protocol_component()).unwrap();
+        assert_eq!(&bytes[0..8], &config.as_slice()[20..28]); // pool config fee
+        assert_eq!(&bytes[40..72], min_balance_update_accept_any().as_slice());
+
+        // The signature recovers over the digest rebuilt from the payload's meta and minBU.
+        let extension = EvmAddress::from_str(EXTENSION).unwrap();
+        let meta = B256::from_slice(&bytes[8..40]);
+        let min_bu = B256::from_slice(&bytes[40..72]);
+        let (token0, token1) = sorted_tokens(swap.token_in(), swap.token_out());
+        let pool_id = pool_id(token0, token1, config).unwrap();
+        let digest = eip712_digest(1, extension, pool_id, meta, min_bu);
+
+        let signature = Signature::try_from(&bytes[72..]).unwrap();
+        assert_eq!(
+            signature
+                .recover_address_from_prehash(&digest)
+                .unwrap(),
+            signer.signer.address()
+        );
+    }
+
+    #[test]
+    fn test_build_user_data_requires_committed_amount() {
+        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        assert!(signer
+            .build_user_data(&signed_swap(None))
+            .is_err());
+    }
+
+    #[test]
+    fn test_nonce_increments_per_payload() {
+        let signer = SignedSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 0, 120);
+        let swap = signed_swap(Some(990_000));
+
+        let first = signer.build_user_data(&swap).unwrap();
+        let second = signer.build_user_data(&swap).unwrap();
+        // Nonce lives in meta bits [191..128] = meta bytes [8..16]; meta starts after the fee(8)
+        // prefix, so that is user_data bytes [16..24]. A fresh nonce changes the payload.
+        assert_ne!(first.as_ref()[16..24], second.as_ref()[16..24]);
+    }
+}

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1610,11 +1610,12 @@ pub struct Swap {
     split: f64,
     /// Per-leg committed output for an exclusive swap.
     ///
-    /// Set only on the single exclusive leg of a surplus route. The on-chain hook signs a
-    /// `maxExchangeRate` derived from this value (`committed_amount_out * denom / amount_in`); the
-    /// component then captures `amount_out - committed_amount_out` as surplus, denominated in this
-    /// swap's `token_out`. `None` for ordinary public swaps. In-process only — consumed by the
-    /// encoder; `#[serde(skip)]` so it never enters the wire format.
+    /// Set only on the single exclusive leg of a surplus route. The encoder derives the on-chain
+    /// extension's controller-signed per-swap fee from this value and the leg's `amount_out`
+    /// (`floor((amount_out - committed_amount_out) * 2^32 / amount_out)`); the component then
+    /// captures `amount_out - committed_amount_out` as surplus, denominated in this swap's
+    /// `token_out`. `None` for ordinary public swaps. In-process only — consumed by the encoder;
+    /// `#[serde(skip)]` so it never enters the wire format.
     #[serde(skip)]
     committed_amount_out: Option<BigUint>,
 }
@@ -1656,7 +1657,7 @@ impl Swap {
     /// Sets the per-leg committed output for an exclusive swap.
     ///
     /// The router stamps this onto the single exclusive leg of a surplus route so the encoder
-    /// can derive the hook's `maxExchangeRate`. See [`Swap::committed_amount_out`].
+    /// can derive the extension's signed fee. See [`Swap::committed_amount_out`].
     pub(crate) fn set_committed_amount_out(&mut self, committed_amount_out: BigUint) {
         self.committed_amount_out = Some(committed_amount_out);
     }
@@ -1713,8 +1714,8 @@ impl Swap {
 
     /// Returns the per-leg committed output, if this is the exclusive leg of a surplus route.
     ///
-    /// `None` for ordinary public swaps. When `Some`, the encoder derives the hook's
-    /// `maxExchangeRate` as `committed_amount_out * denom / amount_in`.
+    /// `None` for ordinary public swaps. When `Some`, the encoder derives the extension's signed
+    /// fee from this and the leg's `amount_out`.
     pub fn committed_amount_out(&self) -> Option<&BigUint> {
         self.committed_amount_out.as_ref()
     }


### PR DESCRIPTION
Jira task: https://propeller-heads.atlassian.net/browse/ENG-6134 

Add a signed_quote module that builds the EIP-712-signed payload for exclusive Ekubo legs and stamps it into the tycho Swap.user_data. The Encoder derives the per-swap fee from the leg's committed_amount_out and signs with a controller key.

TODO: 
- Rebase on [this](https://github.com/propeller-heads/fynd/pull/304) PR and remove local committed_amount_out stub on Swap.