### PR TITLE
feat(config): introduce tuning presets (balanced, deep)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,6 +3436,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "strum 0.27.2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,9 @@ tycho-execution = ">=0.331.0"
 tycho-simulation = ">=0.331.0"
 typetag = "0.2"
 
+# Enum derives (Display, FromStr, variant listing)
+strum = { version = "0.27", features = ["derive"] }
+
 # Compression
 zstd = "0.13"
 

--- a/fynd-core/Cargo.toml
+++ b/fynd-core/Cargo.toml
@@ -37,6 +37,7 @@ tycho-execution.workspace = true
 reqwest.workspace = true
 tokio-tungstenite.workspace = true
 toml.workspace = true
+strum.workspace = true
 alloy = { workspace = true, features = ["sol-types"] }
 
 [features]

--- a/fynd-core/src/config/default_config.toml
+++ b/fynd-core/src/config/default_config.toml
@@ -1,13 +1,18 @@
-# Embedded default solver configuration, compiled into the binary.
+# Embedded default solver configurations, compiled into the binary — one section per
+# preset (see `config::Preset`).
 #
-# This file is the single source of truth for all solver-tuning defaults:
-# `FyndBuilder::new` seeds its initial values from it, and the fynd binary uses it as the
-# base layer of config resolution (CLI flags > local config file > this file).
+# This file is the single source of truth for all solver-tuning defaults: the fynd binary
+# resolves the selected preset's section as the base layer (CLI flags > local config file >
+# remote config > this file), and `FyndBuilder::new` seeds from the `balanced` section.
 #
 # `min_tvl` is intentionally absent: it falls back to a chain-specific default TVL
-# threshold when no layer sets it. Every other field must be defined here — unit tests
-# (`config::tests::test_embedded_default_is_complete_and_valid`) enforce completeness.
+# threshold when no layer sets it. Every other field must be defined in every section —
+# unit tests (`config::tests`) enforce completeness and agreement with the `Preset` enum.
+#
+# NOTE: `balanced` and `deep` currently share the same values; `deep` will be tuned for
+# route quality over latency later.
 
+[balanced]
 tvl_buffer_ratio = 1.1
 min_token_quality = 100
 traded_n_days_ago = 3
@@ -18,7 +23,26 @@ worker_router_min_responses = 0
 partial_blocks = false
 protocols = ["all_onchain"]
 
-[pools.bellman_ford_2_hops]
+[balanced.pools.bellman_ford_2_hops]
+algorithm = "bellman_ford"
+num_workers = 3
+task_queue_capacity = 1000
+min_hops = 1
+max_hops = 2
+timeout_ms = 500
+
+[deep]
+tvl_buffer_ratio = 1.1
+min_token_quality = 100
+traded_n_days_ago = 3
+gas_refresh_interval_secs = 30
+reconnect_delay_secs = 5
+worker_router_timeout_ms = 100
+worker_router_min_responses = 0
+partial_blocks = false
+protocols = ["all_onchain"]
+
+[deep.pools.bellman_ford_2_hops]
 algorithm = "bellman_ford"
 num_workers = 3
 task_queue_capacity = 1000

--- a/fynd-core/src/config/mod.rs
+++ b/fynd-core/src/config/mod.rs
@@ -1,12 +1,19 @@
 //! Layered solver configuration.
 //!
-//! Every solver-tuning field resolves independently through three layers, highest priority
+//! Every solver-tuning field resolves independently through four layers, highest priority
 //! first:
 //!
 //! 1. **Explicit overrides** — lib builder setters or CLI flags
 //! 2. **Local config file** — any subset of the fields, same schema as the embedded default
-//! 3. **Remote config** — tuned values pulled from S3 per chain (see [`remote`])
-//! 4. **Embedded default** — `default_config.toml`, compiled into the binary
+//! 3. **Remote config** — tuned values pulled from S3 per chain, one section per preset (see
+//!    [`remote`])
+//! 4. **Embedded default** — the selected preset's section of `default_config.toml`, compiled into
+//!    the binary
+//!
+//! A [`Preset`] names a tuning profile; both the embedded defaults and the remote payloads
+//! are maintained per preset. Selecting one only changes which defaults apply underneath —
+//! local overrides always win, and the preset itself is chosen via CLI/lib, never inside a
+//! config file.
 //!
 //! The embedded default deserializes directly into a complete [`Config`] — every field
 //! (except the chain-specific `min_tvl`) is required, so a gap between the struct and
@@ -25,9 +32,9 @@
 //! use fynd_core::config::{embedded_default, PartialConfig};
 //!
 //! let overrides = PartialConfig { worker_router_timeout_ms: Some(50), ..Default::default() };
-//! let config = embedded_default()
+//! let config = embedded_default(Preset::Balanced)
 //!     .clone()
-//!     .apply_remote(&remote::default_remote_config_url(chain), timeout)
+//!     .apply_remote(&remote::default_remote_config_url(chain), preset, timeout)
 //!     .await
 //!     .apply(&PartialConfig::from_file("fynd.toml")?)
 //!     .apply(&overrides);
@@ -36,6 +43,47 @@
 //! ```
 
 use std::{collections::HashMap, path::Path, sync::LazyLock};
+
+/// A named tuning profile for the default configuration (embedded and remote).
+///
+/// Presets only select which *defaults* apply; every config layer above them behaves
+/// identically. Each variant corresponds to a section of `default_config.toml` (and a
+/// remote payload path), named after the lowercase variant name; unit tests guard against
+/// the enum and the file drifting apart. Adding a preset requires only a new variant here
+/// and a matching section in the file — names, parsing, and listing are derived.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    strum::Display,
+    strum::EnumString,
+    strum::IntoStaticStr,
+    strum::VariantArray,
+)]
+#[strum(serialize_all = "lowercase", ascii_case_insensitive)]
+pub enum Preset {
+    /// Balanced latency/quality trade-off: the historic defaults.
+    Balanced,
+    /// Tuned for route quality over latency (deeper searches, more generous timeouts).
+    /// NOTE: currently identical to `Balanced`; to be tuned.
+    Deep,
+}
+
+impl Preset {
+    /// All presets, in declaration order.
+    pub fn all() -> &'static [Preset] {
+        <Preset as strum::VariantArray>::VARIANTS
+    }
+
+    /// The preset's name as used in `default_config.toml` sections, remote payload paths,
+    /// and on the CLI.
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
 
 use serde::Deserialize;
 use tycho_simulation::tycho_common::models::{Chain, TvlThresholdTier};
@@ -122,12 +170,77 @@ pub struct PartialConfig {
 }
 
 impl PartialConfig {
+    /// Every field name, for detecting unknown keys in hand-written config files.
+    /// Kept in sync with the struct by `test_known_fields_match_struct`.
+    const KNOWN_FIELDS: &'static [&'static str] = &[
+        "min_tvl",
+        "tvl_buffer_ratio",
+        "min_token_quality",
+        "traded_n_days_ago",
+        "gas_refresh_interval_secs",
+        "reconnect_delay_secs",
+        "worker_router_timeout_ms",
+        "worker_router_min_responses",
+        "partial_blocks",
+        "protocols",
+        "pools",
+    ];
+
+    /// Names of the fields this layer sets, in declaration order.
+    ///
+    /// Used to log what a layer actually changed (e.g. what the remote config applied).
+    pub fn set_fields(&self) -> Vec<&'static str> {
+        // Exhaustive destructuring (no `..`): adding a field without listing it here is a
+        // compile error.
+        let Self {
+            min_tvl,
+            tvl_buffer_ratio,
+            min_token_quality,
+            traded_n_days_ago,
+            gas_refresh_interval_secs,
+            reconnect_delay_secs,
+            worker_router_timeout_ms,
+            worker_router_min_responses,
+            partial_blocks,
+            protocols,
+            pools,
+        } = self;
+        let mut fields = Vec::new();
+        let mut record = |set: bool, name: &'static str| {
+            if set {
+                fields.push(name);
+            }
+        };
+        record(min_tvl.is_some(), "min_tvl");
+        record(tvl_buffer_ratio.is_some(), "tvl_buffer_ratio");
+        record(min_token_quality.is_some(), "min_token_quality");
+        record(traded_n_days_ago.is_some(), "traded_n_days_ago");
+        record(gas_refresh_interval_secs.is_some(), "gas_refresh_interval_secs");
+        record(reconnect_delay_secs.is_some(), "reconnect_delay_secs");
+        record(worker_router_timeout_ms.is_some(), "worker_router_timeout_ms");
+        record(worker_router_min_responses.is_some(), "worker_router_min_responses");
+        record(partial_blocks.is_some(), "partial_blocks");
+        record(protocols.is_some(), "protocols");
+        record(pools.is_some(), "pools");
+        fields
+    }
+
     /// Parses a config layer from a TOML string.
     ///
-    /// `source` names the origin (e.g. a file path) for error messages. Unknown fields are
-    /// ignored (see the type-level docs).
+    /// `source` names the origin (e.g. a file path) for error messages. Unknown keys are
+    /// ignored but logged as warnings: in a hand-written file an unknown key is most
+    /// likely a typo silently falling through to lower layers.
     pub fn from_toml_str(raw: &str, source: &str) -> Result<Self, ConfigError> {
-        toml::from_str(raw)
+        let value: toml::Value = toml::from_str(raw)
+            .map_err(|e| ConfigError::Parse { context: source.to_string(), source: e })?;
+        if let Some(table) = value.as_table() {
+            for key in table.keys() {
+                if !Self::KNOWN_FIELDS.contains(&key.as_str()) {
+                    tracing::warn!(source, key, "unknown config key ignored (typo?)");
+                }
+            }
+        }
+        Self::deserialize(value)
             .map_err(|e| ConfigError::Parse { context: source.to_string(), source: e })
     }
 
@@ -140,38 +253,48 @@ impl PartialConfig {
     }
 }
 
-/// The embedded default configuration, parsed once on first use.
-static EMBEDDED_DEFAULT: LazyLock<Config> = LazyLock::new(|| {
-    toml::from_str(EMBEDDED_DEFAULT_TOML)
-        .expect("embedded default_config.toml is a complete, valid Config; checked by unit tests")
+/// The embedded default configurations, one per preset, parsed once on first use.
+static EMBEDDED_DEFAULTS: LazyLock<HashMap<Preset, Config>> = LazyLock::new(|| {
+    let sections: HashMap<String, Config> = toml::from_str(EMBEDDED_DEFAULT_TOML)
+        .expect("embedded default_config.toml is a complete, valid Config per preset; checked by unit tests");
+    Preset::all()
+        .iter()
+        .map(|&preset| {
+            let config = sections
+                .get(preset.as_str())
+                .expect("every Preset has a default_config.toml section; checked by unit tests")
+                .clone();
+            (preset, config)
+        })
+        .collect()
 });
 
-/// Returns the embedded default configuration (`default_config.toml`), parsed once and
-/// cached.
+/// Returns the embedded default configuration for `preset` (its section of
+/// `default_config.toml`), parsed once and cached.
 ///
-/// This is the single source of truth for all solver-tuning defaults. The TOML
+/// This file is the single source of truth for all solver-tuning defaults. Each section
 /// deserializes directly into a complete [`Config`]; every field is required except the
 /// chain-specific `min_tvl` (see [`Config::min_tvl`]).
-pub fn embedded_default() -> &'static Config {
-    &EMBEDDED_DEFAULT
+pub fn embedded_default(preset: Preset) -> &'static Config {
+    &EMBEDDED_DEFAULTS[&preset]
 }
 
 /// Overall time budget (including retries) for the fetch inside [`get_default`].
 /// Callers wanting a different budget use [`Config::apply_remote`] directly.
 const GET_DEFAULT_FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
 
-/// Returns the embedded default configuration with the latest remotely tuned values for
-/// `chain` applied on top, fetched from the default S3 URL (see
+/// Returns the embedded default configuration for `preset` with the latest remotely tuned
+/// values for `chain` applied on top, fetched from the default S3 URL (see
 /// [`remote::default_remote_config_url`]).
 ///
-/// The simple one-call form of `embedded_default().clone().apply_remote(...)`, with a
-/// built-in 2 s fetch budget. Never fails or panics: on any fetch problem the embedded
+/// The simple one-call form of `embedded_default(preset).clone().apply_remote(...)`, with
+/// a built-in 2 s fetch budget. Never fails or panics: on any fetch problem the embedded
 /// defaults are returned unchanged (a warning is logged). Layer local overrides on top
 /// with [`Config::apply`]; for a custom URL or timeout use [`Config::apply_remote`].
-pub async fn get_default(chain: Chain) -> Config {
-    embedded_default()
+pub async fn get_default(chain: Chain, preset: Preset) -> Config {
+    embedded_default(preset)
         .clone()
-        .apply_remote(&remote::default_remote_config_url(chain), GET_DEFAULT_FETCH_TIMEOUT)
+        .apply_remote(&remote::default_remote_config_url(chain), preset, GET_DEFAULT_FETCH_TIMEOUT)
         .await
 }
 
@@ -340,8 +463,30 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_embedded_presets_match_enum_and_are_valid() {
+        let sections: HashMap<String, Config> =
+            toml::from_str(EMBEDDED_DEFAULT_TOML).expect("embedded file failed to parse");
+        let mut section_names: Vec<&str> = sections
+            .keys()
+            .map(String::as_str)
+            .collect();
+        section_names.sort_unstable();
+        let mut enum_names: Vec<&str> = Preset::all()
+            .iter()
+            .map(|preset| preset.as_str())
+            .collect();
+        enum_names.sort_unstable();
+        assert_eq!(section_names, enum_names, "Preset enum and default_config.toml drifted");
+        for &preset in Preset::all() {
+            embedded_default(preset)
+                .validate()
+                .unwrap_or_else(|e| panic!("embedded '{preset}' failed validation: {e}"));
+        }
+    }
+
+    #[test]
     fn test_embedded_default_is_complete_and_valid() {
-        let config = embedded_default();
+        let config = embedded_default(Preset::Balanced);
         config
             .validate()
             .expect("embedded default failed validation");
@@ -369,7 +514,7 @@ mod tests {
             ..PartialConfig::default()
         };
         // Ascending priority: embedded default, then local config file, then overrides.
-        let config = embedded_default()
+        let config = embedded_default(Preset::Balanced)
             .clone()
             .apply(&local_file)
             .apply(&overrides);
@@ -392,7 +537,7 @@ mod tests {
             protocols: Some(vec!["curve".to_string()]),
             ..PartialConfig::default()
         };
-        let config = embedded_default()
+        let config = embedded_default(Preset::Balanced)
             .clone()
             .apply(&local_file);
         // The whole map/list is replaced, not merged entry by entry.
@@ -404,10 +549,30 @@ mod tests {
     #[test]
     fn test_min_tvl_override() {
         let overrides = PartialConfig { min_tvl: Some(42.0), ..PartialConfig::default() };
-        let config = embedded_default()
+        let config = embedded_default(Preset::Balanced)
             .clone()
             .apply(&overrides);
         assert_eq!(config.min_tvl, Some(42.0));
+    }
+
+    #[test]
+    fn test_known_fields_match_struct() {
+        // A fully-set PartialConfig must report every KNOWN_FIELDS entry: adding a struct
+        // field without updating KNOWN_FIELDS (or vice versa) fails here.
+        let full = PartialConfig {
+            min_tvl: Some(1.0),
+            tvl_buffer_ratio: Some(1.1),
+            min_token_quality: Some(1),
+            traded_n_days_ago: Some(1),
+            gas_refresh_interval_secs: Some(1),
+            reconnect_delay_secs: Some(1),
+            worker_router_timeout_ms: Some(1),
+            worker_router_min_responses: Some(1),
+            partial_blocks: Some(true),
+            protocols: Some(vec![]),
+            pools: Some(HashMap::new()),
+        };
+        assert_eq!(full.set_fields(), PartialConfig::KNOWN_FIELDS);
     }
 
     #[test]
@@ -454,7 +619,7 @@ mod tests {
     #[test]
     fn test_validation_runs_on_resolved_config() {
         let overrides = PartialConfig { tvl_buffer_ratio: Some(0.5), ..PartialConfig::default() };
-        let error = embedded_default()
+        let error = embedded_default(Preset::Balanced)
             .clone()
             .apply(&overrides)
             .validate()
@@ -476,7 +641,7 @@ mod tests {
                 .with_max_hops(2),
         );
         let overrides = PartialConfig { pools: Some(pools), ..PartialConfig::default() };
-        let error = embedded_default()
+        let error = embedded_default(Preset::Balanced)
             .clone()
             .apply(&overrides)
             .validate()

--- a/fynd-core/src/config/remote.rs
+++ b/fynd-core/src/config/remote.rs
@@ -2,8 +2,9 @@
 //!
 //! # Layering
 //!
-//! The remote payload is a [`PartialConfig`] in the same schema as the local config file,
-//! published per chain. It applies **right above the embedded default**:
+//! The remote payload is one document per chain with one [`PartialConfig`] section per
+//! preset (`[balanced]`, `[deep]` — the same layout as the embedded `default_config.toml`);
+//! the selected preset's section applies **right above the embedded default**:
 //!
 //! ```text
 //! CLI flags  >  local config file (fynd.toml)  >  remote config (S3)  >  embedded default
@@ -51,11 +52,11 @@ use std::time::Duration;
 
 use tycho_simulation::tycho_common::models::Chain;
 
-use super::{Config, ConfigError, PartialConfig};
+use super::{Config, ConfigError, PartialConfig, Preset};
 use crate::worker_pool::registry::AVAILABLE_ALGORITHMS;
 
 /// URL template behind [`default_remote_config_url`]; `{chain}` is substituted with the
-/// lowercase chain name.
+/// lowercase chain name. One document per chain holds every preset's section.
 const DEFAULT_REMOTE_URL_TEMPLATE: &str =
     "https://s3.eu-central-1.amazonaws.com/repo.propellerheads-propellerheads/fynd/presets/{chain}/latest.toml";
 
@@ -70,7 +71,7 @@ const RETRY_BACKOFF: Duration = Duration::from_millis(150);
 const MAX_RESPONSE_BYTES: u64 = 256 * 1024;
 
 /// Returns the default remote config URL for `chain` (the PropellerHeads-maintained S3
-/// object with the latest tuned values).
+/// object with the latest tuned values, one section per preset).
 pub fn default_remote_config_url(chain: Chain) -> String {
     DEFAULT_REMOTE_URL_TEMPLATE.replace("{chain}", &chain.to_string())
 }
@@ -143,10 +144,12 @@ impl Config {
     /// `timeout` bounds the whole fetch including retries. This method can never fail or
     /// panic (safety properties 1 and 4): on any fetch error or timeout it logs a warning
     /// and returns `self` unchanged.
-    pub async fn apply_remote(self, url: &str, timeout: Duration) -> Self {
-        match tokio::time::timeout(timeout, fetch_remote_config(url)).await {
+    pub async fn apply_remote(self, url: &str, preset: Preset, timeout: Duration) -> Self {
+        match tokio::time::timeout(timeout, fetch_remote_config(url, preset)).await {
             Ok(Ok(partial)) => {
-                tracing::info!(url, "fetched remote config");
+                // Remote is the one layer that changes without a deploy; log exactly what
+                // it overrides so a bad publish is visible in the startup log.
+                tracing::info!(url, overrides = ?partial.set_fields(), "fetched remote config");
                 self.apply(&partial)
             }
             Ok(Err(e)) => {
@@ -177,7 +180,10 @@ impl Config {
 ///
 /// Returns [`RemoteConfigError`] on any transport, size, parse, or payload-safety problem.
 /// Treat every error as non-fatal: warn and resolve without the remote layer.
-pub async fn fetch_remote_config(url: &str) -> Result<PartialConfig, RemoteConfigError> {
+pub async fn fetch_remote_config(
+    url: &str,
+    preset: Preset,
+) -> Result<PartialConfig, RemoteConfigError> {
     let mut attempt = 1;
     let body = loop {
         match http_get_capped(url).await {
@@ -191,9 +197,17 @@ pub async fn fetch_remote_config(url: &str) -> Result<PartialConfig, RemoteConfi
         }
     };
 
-    let partial = PartialConfig::from_toml_str(&body, url)?;
-    check_payload(&partial)?;
-    Ok(partial)
+    let sections: std::collections::HashMap<String, PartialConfig> = toml::from_str(&body)
+        .map_err(|e| ConfigError::Parse { context: url.to_string(), source: e })?;
+    let Some(partial) = sections.get(preset.as_str()) else {
+        // A legitimate steady state: nothing tuned for this preset (or an empty document).
+        tracing::info!(url, preset = %preset, "remote config has no section for this preset");
+        return Ok(PartialConfig::default());
+    };
+    // Only the selected section is checked: another preset's section may legitimately use
+    // algorithms from a newer binary without breaking this one.
+    check_payload(partial)?;
+    Ok(partial.clone())
 }
 
 /// One GET attempt with the response body capped at [`MAX_RESPONSE_BYTES`]
@@ -301,8 +315,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_applies_valid_payload() {
-        let url = spawn_server(vec![(200, b"worker_router_timeout_ms = 123".to_vec())]).await;
-        let partial = fetch_remote_config(&url)
+        let url =
+            spawn_server(vec![(200, b"[balanced]\nworker_router_timeout_ms = 123".to_vec())]).await;
+        let partial = fetch_remote_config(&url, Preset::Balanced)
             .await
             .expect("fetch errored");
         assert_eq!(partial.worker_router_timeout_ms, Some(123));
@@ -310,14 +325,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fetch_missing_preset_section_is_empty_layer() {
+        // An empty document (the "nothing tuned" steady state) or a document without the
+        // selected preset's section applies nothing — no error, no fallback noise.
+        let url = spawn_server(vec![(200, b"# nothing tuned\n".to_vec())]).await;
+        let partial = fetch_remote_config(&url, Preset::Deep)
+            .await
+            .expect("fetch errored");
+        assert_eq!(partial, PartialConfig::default());
+    }
+
+    #[tokio::test]
     async fn test_fetch_retries_transient_5xx() {
         let url = spawn_server(vec![
             (500, b"".to_vec()),
             (503, b"".to_vec()),
-            (200, b"min_token_quality = 90".to_vec()),
+            (200, b"[balanced]\nmin_token_quality = 90".to_vec()),
         ])
         .await;
-        let partial = fetch_remote_config(&url)
+        let partial = fetch_remote_config(&url, Preset::Balanced)
             .await
             .expect("fetch errored");
         assert_eq!(partial.min_token_quality, Some(90));
@@ -328,7 +354,7 @@ mod tests {
         // A single 404 response; a retry would hang on the closed listener, so completing
         // with an error proves no retry happened.
         let url = spawn_server(vec![(404, b"".to_vec())]).await;
-        let error = fetch_remote_config(&url)
+        let error = fetch_remote_config(&url, Preset::Balanced)
             .await
             .unwrap_err();
         assert!(matches!(error, RemoteConfigError::Request(_)));
@@ -339,7 +365,7 @@ mod tests {
         // S3 answers 301 without a Location header when the URL targets the wrong
         // region; the XML error body must not reach the parser.
         let url = spawn_server(vec![(301, b"<?xml version=\"1.0\"?><Error/>".to_vec())]).await;
-        let error = fetch_remote_config(&url)
+        let error = fetch_remote_config(&url, Preset::Balanced)
             .await
             .unwrap_err();
         assert!(matches!(error, RemoteConfigError::UnexpectedStatus { .. }));
@@ -350,7 +376,7 @@ mod tests {
     async fn test_fetch_rejects_oversized_body() {
         let huge = vec![b'#'; (MAX_RESPONSE_BYTES + 1) as usize];
         let url = spawn_server(vec![(200, huge)]).await;
-        let error = fetch_remote_config(&url)
+        let error = fetch_remote_config(&url, Preset::Balanced)
             .await
             .unwrap_err();
         assert!(matches!(error, RemoteConfigError::TooLarge { .. }));
@@ -359,7 +385,7 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_rejects_garbage_payload() {
         let url = spawn_server(vec![(200, b"not [ valid { toml".to_vec())]).await;
-        let error = fetch_remote_config(&url)
+        let error = fetch_remote_config(&url, Preset::Balanced)
             .await
             .unwrap_err();
         assert!(matches!(error, RemoteConfigError::Parse(_)));
@@ -367,9 +393,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_rejects_unknown_algorithm_payload() {
-        let url =
-            spawn_server(vec![(200, b"[pools.p]\nalgorithm = \"quantum_router\"".to_vec())]).await;
-        let error = fetch_remote_config(&url)
+        let url = spawn_server(vec![(
+            200,
+            b"[balanced.pools.p]\nalgorithm = \"quantum_router\"".to_vec(),
+        )])
+        .await;
+        let error = fetch_remote_config(&url, Preset::Balanced)
             .await
             .unwrap_err();
         assert!(matches!(error, RemoteConfigError::UnknownAlgorithm { .. }));
@@ -379,10 +408,14 @@ mod tests {
     async fn test_apply_remote_falls_back_on_fetch_failure() {
         // Port 9 (discard) refuses connections; the config must come through unchanged,
         // never a panic or an error.
-        let base = super::super::embedded_default().clone();
+        let base = super::super::embedded_default(Preset::Balanced).clone();
         let config = base
             .clone()
-            .apply_remote("http://127.0.0.1:9/latest.toml", Duration::from_millis(200))
+            .apply_remote(
+                "http://127.0.0.1:9/latest.toml",
+                Preset::Balanced,
+                Duration::from_millis(200),
+            )
             .await;
         assert_eq!(config, base);
     }

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -77,6 +77,11 @@ const DEFAULT_TYCHO_USE_TLS: bool = true;
 const DEFAULT_DEPTH_SLIPPAGE_THRESHOLD: f64 = 0.01;
 /// Generous router timeout for standalone (non-server) use. HTTP services should
 /// override this to a tighter value appropriate for their SLA.
+///
+/// Deliberately NOT sourced from `config/default_config.toml` (whose
+/// `worker_router_timeout_ms` targets the HTTP service): editing the file does not change
+/// this standalone default. The one exception to the embedded-config seeding in
+/// [`FyndBuilder::new`].
 const DEFAULT_ROUTER_TIMEOUT: Duration = Duration::from_secs(10);
 
 // serde requires free functions for `#[serde(default = "...")]` — these delegate to the
@@ -383,10 +388,11 @@ pub struct FyndBuilder {
 impl FyndBuilder {
     /// Creates a new builder with the required parameters.
     ///
-    /// Solver-tuning defaults come from the embedded default config
-    /// (`config/default_config.toml`) — the single source of truth. Exception: the worker
-    /// router timeout defaults to a generous standalone value rather than the embedded
-    /// HTTP-service-oriented one.
+    /// Solver-tuning defaults come from the embedded default config's `balanced` preset
+    /// (`config/default_config.toml`) — the single source of truth. Apply a differently
+    /// resolved [`Config`](crate::config::Config) with [`apply_config`](Self::apply_config).
+    /// Exception: the worker router timeout defaults to a generous standalone value rather
+    /// than the embedded HTTP-service-oriented one.
     pub fn new(
         chain: Chain,
         tycho_url: impl Into<String>,
@@ -394,7 +400,7 @@ impl FyndBuilder {
         protocols: Vec<String>,
         min_tvl: f64,
     ) -> Self {
-        let embedded = crate::config::embedded_default();
+        let embedded = crate::config::embedded_default(crate::config::Preset::Balanced);
         Self {
             chain,
             tycho_url: tycho_url.into(),

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -36,7 +36,7 @@ impl WorkerPoolsConfig {
     /// truth for solver-tuning defaults.
     pub fn builtin_default() -> Self {
         Self {
-            pools: fynd_core::config::embedded_default()
+            pools: fynd_core::config::embedded_default(fynd_core::config::Preset::Balanced)
                 .pools
                 .clone(),
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use fynd_core::config::{embedded_default, PartialConfig};
+use fynd_core::config::{embedded_default, PartialConfig, Preset};
 use fynd_rpc::{
     config::{defaults, WorkerPoolsConfig},
     parse_chain,
@@ -15,9 +15,21 @@ use crate::commands::derive_connector_tokens::DeriveConnectorTokensArgs;
 
 /// Builds help text for a config-layered flag, appending the real default value pulled
 /// from the embedded default config (used when neither the CLI nor a config file sets the
-/// field).
+/// field). Shown values are the `balanced` preset's; other presets may differ.
 fn cfg_help(text: &str, default: impl std::fmt::Display) -> String {
     format!("{text} [default: {default}]")
+}
+
+/// Help text for `--preset`, listing the possible values derived from the enum.
+fn preset_help() -> String {
+    let names: Vec<&str> = Preset::all()
+        .iter()
+        .map(|preset| preset.as_str())
+        .collect();
+    format!(
+        "Tuning preset the default config (embedded and remote) is maintained for [possible values: {}]",
+        names.join(", ")
+    )
 }
 
 /// Fynd - High-performance DEX solver built on Tycho
@@ -52,6 +64,10 @@ pub struct ServeArgs {
     /// Target chain (e.g. Ethereum)
     #[arg(short, long, default_value = "Ethereum", value_parser = parse_chain)]
     pub chain: Chain,
+
+    /// Tuning preset selecting which defaults apply (embedded and remote)
+    #[arg(long, env, default_value = "balanced", help = preset_help())]
+    pub preset: Preset,
 
     /// Path to a local TOML config file overriding the embedded defaults. Any subset of
     /// the config fields, same schema as the embedded default config.
@@ -99,7 +115,7 @@ pub struct ServeArgs {
             "List of protocols to index (comma-separated). \"all_onchain\" expands to all \
              on-chain protocols fetched from Tycho RPC and can be combined with explicit \
              entries, e.g. all_onchain,rfq:bebop",
-            embedded_default().protocols.join(","),
+            embedded_default(Preset::Balanced).protocols.join(","),
         ))]
     pub protocols: Vec<String>,
 
@@ -115,35 +131,35 @@ pub struct ServeArgs {
             "TVL buffer ratio: avoids fluctuations from components hovering around a single \
              threshold. With ratio 1.1 and minimum TVL 10 ETH, components are added when \
              TVL >= 10 ETH and removed below 10 / 1.1 ≈ 9.09 ETH",
-            embedded_default().tvl_buffer_ratio,
+            embedded_default(Preset::Balanced).tvl_buffer_ratio,
         ))]
     pub tvl_buffer_ratio: Option<f64>,
 
     /// Minimum token quality filter.
-    #[arg(long, help = cfg_help("Minimum token quality filter", embedded_default().min_token_quality))]
+    #[arg(long, help = cfg_help("Minimum token quality filter", embedded_default(Preset::Balanced).min_token_quality))]
     pub min_token_quality: Option<i32>,
 
     /// Only include tokens traded within this many days.
-    #[arg(long, help = cfg_help("Only include tokens traded within this many days", embedded_default().traded_n_days_ago))]
+    #[arg(long, help = cfg_help("Only include tokens traded within this many days", embedded_default(Preset::Balanced).traded_n_days_ago))]
     pub traded_n_days_ago: Option<u64>,
 
     /// Gas price refresh interval in seconds.
-    #[arg(long, help = cfg_help("Gas price refresh interval in seconds", embedded_default().gas_refresh_interval_secs))]
+    #[arg(long, help = cfg_help("Gas price refresh interval in seconds", embedded_default(Preset::Balanced).gas_refresh_interval_secs))]
     pub gas_refresh_interval_secs: Option<u64>,
 
     /// Reconnect delay on connection failure in seconds.
-    #[arg(long, help = cfg_help("Reconnect delay on connection failure in seconds", embedded_default().reconnect_delay_secs))]
+    #[arg(long, help = cfg_help("Reconnect delay on connection failure in seconds", embedded_default(Preset::Balanced).reconnect_delay_secs))]
     pub reconnect_delay_secs: Option<u64>,
 
     /// Worker router timeout in milliseconds.
-    #[arg(long, help = cfg_help("Worker router timeout in milliseconds", embedded_default().worker_router_timeout_ms))]
+    #[arg(long, help = cfg_help("Worker router timeout in milliseconds", embedded_default(Preset::Balanced).worker_router_timeout_ms))]
     pub worker_router_timeout_ms: Option<u64>,
 
     /// Minimum solver responses before early return (0 = wait for all).
     #[arg(long,
         help = cfg_help(
             "Minimum solver responses before early return (0 = wait for all)",
-            embedded_default().worker_router_min_responses,
+            embedded_default(Preset::Balanced).worker_router_min_responses,
         ))]
     pub worker_router_min_responses: Option<usize>,
 
@@ -169,7 +185,7 @@ pub struct ServeArgs {
             "Enable partial block (flashblock) updates from the Tycho stream: pool state \
              updates arrive mid-block rather than only at finalization, reducing latency. \
              Only applies to on-chain protocols",
-            embedded_default().partial_blocks,
+            embedded_default(Preset::Balanced).partial_blocks,
         ))]
     pub partial_blocks: bool,
 
@@ -272,6 +288,7 @@ mod cli_tests {
         std::env::remove_var("HTTP_HOST");
         std::env::remove_var("HTTP_PORT");
         std::env::remove_var("CONFIG_FILE");
+        std::env::remove_var("PRESET");
         std::env::remove_var("WORKER_POOLS_CONFIG");
         let cli = Cli::try_parse_from(vec!["fynd", "serve"]).expect("parse errored");
 
@@ -287,6 +304,7 @@ mod cli_tests {
         assert!(args.protocols.is_empty());
         // Solver-tuning flags default to None: the config layers supply the values.
         assert_eq!(args.config_file, None);
+        assert_eq!(args.preset, Preset::Balanced);
         assert_eq!(args.min_tvl, None);
         assert_eq!(args.tvl_buffer_ratio, None);
         assert_eq!(args.gas_refresh_interval_secs, None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,40 +285,19 @@ async fn resolve_solver_config(
             .pools = Some(pools);
     }
 
-    let remote_config = if args.no_remote_config {
-        None
-    } else {
+    // Ascending priority: embedded default (per preset), then the remote config, then the
+    // local config file, then CLI overrides.
+    let mut config = embedded_default(args.preset).clone();
+    if !args.no_remote_config {
         let url = args
             .remote_config_url
             .clone()
             .unwrap_or_else(|| remote::default_remote_config_url(args.chain));
-        match tokio::time::timeout(REMOTE_CONFIG_FETCH_TIMEOUT, remote::fetch_remote_config(&url))
-            .await
-        {
-            Ok(Ok(partial)) => {
-                info!(url, "fetched remote config");
-                Some(partial)
-            }
-            Ok(Err(e)) => {
-                warn!(url, error = %e, "remote config fetch failed; continuing without it");
-                None
-            }
-            Err(_elapsed) => {
-                warn!(
-                    url,
-                    timeout_ms = REMOTE_CONFIG_FETCH_TIMEOUT.as_millis() as u64,
-                    "remote config fetch timed out; continuing without it"
-                );
-                None
-            }
-        }
-    };
-
-    // Ascending priority: embedded default, then the remote config, then the local config
-    // file, then CLI overrides.
-    let config = embedded_default()
-        .clone()
-        .apply(&remote_config.unwrap_or_default())
+        config = config
+            .apply_remote(&url, args.preset, REMOTE_CONFIG_FETCH_TIMEOUT)
+            .await;
+    }
+    let config = config
         .apply(&local_file.unwrap_or_default())
         .apply(&overrides);
     config


### PR DESCRIPTION
Stacked on #328 (remote config layer).

## What

Adds the preset concept: a `config::Preset` (`balanced` | `deep`) selects which
*defaults* apply. Both the embedded `default_config.toml` and the per-chain remote
document hold one section per preset (same layout in both files); every layer above
— local config file, CLI flags, legacy worker_pools.toml — behaves unchanged on top.
The two presets currently share identical values; `deep` gets tuned later.

- Selection: `--preset` / `PRESET` (default `balanced`); lib: `get_default(chain, preset)`,
  `Config::apply_remote(url, preset, timeout)`. A preset can never be set from a config file.
- Remote URL stays one document per chain (`presets/{chain}/latest.toml`); the fetch
  selects the preset's section. A missing section (or empty document) is a quiet
  "nothing tuned" state — the already-published empty payloads remain valid.
- The unknown-algorithm safety check runs only on the selected section, so a future
  preset section can use newer algorithms without breaking binaries on other presets.
- `Preset` is strum-derived; parsing, listing, and `--help` values are generated, and a
  unit test fails if the enum and the file sections drift. Adding a preset = one
  variant + one section per file.
- `FyndBuilder::new` and fynd-rpc's `builtin_default()` pin to `balanced`.

## From the design review (fresh-context agent)

Applied: unknown keys in hand-written config files now warn (remote stays fully
permissive for forward compatibility, guarded by a field-list sync test); the remote
layer logs exactly which fields it overrides; the standalone router-timeout exception
is documented at the constant; layer-count doc fix; `--help` text cleanup.

Not applied: `clap::ValueEnum` for `Preset` (fynd-core has no clap dependency — strum
is the boundary-respecting choice); trimming `get_default` (deliberate convenience
API); changing legacy worker_pools.toml pools precedence (explicit
backward-compatibility decision, already warns); value-range floors in `validate()`
(no tuning bounds established yet — the new override logging provides visibility
instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)