### PR TITLE
feat(hindsight): New chain, venue, and solver decoding

### DIFF
--- a/base_pools.toml
+++ b/base_pools.toml
@@ -1,0 +1,46 @@
+# Worker-pools config for running Fynd on Base (chain-id 8453) — pass with
+# `--worker-pools-config base_pools.toml` (e.g. `hindsight monitor --chain base`).
+#
+# Two pools run concurrently; the router keeps the best result by amount_out_net_gas.
+# most_liquid is the cheap single-path baseline; path_frank_wolfe adds split routing that
+# helps larger trades. Both restrict intermediate hops to Base's most-connected tokens, so
+# multi-hop routes can form (the Ethereum-shaped default has no Base connectors and dead-ends
+# most pairs). Counts are approximate Base pool counts and only explain the ordering.
+
+[pools.most_liquid_base]
+algorithm           = "most_liquid"
+num_workers         = 3
+task_queue_capacity = 1000
+max_hops            = 3
+timeout_ms          = 500
+connector_tokens = [
+    "0x4200000000000000000000000000000000000006", # WETH    — 565 pools
+    "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", # USDC    — 259 pools
+    "0xb20a4bd059f5914a2f8b9c18881c637f79efb7df", # ADS     — 104 pools
+    "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b", # VIRTUAL —  89 pools
+    "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf", # cbBTC   —  45 pools
+    "0x0000000000000000000000000000000000000000", # ETH     —  38 pools
+    "0x940181a94a35a4569e4529a3cdfb74e38fd98631", # AERO    —  13 pools
+    "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2", # USDT    —  11 pools
+    "0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf", # VVV     —  11 pools
+    "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22", # cbETH   —  10 pools
+]
+
+[pools.path_frank_wolfe_base]
+algorithm           = "path_frank_wolfe"
+num_workers         = 3
+task_queue_capacity = 1000
+max_hops            = 3
+timeout_ms          = 1000
+connector_tokens = [
+    "0x4200000000000000000000000000000000000006", # WETH    — 565 pools
+    "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", # USDC    — 259 pools
+    "0xb20a4bd059f5914a2f8b9c18881c637f79efb7df", # ADS     — 104 pools
+    "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b", # VIRTUAL —  89 pools
+    "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf", # cbBTC   —  45 pools
+    "0x0000000000000000000000000000000000000000", # ETH     —  38 pools
+    "0x940181a94a35a4569e4529a3cdfb74e38fd98631", # AERO    —  13 pools
+    "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2", # USDT    —  11 pools
+    "0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf", # VVV     —  11 pools
+    "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22", # cbETH   —  10 pools
+]

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -46,14 +46,14 @@ Match → trace → decode → veto → record.
 |---|---|
 | `matching.rs` | Receipt-only filter: is this transaction a solver trade at all, plus match-time vetoes |
 | `decode.rs` | The `TradeDecoder` trait, the matched entity → decoders mapping, `DecodeContext`, `TraderFlow` |
-| `netting_decoders.rs` | Netting toolkit (`sender_flow`, `venue_flow`) plus the `SenderNetting`/`IntentNetting` decoders |
+| `netting_decoders.rs` | Netting toolkit (`sender_flow`, `venue_flow`) plus the `SenderNetting` decoder |
 | `transfer_ledger.rs` | Builds a transfer ledger from logs and native ETH flows |
 | `veto.rs` | The shared `Veto` type, plus post-decode vetoes of non-comparable shapes (NFT purchases, mis-paired wrap trades) |
 | `registry.rs` | Per-chain address book, loaded from TOML (see below) |
 | `sandwich.rs` | Flags trades bracketed by a front/back attacker pair (see the design spec) |
 | `venues/` | Per-venue `TradeDecoder` impls (Relay, MetaMask, Rabby), listed in `venues::decoders_for` |
 | `solvers/` | Per-solver knowledge: embedded quotes, match-time vetoes, attribution |
-| `intent.rs` | Intent-fill decoding for intent fills and batch settlements |
+| `intents/` | Intent-role decoders (solver-sent, trader-not-sender): `cow.rs` reads CoW's `Trade` event, `netting.rs` is the generic net-flow finder, `decoders_for` lists them |
 | `trace.rs` | Transaction trace fetching and processing |
 
 `src/verify/` contains the Allium integration:

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -51,7 +51,7 @@ Match → trace → decode → veto → record.
 | `veto.rs` | The shared `Veto` type, plus post-decode vetoes of non-comparable shapes (NFT purchases, mis-paired wrap trades) |
 | `registry.rs` | Per-chain address book, loaded from TOML (see below) |
 | `sandwich.rs` | Flags trades bracketed by a front/back attacker pair (see the design spec) |
-| `venues/` | Per-venue `TradeDecoder` impls (Relay, MetaMask), listed in `venues::decoders_for` |
+| `venues/` | Per-venue `TradeDecoder` impls (Relay, MetaMask, Rabby), listed in `venues::decoders_for` |
 | `solvers/` | Per-solver knowledge: embedded quotes, match-time vetoes, attribution |
 | `intent.rs` | Intent-fill decoding for intent fills and batch settlements |
 | `trace.rs` | Transaction trace fetching and processing |

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -34,6 +34,7 @@ alloy = { workspace = true, features = [
     "provider-debug-api",
     "rpc-types-eth",
     "rpc-types-trace",
+    "network",
 ] }
 
 # HTTP (for RPC URL parsing) + metrics server

--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -15,7 +15,7 @@ measurable value of adding Fynd to a venue.
 | `verify` | Diff decoded trades against Allium's `aggregator_trades` ground truth (dev check) |
 | `monitor` | Live: drive an in-process Fynd solver block-by-block, re-solve every settled trade, emit JSONL + Prometheus metrics |
 
-All take `--chain` (selects the address book; only `ethereum` is built in) and `--registry` /
+All take `--chain` (selects the address book) and `--registry` /
 `HINDSIGHT_REGISTRY` to load a custom address book. See `--help` per subcommand and
 [CLAUDE.md](CLAUDE.md) for environment variables.
 
@@ -195,7 +195,7 @@ collectors are re-verified on every chain a venue is added on.
 | Extend what Hindsight knows about a venue | That venue's module in `venues/` — never anywhere else | Decoding degrades silently |
 | Add a new decode method | A `TradeDecoder` (a `netting`/`calldata` toolkit function behind it), listed for the entities that use it | Transactions the existing decoders cannot read stay undecoded |
 | Reject decodes that are not real trades (an NFT purchase's payment leg, a mis-paired wrap) | A check in `veto.rs` | Records that are not trades enter the comparison |
-| Support a new chain | A `registry/<chain>.toml` address book (all sections required), plus decoders for its venues and `SolverKnowledge` for its solvers that have none yet | Only `ethereum` is built in |
+| Support a new chain | A `registry/<chain>.toml` address book (all sections required), plus decoders for its venues and `SolverKnowledge` for its solvers that have none yet | The chain has no built-in book and must be passed via `--registry` |
 
 ### Re-solve monitor (`src/resolve/`)
 

--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -51,7 +51,7 @@ All take `--chain` (selects the address book) and `--registry` /
            └────────┬────────┘   list several — a richer source first, a general one as fallback):
                     │
                     │   direct solver           →  [ SenderNetting ]
-                    │   batch settler / solver  →  [ IntentNetting ]
+                    │   batch settler / solver  →  [ CowSettlement, IntentNetting ]
                     │   venue relay             →  [ RelayNetting ]
                     │   venue metamask          →  [ MetaMaskNetting ]
                     │  TraderFlow
@@ -59,7 +59,7 @@ All take `--chain` (selects the address book) and `--registry` /
            ┌─────────────────┐  embedded_quote  ┌─────────────────┐
            │ post-processing │ ───────────────▶ │ SolverKnowledge │
            └────────┬────────┘                  └─────────────────┘
-                    │  veto → attribution → gas → quote → sandwich scan
+                    │  veto → client attribution → solver attribution → gas → quote → sandwich scan
                     ▼
               DecodedTrade
 ```
@@ -84,7 +84,7 @@ trait TradeDecoder<P> {
 // decode.rs — the matched entity selects its decoders
 match role {
     Sender      => vec![Box::new(SenderNetting)],
-    Intent       => vec![Box::new(IntentNetting)],
+    Intent      => intents::decoders_for(),       // [CowSettlement, IntentNetting]
     Venue(name) => venues::decoders_for(name),   // e.g. "relay" → [RelayNetting]
 }
 ```
@@ -115,25 +115,27 @@ match role {
                       │                    │      TraderRole::Sender   TraderRole::Intent
                       │                    │             │                │
                       ▼                    ▼             ▼                ▼
-           venues::decoders_for(name)  IntentNetting  SenderNetting   IntentNetting
-                      │                 └──────── netting_decoders.rs ─────────┘
+           venues::decoders_for(name)  intents::decoders_for()  SenderNetting   intents::decoders_for()
+                      │                 └──── intents/ ────┘    netting_dec.rs  └──── intents/ ────┘
            ┌──────────┴───────────┐
            ▼                      ▼
      [RelayNetting]        [MetaMaskNetting]
      (venues/relay.rs)     (venues/metamask.rs)
 
    direct call vs a solver-settled intent order — SAME solver, DIFFERENT decoder:
-     0x called directly             → Sender → [ SenderNetting ]  (your own tx, your gas)
-     0x settling your intent order  → Intent → [ IntentNetting ]  (a solver settles for you)
-   when a solver settles an intent order, its own decoder can replace IntentNetting.
+     0x called directly             → Sender → [ SenderNetting ]        (your own tx, your gas)
+     0x settling your intent order  → Intent → intents::decoders_for()  (a solver settles for you)
+   an intent source with a richer signal gets its own decoder ahead of the netting fallback —
+   CoW reads its Trade event (intents/cow.rs), then IntentNetting catches the rest.
 
    implement a new decoder where the entity that carries the flow lives:
    ├─ new venue                       → venues/<name>.rs  +  arm in venues::decoders_for("<name>")
-   └─ new read for an existing venue  → another TradeDecoder in that venue's list (first-wins order)
+   ├─ new read for an existing venue  → another TradeDecoder in that venue's list (first-wins order)
+   └─ new intent source (a settler)   → intents/<name>.rs  +  entry in intents::decoders_for()
 
-   replace a Sender/Intent leaf in decode.rs decoders_for — the arm is global, so:
-     Intent => [ MyDecoder, IntentNetting ]   # prepend: self-guard; netting stays the fallback
-     Intent => [ MyDecoder ]                  # full swap: no fallback — must cover every intent trade
+   the Intent list lives in intents::decoders_for() (first-wins order):
+     [ MyDecoder, IntentNetting ]   # prepend: self-guard; netting stays the fallback
+     [ MyDecoder ]                  # full swap: no fallback — must cover every intent trade
 ```
 
 One transaction goes to one entity — a direct sender, an intent order, or a specific venue — and
@@ -156,10 +158,10 @@ the swap. `MetaMaskNetting` backs the fee out to 991.
 ### Solver knowledge (`solvers/`)
 
 What a solver's transactions reveal beyond its address — a calldata quote (KyberSwap's
-`clientData`, ParaSwap's word layout, 0x's `POSITIVE_SLIPPAGE` `expectedAmount`), a match-time
-veto (LiFi's bridge orders). Both methods default to "nothing to add", so most solvers are a
-single address-book line with no code; those with code are registered in
-`solvers::IMPLEMENTATIONS`.
+`clientData`, ParaSwap's word layout, 0x's positive-slippage action), a match-time veto (LiFi's
+bridge orders), or the integrator tag a frontend records in the solver's event (LiFi's Diamond).
+Every method defaults to "nothing to add", so most solvers are a single address-book line with no
+code; those with code are registered in `solvers::IMPLEMENTATIONS`.
 
 ```rust
 trait SolverKnowledge {
@@ -168,8 +170,27 @@ trait SolverKnowledge {
 
     /// The veto this solver's logs place on a matched transaction that is not a swap.
     fn solver_veto(&self, logs: &[Log]) -> Option<Veto> { None }
+
+    /// The order-flow integrator tag this solver records in its logs, when it exposes one.
+    fn integrator(&self, logs: &[Log]) -> Option<String> { None }
 }
 ```
+
+### Client attribution (`clients.rs`)
+
+The venue is normally the contract the trader entered through (`tx.to`). Some order-flow clients own
+the flow without being that contract, so after a flow is decoded one step can override the venue from
+a registry fingerprint. Nothing in `clients.rs` names a specific client — it reads three maps from
+the address book:
+
+- **owning trader** (`[client_owners]`) — the flow was read from a known client address (kpk's Safes,
+  surfaced from the CoW decoder's owner).
+- **fee wallet** (`[client_fees]`) — a known client fee wallet took the output-token fee (Phantom,
+  Robinhood, LlamaSwap's 0x surplus); the fee is grossed back. Only inside an already-matched trade,
+  so a dust spray to a fee wallet is not mistaken for flow.
+- **provider integrator tag** (`[client_integrators]`) — a provider's event carried an integrator
+  string mapped to a client (LiFi frontends). The tag is read by that provider's
+  `SolverKnowledge::integrator`, so `clients.rs` stays provider-agnostic.
 
 ### Per protocol, not per chain
 
@@ -193,6 +214,8 @@ collectors are re-verified on every chain a venue is added on.
 | Skip a solver's non-swap orders | A `solver_veto` method on its `SolverKnowledge` impl | Those orders decode as trades that never happened, with absurd rates |
 | Add a venue | A `[venues.<name>]` section in the address book, a `TradeDecoder` in `venues/`, one arm in `venues::decoders_for` | The venue's trades are missed: with no entry-point match they only surface when a known solver logs inside them, and intent decoding then excludes the trader |
 | Extend what Hindsight knows about a venue | That venue's module in `venues/` — never anywhere else | Decoding degrades silently |
+| Decode an intent settler (CoW-style) | A `TradeDecoder` in `intents/`, listed in `intents::decoders_for` ahead of the netting fallback | The settler's trades decode by net flow, losing exact amounts and (for contract owners) the client |
+| Attribute a new client (owner / fee wallet / integrator tag) | The matching address-book map (`[client_owners]` / `[client_fees]` / `[client_integrators]`); a new provider's tag also needs `SolverKnowledge::integrator` | The client's trades are attributed to the underlying router or settler, not the client |
 | Add a new decode method | A `TradeDecoder` (a `netting`/`calldata` toolkit function behind it), listed for the entities that use it | Transactions the existing decoders cannot read stay undecoded |
 | Reject decodes that are not real trades (an NFT purchase's payment leg, a mis-paired wrap) | A check in `veto.rs` | Records that are not trades enter the comparison |
 | Support a new chain | A `registry/<chain>.toml` address book (all sections required), plus decoders for its venues and `SolverKnowledge` for its solvers that have none yet | The chain has no built-in book and must be passed via `--registry` |

--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -156,9 +156,10 @@ the swap. `MetaMaskNetting` backs the fee out to 991.
 ### Solver knowledge (`solvers/`)
 
 What a solver's transactions reveal beyond its address — a calldata quote (KyberSwap's
-`clientData`, ParaSwap's word layout), a match-time veto (LiFi's bridge orders). Both methods
-default to "nothing to add", so most solvers are a single address-book line with no code; those
-with code are registered in `solvers::IMPLEMENTATIONS`.
+`clientData`, ParaSwap's word layout, 0x's `POSITIVE_SLIPPAGE` `expectedAmount`), a match-time
+veto (LiFi's bridge orders). Both methods default to "nothing to add", so most solvers are a
+single address-book line with no code; those with code are registered in
+`solvers::IMPLEMENTATIONS`.
 
 ```rust
 trait SolverKnowledge {

--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -180,14 +180,17 @@ trait SolverKnowledge {
 
 The venue is normally the contract the trader entered through (`tx.to`). Some order-flow clients own
 the flow without being that contract, so after a flow is decoded one step can override the venue from
-a registry fingerprint. Nothing in `clients.rs` names a specific client — it reads three maps from
+a registry fingerprint. Nothing in `clients.rs` names a specific client — it reads four maps from
 the address book:
 
 - **owning trader** (`[client_owners]`) — the flow was read from a known client address (kpk's Safes,
   surfaced from the CoW decoder's owner).
+- **CoW appData tag** (`[client_appdata]`) — the settled order committed a frontend tag (`appCode`)
+  whose appData hash maps to a client (LlamaSwap). The hash is read from the settle calldata by
+  `intents::client_tag`, so `clients.rs` stays protocol-agnostic.
 - **fee wallet** (`[client_fees]`) — a known client fee wallet took the output-token fee (Phantom,
-  Robinhood, LlamaSwap's 0x surplus); the fee is grossed back. Only inside an already-matched trade,
-  so a dust spray to a fee wallet is not mistaken for flow.
+  Robinhood); the fee is grossed back. Only inside an already-matched trade, so a dust spray to a
+  fee wallet is not mistaken for flow.
 - **provider integrator tag** (`[client_integrators]`) — a provider's event carried an integrator
   string mapped to a client (LiFi frontends). The tag is read by that provider's
   `SolverKnowledge::integrator`, so `clients.rs` stays provider-agnostic.
@@ -215,7 +218,7 @@ collectors are re-verified on every chain a venue is added on.
 | Add a venue | A `[venues.<name>]` section in the address book, a `TradeDecoder` in `venues/`, one arm in `venues::decoders_for` | The venue's trades are missed: with no entry-point match they only surface when a known solver logs inside them, and intent decoding then excludes the trader |
 | Extend what Hindsight knows about a venue | That venue's module in `venues/` — never anywhere else | Decoding degrades silently |
 | Decode an intent settler (CoW-style) | A `TradeDecoder` in `intents/`, listed in `intents::decoders_for` ahead of the netting fallback | The settler's trades decode by net flow, losing exact amounts and (for contract owners) the client |
-| Attribute a new client (owner / fee wallet / integrator tag) | The matching address-book map (`[client_owners]` / `[client_fees]` / `[client_integrators]`); a new provider's tag also needs `SolverKnowledge::integrator` | The client's trades are attributed to the underlying router or settler, not the client |
+| Attribute a new client (owner / appData tag / fee wallet / integrator tag) | The matching address-book map (`[client_owners]` / `[client_appdata]` / `[client_fees]` / `[client_integrators]`); a provider's integrator tag also needs `SolverKnowledge::integrator` | The client's trades are attributed to the underlying router or settler, not the client |
 | Add a new decode method | A `TradeDecoder` (a `netting`/`calldata` toolkit function behind it), listed for the entities that use it | Transactions the existing decoders cannot read stay undecoded |
 | Reject decodes that are not real trades (an NFT purchase's payment leg, a mis-paired wrap) | A check in `veto.rs` | Records that are not trades enter the comparison |
 | Support a new chain | A `registry/<chain>.toml` address book (all sections required), plus decoders for its venues and `SolverKnowledge` for its solvers that have none yet | The chain has no built-in book and must be passed via `--registry` |

--- a/tools/hindsight/src/decoder/clients.rs
+++ b/tools/hindsight/src/decoder/clients.rs
@@ -1,16 +1,20 @@
 //! Order-flow client attribution.
 //!
 //! A trade's venue is normally the contract the trader entered through (`tx.to`). Some clients own
-//! the order flow without being that contract — kpk's Safes settle through `CoW`, so `tx.to` is
-//! the solver and the client is only visible as the order's owner. This module recognizes those
-//! clients from the decoded flow and overrides the venue label accordingly.
+//! the order flow without being that contract, and are recognized here from the decoded flow —
+//! overriding the venue label. Every fingerprint is registry-driven; nothing here knows about a
+//! specific client or provider.
 //!
-//! Two fingerprints today:
-//! - **owning trader** — the swap's net flow was read from a known client address (kpk's Safes).
-//! - **fee wallet** — the trade routed through a shared router (0x) but a known client fee wallet
-//!   received the output-token fee (Phantom, Robinhood). The fee is backed out so the settled
-//!   output stays gross. This is only checked inside an already-matched solver trade, so the
-//!   dust-spray gotcha (bare transfers to a fee wallet) does not apply.
+//! Three fingerprints, tried in order:
+//! - **owning trader** — the swap's net flow was read from a known client address
+//!   (`[client_owners]`).
+//! - **fee wallet** — a known client fee wallet received the output-token fee (`[client_fees]`);
+//!   the fee is backed out so the settled output stays gross. Checked only inside an
+//!   already-matched solver trade, so a bare dust transfer to a fee wallet is not mistaken for
+//!   flow.
+//! - **provider integrator tag** — a provider's event carried an integrator string mapped to a
+//!   client (`[client_integrators]`). The tag is extracted by the caller (it is provider-specific;
+//!   see `crate::decoder::solvers::integrator`), so this module stays generic.
 
 use std::collections::HashSet;
 
@@ -19,22 +23,27 @@ use alloy::primitives::{Address, U256};
 use crate::decoder::{decode::TraderFlow, registry::Registry, transfer_ledger::TransferLedger};
 
 /// The order-flow client for a decoded flow, when a fingerprint matches. On a fee-wallet match the
-/// client's fee is backed out of `flow` (added to the gross output), unless a venue decoder already
+/// client's fee is backed out of `flow` (added to the gross output) unless a venue decoder already
 /// accounted a fee.
 pub(crate) fn attribute(
     registry: &Registry,
     flow: &mut TraderFlow,
     ledger: &TransferLedger,
+    integrator: Option<&str>,
 ) -> Option<String> {
     if let Some(client) = registry.client_for_owner(flow.tracked) {
         return Some(client.to_string());
     }
-    let (client, fee) = fee_client(registry, ledger, flow.swap.token_out)?;
-    if flow.venue_fee_out.is_none() {
-        flow.venue_fee_out = Some(fee);
-        flow.swap.amount_out = flow.swap.amount_out.saturating_add(fee);
+    if let Some((client, fee)) = fee_client(registry, ledger, flow.swap.token_out) {
+        if flow.venue_fee_out.is_none() {
+            flow.venue_fee_out = Some(fee);
+            flow.swap.amount_out = flow.swap.amount_out.saturating_add(fee);
+        }
+        return Some(client);
     }
-    Some(client)
+    integrator
+        .and_then(|tag| registry.client_for_integrator(tag))
+        .map(str::to_string)
 }
 
 /// The client whose fee wallet received the output token in this trade, with the fee amount.
@@ -71,7 +80,7 @@ mod tests {
         let kpk_safe = address!("0x4f2083f5fbede34c2714affb3105539775f7fe64");
         let ledger = TransferLedger::from_transaction(&[], &[]);
         let mut flow = TraderFlow::without_fees(kpk_safe, swap(addr(10), 1, addr(11), 2));
-        assert_eq!(attribute(&registry, &mut flow, &ledger).as_deref(), Some("kpk"));
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None).as_deref(), Some("kpk"));
     }
 
     #[test]
@@ -79,7 +88,7 @@ mod tests {
         let registry = Registry::ethereum();
         let ledger = TransferLedger::from_transaction(&[], &[]);
         let mut flow = TraderFlow::without_fees(addr(9), swap(addr(10), 1, addr(11), 2));
-        assert_eq!(attribute(&registry, &mut flow, &ledger), None);
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None), None);
     }
 
     #[test]
@@ -100,9 +109,23 @@ mod tests {
         let ledger = TransferLedger::from_transaction(&logs, &[]);
         let mut flow = TraderFlow::without_fees(user, swap(token_in, 1000, token_out, 9915));
 
-        assert_eq!(attribute(&registry, &mut flow, &ledger).as_deref(), Some("phantom"));
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None).as_deref(), Some("phantom"));
         assert_eq!(flow.venue_fee_out, Some(U256::from(85)));
         assert_eq!(flow.swap.amount_out, U256::from(10000));
+    }
+
+    #[test]
+    fn test_integrator_tag_attributes_client() {
+        // A provider integrator tag maps to its client, case-insensitively; an unknown tag does
+        // not.
+        let registry = Registry::ethereum();
+        let ledger = TransferLedger::from_transaction(&[], &[]);
+        let mut flow = TraderFlow::without_fees(addr(1), swap(addr(10), 1, addr(11), 2));
+        assert_eq!(
+            attribute(&registry, &mut flow, &ledger, Some("Infinex")).as_deref(),
+            Some("infinex")
+        );
+        assert_eq!(attribute(&registry, &mut flow, &ledger, Some("somedapp")), None);
     }
 
     #[test]
@@ -119,6 +142,6 @@ mod tests {
         ];
         let ledger = TransferLedger::from_transaction(&logs, &[]);
         let mut flow = TraderFlow::without_fees(user, swap(token_in, 1000, token_out, 2000));
-        assert_eq!(attribute(&registry, &mut flow, &ledger), None);
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None), None);
     }
 }

--- a/tools/hindsight/src/decoder/clients.rs
+++ b/tools/hindsight/src/decoder/clients.rs
@@ -5,18 +5,56 @@
 //! the solver and the client is only visible as the order's owner. This module recognizes those
 //! clients from the decoded flow and overrides the venue label accordingly.
 //!
-//! Fingerprints are added here as clients need them: the owning trader address today; fee-wallet
-//! and provider-integrator fingerprints follow the same override.
+//! Two fingerprints today:
+//! - **owning trader** — the swap's net flow was read from a known client address (kpk's Safes).
+//! - **fee wallet** — the trade routed through a shared router (0x) but a known client fee wallet
+//!   received the output-token fee (Phantom, Robinhood). The fee is backed out so the settled
+//!   output stays gross. This is only checked inside an already-matched solver trade, so the
+//!   dust-spray gotcha (bare transfers to a fee wallet) does not apply.
 
-use crate::decoder::{decode::TraderFlow, registry::Registry};
+use std::collections::HashSet;
 
-/// The order-flow client for a decoded flow, when a fingerprint matches. Today the only fingerprint
-/// is the owning trader address (`registry.client_for_owner`) — the client whose Safe or account
-/// the swap's net flow was read from.
-pub(crate) fn attribute(registry: &Registry, flow: &TraderFlow) -> Option<String> {
-    registry
-        .client_for_owner(flow.tracked)
-        .map(str::to_string)
+use alloy::primitives::{Address, U256};
+
+use crate::decoder::{decode::TraderFlow, registry::Registry, transfer_ledger::TransferLedger};
+
+/// The order-flow client for a decoded flow, when a fingerprint matches. On a fee-wallet match the
+/// client's fee is backed out of `flow` (added to the gross output), unless a venue decoder already
+/// accounted a fee.
+pub(crate) fn attribute(
+    registry: &Registry,
+    flow: &mut TraderFlow,
+    ledger: &TransferLedger,
+) -> Option<String> {
+    if let Some(client) = registry.client_for_owner(flow.tracked) {
+        return Some(client.to_string());
+    }
+    let (client, fee) = fee_client(registry, ledger, flow.swap.token_out)?;
+    if flow.venue_fee_out.is_none() {
+        flow.venue_fee_out = Some(fee);
+        flow.swap.amount_out = flow.swap.amount_out.saturating_add(fee);
+    }
+    Some(client)
+}
+
+/// The client whose fee wallet received the output token in this trade, with the fee amount.
+/// `None` when no client fee wallet took a non-zero cut of the output token.
+fn fee_client(
+    registry: &Registry,
+    ledger: &TransferLedger,
+    token_out: Address,
+) -> Option<(String, U256)> {
+    for (wallet, client) in registry.client_fees() {
+        let fee = ledger
+            .received_by(&HashSet::from([*wallet]))
+            .get(&token_out)
+            .copied()
+            .filter(|amount| !amount.is_zero());
+        if let Some(fee) = fee {
+            return Some((client.clone(), fee));
+        }
+    }
+    None
 }
 
 #[cfg(test)]
@@ -24,21 +62,63 @@ mod tests {
     use alloy::primitives::address;
 
     use super::*;
-    use crate::decoder::test_utils::{addr, swap};
+    use crate::decoder::test_utils::{addr, make_transfer_log, swap};
 
     #[test]
     fn test_attributes_owner_to_client() {
         // A CoW-settled kpk trade nets to the Safe that owns the order; the client is that Safe.
         let registry = Registry::ethereum();
         let kpk_safe = address!("0x4f2083f5fbede34c2714affb3105539775f7fe64");
-        let flow = TraderFlow::without_fees(kpk_safe, swap(addr(10), 1, addr(11), 2));
-        assert_eq!(attribute(&registry, &flow).as_deref(), Some("kpk"));
+        let ledger = TransferLedger::from_transaction(&[], &[]);
+        let mut flow = TraderFlow::without_fees(kpk_safe, swap(addr(10), 1, addr(11), 2));
+        assert_eq!(attribute(&registry, &mut flow, &ledger).as_deref(), Some("kpk"));
     }
 
     #[test]
     fn test_unknown_owner_is_not_a_client() {
         let registry = Registry::ethereum();
-        let flow = TraderFlow::without_fees(addr(9), swap(addr(10), 1, addr(11), 2));
-        assert_eq!(attribute(&registry, &flow), None);
+        let ledger = TransferLedger::from_transaction(&[], &[]);
+        let mut flow = TraderFlow::without_fees(addr(9), swap(addr(10), 1, addr(11), 2));
+        assert_eq!(attribute(&registry, &mut flow, &ledger), None);
+    }
+
+    #[test]
+    fn test_fee_wallet_attributes_and_grosses_fee_back() {
+        // A 0x-routed Phantom swap: the buy-token fee reaches Phantom's wallet. It must be added
+        // back so the settled output is gross (else every Phantom swap under-reports by 85 bps).
+        let registry = Registry::ethereum();
+        let phantom = address!("0x2cffed5d56eb6a17662756ca0fdf350e732c9818");
+        let user = addr(1);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+        let logs = vec![
+            make_transfer_log(token_in, user, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, user, U256::from(9915)),
+            make_transfer_log(token_out, pool, phantom, U256::from(85)),
+        ];
+        let ledger = TransferLedger::from_transaction(&logs, &[]);
+        let mut flow = TraderFlow::without_fees(user, swap(token_in, 1000, token_out, 9915));
+
+        assert_eq!(attribute(&registry, &mut flow, &ledger).as_deref(), Some("phantom"));
+        assert_eq!(flow.venue_fee_out, Some(U256::from(85)));
+        assert_eq!(flow.swap.amount_out, U256::from(10000));
+    }
+
+    #[test]
+    fn test_no_fee_transfer_is_not_a_client() {
+        // Dust to the fee wallet in a token other than the output is not this trade's fee.
+        let registry = Registry::ethereum();
+        let user = addr(1);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+        let logs = vec![
+            make_transfer_log(token_in, user, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, user, U256::from(2000)),
+        ];
+        let ledger = TransferLedger::from_transaction(&logs, &[]);
+        let mut flow = TraderFlow::without_fees(user, swap(token_in, 1000, token_out, 2000));
+        assert_eq!(attribute(&registry, &mut flow, &ledger), None);
     }
 }

--- a/tools/hindsight/src/decoder/clients.rs
+++ b/tools/hindsight/src/decoder/clients.rs
@@ -5,9 +5,13 @@
 //! overriding the venue label. Every fingerprint is registry-driven; nothing here knows about a
 //! specific client or provider.
 //!
-//! Three fingerprints, tried in order:
+//! Four fingerprints, tried in order:
 //! - **owning trader** — the swap's net flow was read from a known client address
 //!   (`[client_owners]`).
+//! - **`CoW` appData tag** — the settled order committed a frontend tag (`appCode`) whose appData
+//!   hash maps to a client (`[client_appdata]`). The hash is extracted by the caller (it is
+//!   `CoW`-specific; see `crate::decoder::intents::cow::order_app_data`), so this module stays
+//!   generic.
 //! - **fee wallet** — a known client fee wallet received the output-token fee (`[client_fees]`);
 //!   the fee is backed out so the settled output stays gross. Checked only inside an
 //!   already-matched solver trade, so a bare dust transfer to a fee wallet is not mistaken for
@@ -18,7 +22,7 @@
 
 use std::collections::HashSet;
 
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, B256, U256};
 
 use crate::decoder::{decode::TraderFlow, registry::Registry, transfer_ledger::TransferLedger};
 
@@ -30,8 +34,12 @@ pub(crate) fn attribute(
     flow: &mut TraderFlow,
     ledger: &TransferLedger,
     integrator: Option<&str>,
+    app_data: Option<B256>,
 ) -> Option<String> {
     if let Some(client) = registry.client_for_owner(flow.tracked) {
+        return Some(client.to_string());
+    }
+    if let Some(client) = app_data.and_then(|hash| registry.client_for_appdata(hash)) {
         return Some(client.to_string());
     }
     if let Some((client, fee)) = fee_client(registry, ledger, flow.swap.token_out) {
@@ -68,7 +76,7 @@ fn fee_client(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::address;
+    use alloy::primitives::{address, b256};
 
     use super::*;
     use crate::decoder::test_utils::{addr, make_transfer_log, swap};
@@ -80,7 +88,7 @@ mod tests {
         let kpk_safe = address!("0x4f2083f5fbede34c2714affb3105539775f7fe64");
         let ledger = TransferLedger::from_transaction(&[], &[]);
         let mut flow = TraderFlow::without_fees(kpk_safe, swap(addr(10), 1, addr(11), 2));
-        assert_eq!(attribute(&registry, &mut flow, &ledger, None).as_deref(), Some("kpk"));
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None, None).as_deref(), Some("kpk"));
     }
 
     #[test]
@@ -88,7 +96,22 @@ mod tests {
         let registry = Registry::ethereum();
         let ledger = TransferLedger::from_transaction(&[], &[]);
         let mut flow = TraderFlow::without_fees(addr(9), swap(addr(10), 1, addr(11), 2));
-        assert_eq!(attribute(&registry, &mut flow, &ledger, None), None);
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None, None), None);
+    }
+
+    #[test]
+    fn test_appdata_tag_attributes_client() {
+        // A CoW order carrying DefiLlama's appData hash is attributed to LlamaSwap; an unregistered
+        // hash is not.
+        let registry = Registry::ethereum();
+        let ledger = TransferLedger::from_transaction(&[], &[]);
+        let defillama = b256!("0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422");
+        let mut flow = TraderFlow::without_fees(addr(1), swap(addr(10), 1, addr(11), 2));
+        assert_eq!(
+            attribute(&registry, &mut flow, &ledger, None, Some(defillama)).as_deref(),
+            Some("llamaswap")
+        );
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None, Some(B256::ZERO)), None);
     }
 
     #[test]
@@ -109,7 +132,10 @@ mod tests {
         let ledger = TransferLedger::from_transaction(&logs, &[]);
         let mut flow = TraderFlow::without_fees(user, swap(token_in, 1000, token_out, 9915));
 
-        assert_eq!(attribute(&registry, &mut flow, &ledger, None).as_deref(), Some("phantom"));
+        assert_eq!(
+            attribute(&registry, &mut flow, &ledger, None, None).as_deref(),
+            Some("phantom")
+        );
         assert_eq!(flow.venue_fee_out, Some(U256::from(85)));
         assert_eq!(flow.swap.amount_out, U256::from(10000));
     }
@@ -122,10 +148,10 @@ mod tests {
         let ledger = TransferLedger::from_transaction(&[], &[]);
         let mut flow = TraderFlow::without_fees(addr(1), swap(addr(10), 1, addr(11), 2));
         assert_eq!(
-            attribute(&registry, &mut flow, &ledger, Some("Infinex")).as_deref(),
+            attribute(&registry, &mut flow, &ledger, Some("Infinex"), None).as_deref(),
             Some("infinex")
         );
-        assert_eq!(attribute(&registry, &mut flow, &ledger, Some("somedapp")), None);
+        assert_eq!(attribute(&registry, &mut flow, &ledger, Some("somedapp"), None), None);
     }
 
     #[test]
@@ -142,6 +168,6 @@ mod tests {
         ];
         let ledger = TransferLedger::from_transaction(&logs, &[]);
         let mut flow = TraderFlow::without_fees(user, swap(token_in, 1000, token_out, 2000));
-        assert_eq!(attribute(&registry, &mut flow, &ledger, None), None);
+        assert_eq!(attribute(&registry, &mut flow, &ledger, None, None), None);
     }
 }

--- a/tools/hindsight/src/decoder/clients.rs
+++ b/tools/hindsight/src/decoder/clients.rs
@@ -1,0 +1,44 @@
+//! Order-flow client attribution.
+//!
+//! A trade's venue is normally the contract the trader entered through (`tx.to`). Some clients own
+//! the order flow without being that contract — kpk's Safes settle through `CoW`, so `tx.to` is
+//! the solver and the client is only visible as the order's owner. This module recognizes those
+//! clients from the decoded flow and overrides the venue label accordingly.
+//!
+//! Fingerprints are added here as clients need them: the owning trader address today; fee-wallet
+//! and provider-integrator fingerprints follow the same override.
+
+use crate::decoder::{decode::TraderFlow, registry::Registry};
+
+/// The order-flow client for a decoded flow, when a fingerprint matches. Today the only fingerprint
+/// is the owning trader address (`registry.client_for_owner`) — the client whose Safe or account
+/// the swap's net flow was read from.
+pub(crate) fn attribute(registry: &Registry, flow: &TraderFlow) -> Option<String> {
+    registry
+        .client_for_owner(flow.tracked)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::address;
+
+    use super::*;
+    use crate::decoder::test_utils::{addr, swap};
+
+    #[test]
+    fn test_attributes_owner_to_client() {
+        // A CoW-settled kpk trade nets to the Safe that owns the order; the client is that Safe.
+        let registry = Registry::ethereum();
+        let kpk_safe = address!("0x4f2083f5fbede34c2714affb3105539775f7fe64");
+        let flow = TraderFlow::without_fees(kpk_safe, swap(addr(10), 1, addr(11), 2));
+        assert_eq!(attribute(&registry, &flow).as_deref(), Some("kpk"));
+    }
+
+    #[test]
+    fn test_unknown_owner_is_not_a_client() {
+        let registry = Registry::ethereum();
+        let flow = TraderFlow::without_fees(addr(9), swap(addr(10), 1, addr(11), 2));
+        assert_eq!(attribute(&registry, &flow), None);
+    }
+}

--- a/tools/hindsight/src/decoder/decode.rs
+++ b/tools/hindsight/src/decoder/decode.rs
@@ -22,7 +22,8 @@ use alloy::{
 use async_trait::async_trait;
 
 use crate::decoder::{
-    netting_decoders::{IntentNetting, SenderNetting},
+    intents,
+    netting_decoders::SenderNetting,
     registry::{Registry, VenueAddresses},
     transfer_ledger::{NetSwap, TransferLedger},
     venues,
@@ -77,7 +78,7 @@ impl<'a> TraderRole<'a> {
 fn decoders_for<P: Provider>(role: TraderRole<'_>) -> Vec<Box<dyn TradeDecoder<P>>> {
     match role {
         TraderRole::Sender => vec![Box::new(SenderNetting)],
-        TraderRole::Intent => vec![Box::new(IntentNetting)],
+        TraderRole::Intent => intents::decoders_for(),
         TraderRole::Venue(name) => venues::decoders_for(name),
     }
 }

--- a/tools/hindsight/src/decoder/decode.rs
+++ b/tools/hindsight/src/decoder/decode.rs
@@ -15,9 +15,9 @@
 use std::collections::HashMap;
 
 use alloy::{
+    network::AnyTransactionReceipt,
     primitives::{Address, U256},
     providers::Provider,
-    rpc::types::TransactionReceipt,
 };
 use async_trait::async_trait;
 
@@ -120,7 +120,7 @@ pub(crate) struct DecodeContext<'a, P> {
     /// Cross-block contract-code cache, owned by the decoder.
     pub code_cache: &'a mut HashMap<Address, bool>,
     /// The matched transaction's receipt (sender, logs).
-    pub receipt: &'a TransactionReceipt,
+    pub receipt: &'a AnyTransactionReceipt,
     /// The contract the transaction entered through (`tx.to`).
     pub entry_point: Address,
     /// The transaction's flattened value movements.

--- a/tools/hindsight/src/decoder/intents/cow.rs
+++ b/tools/hindsight/src/decoder/intents/cow.rs
@@ -1,0 +1,211 @@
+//! `CoW` Protocol settlement decoding.
+//!
+//! `CoW` settles signed orders in a batch: `tx.to` is the settlement contract and `tx.from` is the
+//! solver, so the trade is an order owner's — read here from the `GPv2` `Trade` event the
+//! settlement emits per order. The event gives the exact executed amounts and the owner directly,
+//! which is more precise than netting the settlement's transfers and names the owner for client
+//! attribution (`kpk`).
+//!
+//! One trade is produced per transaction, so only single-order settlements are decoded; a batch
+//! settling several orders is declined to the generic intent netting (which nets one swapper's
+//! flow). `CoW`'s fee is taken from the sell token and backed out of the input so a re-solve
+//! compares like-for-like — modern `CoW` records a zero on-chain fee (it is priced into the order).
+
+use alloy::{
+    primitives::{address, Address},
+    providers::Provider,
+    sol,
+    sol_types::SolEvent,
+};
+use async_trait::async_trait;
+
+use crate::decoder::{
+    decode::{DecodeContext, GasScope, TradeDecoder, TraderFlow},
+    transfer_ledger::{to_primitive_log, NetSwap},
+};
+
+sol! {
+    /// `GPv2` per-order settlement event.
+    event Trade(
+        address indexed owner,
+        address sellToken,
+        address buyToken,
+        uint256 sellAmount,
+        uint256 buyAmount,
+        uint256 feeAmount,
+        bytes orderUid
+    );
+}
+
+/// `CoW`'s sentinel for native ETH in buy orders, mapped to the zero address like every other flow.
+const COW_NATIVE_ETH: Address = address!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+/// `CoW`'s settlement decoder, reading the `GPv2` `Trade` event.
+pub(crate) struct CowSettlement;
+
+#[async_trait]
+impl<P: Provider> TradeDecoder<P> for CowSettlement {
+    fn name(&self) -> &'static str {
+        "cow-trade"
+    }
+
+    async fn decode(&self, ctx: &mut DecodeContext<'_, P>) -> Option<TraderFlow> {
+        let mut trades = ctx.receipt.logs().iter().filter(|log| {
+            ctx.registry
+                .is_batch_settler(log.address()) &&
+                log.topics().first() == Some(&Trade::SIGNATURE_HASH)
+        });
+        let first = trades.next()?;
+        // One trade per transaction: a multi-order batch is left to the generic intent netting.
+        if trades.next().is_some() {
+            return None;
+        }
+        let trade = Trade::decode_log(&to_primitive_log(first)).ok()?;
+
+        // CoW's fee is taken from the sell token, so the amount that actually reached the market is
+        // the executed sell minus the fee.
+        let amount_in = trade
+            .sellAmount
+            .saturating_sub(trade.feeAmount);
+        let fee = (!trade.feeAmount.is_zero()).then_some(trade.feeAmount);
+        Some(TraderFlow {
+            tracked: trade.owner,
+            swap: NetSwap {
+                token_in: normalize_native(trade.sellToken),
+                amount_in,
+                token_out: normalize_native(trade.buyToken),
+                amount_out: trade.buyAmount,
+            },
+            venue_fee_in: fee,
+            venue_fee_out: None,
+            solver_override: None,
+            // The solver pays settlement gas and recoups it in the order price, not the trader.
+            gas_scope: GasScope::NotCharged,
+        })
+    }
+}
+
+fn normalize_native(token: Address) -> Address {
+    if token == COW_NATIVE_ETH {
+        Address::ZERO
+    } else {
+        token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use alloy::{
+        primitives::{address, Bytes, U256},
+        providers::RootProvider,
+        rpc::{client::RpcClient, types::Log},
+        transports::mock::Asserter,
+    };
+
+    use super::*;
+    use crate::decoder::{
+        registry::Registry,
+        test_utils::{addr, receipt, swap, tx_hash},
+        transfer_ledger::TransferLedger,
+    };
+
+    /// The Ethereum `CoW` settlement contract (a registered batch settler).
+    const COW_SETTLEMENT: Address = address!("0x9008d19f58aabd9ed0d60971565aa8510560ab41");
+
+    fn trade_log(
+        settler: Address,
+        owner: Address,
+        sell_token: Address,
+        buy_token: Address,
+        sell_amount: u64,
+        buy_amount: u64,
+        fee_amount: u64,
+    ) -> Log {
+        let event = Trade {
+            owner,
+            sellToken: sell_token,
+            buyToken: buy_token,
+            sellAmount: U256::from(sell_amount),
+            buyAmount: U256::from(buy_amount),
+            feeAmount: U256::from(fee_amount),
+            orderUid: Bytes::new(),
+        };
+        let data = event.encode_log_data();
+        let primitive = alloy::primitives::Log::new_unchecked(
+            settler,
+            data.topics().to_vec(),
+            data.data.clone(),
+        );
+        Log { inner: primitive, ..Default::default() }
+    }
+
+    async fn decode(logs: Vec<Log>) -> Option<TraderFlow> {
+        let registry = Registry::ethereum();
+        let provider = RootProvider::new(RpcClient::mocked(Asserter::new()));
+        let mut code_cache = HashMap::new();
+        let receipt = receipt(tx_hash(1), addr(2), Some(COW_SETTLEMENT), logs);
+        let transfer_ledger = TransferLedger::from_transaction(&[], &[]);
+        let mut ctx = DecodeContext {
+            provider: &provider,
+            registry: &registry,
+            code_cache: &mut code_cache,
+            receipt: &receipt,
+            entry_point: COW_SETTLEMENT,
+            transfer_ledger: &transfer_ledger,
+            input: &[],
+            venue: None,
+        };
+        CowSettlement.decode(&mut ctx).await
+    }
+
+    #[tokio::test]
+    async fn test_single_order_reads_the_trade_event() {
+        let owner = addr(100);
+        let sell = addr(10);
+        let buy = addr(11);
+        // Fee is taken from the sell token: 10 of the 1000 sold is the fee, 990 reached the market.
+        let flow = decode(vec![trade_log(COW_SETTLEMENT, owner, sell, buy, 1000, 2000, 10)])
+            .await
+            .unwrap();
+        assert_eq!(flow.tracked, owner);
+        assert_eq!(flow.swap, swap(sell, 990, buy, 2000));
+        assert_eq!(flow.venue_fee_in, Some(U256::from(10)));
+        assert_eq!(flow.gas_scope, GasScope::NotCharged);
+    }
+
+    #[tokio::test]
+    async fn test_native_eth_sentinel_normalized() {
+        let flow = decode(vec![trade_log(
+            COW_SETTLEMENT,
+            addr(100),
+            addr(10),
+            COW_NATIVE_ETH,
+            1000,
+            5,
+            0,
+        )])
+        .await
+        .unwrap();
+        assert_eq!(flow.swap.token_out, Address::ZERO);
+        assert_eq!(flow.venue_fee_in, None);
+    }
+
+    #[tokio::test]
+    async fn test_multi_order_batch_declined() {
+        // Two orders in one settlement: one trade per transaction, so this is left to intent
+        // netting.
+        let logs = vec![
+            trade_log(COW_SETTLEMENT, addr(100), addr(10), addr(11), 1000, 2000, 0),
+            trade_log(COW_SETTLEMENT, addr(101), addr(11), addr(10), 2000, 1000, 0),
+        ];
+        assert!(decode(logs).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_no_trade_event_declined() {
+        // A non-CoW intent fill (no Trade event) is declined so intent netting runs instead.
+        assert!(decode(vec![]).await.is_none());
+    }
+}

--- a/tools/hindsight/src/decoder/intents/cow.rs
+++ b/tools/hindsight/src/decoder/intents/cow.rs
@@ -12,10 +12,10 @@
 //! compares like-for-like — modern `CoW` records a zero on-chain fee (it is priced into the order).
 
 use alloy::{
-    primitives::{address, Address},
+    primitives::{address, Address, B256},
     providers::Provider,
     sol,
-    sol_types::SolEvent,
+    sol_types::{SolCall, SolEvent},
 };
 use async_trait::async_trait;
 
@@ -35,6 +35,45 @@ sol! {
         uint256 feeAmount,
         bytes orderUid
     );
+
+    /// `GPv2Settlement.settle`, decoded only for the per-order `appData` hash — the frontend tag
+    /// (`appCode`) the event does not carry. The other fields are named to match the ABI so the
+    /// decode lines up; only `trades[].appData` is read.
+    struct SettleTrade {
+        uint256 sellTokenIndex;
+        uint256 buyTokenIndex;
+        address receiver;
+        uint256 sellAmount;
+        uint256 buyAmount;
+        uint32 validTo;
+        bytes32 appData;
+        uint256 feeAmount;
+        uint256 flags;
+        uint256 executedAmount;
+        bytes signature;
+    }
+    struct SettleInteraction {
+        address target;
+        uint256 value;
+        bytes callData;
+    }
+    function settle(
+        address[] tokens,
+        uint256[] clearingPrices,
+        SettleTrade[] trades,
+        SettleInteraction[][3] interactions
+    );
+}
+
+/// The settled order's `appData` hash, read from the `settle` calldata. `None` unless the batch
+/// settles exactly one order — the same single-order rule `CowSettlement` applies, since a
+/// multi-order batch has no single frontend to attribute.
+pub(crate) fn order_app_data(input: &[u8]) -> Option<B256> {
+    let call = settleCall::abi_decode(input).ok()?;
+    let [trade] = call.trades.as_slice() else {
+        return None;
+    };
+    Some(trade.appData)
 }
 
 /// `CoW`'s sentinel for native ETH in buy orders, mapped to the zero address like every other flow.
@@ -98,9 +137,10 @@ mod tests {
     use std::collections::HashMap;
 
     use alloy::{
-        primitives::{address, Bytes, U256},
+        primitives::{address, b256, Bytes, U256},
         providers::RootProvider,
         rpc::{client::RpcClient, types::Log},
+        sol_types::SolCall,
         transports::mock::Asserter,
     };
 
@@ -207,5 +247,48 @@ mod tests {
     async fn test_no_trade_event_declined() {
         // A non-CoW intent fill (no Trade event) is declined so intent netting runs instead.
         assert!(decode(vec![]).await.is_none());
+    }
+
+    fn settle_trade(app_data: B256) -> SettleTrade {
+        SettleTrade {
+            sellTokenIndex: U256::ZERO,
+            buyTokenIndex: U256::ZERO,
+            receiver: Address::ZERO,
+            sellAmount: U256::ZERO,
+            buyAmount: U256::ZERO,
+            validTo: 0,
+            appData: app_data,
+            feeAmount: U256::ZERO,
+            flags: U256::ZERO,
+            executedAmount: U256::ZERO,
+            signature: Bytes::new(),
+        }
+    }
+
+    fn settle_calldata(trades: Vec<SettleTrade>) -> Vec<u8> {
+        settleCall {
+            tokens: vec![],
+            clearingPrices: vec![],
+            trades,
+            interactions: Default::default(),
+        }
+        .abi_encode()
+    }
+
+    #[test]
+    fn test_single_order_reads_app_data() {
+        let app = b256!("0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422");
+        assert_eq!(order_app_data(&settle_calldata(vec![settle_trade(app)])), Some(app));
+    }
+
+    #[test]
+    fn test_multi_order_batch_has_no_single_app_data() {
+        let trades = vec![settle_trade(B256::ZERO), settle_trade(B256::ZERO)];
+        assert!(order_app_data(&settle_calldata(trades)).is_none());
+    }
+
+    #[test]
+    fn test_non_settle_calldata_has_no_app_data() {
+        assert!(order_app_data(&[0u8; 4]).is_none());
     }
 }

--- a/tools/hindsight/src/decoder/intents/mod.rs
+++ b/tools/hindsight/src/decoder/intents/mod.rs
@@ -1,0 +1,19 @@
+//! Intent-role decoders: transactions a solver sends on the trader's behalf.
+//!
+//! Unlike a venue (entered by the trader, so the sender is the trader), an intent fill or batch
+//! settlement is sent by a solver — the trader only signed an order. So these decoders find the
+//! real trader inside the transaction rather than reading the sender's flow. This mirrors
+//! `venues/`: one place lists the Intent role's decoders, tried in order.
+
+pub(crate) mod cow;
+pub(crate) mod netting;
+
+use alloy::providers::Provider;
+
+use crate::decoder::decode::TradeDecoder;
+
+/// The decoders tried for the Intent role, first flow wins: a source with a rich signal (`CoW`'s
+/// `Trade` event) is tried before the generic net-flow finder that works for any intent fill.
+pub(crate) fn decoders_for<P: Provider>() -> Vec<Box<dyn TradeDecoder<P>>> {
+    vec![Box::new(cow::CowSettlement), Box::new(netting::IntentNetting)]
+}

--- a/tools/hindsight/src/decoder/intents/mod.rs
+++ b/tools/hindsight/src/decoder/intents/mod.rs
@@ -8,12 +8,26 @@
 pub(crate) mod cow;
 pub(crate) mod netting;
 
-use alloy::providers::Provider;
+use alloy::{
+    primitives::{Address, B256},
+    providers::Provider,
+};
 
-use crate::decoder::decode::TradeDecoder;
+use crate::decoder::{decode::TradeDecoder, registry::Registry};
 
 /// The decoders tried for the Intent role, first flow wins: a source with a rich signal (`CoW`'s
 /// `Trade` event) is tried before the generic net-flow finder that works for any intent fill.
 pub(crate) fn decoders_for<P: Provider>() -> Vec<Box<dyn TradeDecoder<P>>> {
     vec![Box::new(cow::CowSettlement), Box::new(netting::IntentNetting)]
+}
+
+/// The order-flow tag a batch settlement carries for client attribution: `CoW`'s per-order
+/// `appData` hash, read from the settle calldata. `None` for entries that are not batch settlers
+/// and for multi-order batches. Mirrors `solvers::integrator` — the orchestrator asks for a tag
+/// without knowing which intent protocol produced it.
+pub(crate) fn client_tag(registry: &Registry, entry_point: Address, input: &[u8]) -> Option<B256> {
+    registry
+        .is_batch_settler(entry_point)
+        .then(|| cow::order_app_data(input))
+        .flatten()
 }

--- a/tools/hindsight/src/decoder/intents/netting.rs
+++ b/tools/hindsight/src/decoder/intents/netting.rs
@@ -1,19 +1,43 @@
-//! Intent-finding for intent fills and batch settlements.
+//! Generic intent decoding: the fallback for the Intent role.
 //!
-//! Covers transactions where the sender is not the trader: solver-initiated
-//! intent fills (`UniswapX`, 1inch limit orders) and batch settlements (`CoW`),
-//! where the real swap is an order swapper's net flow.
+//! Covers transactions where the sender is not the trader — solver-initiated intent fills
+//! (`UniswapX`, 1inch limit orders) and batch settlements — by finding the order swapper's net
+//! flow. `IntentNetting` is the decoder; `find_intent_trade` does the finding. A source with a
+//! richer signal (see `super::cow`) is tried ahead of this.
 
 use std::collections::HashMap;
 
 use alloy::{primitives::Address, providers::Provider};
+use async_trait::async_trait;
 use tracing::warn;
 
 use crate::decoder::{
-    decode::TraderFlow,
+    decode::{DecodeContext, TradeDecoder, TraderFlow},
     registry::Registry,
     transfer_ledger::{NetSwap, TransferLedger},
 };
+
+/// Solver-initiated intent fills and batch settlements: the sender acts on the swapper's behalf, so
+/// the real swap is the swapper's net flow.
+pub(crate) struct IntentNetting;
+
+#[async_trait]
+impl<P: Provider> TradeDecoder<P> for IntentNetting {
+    fn name(&self) -> &'static str {
+        "intent-netting"
+    }
+
+    async fn decode(&self, ctx: &mut DecodeContext<'_, P>) -> Option<TraderFlow> {
+        find_intent_trade(
+            ctx.provider,
+            ctx.transfer_ledger,
+            &[ctx.entry_point, ctx.receipt.from],
+            ctx.registry,
+            ctx.code_cache,
+        )
+        .await
+    }
+}
 
 /// Find the order swapper's trade in a solver-initiated intent fill.
 ///

--- a/tools/hindsight/src/decoder/matching.rs
+++ b/tools/hindsight/src/decoder/matching.rs
@@ -4,14 +4,17 @@
 //! anything costs a trace. It answers only "is this a solver trade at all" — how the trade is
 //! then decoded is the decoders' job (see `decode`).
 
-use alloy::{primitives::Address, rpc::types::TransactionReceipt};
+use alloy::{
+    network::{AnyTransactionReceipt, ReceiptResponse},
+    primitives::Address,
+};
 use tracing::debug;
 
 use crate::decoder::{registry::Registry, solvers};
 
 /// A transaction identified as a solver trade, ready to be traced and decoded.
 pub(crate) struct MatchedSolverTrade<'a> {
-    pub receipt: &'a TransactionReceipt,
+    pub receipt: &'a AnyTransactionReceipt,
     /// The contract the transaction entered through (`tx.to`).
     pub entry_point: Address,
 }
@@ -24,7 +27,7 @@ pub(crate) struct MatchedSolverTrade<'a> {
 /// Matched transactions whose logs mark a non-swap order shape are vetoed
 /// here (see `solvers::solver_veto`), before they cost a trace.
 pub(crate) fn select<'a>(
-    receipt: &'a TransactionReceipt,
+    receipt: &'a AnyTransactionReceipt,
     registry: &Registry,
 ) -> Option<MatchedSolverTrade<'a>> {
     let matched = match_entry(receipt, registry)?;
@@ -43,7 +46,7 @@ pub(crate) fn select<'a>(
 
 /// Match a receipt by its entry point or its solver logs.
 fn match_entry<'a>(
-    receipt: &'a TransactionReceipt,
+    receipt: &'a AnyTransactionReceipt,
     registry: &Registry,
 ) -> Option<MatchedSolverTrade<'a>> {
     if !receipt.status() {

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -16,7 +16,7 @@
 
 mod clients;
 mod decode;
-mod intent;
+mod intents;
 mod matching;
 mod netting_decoders;
 mod registry;

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -14,6 +14,7 @@
 //! entity), `transfer_ledger` answers all value-flow questions, `veto` rejects shapes that are not
 //! comparable trades, and `registry` is the address book behind matching.
 
+mod clients;
 mod decode;
 mod intent;
 mod matching;
@@ -284,11 +285,17 @@ impl<P: Provider> Decoder<P> {
         let quote = solvers::embedded_quote(&attribution.solver, &root.input, flow.swap.amount_in)
             .filter(|quote| solvers::plausible_quote(quote, flow.swap.amount_out));
 
+        // The order-flow client, when a client fingerprint matches (e.g. a kpk Safe owning a
+        // CoW-settled order), overrides the entry-point label — which for those clients is only
+        // the shared settlement contract or router.
+        let venue =
+            clients::attribute(registry, &flow).unwrap_or_else(|| registry.label(entry_point));
+
         Some(DecodedTrade {
             tx_hash: receipt.transaction_hash,
             block_number,
             tx_index,
-            venue: registry.label(entry_point),
+            venue,
             solver: attribution.solver,
             solver_source: attribution.source,
             decoder,

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -262,6 +262,12 @@ impl<P: Provider> Decoder<P> {
             return None;
         }
 
+        // A client fingerprint (a kpk Safe owning the order, or a client fee wallet taking the fee
+        // on a shared router) overrides the entry-point label, backing any client fee out before
+        // the quote check reads the grossed output.
+        let venue = clients::attribute(registry, &mut flow, &transfer_ledger)
+            .unwrap_or_else(|| registry.label(entry_point));
+
         let attribution = solvers::attribution::attribute(
             flow.solver_override.take(),
             root,
@@ -284,12 +290,6 @@ impl<P: Provider> Decoder<P> {
         // quote, and unit-checked against the settled amount (quotes are self-reported).
         let quote = solvers::embedded_quote(&attribution.solver, &root.input, flow.swap.amount_in)
             .filter(|quote| solvers::plausible_quote(quote, flow.swap.amount_out));
-
-        // The order-flow client, when a client fingerprint matches (e.g. a kpk Safe owning a
-        // CoW-settled order), overrides the entry-point label — which for those clients is only
-        // the shared settlement contract or router.
-        let venue =
-            clients::attribute(registry, &flow).unwrap_or_else(|| registry.label(entry_point));
 
         Some(DecodedTrade {
             tx_hash: receipt.transaction_hash,

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -262,9 +262,9 @@ impl<P: Provider> Decoder<P> {
             return None;
         }
 
-        // A client fingerprint (a kpk Safe owning the order, or a client fee wallet taking the fee
-        // on a shared router) overrides the entry-point label, backing any client fee out before
-        // the quote check reads the grossed output.
+        // A client fingerprint (owning trader, fee wallet, or integrator tag — see `clients`)
+        // overrides the entry-point label, backing any client fee out before the quote check reads
+        // the grossed output.
         let integrator = solvers::integrator(logs);
         let venue =
             clients::attribute(registry, &mut flow, &transfer_ledger, integrator.as_deref())

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -265,8 +265,10 @@ impl<P: Provider> Decoder<P> {
         // A client fingerprint (a kpk Safe owning the order, or a client fee wallet taking the fee
         // on a shared router) overrides the entry-point label, backing any client fee out before
         // the quote check reads the grossed output.
-        let venue = clients::attribute(registry, &mut flow, &transfer_ledger)
-            .unwrap_or_else(|| registry.label(entry_point));
+        let integrator = solvers::integrator(logs);
+        let venue =
+            clients::attribute(registry, &mut flow, &transfer_ledger, integrator.as_deref())
+                .unwrap_or_else(|| registry.label(entry_point));
 
         let attribution = solvers::attribution::attribute(
             flow.solver_override.take(),

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -262,13 +262,20 @@ impl<P: Provider> Decoder<P> {
             return None;
         }
 
-        // A client fingerprint (owning trader, fee wallet, or integrator tag — see `clients`)
-        // overrides the entry-point label, backing any client fee out before the quote check reads
-        // the grossed output.
+        // A client fingerprint (owning trader, CoW appData tag, fee wallet, or integrator tag — see
+        // `clients`) overrides the entry-point label, backing any client fee out before the quote
+        // check reads the grossed output. The appData tag is read from a batch settler's calldata;
+        // other transactions carry none.
         let integrator = solvers::integrator(logs);
-        let venue =
-            clients::attribute(registry, &mut flow, &transfer_ledger, integrator.as_deref())
-                .unwrap_or_else(|| registry.label(entry_point));
+        let app_data = intents::client_tag(registry, entry_point, &root.input);
+        let venue = clients::attribute(
+            registry,
+            &mut flow,
+            &transfer_ledger,
+            integrator.as_deref(),
+            app_data,
+        )
+        .unwrap_or_else(|| registry.label(entry_point));
 
         let attribution = solvers::attribution::attribute(
             flow.solver_override.take(),

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -32,6 +32,8 @@ mod test_utils;
 use std::collections::HashMap;
 
 use alloy::{
+    eips::BlockId,
+    network::AnyTransactionReceipt,
     primitives::{Address, TxHash, U256},
     providers::Provider,
     rpc::types::trace::geth::CallFrame,
@@ -155,9 +157,17 @@ impl<P: Provider> Decoder<P> {
         &mut self,
         block_number: u64,
     ) -> anyhow::Result<Vec<DecodedTrade>> {
-        let receipts = self
+        // Fetch receipts as `AnyTransactionReceipt` rather than the Ethereum-typed default:
+        // OP-stack chains (Base) put a system deposit transaction (type `0x7e`) first in
+        // every block, which the Ethereum receipt enum rejects — failing the whole
+        // `eth_getBlockReceipts` batch. The `Any` receipt tolerates unknown transaction
+        // types.
+        let receipts: Vec<AnyTransactionReceipt> = self
             .provider
-            .get_block_receipts(block_number.into())
+            .raw_request::<_, Option<Vec<AnyTransactionReceipt>>>(
+                "eth_getBlockReceipts".into(),
+                (BlockId::from(block_number),),
+            )
             .await
             .with_context(|| format!("failed to fetch receipts for block {block_number}"))?
             .ok_or_else(|| anyhow::anyhow!("block {block_number} not found"))?;

--- a/tools/hindsight/src/decoder/netting_decoders.rs
+++ b/tools/hindsight/src/decoder/netting_decoders.rs
@@ -4,10 +4,9 @@
 //! trace (see `transfer_ledger`) — what actually moved, not what any contract or calldata
 //! declared. It needs no knowledge of any router's format.
 //!
-//! This module is both a toolkit and two decoders. The toolkit — `sender_flow` and
-//! `venue_flow` — is the shared netting engine the venue decoders build on. The decoders are
-//! the venue-less cases: `SenderNetting` for direct solver swaps and `IntentNetting` for
-//! filler-initiated intent fills and batch settlements.
+//! This module is a toolkit plus one decoder. The toolkit — `sender_flow` and `venue_flow` — is
+//! the shared netting engine the venue decoders build on. The decoder is `SenderNetting`, for
+//! direct solver swaps; intent fills and batch settlements are decoded in `super::intents`.
 //!
 //! Netting requires the trader to both pay and receive. When the swap's output is delivered to a
 //! different receiver, nothing nets against the trader's input and the transaction is declined —
@@ -20,7 +19,6 @@ use async_trait::async_trait;
 
 use crate::decoder::{
     decode::{DecodeContext, GasScope, TradeDecoder, TraderFlow},
-    intent,
     transfer_ledger::{NetSwap, TransferLedger},
 };
 
@@ -119,27 +117,5 @@ impl<P: Provider> TradeDecoder<P> for SenderNetting {
 
     async fn decode(&self, ctx: &mut DecodeContext<'_, P>) -> Option<TraderFlow> {
         sender_flow(ctx.transfer_ledger, ctx.receipt.from, ctx.entry_point)
-    }
-}
-
-/// Solver-initiated intent fills and batch settlements: the sender acts on the swapper's behalf, so
-/// the real swap is the swapper's net flow.
-pub(crate) struct IntentNetting;
-
-#[async_trait]
-impl<P: Provider> TradeDecoder<P> for IntentNetting {
-    fn name(&self) -> &'static str {
-        "intent-netting"
-    }
-
-    async fn decode(&self, ctx: &mut DecodeContext<'_, P>) -> Option<TraderFlow> {
-        intent::find_intent_trade(
-            ctx.provider,
-            ctx.transfer_ledger,
-            &[ctx.entry_point, ctx.receipt.from],
-            ctx.registry,
-            ctx.code_cache,
-        )
-        .await
     }
 }

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -37,6 +37,11 @@ struct AddressBook {
     /// books that have no owner-identified clients.
     #[serde(default)]
     client_owners: HashMap<Address, String>,
+    /// Fee-wallet address → client, for clients that route through a shared router and are only
+    /// identified by the fee transferred to their wallet (Phantom, Robinhood). Absent in books
+    /// with no fee-identified clients.
+    #[serde(default)]
+    client_fees: HashMap<Address, String>,
 }
 
 /// A venue's address-book section on one chain: the contracts users enter through, the
@@ -103,6 +108,9 @@ pub(crate) struct Registry {
     /// Trader address → order-flow client name, for clients identified by who owns the order
     /// rather than by the entry point (e.g. kpk's Safes settling through `CoW`).
     client_owners: HashMap<Address, String>,
+    /// Fee-wallet address → client name, for clients identified by the fee they take on a shared
+    /// router rather than by the entry point (Phantom, Robinhood).
+    client_fees: HashMap<Address, String>,
 }
 
 impl Registry {
@@ -183,6 +191,7 @@ impl Registry {
             usd_stablecoins,
             venues: book.venues,
             client_owners: book.client_owners,
+            client_fees: book.client_fees,
         })
     }
 
@@ -244,6 +253,12 @@ impl Registry {
         self.client_owners
             .get(&address)
             .map(String::as_str)
+    }
+
+    /// Fee-wallet → client map, for attributing clients identified only by their fee leg on a
+    /// shared router (see `crate::decoder::clients`).
+    pub(crate) fn client_fees(&self) -> &HashMap<Address, String> {
+        &self.client_fees
     }
 
     /// The venue whose entry point this address is, if any.

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -33,6 +33,10 @@ struct AddressBook {
     solvers: HashMap<Address, String>,
     venues: HashMap<String, VenueAddresses>,
     labels: HashMap<Address, String>,
+    /// Trader addresses that identify an order-flow client (e.g. kpk's Safes on `CoW`). Absent in
+    /// books that have no owner-identified clients.
+    #[serde(default)]
+    client_owners: HashMap<Address, String>,
 }
 
 /// A venue's address-book section on one chain: the contracts users enter through, the
@@ -96,6 +100,9 @@ pub(crate) struct Registry {
     usd_stablecoins: Vec<(Address, u32)>,
     /// Venue address sets, keyed by the venue name from the address book.
     venues: HashMap<String, VenueAddresses>,
+    /// Trader address → order-flow client name, for clients identified by who owns the order
+    /// rather than by the entry point (e.g. kpk's Safes settling through `CoW`).
+    client_owners: HashMap<Address, String>,
 }
 
 impl Registry {
@@ -175,6 +182,7 @@ impl Registry {
             infrastructure: book.infrastructure,
             usd_stablecoins,
             venues: book.venues,
+            client_owners: book.client_owners,
         })
     }
 
@@ -228,6 +236,14 @@ impl Registry {
     /// The named venue's address book section, when the book has one.
     pub(crate) fn venue(&self, name: &str) -> Option<&VenueAddresses> {
         self.venues.get(name)
+    }
+
+    /// The order-flow client that owns trades from this trader address, if any. Used to attribute
+    /// clients identified by who owns the order (e.g. kpk's Safes) rather than by `tx.to`.
+    pub(crate) fn client_for_owner(&self, address: Address) -> Option<&str> {
+        self.client_owners
+            .get(&address)
+            .map(String::as_str)
     }
 
     /// The venue whose entry point this address is, if any.

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -1,8 +1,8 @@
 //! The decoder's address book: which contracts are solvers, venues, batch settlers, and
 //! venue infrastructure on one chain.
 //!
-//! The data is pure configuration and lives in TOML — the built-in Ethereum address book is
-//! embedded from `registry/ethereum.toml`; `--registry <path>` loads a modified or per-chain
+//! The data is pure configuration and lives in TOML — the built-in address books are embedded
+//! from the `registry/` directory; `--registry <path>` loads a modified or per-chain
 //! address book without recompiling. This module only holds the lookups the decoders ask
 //! (`Registry::is_solver`, `Registry::is_batch_settler`, `Registry::label`, …).
 
@@ -19,6 +19,7 @@ use serde::Deserialize;
 /// The built-in Ethereum address book, embedded at compile time (validated by tests, so it
 /// cannot fail to parse at runtime).
 const ETHEREUM_TOML: &str = include_str!("registry/ethereum.toml");
+const BASE_TOML: &str = include_str!("registry/base.toml");
 
 /// On-disk shape of a chain's address book. Field meanings are documented in
 /// `registry/ethereum.toml`.
@@ -109,8 +110,9 @@ impl Registry {
         }
         match chain.to_lowercase().as_str() {
             "ethereum" => Ok(Self::ethereum()),
+            "base" => Ok(Self::base()),
             other => anyhow::bail!(
-                "no built-in decoder address registry for chain '{other}' (only ethereum); \
+                "no built-in decoder address registry for chain '{other}' (only ethereum, base); \
                  pass --registry with that chain's address book"
             ),
         }
@@ -119,6 +121,11 @@ impl Registry {
     /// The built-in Ethereum address book.
     pub(crate) fn ethereum() -> Self {
         Self::from_toml(ETHEREUM_TOML).expect("embedded ethereum registry must parse")
+    }
+
+    /// The built-in Base address book.
+    pub(crate) fn base() -> Self {
+        Self::from_toml(BASE_TOML).expect("embedded base registry must parse")
     }
 
     fn from_toml(text: &str) -> anyhow::Result<Self> {
@@ -259,10 +266,23 @@ mod tests {
     }
 
     #[test]
-    fn test_load_ethereum() {
+    fn test_embedded_base_book() {
+        let registry = Registry::base();
+        assert!(!registry.solvers.is_empty());
+        assert!(!registry
+            .venue("relay")
+            .unwrap()
+            .entry_points
+            .is_empty());
+    }
+
+    #[test]
+    fn test_load_builtin_chains() {
         assert!(Registry::load("ethereum", None).is_ok());
         assert!(Registry::load("Ethereum", None).is_ok());
-        assert!(Registry::load("base", None).is_err());
+        assert!(Registry::load("base", None).is_ok());
+        assert!(Registry::load("BASE", None).is_ok());
+        assert!(Registry::load("arbitrum", None).is_err());
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -12,7 +12,7 @@ use std::{
     path::Path,
 };
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, B256};
 use anyhow::Context;
 use serde::Deserialize;
 
@@ -47,6 +47,10 @@ struct AddressBook {
     /// books with no integrator-identified clients.
     #[serde(default)]
     client_integrators: HashMap<String, String>,
+    /// `CoW` order `appData` hash → client, for clients identified by the frontend tag (`appCode`)
+    /// committed into an order (`LlamaSwap`). Absent in books with no appData-identified clients.
+    #[serde(default)]
+    client_appdata: HashMap<B256, String>,
 }
 
 /// A venue's address-book section on one chain: the contracts users enter through, the
@@ -119,6 +123,9 @@ pub(crate) struct Registry {
     /// Provider integrator tag (lowercase) → client name, for clients identified by the integrator
     /// string a provider records in its event (`LiFi` frontends: Infinex, Robinhood).
     client_integrators: HashMap<String, String>,
+    /// `CoW` order `appData` hash → client name, for clients identified by the frontend tag
+    /// (`appCode`) committed into an order (`LlamaSwap`).
+    client_appdata: HashMap<B256, String>,
 }
 
 impl Registry {
@@ -205,6 +212,7 @@ impl Registry {
                 .into_iter()
                 .map(|(tag, client)| (tag.to_lowercase(), client))
                 .collect(),
+            client_appdata: book.client_appdata,
         })
     }
 
@@ -279,6 +287,14 @@ impl Registry {
     pub(crate) fn client_for_integrator(&self, integrator: &str) -> Option<&str> {
         self.client_integrators
             .get(&integrator.to_lowercase())
+            .map(String::as_str)
+    }
+
+    /// The client for a `CoW` order `appData` hash, if one is registered. Used to attribute
+    /// frontends by the `appCode` tag committed into the order (`LlamaSwap`).
+    pub(crate) fn client_for_appdata(&self, app_data: B256) -> Option<&str> {
+        self.client_appdata
+            .get(&app_data)
             .map(String::as_str)
     }
 

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -42,6 +42,11 @@ struct AddressBook {
     /// with no fee-identified clients.
     #[serde(default)]
     client_fees: HashMap<Address, String>,
+    /// Provider integrator tag → client, for clients identified by the integrator string in a
+    /// provider's event (`LiFi` frontends: Infinex, Robinhood). Keys are lowercase. Absent in
+    /// books with no integrator-identified clients.
+    #[serde(default)]
+    client_integrators: HashMap<String, String>,
 }
 
 /// A venue's address-book section on one chain: the contracts users enter through, the
@@ -111,6 +116,9 @@ pub(crate) struct Registry {
     /// Fee-wallet address → client name, for clients identified by the fee they take on a shared
     /// router rather than by the entry point (Phantom, Robinhood).
     client_fees: HashMap<Address, String>,
+    /// Provider integrator tag (lowercase) → client name, for clients identified by the integrator
+    /// string a provider records in its event (`LiFi` frontends: Infinex, Robinhood).
+    client_integrators: HashMap<String, String>,
 }
 
 impl Registry {
@@ -192,6 +200,11 @@ impl Registry {
             venues: book.venues,
             client_owners: book.client_owners,
             client_fees: book.client_fees,
+            client_integrators: book
+                .client_integrators
+                .into_iter()
+                .map(|(tag, client)| (tag.to_lowercase(), client))
+                .collect(),
         })
     }
 
@@ -259,6 +272,14 @@ impl Registry {
     /// shared router (see `crate::decoder::clients`).
     pub(crate) fn client_fees(&self) -> &HashMap<Address, String> {
         &self.client_fees
+    }
+
+    /// The client for a provider integrator tag (case-insensitive), if one is registered. Used to
+    /// attribute `LiFi` frontends by the integrator string in the swap event.
+    pub(crate) fn client_for_integrator(&self, integrator: &str) -> Option<&str> {
+        self.client_integrators
+            .get(&integrator.to_lowercase())
+            .map(String::as_str)
     }
 
     /// The venue whose entry point this address is, if any.

--- a/tools/hindsight/src/decoder/registry/base.toml
+++ b/tools/hindsight/src/decoder/registry/base.toml
@@ -89,5 +89,11 @@ hashflow = "hashflow"
 entry_points = ["0x02e5be68d46dac0b524905bff209cf47ee6db2a9"]
 fee_collectors = ["0xcd6b980029e6e6e0733ac8ec3e02be9410d09799"]
 
+# Rainbow's own router — same address as mainnet (Rainbow deploys it identically across chains).
+# Input-side fee read from calldata; no fee collector (see rainbow.rs).
+[venues.rainbow]
+entry_points = ["0x00000000009726632680fb29d3f7a9734e3010e2"]
+fee_collectors = []
+
 # No Base-specific label data yet (display-only tier).
 [labels]

--- a/tools/hindsight/src/decoder/registry/base.toml
+++ b/tools/hindsight/src/decoder/registry/base.toml
@@ -1,0 +1,90 @@
+# Base (chain-id 8453) address book for trade decoding. Same structure as ethereum.toml — see it
+# and registry.rs for what each section drives. Addresses gathered 2026-07-21.
+#
+# Accuracy note: a wrong or missing *solver* address only costs coverage (the swap fails to
+# match), but a wrong *venue fee collector* produces wrong records (the fee stays inside the
+# amounts). Every venue fee collector below was verified on-chain against live Base swaps
+# (2026-07-21), not assumed from the mainnet book.
+
+# Wrapped-native token: WETH on Base (canonical OP-stack predeploy).
+wrapped_native = "0x4200000000000000000000000000000000000006"
+
+# Permit2 — same deterministic address on every chain.
+infrastructure = ["0x000000000022d473030f116ddee9f6b43ac78ba3"] # Permit2
+
+# CoW Protocol Settlement — same address on every chain.
+batch_settlers = ["0x9008d19f58aabd9ed0d60971565aa8510560ab41"]
+
+# Stablecoins anchoring the native token to USD (address = decimals).
+[usd_stablecoins]
+"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913" = 6  # USDC (native, Circle)
+"0xd9aaec86b65d86f6a7b5b1b0c42ffa531710b6ca" = 6  # USDbC (bridged USDC)
+"0x50c5725949a6f0c72e6c4a641f24049a917db0cb" = 18 # DAI
+
+# Solver routers — the venue that actually settles a swap.
+[solvers]
+# 1inch v6 and v5 Aggregation Routers (same deterministic addresses as mainnet)
+"0x111111125421ca6dc452d289314280a0f8842a65" = "1inch"
+"0x1111111254eeb25477b68fb85ed929f73a960582" = "1inch"
+# 0x Settler AllowanceHolder (same address as mainnet)
+"0x0000000000001ff3684f28c67538d4d072c22734" = "0x"
+# CoW Protocol Settlement
+"0x9008d19f58aabd9ed0d60971565aa8510560ab41" = "cow"
+# ParaSwap Augustus v6.2 (same address as mainnet)
+"0x6a000f20005980200259b80c5102003040001068" = "paraswap"
+# KyberSwap MetaAggregationRouter v2 (same address as mainnet)
+"0x6131b5fae19ea4f9d964eac0408e4408b66337b5" = "kyberswap"
+# LiFi Diamond (same address as mainnet)
+"0x1231deb6f5749ef6ce6943a275a1d3e7486f4eae" = "lifi"
+# Uniswap Universal Router (V1_2) and SwapRouter02 on Base
+"0x3fc91a3afd70395cd496c647d5a6cc9d4b2b7fad" = "uniswap"
+"0x2626664c2603336e57b271c5c0b26f421741e481" = "uniswap"
+# OKX DEX Router on Base — router and exactOut router (OKX onchain-OS docs)
+"0x5e2f47bd7d4b357fcfd0bb224eb665773b1b9801" = "okx"
+"0x77449ff075c0a385796da0762bcb46fd5cc884c6" = "okx"
+# Tycho (PropellerHeads) router on Base (tycho-execution config/router_addresses.json)
+"0x2d3524b9b5dae34b646614eebb1e038d403e4cac" = "tycho"
+
+# Venues. Relay's Base contracts and fee collector are the same addresses as mainnet — Relay docs
+# list the Base solver/fee collector as 0xf70da978…, so its fee back-out is verified. Its routers
+# are the Cancun-EVM deployment (Base is Cancun), identical to the mainnet book.
+[venues.relay]
+entry_points = [
+    "0xf5042e6ffac5a625d4e7848e0b01373d8eb9e222",
+    "0x3ec130b627944cad9b2750300ecb0a695da522b6",
+    "0xb92fe925dc43a0ecde6c8b1a2709c170ec4fff4f",
+    "0xccc88a9d1b4ed6b0eaba998850414b24f1c315be",
+    "0x58cc3e0aa6cd7bf795832a225179ec2d848ce3e7",
+]
+fee_collectors = ["0xf70da97812cb96acdf810712aa562db8dfa3dbef"]
+
+# MetaMask Swap Router on Base. Verified on-chain: 25/25 sampled fee-paying swaps entered through
+# 0xdb9b1e94… (a contract), paying the fee to 0xe3478b0b… — the mainnet fee wallet 1; mainnet
+# wallet 2 is unused on Base. The Basescan-labelled "MetaMaskSwapRouter"
+# 0xb1aa0a09d43b6b4f289ef14f2441339acdb551ac is NOT the live entry point on Base.
+[venues.metamask]
+entry_points = ["0xdb9b1e94b5b69df7e401ddbede43491141047db3"]
+fee_collectors = ["0xe3478b0bb1a5084567c319096437924948be1964"]
+
+[venues.metamask.solver_aliases]
+oneinch = "1inch"
+zeroex = "0x"
+uniswap = "uniswap"
+okx = "okx"
+kyber = "kyberswap"
+paraswap = "paraswap"
+airswap = "airswap"
+openocean = "openocean"
+hashflow = "hashflow"
+
+# Rabby SwapProxy — same address as mainnet, deployed on Base. Verified on-chain: 837 fee legs in
+# a 10k-block sample were paid to 0xcd6b9800… (mainnet fee wallet 1) from the proxy and from
+# shared solver routers (1inch, 0x, KyberSwap, Uniswap); the mainnet historical wallet 0x39041f…
+# is unused on Base. As on mainnet, only the proxy is an entry point — shared-router Rabby swaps
+# are recognised by the fee leg (see rabby.rs), not by tx.to.
+[venues.rabby]
+entry_points = ["0x02e5be68d46dac0b524905bff209cf47ee6db2a9"]
+fee_collectors = ["0xcd6b980029e6e6e0733ac8ec3e02be9410d09799"]
+
+# No Base-specific label data yet (display-only tier).
+[labels]

--- a/tools/hindsight/src/decoder/registry/base.toml
+++ b/tools/hindsight/src/decoder/registry/base.toml
@@ -44,6 +44,9 @@ batch_settlers = ["0x9008d19f58aabd9ed0d60971565aa8510560ab41"]
 "0x77449ff075c0a385796da0762bcb46fd5cc884c6" = "okx"
 # Tycho (PropellerHeads) router on Base (tycho-execution config/router_addresses.json)
 "0x2d3524b9b5dae34b646614eebb1e038d403e4cac" = "tycho"
+# Fly (formerly Magpie) DexAggregator — same address on Base and most chains
+# (docs.fly.trade/developers/deployments)
+"0x20f6ee51340adeed01a59b0e65cb3703f3dc860c" = "fly"
 
 # Venues. Relay's Base contracts and fee collector are the same addresses as mainnet — Relay docs
 # list the Base solver/fee collector as 0xf70da978…, so its fee back-out is verified. Its routers

--- a/tools/hindsight/src/decoder/registry/base.toml
+++ b/tools/hindsight/src/decoder/registry/base.toml
@@ -100,5 +100,11 @@ fee_collectors = []
 [client_integrators]
 "infinex" = "infinex"
 
+# Clients identified by the appData hash a CoW order carries (appCode names the frontend). CoW
+# settles on Base too, and the hash is the same across chains. Keyed by the 32-byte appData hash.
+[client_appdata]
+# LlamaSwap (DefiLlama): appCode "DefiLlama".
+"0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422" = "llamaswap"
+
 # No Base-specific label data yet (display-only tier).
 [labels]

--- a/tools/hindsight/src/decoder/registry/base.toml
+++ b/tools/hindsight/src/decoder/registry/base.toml
@@ -95,5 +95,10 @@ fee_collectors = ["0xcd6b980029e6e6e0733ac8ec3e02be9410d09799"]
 entry_points = ["0x00000000009726632680fb29d3f7a9734e3010e2"]
 fee_collectors = []
 
+# LiFi frontends identified by the integrator tag in the LiFi swap event (Infinex's volume is
+# heavier on Base than on mainnet). Keys are lowercase.
+[client_integrators]
+"infinex" = "infinex"
+
 # No Base-specific label data yet (display-only tier).
 [labels]

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -134,3 +134,15 @@ fee_collectors = [
     "0xcd6b980029e6e6e0733ac8ec3e02be9410d09799",
     "0x39041f1b366fe33f9a5a79de5120f2aee2577ebc",
 ]
+
+[venues.coinbase]
+# Coinbase Wallet's swap proxies — the app-owned `tx.to` for its 0x-powered swaps ("aggregation is
+# powered by 0x", docs.cdp.coinbase.com). These proxies have been quiet since late 2025 (flow may
+# have moved off them — see the Hindsight targets doc); kept so historical trades decode and to
+# catch a resumption.
+entry_points = [
+    "0x8df6084e3b84a65ab9dd2325b5422e5debd8944a",
+    "0xe66b31678d6c16e9ebf358268a790b763c133750",
+]
+# Coinbase's 0x integration fee, taken from the output token and sent to this wallet.
+fee_collectors = ["0x382ffce2287252f930e1c8dc9328dac5bf282ba1"]

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -154,3 +154,16 @@ fee_collectors = ["0x382ffce2287252f930e1c8dc9328dac5bf282ba1"]
 "0x4f2083f5fbede34c2714affb3105539775f7fe64" = "kpk" # ENS Endowment
 "0x38f6a1b46144faee6a6d9f79d8de264c18e23848" = "kpk" # USD Alpha
 "0x99b9f5f24205cb88e33b1cc72008f644fc23768b" = "kpk" # ETH Alpha
+
+# Clients identified by the fee they take on a shared router (0x): the entry point is 0x's shared
+# AllowanceHolder, so the only fingerprint is the fee transfer to the client's wallet. Recognized
+# inside a matched solver trade (never a bare transfer), so the dust-spray gotcha does not apply.
+# The fee is taken from the output (buy) token and backed out so the settled output is gross.
+[client_fees]
+# Phantom: 0.85% buy-token fee. Current wallet confirmed 2026-07-17; earlier wallet retired
+# 2025-07-25 — both kept so either window decodes.
+"0x2cffed5d56eb6a17662756ca0fdf350e732c9818" = "phantom"
+"0x7afa9d836d2fccf172b66622625e56404e465dbd" = "phantom"
+# Robinhood Wallet: fee wallet confirmed 2026-07-17 (swaps are ERC-4337; identify by the fee leg,
+# never the bundler sender).
+"0xad01c20d5886137e056775af56915de824c8fce5" = "robinhood"

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -121,3 +121,16 @@ paraswap = "paraswap"
 airswap = "airswap"
 openocean = "openocean"
 hashflow = "hashflow"
+
+[venues.rabby]
+# Rabby SwapProxy — the app-owned router `tx.to` for its Uniswap-routed swaps. Rabby also routes
+# through shared solver routers (0x, 1inch, Sushi), where `tx.to` is the solver's own contract and
+# the only Rabby fingerprint is the fee leg below; those are not keyed here (see rabby.rs).
+entry_points = ["0x02e5be68d46dac0b524905bff209cf47ee6db2a9"]
+# Rabby fee wallets: a flat 0.25% of the output token. Current wallet confirmed 2026-07-17 via two
+# decoded live swaps through different venues; the historical wallet took the fee through ~Sep 2025
+# before rotating. Both are listed so trades in either window decode with the fee backed out.
+fee_collectors = [
+    "0xcd6b980029e6e6e0733ac8ec3e02be9410d09799",
+    "0x39041f1b366fe33f9a5a79de5120f2aee2577ebc",
+]

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -147,6 +147,13 @@ entry_points = [
 # Coinbase's 0x integration fee, taken from the output token and sent to this wallet.
 fee_collectors = ["0x382ffce2287252f930e1c8dc9328dac5bf282ba1"]
 
+[venues.rainbow]
+# Rainbow's own router ("Rainbow: Router"; same address on ETH/Base/Arb/OP/Polygon). It wraps 0x
+# and takes its fee on the input side, passed as the call's feeAmount argument and kept by the
+# router — no fee transfer, so the fee is read from calldata (see rainbow.rs). No fee collector.
+entry_points = ["0x00000000009726632680fb29d3f7a9734e3010e2"]
+fee_collectors = []
+
 # Order-flow clients identified by the trader address that owns the order, not by tx.to. kpk is a
 # treasury manager whose Safes trade through CoW: tx.from is the CoW solver, so the client is only
 # visible as the Safe owning the settled order. Addresses from docs.kpk.io / karpatkey.

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -146,3 +146,11 @@ entry_points = [
 ]
 # Coinbase's 0x integration fee, taken from the output token and sent to this wallet.
 fee_collectors = ["0x382ffce2287252f930e1c8dc9328dac5bf282ba1"]
+
+# Order-flow clients identified by the trader address that owns the order, not by tx.to. kpk is a
+# treasury manager whose Safes trade through CoW: tx.from is the CoW solver, so the client is only
+# visible as the Safe owning the settled order. Addresses from docs.kpk.io / karpatkey.
+[client_owners]
+"0x4f2083f5fbede34c2714affb3105539775f7fe64" = "kpk" # ENS Endowment
+"0x38f6a1b46144faee6a6d9f79d8de264c18e23848" = "kpk" # USD Alpha
+"0x99b9f5f24205cb88e33b1cc72008f644fc23768b" = "kpk" # ETH Alpha

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -181,3 +181,11 @@ fee_collectors = []
 [client_integrators]
 "infinex" = "infinex"
 "robinhood" = "robinhood"
+
+# Clients identified by the appData hash a CoW order carries: appCode names the frontend that
+# built the order. CoW commits this hash into each order; it appears in the settle calldata, not
+# the Trade event. Keyed by the 32-byte appData hash.
+[client_appdata]
+# LlamaSwap (DefiLlama): appCode "DefiLlama". A low-frequency, fee-free frontend whose other legs
+# (0x, Kyber) tag it only off-chain, so this CoW hash is its one on-chain fingerprint.
+"0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422" = "llamaswap"

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -174,3 +174,10 @@ fee_collectors = []
 # Robinhood Wallet: fee wallet confirmed 2026-07-17 (swaps are ERC-4337; identify by the fee leg,
 # never the bundler sender).
 "0xad01c20d5886137e056775af56915de824c8fce5" = "robinhood"
+
+# Clients identified by the integrator tag a provider records in its swap event. LiFi frontends
+# route through the shared LiFi Diamond, so the integrator string in LiFiGenericSwapCompleted /
+# LiFiSwappedGeneric is the only fingerprint. Keys are lowercase (matched case-insensitively).
+[client_integrators]
+"infinex" = "infinex"
+"robinhood" = "robinhood"

--- a/tools/hindsight/src/decoder/sandwich.rs
+++ b/tools/hindsight/src/decoder/sandwich.rs
@@ -13,8 +13,8 @@
 use std::collections::HashSet;
 
 use alloy::{
+    network::AnyTransactionReceipt,
     primitives::{Address, TxHash, U256},
-    rpc::types::TransactionReceipt,
     sol,
     sol_types::SolEvent,
 };
@@ -54,7 +54,7 @@ pub(crate) struct SandwichEvidence {
 /// both sides of their own trade is not a sandwich. Candidate pairs are tried closest front
 /// first, then closest back, so the first match found is the tightest bracket.
 pub(crate) fn detect(
-    receipts: &[TransactionReceipt],
+    receipts: &[AnyTransactionReceipt],
     victim_index: usize,
     victim: &DecodedTrade,
     registry: &Registry,
@@ -101,8 +101,8 @@ pub(crate) fn detect(
 /// real sandwich bots settle through private contracts. A link matching the victim's own sender
 /// is also excluded: a trader on both sides of their own trade is not a sandwich.
 fn shared_attacker(
-    front: &TransactionReceipt,
-    back: &TransactionReceipt,
+    front: &AnyTransactionReceipt,
+    back: &AnyTransactionReceipt,
     victim_sender: Address,
     registry: &Registry,
 ) -> Option<Address> {
@@ -123,8 +123,8 @@ fn shared_attacker(
 /// when either leg missed the overlap.
 fn overlapping_pools(
     victim_pools: &HashSet<Address>,
-    front: &TransactionReceipt,
-    back: &TransactionReceipt,
+    front: &AnyTransactionReceipt,
+    back: &AnyTransactionReceipt,
     registry: &Registry,
 ) -> Option<Vec<Address>> {
     let front_overlap: HashSet<Address> = pool_addresses(front, registry)
@@ -153,7 +153,7 @@ fn overlapping_pools(
 /// addresses (the wrapped-native token's `Deposit`/`Withdrawal`, Permit2's permit events) log on
 /// most swaps without being pools: counting any of them would give two transactions that merely
 /// share a token or an infrastructure contract a trivial "pool" overlap.
-fn pool_addresses(receipt: &TransactionReceipt, registry: &Registry) -> HashSet<Address> {
+fn pool_addresses(receipt: &AnyTransactionReceipt, registry: &Registry) -> HashSet<Address> {
     let mut pools = HashSet::new();
     for log in receipt.logs() {
         let token_event = log
@@ -185,8 +185,8 @@ fn direction_token(victim_token_out: Address, registry: &Registry) -> Address {
 /// itself, plus the pair's shared target contract when the link was a shared sender — a bot's
 /// inventory usually sits in its private contract, not in the EOA that signs.
 fn direction_entities(
-    front: &TransactionReceipt,
-    back: &TransactionReceipt,
+    front: &AnyTransactionReceipt,
+    back: &AnyTransactionReceipt,
     attacker: Address,
     victim_sender: Address,
     registry: &Registry,
@@ -212,8 +212,8 @@ fn direction_entities(
 /// is missing an attacker whose legs move only native ETH — invisible in receipts — which is rare:
 /// bots keep inventory wrapped precisely because pools settle in WETH.
 fn accumulates_then_disposes(
-    front: &TransactionReceipt,
-    back: &TransactionReceipt,
+    front: &AnyTransactionReceipt,
+    back: &AnyTransactionReceipt,
     entities: &[Address],
     token: Address,
 ) -> bool {
@@ -225,7 +225,7 @@ fn accumulates_then_disposes(
 }
 
 /// `(received, sent)` totals of `token` for `entity` across a receipt's ERC-20 `Transfer` logs.
-fn token_flow(receipt: &TransactionReceipt, entity: Address, token: Address) -> (U256, U256) {
+fn token_flow(receipt: &AnyTransactionReceipt, entity: Address, token: Address) -> (U256, U256) {
     let mut received = U256::ZERO;
     let mut sent = U256::ZERO;
     for log in receipt.logs() {

--- a/tools/hindsight/src/decoder/solvers/lifi.rs
+++ b/tools/hindsight/src/decoder/solvers/lifi.rs
@@ -5,7 +5,7 @@
 
 use alloy::{rpc::types::Log, sol, sol_types::SolEvent};
 
-use crate::decoder::{solvers::SolverKnowledge, veto::Veto};
+use crate::decoder::{solvers::SolverKnowledge, transfer_ledger::to_primitive_log, veto::Veto};
 
 /// The `LiFi` solver.
 pub(crate) struct Lifi;
@@ -21,6 +21,26 @@ impl SolverKnowledge for Lifi {
             .any(|log| log.topics().first() == Some(&LiFiTransferStarted::SIGNATURE_HASH))
             .then_some(Veto::BridgeOrder)
     }
+
+    /// The integrator tag a same-chain `LiFi` swap declares, from either generic-swap event. This
+    /// is the only fingerprint of a `LiFi` frontend (Infinex, Robinhood's `LiFi` leg), which routes
+    /// through the shared Diamond.
+    fn integrator(&self, logs: &[Log]) -> Option<String> {
+        logs.iter()
+            .find_map(|log| match log.topics().first() {
+                Some(topic) if *topic == LiFiGenericSwapCompleted::SIGNATURE_HASH => {
+                    LiFiGenericSwapCompleted::decode_log(&to_primitive_log(log))
+                        .ok()
+                        .map(|event| event.integrator.clone())
+                }
+                Some(topic) if *topic == LiFiSwappedGeneric::SIGNATURE_HASH => {
+                    LiFiSwappedGeneric::decode_log(&to_primitive_log(log))
+                        .ok()
+                        .map(|event| event.integrator.clone())
+                }
+                _ => None,
+            })
+    }
 }
 
 sol! {
@@ -29,6 +49,29 @@ sol! {
     event LiFiTransferStarted(
         (bytes32, string, string, address, address, address, uint256, uint256, bool, bool)
             bridgeData
+    );
+
+    /// Same-chain `LiFi` swap, current facet — carries the integrator tag as its first string.
+    event LiFiGenericSwapCompleted(
+        bytes32 indexed transactionId,
+        string integrator,
+        string referrer,
+        address receiver,
+        address fromAssetId,
+        address toAssetId,
+        uint256 fromAmount,
+        uint256 toAmount
+    );
+
+    /// Same-chain `LiFi` swap, older facet — same integrator tag, no `receiver` field.
+    event LiFiSwappedGeneric(
+        bytes32 indexed transactionId,
+        string integrator,
+        string referrer,
+        address fromAssetId,
+        address toAssetId,
+        uint256 fromAmount,
+        uint256 toAmount
     );
 }
 
@@ -54,5 +97,30 @@ mod tests {
 
         let swap_logs = vec![make_transfer_log(addr(10), addr(1), addr(2), U256::from(1000))];
         assert_eq!(Lifi.solver_veto(&swap_logs), None);
+    }
+
+    #[test]
+    fn test_integrator_from_generic_swap() {
+        use alloy::primitives::{Address, B256};
+
+        let event = LiFiGenericSwapCompleted {
+            transactionId: B256::ZERO,
+            integrator: "infinex".to_string(),
+            referrer: String::new(),
+            receiver: Address::ZERO,
+            fromAssetId: addr(10),
+            toAssetId: addr(11),
+            fromAmount: U256::from(1000),
+            toAmount: U256::from(2000),
+        };
+        let data = event.encode_log_data();
+        let primitive =
+            PrimitiveLog::new_unchecked(addr(70), data.topics().to_vec(), data.data.clone());
+        let logs = vec![Log { inner: primitive, ..Default::default() }];
+        assert_eq!(Lifi.integrator(&logs).as_deref(), Some("infinex"));
+
+        // A non-LiFi log carries no integrator.
+        let other = vec![make_transfer_log(addr(10), addr(1), addr(2), U256::from(1))];
+        assert_eq!(Lifi.integrator(&other), None);
     }
 }

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -53,6 +53,14 @@ pub(crate) trait SolverKnowledge: Send + Sync {
     fn solver_veto(&self, _logs: &[Log]) -> Option<Veto> {
         None
     }
+
+    /// The order-flow integrator tag this solver records in its logs, when it exposes one. A
+    /// solver that fronts other apps (`LiFi`'s Diamond) carries the frontend's integrator string in
+    /// its swap event; client attribution maps that tag to a client (see
+    /// `crate::decoder::clients`).
+    fn integrator(&self, _logs: &[Log]) -> Option<String> {
+        None
+    }
 }
 
 /// The solvers with a `SolverKnowledge` implementation, by address-book name. A solver absent
@@ -83,6 +91,15 @@ pub(crate) fn solver_veto(logs: &[Log], entry_point: Address, registry: &Registr
         }
     }
     None
+}
+
+/// The order-flow integrator tag declared in a transaction's logs, from whichever solver records
+/// one. Only a solver that fronts other apps (`LiFi`) returns a tag; the rest default to `None`, so
+/// the first hit is the answer.
+pub(crate) fn integrator(logs: &[Log]) -> Option<String> {
+    IMPLEMENTATIONS
+        .iter()
+        .find_map(|(_, knowledge)| knowledge.integrator(logs))
 }
 
 /// The solver's off-chain quote declared in the transaction's calldata, when the attributed

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod attribution;
 pub(crate) mod kyberswap;
 pub(crate) mod lifi;
 pub(crate) mod paraswap;
+pub(crate) mod zeroex;
 
 use alloy::{
     primitives::{Address, U256},
@@ -57,6 +58,7 @@ pub(crate) trait SolverKnowledge: Send + Sync {
 /// The solvers with a `SolverKnowledge` implementation, by address-book name. A solver absent
 /// here needs none — its address-book entry alone is complete.
 const IMPLEMENTATIONS: &[(&str, &'static dyn SolverKnowledge)] = &[
+    ("0x", &zeroex::ZeroEx),
     ("kyberswap", &kyberswap::Kyberswap),
     ("lifi", &lifi::Lifi),
     ("paraswap", &paraswap::Paraswap),

--- a/tools/hindsight/src/decoder/solvers/zeroex.rs
+++ b/tools/hindsight/src/decoder/solvers/zeroex.rs
@@ -1,0 +1,111 @@
+//! 0x-specific calldata extraction.
+//!
+//! 0x's Settler does not embed a self-describing quote the way `KyberSwap` does — its calldata is
+//! an array of encoded actions, and the numbers in them are slippage floors (`minAmountOut`), not
+//! the quoted output. The one action that carries the quote is `POSITIVE_SLIPPAGE(address
+//! recipient, address token, uint256 expectedAmount, uint256 maxBps)` (0x-settler
+//! `ISettlerActions`): when 0x collects positive slippage for an integrator, `expectedAmount` is
+//! the output the route was quoted at, and execution above it is skimmed as surplus.
+//!
+//! So the quote is recoverable only for the swaps that include that action — integrators that let
+//! 0x collect surplus. Wallet integrations that take their own fee (Phantom, Robinhood, …) do not,
+//! and those decode without a quote. Partial coverage, but better than none for the highest-volume
+//! competitor.
+
+use alloy::primitives::U256;
+
+use crate::decoder::solvers::{SolverKnowledge, SolverQuote};
+
+/// The `POSITIVE_SLIPPAGE(address,address,uint256,uint256)` action selector.
+const POSITIVE_SLIPPAGE: [u8; 4] = [0x34, 0xee, 0x90, 0xca];
+
+/// The 0x solver.
+pub(crate) struct ZeroEx;
+
+impl SolverKnowledge for ZeroEx {
+    /// Extract 0x's quoted output from a `POSITIVE_SLIPPAGE` action, when the calldata has one.
+    ///
+    /// The action is located by its selector rather than by decoding the Settler call, so it is
+    /// found whether 0x is the entry point, wrapped by `AllowanceHolder`, or nested inside another
+    /// venue's calldata. The `recipient` and `token` words after the selector must be addresses
+    /// (top 12 bytes zero); this rejects a stray selector match in unrelated calldata. The caller
+    /// unit-checks the quote against the settled amount.
+    fn embedded_quote(&self, input: &[u8], _amount_in: U256) -> Option<SolverQuote> {
+        let start = input
+            .windows(POSITIVE_SLIPPAGE.len())
+            .position(|window| window == POSITIVE_SLIPPAGE)?;
+        // Three words after the selector: recipient, token, expectedAmount.
+        let action = input.get(start + 4..start + 4 + 96)?;
+        let is_address = |word: &[u8]| word[..12].iter().all(|&byte| byte == 0);
+        if !is_address(&action[0..32]) || !is_address(&action[32..64]) {
+            return None;
+        }
+        let amount_out = U256::from_be_slice(&action[64..96]);
+        if amount_out.is_zero() {
+            return None;
+        }
+        Some(SolverQuote { amount_out, source: None, timestamp: None })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::Address;
+
+    use super::*;
+    use crate::decoder::test_utils::addr;
+
+    /// A `POSITIVE_SLIPPAGE` action, ABI-encoded as it appears in the Settler `actions` array,
+    /// surrounded by other calldata bytes.
+    fn calldata_with_positive_slippage(token: Address, expected: u128) -> Vec<u8> {
+        let mut action = POSITIVE_SLIPPAGE.to_vec();
+        action.extend_from_slice(addr(7).into_word().as_slice()); // recipient
+        action.extend_from_slice(token.into_word().as_slice());
+        action.extend_from_slice(&U256::from(expected).to_be_bytes::<32>());
+        action.extend_from_slice(&U256::from(50u64).to_be_bytes::<32>()); // maxBps
+
+        let mut input = vec![0x11u8; 68]; // an outer selector + leading words
+        input.extend_from_slice(&action);
+        input.extend_from_slice(&[0u8; 32]); // trailing calldata
+        input
+    }
+
+    #[test]
+    fn test_selector_matches_settler_action() {
+        // bytes4(keccak256("POSITIVE_SLIPPAGE(address,address,uint256,uint256)")) — verified
+        // against the 0x-settler ISettlerActions source.
+        assert_eq!(POSITIVE_SLIPPAGE, [0x34, 0xee, 0x90, 0xca]);
+    }
+
+    #[test]
+    fn test_reads_expected_amount() {
+        let input = calldata_with_positive_slippage(addr(11), 2_000_000);
+        let quote = ZeroEx
+            .embedded_quote(&input, U256::ZERO)
+            .unwrap();
+        assert_eq!(quote.amount_out, U256::from(2_000_000u64));
+        assert_eq!(quote.source, None);
+        assert_eq!(quote.timestamp, None);
+    }
+
+    #[test]
+    fn test_no_positive_slippage_action() {
+        // A 0x swap without the action (a wallet integrator taking its own fee) carries no quote.
+        assert!(ZeroEx
+            .embedded_quote(&[0x00; 200], U256::ZERO)
+            .is_none());
+        assert!(ZeroEx
+            .embedded_quote(&[], U256::ZERO)
+            .is_none());
+    }
+
+    #[test]
+    fn test_stray_selector_without_address_words() {
+        // The selector bytes appearing amid non-address data (a coincidental match) are rejected.
+        let mut input = POSITIVE_SLIPPAGE.to_vec();
+        input.extend_from_slice(&[0xff; 96]);
+        assert!(ZeroEx
+            .embedded_quote(&input, U256::ZERO)
+            .is_none());
+    }
+}

--- a/tools/hindsight/src/decoder/solvers/zeroex.rs
+++ b/tools/hindsight/src/decoder/solvers/zeroex.rs
@@ -1,35 +1,32 @@
-//! 0x-specific calldata extraction.
+//! 0x calldata extraction.
 //!
-//! 0x's Settler does not embed a self-describing quote the way `KyberSwap` does — its calldata is
-//! an array of encoded actions, and the numbers in them are slippage floors (`minAmountOut`), not
-//! the quoted output. The one action that carries the quote is `POSITIVE_SLIPPAGE(address
-//! recipient, address token, uint256 expectedAmount, uint256 maxBps)` (0x-settler
-//! `ISettlerActions`): when 0x collects positive slippage for an integrator, `expectedAmount` is
-//! the output the route was quoted at, and execution above it is skimmed as surplus.
+//! 0x's Settler calldata is a list of encoded actions whose numbers are slippage floors, not the
+//! quoted output. Only the positive-slippage action carries the quote: when 0x skims surplus for an
+//! integrator, it records the output the route was quoted at, and execution above it is the
+//! surplus. That is the one quote 0x exposes on-chain.
 //!
-//! So the quote is recoverable only for the swaps that include that action — integrators that let
-//! 0x collect surplus. Wallet integrations that take their own fee (Phantom, Robinhood, …) do not,
-//! and those decode without a quote. Partial coverage, but better than none for the highest-volume
+//! So a quote is recovered only for swaps that let 0x skim surplus. Wallets that take their own fee
+//! (Phantom, Robinhood) do not, and decode without a quote — partial coverage of the highest-volume
 //! competitor.
 
 use alloy::primitives::U256;
 
 use crate::decoder::solvers::{SolverKnowledge, SolverQuote};
 
-/// The `POSITIVE_SLIPPAGE(address,address,uint256,uint256)` action selector.
+/// Selector of 0x's positive-slippage action (`bytes4` of its signature; see the test).
 const POSITIVE_SLIPPAGE: [u8; 4] = [0x34, 0xee, 0x90, 0xca];
 
 /// The 0x solver.
 pub(crate) struct ZeroEx;
 
 impl SolverKnowledge for ZeroEx {
-    /// Extract 0x's quoted output from a `POSITIVE_SLIPPAGE` action, when the calldata has one.
+    /// Extract 0x's quoted output from the positive-slippage action, when the calldata has one.
     ///
-    /// The action is located by its selector rather than by decoding the Settler call, so it is
-    /// found whether 0x is the entry point, wrapped by `AllowanceHolder`, or nested inside another
-    /// venue's calldata. The `recipient` and `token` words after the selector must be addresses
-    /// (top 12 bytes zero); this rejects a stray selector match in unrelated calldata. The caller
-    /// unit-checks the quote against the settled amount.
+    /// The action is found by its selector, not by decoding the whole Settler call, so it is picked
+    /// up wherever 0x sits — the entry point, behind the shared allowance contract, or nested in
+    /// another venue's calldata. The two address words after the selector must have their top 12
+    /// bytes zero, which rejects a stray selector match in unrelated bytes. The caller unit-checks
+    /// the quote against the settled amount.
     fn embedded_quote(&self, input: &[u8], _amount_in: U256) -> Option<SolverQuote> {
         let start = input
             .windows(POSITIVE_SLIPPAGE.len())

--- a/tools/hindsight/src/decoder/test_utils.rs
+++ b/tools/hindsight/src/decoder/test_utils.rs
@@ -1,7 +1,9 @@
 use alloy::{
-    consensus::{Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom},
+    consensus::{Eip658Value, Receipt, ReceiptWithBloom},
+    network::{AnyReceiptEnvelope, AnyTransactionReceipt},
     primitives::{address, Address, Bloom, Bytes, Log as PrimitiveLog, TxHash, B256, U256},
     rpc::types::{trace::geth::CallFrame, Log, TransactionReceipt},
+    serde::WithOtherFields,
     sol_types::SolEvent,
 };
 
@@ -92,12 +94,19 @@ pub(crate) fn receipt(
     from: Address,
     to: Option<Address>,
     logs: Vec<Log>,
-) -> TransactionReceipt {
-    TransactionReceipt {
-        inner: ReceiptEnvelope::Legacy(ReceiptWithBloom {
-            receipt: Receipt { status: Eip658Value::Eip658(true), cumulative_gas_used: 0, logs },
-            logs_bloom: Bloom::default(),
-        }),
+) -> AnyTransactionReceipt {
+    WithOtherFields::new(TransactionReceipt {
+        inner: AnyReceiptEnvelope {
+            inner: ReceiptWithBloom {
+                receipt: Receipt {
+                    status: Eip658Value::Eip658(true),
+                    cumulative_gas_used: 0,
+                    logs,
+                },
+                logs_bloom: Bloom::default(),
+            },
+            r#type: 0,
+        },
         transaction_hash: hash,
         transaction_index: None,
         block_hash: None,
@@ -109,5 +118,5 @@ pub(crate) fn receipt(
         from,
         to,
         contract_address: None,
-    }
+    })
 }

--- a/tools/hindsight/src/decoder/venues/coinbase.rs
+++ b/tools/hindsight/src/decoder/venues/coinbase.rs
@@ -1,0 +1,134 @@
+//! Coinbase Wallet decoding.
+//!
+//! Coinbase Wallet's in-app swaps are 0x-powered ("aggregation is powered by 0x",
+//! docs.cdp.coinbase.com): the app enters through its own proxy contracts and takes a fee in the
+//! output token, sent to its fee wallet. Nets the sender's flow and backs that fee out through the
+//! shared `venue_flow` — no venue-specific corrections.
+
+use alloy::providers::Provider;
+use async_trait::async_trait;
+
+use crate::decoder::{
+    decode::{DecodeContext, TradeDecoder, TraderFlow},
+    netting_decoders::venue_flow,
+};
+
+/// Coinbase Wallet's netting decoder.
+pub(crate) struct CoinbaseNetting;
+
+#[async_trait]
+impl<P: Provider> TradeDecoder<P> for CoinbaseNetting {
+    fn name(&self) -> &'static str {
+        "coinbase-netting"
+    }
+
+    /// Net the sender's flow and back the output-token fee out.
+    async fn decode(&self, ctx: &mut DecodeContext<'_, P>) -> Option<TraderFlow> {
+        let addresses = ctx.venue?;
+        venue_flow(
+            ctx.transfer_ledger,
+            ctx.receipt.from,
+            ctx.entry_point,
+            &addresses.fee_collectors,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use alloy::{
+        primitives::{Address, U256},
+        providers::RootProvider,
+        rpc::client::RpcClient,
+        transports::mock::Asserter,
+    };
+
+    use super::*;
+    use crate::decoder::{
+        registry::Registry,
+        test_utils::{addr, make_transfer_log, receipt, swap, tx_hash},
+        transfer_ledger::TransferLedger,
+    };
+
+    fn fee_wallet(registry: &Registry) -> Address {
+        *registry
+            .venue("coinbase")
+            .unwrap()
+            .fee_collectors
+            .iter()
+            .next()
+            .unwrap()
+    }
+
+    async fn decode(
+        registry: &Registry,
+        ledger: &TransferLedger,
+        sender: Address,
+        entry_point: Address,
+    ) -> Option<TraderFlow> {
+        let provider = RootProvider::new(RpcClient::mocked(Asserter::new()));
+        let mut code_cache = HashMap::new();
+        let receipt = receipt(tx_hash(1), sender, Some(entry_point), vec![]);
+        let mut ctx = DecodeContext {
+            provider: &provider,
+            registry,
+            code_cache: &mut code_cache,
+            receipt: &receipt,
+            entry_point,
+            transfer_ledger: ledger,
+            input: &[],
+            venue: registry.venue("coinbase"),
+        };
+        CoinbaseNetting.decode(&mut ctx).await
+    }
+
+    #[tokio::test]
+    async fn test_output_token_fee_backed_out() {
+        // The fee reaches the collector in the output token, so the shared back-out grosses it into
+        // amount_out — else the settled output is under-reported and every comparison overcredits
+        // Fynd.
+        let registry = Registry::ethereum();
+        let collector = fee_wallet(&registry);
+        let user = addr(1);
+        let proxy = addr(2);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, user, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, user, U256::from(1990)),
+            make_transfer_log(token_out, pool, collector, U256::from(10)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+
+        let flow = decode(&registry, &transfer_ledger, user, proxy)
+            .await
+            .unwrap();
+        assert_eq!(flow.swap, swap(token_in, 1000, token_out, 2000));
+        assert_eq!(flow.venue_fee_out, Some(U256::from(10)));
+    }
+
+    #[tokio::test]
+    async fn test_fee_free_trade() {
+        let registry = Registry::ethereum();
+        let user = addr(1);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, user, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, user, U256::from(2000)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+
+        let flow = decode(&registry, &transfer_ledger, user, pool)
+            .await
+            .unwrap();
+        assert_eq!(flow.swap, swap(token_in, 1000, token_out, 2000));
+        assert_eq!(flow.venue_fee_out, None);
+    }
+}

--- a/tools/hindsight/src/decoder/venues/mod.rs
+++ b/tools/hindsight/src/decoder/venues/mod.rs
@@ -25,6 +25,7 @@
 //! address book's comments) before a venue is added.
 
 pub(crate) mod metamask;
+pub(crate) mod rabby;
 pub(crate) mod relay;
 
 use alloy::providers::{Provider, RootProvider};
@@ -38,6 +39,7 @@ pub(crate) fn decoders_for<P: Provider>(name: &str) -> Vec<Box<dyn TradeDecoder<
     match name {
         "relay" => vec![Box::new(relay::RelayNetting)],
         "metamask" => vec![Box::new(metamask::MetaMaskNetting)],
+        "rabby" => vec![Box::new(rabby::RabbyNetting)],
         _ => vec![],
     }
 }

--- a/tools/hindsight/src/decoder/venues/mod.rs
+++ b/tools/hindsight/src/decoder/venues/mod.rs
@@ -24,6 +24,7 @@
 //! The second failure mode is why fee collectors are verified against on-chain samples (see the
 //! address book's comments) before a venue is added.
 
+pub(crate) mod coinbase;
 pub(crate) mod metamask;
 pub(crate) mod rabby;
 pub(crate) mod relay;
@@ -40,6 +41,7 @@ pub(crate) fn decoders_for<P: Provider>(name: &str) -> Vec<Box<dyn TradeDecoder<
         "relay" => vec![Box::new(relay::RelayNetting)],
         "metamask" => vec![Box::new(metamask::MetaMaskNetting)],
         "rabby" => vec![Box::new(rabby::RabbyNetting)],
+        "coinbase" => vec![Box::new(coinbase::CoinbaseNetting)],
         _ => vec![],
     }
 }

--- a/tools/hindsight/src/decoder/venues/mod.rs
+++ b/tools/hindsight/src/decoder/venues/mod.rs
@@ -27,6 +27,7 @@
 pub(crate) mod coinbase;
 pub(crate) mod metamask;
 pub(crate) mod rabby;
+pub(crate) mod rainbow;
 pub(crate) mod relay;
 
 use alloy::providers::{Provider, RootProvider};
@@ -42,6 +43,7 @@ pub(crate) fn decoders_for<P: Provider>(name: &str) -> Vec<Box<dyn TradeDecoder<
         "metamask" => vec![Box::new(metamask::MetaMaskNetting)],
         "rabby" => vec![Box::new(rabby::RabbyNetting)],
         "coinbase" => vec![Box::new(coinbase::CoinbaseNetting)],
+        "rainbow" => vec![Box::new(rainbow::RainbowCalldata)],
         _ => vec![],
     }
 }

--- a/tools/hindsight/src/decoder/venues/rabby.rs
+++ b/tools/hindsight/src/decoder/venues/rabby.rs
@@ -1,0 +1,189 @@
+//! Rabby decoding.
+//!
+//! Rabby is a consumer wallet with its own meta-aggregator: it picks among many solvers and takes
+//! a flat 0.25% of the output token as its fee. Only its Uniswap-routed swaps enter through
+//! Rabby's own `SwapProxy` contract; the rest go straight to the chosen solver's router, where
+//! `tx.to` is that solver and the sole Rabby fingerprint is the fee transfer. Matching keys on the
+//! entry point, so only the `SwapProxy` swaps are recognized as Rabby here — the shared-router
+//! swaps decode as the solver's own trades with the 0.25% fee still inside the amounts.
+//!
+//! On a swap whose output is native ETH, Rabby unwraps the proceeds to the trader but keeps its
+//! cut in WETH beforehand, so the fee reaches the collector denominated in the wrapped token
+//! while the trade's output token is native ETH. The shared fee back-out matches the exact output
+//! token and would miss that, so the wrapped-native fee is recognized here and grossed back into
+//! the ETH output.
+
+use alloy::{primitives::Address, providers::Provider};
+use async_trait::async_trait;
+
+use crate::decoder::{
+    decode::{DecodeContext, TradeDecoder, TraderFlow},
+    netting_decoders::venue_flow,
+};
+
+/// Rabby's netting decoder.
+pub(crate) struct RabbyNetting;
+
+#[async_trait]
+impl<P: Provider> TradeDecoder<P> for RabbyNetting {
+    fn name(&self) -> &'static str {
+        "rabby-netting"
+    }
+
+    /// Net the sender's flow and back the 0.25% fee out. A fee in the output token is handled by
+    /// the shared `venue_flow`; a WETH fee on an ETH-output swap is grossed back in here.
+    async fn decode(&self, ctx: &mut DecodeContext<'_, P>) -> Option<TraderFlow> {
+        let addresses = ctx.venue?;
+        let mut flow = venue_flow(
+            ctx.transfer_ledger,
+            ctx.receipt.from,
+            ctx.entry_point,
+            &addresses.fee_collectors,
+        )?;
+
+        if flow.swap.token_out == Address::ZERO && flow.venue_fee_out.is_none() {
+            let wrapped_fee = ctx
+                .transfer_ledger
+                .received_by(&addresses.fee_collectors)
+                .get(&ctx.registry.wrapped_native())
+                .copied()
+                .filter(|fee| !fee.is_zero());
+            if let Some(fee) = wrapped_fee {
+                flow.venue_fee_out = Some(fee);
+                flow.swap.amount_out = flow.swap.amount_out.saturating_add(fee);
+            }
+        }
+        Some(flow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use alloy::{
+        primitives::U256, providers::RootProvider, rpc::client::RpcClient,
+        transports::mock::Asserter,
+    };
+
+    use super::*;
+    use crate::decoder::{
+        decode::GasScope,
+        registry::Registry,
+        test_utils::{addr, make_transfer_log, receipt, swap, tx_hash},
+        transfer_ledger::TransferLedger,
+    };
+
+    fn fee_wallet(registry: &Registry) -> Address {
+        *registry
+            .venue("rabby")
+            .unwrap()
+            .fee_collectors
+            .iter()
+            .next()
+            .unwrap()
+    }
+
+    /// Decode a Rabby transaction through the full `RabbyNetting` decoder.
+    async fn decode(
+        registry: &Registry,
+        ledger: &TransferLedger,
+        sender: Address,
+        entry_point: Address,
+    ) -> Option<TraderFlow> {
+        let provider = RootProvider::new(RpcClient::mocked(Asserter::new()));
+        let mut code_cache = HashMap::new();
+        let receipt = receipt(tx_hash(1), sender, Some(entry_point), vec![]);
+        let mut ctx = DecodeContext {
+            provider: &provider,
+            registry,
+            code_cache: &mut code_cache,
+            receipt: &receipt,
+            entry_point,
+            transfer_ledger: ledger,
+            input: &[],
+            venue: registry.venue("rabby"),
+        };
+        RabbyNetting.decode(&mut ctx).await
+    }
+
+    #[tokio::test]
+    async fn test_eth_output_wraps_fee_back_in() {
+        // Live tx 0x96c81d9b… shape: USDC in, ETH out through the SwapProxy. Rabby takes its
+        // 0.25% cut in WETH before unwrapping the rest to the trader, so the fee reaches the
+        // collector as WETH while the output token is native ETH. It must be grossed back into
+        // amount_out, else every ETH-output Rabby swap under-reports the settled output by 25 bps.
+        let registry = Registry::ethereum();
+        let collector = fee_wallet(&registry);
+        let user = addr(1);
+        let router = addr(2);
+        let pool = addr(50);
+        let usdc = addr(10);
+        let weth = registry.wrapped_native();
+
+        let logs = vec![
+            make_transfer_log(usdc, user, pool, U256::from(4000)),
+            make_transfer_log(weth, pool, router, U256::from(8000)),
+            make_transfer_log(weth, router, collector, U256::from(20)),
+        ];
+        let native = vec![(router, user, U256::from(7980))];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &native);
+
+        let flow = decode(&registry, &transfer_ledger, user, router)
+            .await
+            .unwrap();
+        assert_eq!(flow.tracked, user);
+        assert_eq!(flow.swap, swap(usdc, 4000, Address::ZERO, 8000));
+        assert_eq!(flow.venue_fee_in, None);
+        assert_eq!(flow.venue_fee_out, Some(U256::from(20)));
+        assert_eq!(flow.gas_scope, GasScope::SolverFrame);
+    }
+
+    #[tokio::test]
+    async fn test_token_output_fee() {
+        // Token-to-token swap: the fee reaches the collector in the output token itself, so the
+        // shared back-out grosses it in and the Rabby wrapped-native branch stays out of the way.
+        let registry = Registry::ethereum();
+        let collector = fee_wallet(&registry);
+        let user = addr(1);
+        let router = addr(2);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, user, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, user, U256::from(1995)),
+            make_transfer_log(token_out, pool, collector, U256::from(5)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+
+        let flow = decode(&registry, &transfer_ledger, user, router)
+            .await
+            .unwrap();
+        assert_eq!(flow.swap, swap(token_in, 1000, token_out, 2000));
+        assert_eq!(flow.venue_fee_out, Some(U256::from(5)));
+    }
+
+    #[tokio::test]
+    async fn test_fee_free_trade() {
+        let registry = Registry::ethereum();
+        let user = addr(1);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, user, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, user, U256::from(2000)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+
+        let flow = decode(&registry, &transfer_ledger, user, pool)
+            .await
+            .unwrap();
+        assert_eq!(flow.swap, swap(token_in, 1000, token_out, 2000));
+        assert_eq!(flow.venue_fee_in, None);
+        assert_eq!(flow.venue_fee_out, None);
+    }
+}

--- a/tools/hindsight/src/decoder/venues/rainbow.rs
+++ b/tools/hindsight/src/decoder/venues/rainbow.rs
@@ -20,7 +20,7 @@ use crate::decoder::{
     netting_decoders::venue_flow,
 };
 
-/// Selector of `fillQuoteEthToToken(address buyToken, address to, bytes data, uint256 feeAmount)`.
+/// Selector of Rainbow's ETH→token call, whose 4th argument is the input-side fee.
 const FILL_QUOTE_ETH_TO_TOKEN: [u8; 4] = [0x3c, 0x2b, 0x9a, 0x7d];
 
 /// Rainbow's calldata decoder.

--- a/tools/hindsight/src/decoder/venues/rainbow.rs
+++ b/tools/hindsight/src/decoder/venues/rainbow.rs
@@ -1,0 +1,148 @@
+//! Rainbow decoding.
+//!
+//! Rainbow is a consumer wallet with its own router (`0x0000…10e2`, the same address on every
+//! chain it supports). It wraps 0x and takes its fee on the input side, passed explicitly as the
+//! call's `feeAmount` argument and kept by the router — there is no fee transfer to observe, so the
+//! fee is read from the calldata.
+//!
+//! Only the ETH→token entry (`fillQuoteEthToToken`) is decoded: its `feeAmount` is an absolute
+//! amount of the input ETH (verified on-chain, tx 0xe09cf895…). The token→ETH and token→token
+//! entries encode their cut as a basis-point rate instead (see `rainbow-me/swaps`), so they are
+//! declined until that is verified — a declined trade is a coverage gap, never a mis-priced record.
+
+use std::collections::HashSet;
+
+use alloy::{primitives::U256, providers::Provider};
+use async_trait::async_trait;
+
+use crate::decoder::{
+    decode::{DecodeContext, TradeDecoder, TraderFlow},
+    netting_decoders::venue_flow,
+};
+
+/// Selector of `fillQuoteEthToToken(address buyToken, address to, bytes data, uint256 feeAmount)`.
+const FILL_QUOTE_ETH_TO_TOKEN: [u8; 4] = [0x3c, 0x2b, 0x9a, 0x7d];
+
+/// Rainbow's calldata decoder.
+pub(crate) struct RainbowCalldata;
+
+#[async_trait]
+impl<P: Provider> TradeDecoder<P> for RainbowCalldata {
+    fn name(&self) -> &'static str {
+        "rainbow-calldata"
+    }
+
+    /// Net the sender's flow, then subtract the input-side fee read from the calldata so the
+    /// amount that entered the swap is comparable to a re-solve. Declines any non-ETH→token call.
+    async fn decode(&self, ctx: &mut DecodeContext<'_, P>) -> Option<TraderFlow> {
+        let fee = eth_to_token_fee(ctx.input)?;
+        // The router keeps no fee transfer, so there is nothing for `venue_flow` to back out; it
+        // just nets the sender. The input-side fee is applied here.
+        let mut flow =
+            venue_flow(ctx.transfer_ledger, ctx.receipt.from, ctx.entry_point, &HashSet::new())?;
+        flow.venue_fee_in = Some(fee);
+        flow.swap.amount_in = flow.swap.amount_in.saturating_sub(fee);
+        Some(flow)
+    }
+}
+
+/// The input-side fee of a `fillQuoteEthToToken` call — its 4th (static `uint256`) argument — or
+/// `None` for any other selector or a too-short input.
+fn eth_to_token_fee(input: &[u8]) -> Option<U256> {
+    let (selector, args) = input.split_at_checked(4)?;
+    if selector != FILL_QUOTE_ETH_TO_TOKEN {
+        return None;
+    }
+    // Args are `buyToken, to, data (offset), feeAmount`; `feeAmount` is the 4th 32-byte word.
+    let word = args.get(3 * 32..4 * 32)?;
+    Some(U256::from_be_slice(word))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use alloy::{
+        primitives::{Address, U256},
+        providers::RootProvider,
+        rpc::client::RpcClient,
+        transports::mock::Asserter,
+    };
+
+    use super::*;
+    use crate::decoder::{
+        registry::Registry,
+        test_utils::{addr, make_transfer_log, receipt, swap, tx_hash},
+        transfer_ledger::TransferLedger,
+    };
+
+    /// `fillQuoteEthToToken` calldata carrying `fee` as its 4th word.
+    fn eth_to_token_calldata(fee: u64) -> Vec<u8> {
+        let mut input = FILL_QUOTE_ETH_TO_TOKEN.to_vec();
+        input.extend_from_slice(&[0u8; 32]); // buyToken
+        input.extend_from_slice(&[0u8; 32]); // to
+        input.extend_from_slice(&[0u8; 32]); // data offset
+        input.extend_from_slice(&U256::from(fee).to_be_bytes::<32>()); // feeAmount
+        input
+    }
+
+    async fn decode(
+        input: &[u8],
+        ledger: &TransferLedger,
+        entry_point: Address,
+    ) -> Option<TraderFlow> {
+        let registry = Registry::ethereum();
+        let provider = RootProvider::new(RpcClient::mocked(Asserter::new()));
+        let mut code_cache = HashMap::new();
+        let user = addr(1);
+        let receipt = receipt(tx_hash(1), user, Some(entry_point), vec![]);
+        let mut ctx = DecodeContext {
+            provider: &provider,
+            registry: &registry,
+            code_cache: &mut code_cache,
+            receipt: &receipt,
+            entry_point,
+            transfer_ledger: ledger,
+            input,
+            venue: registry.venue("rainbow"),
+        };
+        RainbowCalldata.decode(&mut ctx).await
+    }
+
+    #[tokio::test]
+    async fn test_eth_to_token_subtracts_input_fee() {
+        // ETH in, token out through the Rainbow router: the fee is part of the ETH the user sent
+        // but never entered the swap, so amount_in must drop by it (else Fynd is handed the fee).
+        let user = addr(1);
+        let router = addr(2);
+        let pool = addr(50);
+        let token_out = addr(11);
+        let native = vec![(user, router, U256::from(18_500))];
+        let logs = vec![make_transfer_log(token_out, pool, user, U256::from(34_000))];
+        let ledger = TransferLedger::from_transaction(&logs, &native);
+
+        let flow = decode(&eth_to_token_calldata(157), &ledger, router)
+            .await
+            .unwrap();
+        assert_eq!(flow.swap, swap(Address::ZERO, 18_500 - 157, token_out, 34_000));
+        assert_eq!(flow.venue_fee_in, Some(U256::from(157)));
+        assert_eq!(flow.venue_fee_out, None);
+    }
+
+    #[tokio::test]
+    async fn test_other_selector_declined() {
+        // A non-ETH→token call (here an empty/unknown selector) is declined rather than decoded
+        // without its fee.
+        let user = addr(1);
+        let router = addr(2);
+        let pool = addr(50);
+        let token_out = addr(11);
+        let native = vec![(user, router, U256::from(18_500))];
+        let logs = vec![make_transfer_log(token_out, pool, user, U256::from(34_000))];
+        let ledger = TransferLedger::from_transaction(&logs, &native);
+
+        assert!(decode(&[0xde, 0xad, 0xbe, 0xef], &ledger, router)
+            .await
+            .is_none());
+    }
+}

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -40,7 +40,7 @@ enum Command {
 /// Chain-specific configuration beyond the RPC endpoint and address book belongs here too.
 #[derive(Args)]
 pub(crate) struct ChainArgs {
-    /// Chain to operate on — selects the decoder's address book (only ethereum is built in)
+    /// Chain to operate on — selects the decoder's address book
     #[arg(long = "chain", value_name = "CHAIN", default_value = "ethereum")]
     pub name: String,
 

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -7,7 +7,11 @@
 //! parent module via a mock `SteppingSolver`; this live driver is exercised by the gated
 //! integration test in `tests/` (requires `TYCHO_URL` + `RPC_URL`).
 
-use std::time::{Duration, Instant};
+use std::{
+    future::Future,
+    pin::Pin,
+    time::{Duration, Instant},
+};
 
 use alloy::{
     primitives::{Address, U256},
@@ -324,10 +328,48 @@ fn default_lag_blocks(chain: &str) -> u64 {
     (20 * 60 / block_secs).max(1)
 }
 
+/// Resolves when the process receives Ctrl-C (SIGINT), the signal the monitor treats as "stop".
+/// If the handler cannot be installed the future never resolves, so a failed registration disables
+/// graceful shutdown rather than tearing the run down immediately.
+async fn shutdown_signal() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        warn!(error = %e, "failed to install Ctrl-C handler; graceful shutdown disabled");
+        std::future::pending::<()>().await;
+    }
+}
+
+/// Rebuild the solver after a feed death, retrying with backoff until it succeeds. Returns `None`
+/// when `shutdown` resolves first (Ctrl-C during the retry loop or a build), so the caller stops
+/// instead of rebuilding.
+async fn rebuild_after_feed_death<S: Future<Output = ()>>(
+    cfg: &MonitorArgs,
+    chain: Chain,
+    protocols: &[String],
+    pools_config: &fynd_rpc::config::WorkerPoolsConfig,
+    mut shutdown: Pin<&mut S>,
+) -> Option<(Solver, BlockStepController)> {
+    loop {
+        let rebuilt = tokio::select! {
+            biased;
+            () = shutdown.as_mut() => return None,
+            result = async {
+                tokio::time::sleep(REBUILD_BACKOFF).await;
+                build_solver(cfg, chain, protocols, pools_config).await
+            } => result,
+        };
+        match rebuilt {
+            Ok(built) => return Some(built),
+            Err(e) => warn!(error = %e, "solver rebuild failed; retrying"),
+        }
+    }
+}
+
 /// Build the in-process stepped solver and re-solve each block's settled trades as a top/back
 /// range. When the tycho feed dies (its stream ends, or no block arrives within
 /// `FEED_DEAD_TIMEOUT`), the solver is torn down and rebuilt in place — fresh subscriptions,
 /// same decoder cache and comparisons file — so a long unattended run survives feed failures.
+/// Ctrl-C stops the run cleanly at any await point, tearing the current solver down before
+/// returning.
 pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
     let chain = parse_chain(&cfg.chain.name)
         .map_err(|e| anyhow::anyhow!("invalid --chain '{}': {e}", cfg.chain.name))?;
@@ -385,37 +427,55 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
         .max_lag_blocks
         .unwrap_or_else(|| default_lag_blocks(&cfg.chain.name));
     info!(max_lag_blocks, "chain-head lag threshold");
+
+    // Resolves on Ctrl-C, so a long run stops cleanly at any await below — including the
+    // multi-minute solver builds. On shutdown the in-flight block is abandoned, the solver's
+    // workers and background tasks are torn down, and `comparisons` flushes as it drops.
+    let shutdown = shutdown_signal();
+    tokio::pin!(shutdown);
+
     // The first build fails fast — an error here is a configuration problem. Rebuilds after a
     // feed death retry forever, since the config is known good and failures are transient.
-    let (mut solver, mut controller) = build_solver(&cfg, chain, &protocols, &pools_config).await?;
+    let (mut solver, mut controller) = tokio::select! {
+        biased;
+        () = &mut shutdown => return Ok(()),
+        built = build_solver(&cfg, chain, &protocols, &pools_config) => built?,
+    };
     loop {
         let adapter =
             StepAdapter { solver: &solver, controller: &controller, timeout_ms: cfg.timeout_ms };
-        match run_session(
-            &cfg,
-            max_lag_blocks,
-            &adapter,
-            &mut decoder,
-            &mut comparisons,
-            &mut totals,
-        )
-        .await
-        {
-            SessionEnd::Complete => return Ok(()),
-            SessionEnd::Unhealthy(reason) => {
-                warn!(reason, "session unhealthy; rebuilding the solver to resubscribe");
-                telemetry::record_feed_rebuild();
+        let reason = tokio::select! {
+            biased;
+            () = &mut shutdown => {
+                info!("received Ctrl-C; shutting down");
+                break;
             }
-        }
-        solver.shutdown();
-        (solver, controller) = loop {
-            tokio::time::sleep(REBUILD_BACKOFF).await;
-            match build_solver(&cfg, chain, &protocols, &pools_config).await {
-                Ok(built) => break built,
-                Err(e) => warn!(error = %e, "solver rebuild failed; retrying"),
-            }
+            end = run_session(
+                &cfg,
+                max_lag_blocks,
+                &adapter,
+                &mut decoder,
+                &mut comparisons,
+                &mut totals,
+            ) => match end {
+                SessionEnd::Complete => break,
+                SessionEnd::Unhealthy(reason) => reason,
+            },
         };
+        warn!(reason, "session unhealthy; rebuilding the solver to resubscribe");
+        telemetry::record_feed_rebuild();
+        solver.shutdown();
+        let Some(built) =
+            rebuild_after_feed_death(&cfg, chain, &protocols, &pools_config, shutdown.as_mut())
+                .await
+        else {
+            info!("received Ctrl-C during rebuild; shutting down");
+            return Ok(());
+        };
+        (solver, controller) = built;
     }
+    solver.shutdown();
+    Ok(())
 }
 
 /// Drive one solver session: step blocks and re-solve each block's settled trades until the run

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -96,11 +96,10 @@ pub(crate) struct MonitorArgs {
 
     /// Chain-head lag (in blocks) beyond which the session is considered unhealthy and the solver
     /// is rebuilt — seen live: a worker died, every solve crawled, and the monitor slid hours
-    /// behind while the feed-dead watchdog never fired (blocks still trickled through). The
-    /// default is ~20 minutes on Ethereum mainnet's 12s blocks; scale it to the chain's block
-    /// time
-    #[arg(long, default_value_t = 100)]
-    pub max_lag_blocks: u64,
+    /// behind while the feed-dead watchdog never fired (blocks still trickled through). When
+    /// omitted, defaults to roughly 20 minutes' worth of blocks for the chain's block time
+    #[arg(long)]
+    pub max_lag_blocks: Option<u64>,
 
     /// Write one JSON line per re-solved trade (every comparison — wins, losses, and unsolvable
     /// coverage gaps) into this directory as `comparisons-YYYY-MM-DD.jsonl`, rotated at each UTC
@@ -314,6 +313,17 @@ async fn build_solver(
         .map_err(|e| anyhow::anyhow!("failed to build solver: {e}"))
 }
 
+/// Default chain-head lag threshold in blocks — about 20 minutes at the chain's block time, so the
+/// wall-clock tolerance stays roughly the same across chains. Used when `--max-lag-blocks` is not
+/// given; an unrecognised chain falls back to the 12-second-block assumption.
+fn default_lag_blocks(chain: &str) -> u64 {
+    let block_secs = match chain.to_lowercase().as_str() {
+        "base" => 2,
+        _ => 12,
+    };
+    (20 * 60 / block_secs).max(1)
+}
+
 /// Build the in-process stepped solver and re-solve each block's settled trades as a top/back
 /// range. When the tycho feed dies (its stream ends, or no block arrives within
 /// `FEED_DEAD_TIMEOUT`), the solver is torn down and rebuilt in place — fresh subscriptions,
@@ -371,13 +381,26 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
     };
 
     let mut totals = Totals::default();
+    let max_lag_blocks = cfg
+        .max_lag_blocks
+        .unwrap_or_else(|| default_lag_blocks(&cfg.chain.name));
+    info!(max_lag_blocks, "chain-head lag threshold");
     // The first build fails fast — an error here is a configuration problem. Rebuilds after a
     // feed death retry forever, since the config is known good and failures are transient.
     let (mut solver, mut controller) = build_solver(&cfg, chain, &protocols, &pools_config).await?;
     loop {
         let adapter =
             StepAdapter { solver: &solver, controller: &controller, timeout_ms: cfg.timeout_ms };
-        match run_session(&cfg, &adapter, &mut decoder, &mut comparisons, &mut totals).await {
+        match run_session(
+            &cfg,
+            max_lag_blocks,
+            &adapter,
+            &mut decoder,
+            &mut comparisons,
+            &mut totals,
+        )
+        .await
+        {
             SessionEnd::Complete => return Ok(()),
             SessionEnd::Unhealthy(reason) => {
                 warn!(reason, "session unhealthy; rebuilding the solver to resubscribe");
@@ -399,6 +422,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
 /// completes or the feed dies.
 async fn run_session<P: Provider>(
     cfg: &MonitorArgs,
+    max_lag_blocks: u64,
     adapter: &StepAdapter<'_>,
     decoder: &mut Decoder<P>,
     comparisons: &mut Option<super::jsonl::RotatingWriter>,
@@ -437,7 +461,7 @@ async fn run_session<P: Provider>(
             .get_block_number()
             .await
         {
-            if head.saturating_sub(target) > cfg.max_lag_blocks {
+            if head.saturating_sub(target) > max_lag_blocks {
                 return SessionEnd::Unhealthy(format!(
                     "monitor is {} blocks behind head {head}; presuming an unhealthy session",
                     head - target
@@ -556,6 +580,14 @@ fn core_to_alloy(address: &CoreAddress) -> Option<Address> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_default_lag_blocks_scales_with_block_time() {
+        assert_eq!(default_lag_blocks("ethereum"), 100); // 12s blocks
+        assert_eq!(default_lag_blocks("base"), 600); // 2s blocks
+        assert_eq!(default_lag_blocks("BASE"), 600);
+        assert_eq!(default_lag_blocks("unknown"), 100);
+    }
+
     /// End-to-end smoke test of the live two-state monitor against a real solver.
     ///
     /// `#[ignore]`d so it never runs in CI (no Tycho/RPC). Run with:
@@ -578,7 +610,7 @@ mod tests {
             timeout_ms: 10_000,
             metrics_port: None,
             max_blocks: Some(1),
-            max_lag_blocks: 100,
+            max_lag_blocks: Some(100),
             comparisons_dir: None,
         })
         .await


### PR DESCRIPTION
Extends the decoder (#313) to a new chain, more clients, and a client-attribution layer that identifies the order-flow owner when the entry point alone cannot.

Client addresses and fingerprints come from the [Top Client Swap Addresses — Hindsight Targets](https://propeller-heads.atlassian.net/wiki/spaces/DEFI/pages/3834904577/Top+Client+Swap+Addresses+-+Hindsight+Targets#Confirmed-clients) doc (sources cited there, example txs verified on-chain 2026-07-17).

## Base chain

- Base address book (`registry/base.toml`): wrapped native, stablecoins, batch settlers, solvers, and venues, with fee collectors verified on-chain.
- OP-stack receipts: fetch as `AnyTransactionReceipt` so the system deposit transaction (type `0x7e`) does not fail the whole block.
- `base_pools.toml` worker-pools config for running the monitor on Base.
- Monitor chain-head lag threshold defaults to ~20 minutes of the chain's block time (2s on Base), not a fixed block count.

## Monitor

- Ctrl-C shuts the run down cleanly: the signal is raced against every long await (initial build, per-block session, feed-death rebuild), the solver's workers and background tasks are torn down, and the process exits.

## Client attribution

A single step overrides the venue after decode when a client owns the order flow without being `tx.to`. It is registry-driven; the provider-specific pieces (reading LiFi's event, reading a CoW order's appData) sit behind the decoder/solver modules. Four fingerprints:

- **owning trader** (`[client_owners]`) — kpk's Safes settling through CoW, surfaced from the CoW `Trade` event's owner.
- **CoW appData tag** (`[client_appdata]`) — LlamaSwap, from the static appData hash (appCode "DefiLlama") its CoW orders commit, read from the settle calldata.
- **fee wallet** (`[client_fees]`) — Phantom, Robinhood; the fee is grossed back so the settled output stays comparable. Checked only inside a matched solver trade, so a bare dust transfer to a fee wallet is not mistaken for flow.
- **provider integrator tag** (`[client_integrators]`) — LiFi frontends (Infinex on ETH and Base; Robinhood's LiFi leg), read from the LiFi swap event.

This closes the earlier gap where a client routing through a shared router (0x, 1inch) looked like that router's own trade.

## Venues and solvers

- **Rabby** — own router, fee removed.
- **Coinbase Wallet** — own proxies plus fee wallet.
- **Rainbow** — own router; input-side fee read from calldata.
- **Fly** (Magpie) — Base solver.
- **0x quote** recovery from positive slippage.

## CoW settlements

Single-order CoW settlements are read from the GPv2 `Trade` event: exact executed amounts, the fee backed out of the input, and the owner taken directly from the event (so kpk attribution is exact). Runs only when CoW is the entry point — a CoW settlement reached through a venue (Relay) decodes as that venue's trade with CoW as the underlying solver. The Intent-role decoders (CoW, plus the generic net-flow finder it falls back to) live under a new `intents/` module, mirroring `venues/`. This covers the large majority of CoW flow: in a recent ~700-block on-chain sample, 97% of settlements were single-order (456 of 471); multi-order batches fall back to net-flow decoding.

## Limitations

- **CoW multi-order batches** fall back to net-flow decoding (one trade per transaction), so batch volume is under-counted, as before.
- **Rainbow** decodes only its ETH→token entry; the token→ETH and token→token entries encode a basis-point fee and are declined (a coverage gap, not a mispriced trade) until verified on-chain.
- **LlamaSwap** is caught only on its CoW leg (the appData hash). Its 0x-surplus recipient, tried first, turned out dead — no on-chain inflows for months — and its Kyber leg is tagged only off-chain, so those are not decodable here. LlamaSwap's CoW flow is very sparse (0 orders in a 26h/3,773-settlement on-chain sample), so it rarely appears — expected, not a miss.
- **Coinbase Wallet**'s proxies have been quiet since late 2025, so it mainly decodes historical flow.
- **Relay on Base** decodes ~65% of its flow (670 of 1,027 in the Base run); the rest deliver the swap output to a receiver other than the sender, so net-flow decoding declines — a coverage miss, not a mispriced trade.

## Notes

- kpk is a low-frequency client by design — the targets doc characterizes it as very large, infrequent tickets (single trades in the $10Ms), so it is expected not to appear in a short sample window. Its attribution is exercised by the CoW Trade decoder (owner read from the event), which fired throughout the run; a longer window would surface it.
- Rainbow's fee mechanic was not what its "fee held in-router" description implied — it is an input-side fee argument in the call, retained by the router (verified on tx `0xe09cf895…`). The decoder reads that argument rather than a fee transfer.
- CoW's on-chain fee is zero on modern orders (priced into the order), so the input-fee back-out is exact for current flow and best-effort for legacy non-zero fees.
- Fee-identified clients are only recognized inside an already-matched solver trade, which sidesteps the dust-spray problem (labeled fee wallets are heavily spammed) that a naive "transfers to the fee wallet" scan would hit.

## Sample run

Exercised across three monitor runs — **Ethereum** (1000 + 300 blocks, `--min-tvl 100`) and **Base** (1000 blocks, `--min-tvl 10`) — 8,587 re-solved trades combined. Everything listed is new in this PR (Base support included).

| Category | Combined across the three runs |
|---|---|
| **Client attributions** (wallets/frontends) | phantom 171 · rabby 101 · robinhood 97 · rainbow 1 — all Ethereum. kpk, LlamaSwap, Coinbase, Infinex are wired but too rare to appear in these windows |
| **Solver** | fly 32 — Base |
| **Decoders** | sender-netting 3927 · intent-netting 1991 · relay-netting 1435 · metamask-netting 640 · **cow-trade 492** · rabby-netting 101 · **rainbow-calldata 1** |
| **Verdicts** (top-of-block) | win 1877 · loss 1292 · unsolvable 5388 · coverage-miss 20 · sandwiched 10 |

New decoders this PR are **cow-trade** and **rainbow-calldata**; the `*-netting` decoders are the existing pipeline, shown for volume context. `cow` and `fly` are solvers (settlement/routing), not client attributions — CoW settlement decoding shows up as the `cow-trade` decoder.

**Why kpk, LlamaSwap, Coinbase, and Infinex have no live example here.** Their fingerprints are wired and unit-tested; they just had no matching trade in these windows — each is low-frequency or off its former flow:

- **kpk** — very large, infrequent tickets by design (single trades in the $10Ms, per the targets doc). Attributed from the CoW `Trade` owner, which fired throughout — just never for a kpk Safe.
- **LlamaSwap** — its only on-chain fingerprint is the CoW appData hash, and its CoW flow is very sparse (0 orders in a 26h / 3,773-settlement on-chain sample).
- **Coinbase Wallet** — its swap proxies have been quiet since late 2025, so it mainly decodes historical flow.
- **Infinex** — read from the LiFi integrator tag; LiFi decoded 54× on Base but no Infinex-tagged order landed in the ~33-min Base window.

**Wins sanity — no real-money artifacts.** On trades settling >$1k (245 wins) bps tops out at 244 and 221 fall under 50 bps. Extreme bps is a dust effect only: all 63 wins above 1000 bps are sub-$10 trades, and the two >100% ("impossible") wins are sub-$1 dust ($0.30 and $0.10 settled, ~$0.005 total). No fee-backed client (phantom / rabby / robinhood / metamask) appears among the top wins — the fee back-out holds. No structural artifacts: no zero-amount or same-token trades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



