### PR TITLE
feat(hindsight): measure slippage by re-executing top routes at back-of-block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,6 +3835,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "async-trait",
+ "chrono",
  "clap",
  "futures 0.3.32",
  "fynd-client",

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -15,6 +15,7 @@ applications.
 | `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `PoolDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
 | `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
 | `price_guard/`        | Price guard: external price validation for quotes. Sub-modules: `guard` (validation logic), `binance_ws` (Binance WebSocket price provider), `hyperliquid` (Hyperliquid oracle provider), `provider_registry`, `config`, `utils` |
+| `replay.rs`           | `replay_route(&Route, &MarketState)` — re-execute an already-built route against a (possibly newer) market state, honoring split fractions and shared-pool depletion. Used by `hindsight` to measure quote-to-execution slippage |
 | `encoding/`           | `Encoder` wraps `tycho-execution` to produce ABI-encoded calldata (singleSwap, sequentialSwap, Permit2 variants). Computes `FeeBreakdown` mirroring on-chain `FeeCalculator` logic. `RouterFees`/`SharedRouterFees` hold default + per-client fee rates; `RouterFeeFetcher` refreshes them from the FeeCalculator contract every 5 min |
 | `types/`              | Core types: `Order`, `Route`, `Swap`, `Quote`, `QuoteRequest`, `BlockInfo`, `EncodingOptions`, `FeeBreakdown`, error types                                                         |
 

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -35,6 +35,8 @@ pub mod feed;
 pub mod graph;
 /// External price validation for quotes.
 pub mod price_guard;
+/// Re-execute an already-built route against a (possibly newer) market state.
+pub mod replay;
 /// [`FyndBuilder`](solver::FyndBuilder) assembles the full pipeline and returns a
 /// [`Solver`](solver::Solver).
 pub mod solver;
@@ -58,6 +60,7 @@ pub use price_guard::{
     config::PriceGuardConfig,
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
+pub use replay::{replay_route, ReplayError, RouteReplay};
 pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
 /// Processes ephemeral pending bundles against live Tycho market state. Obtained by calling
 /// [`FyndBuilder::build_with_pending`](solver::FyndBuilder::build_with_pending).

--- a/fynd-core/src/replay.rs
+++ b/fynd-core/src/replay.rs
@@ -1,0 +1,340 @@
+//! Re-execute an already-built [`Route`] against a (possibly newer)
+//! [`MarketState`](crate::feed::market_data::MarketState).
+//!
+//! A route emitted by a solving algorithm pins pools, token order, and split fractions. Replaying
+//! it against a later block's pool states answers "what would this exact route have produced at
+//! that state" — the in-process equivalent of submitting the already-encoded transaction at that
+//! block. Used by tooling (e.g. `hindsight`) to measure slippage between quote time and
+//! execution time.
+
+use std::collections::HashMap;
+
+use num_bigint::BigUint;
+use tycho_simulation::tycho_common::{models::Address, simulation::protocol_sim::ProtocolSim};
+
+use crate::{
+    algorithm::split_primitives::split_amount,
+    feed::market_data::MarketState,
+    types::{ComponentId, Route, Swap},
+};
+
+/// The outcome of replaying a route: final output and summed per-swap gas.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteReplay {
+    /// Amount of the route's output token produced.
+    pub amount_out: BigUint,
+    /// Sum of the per-swap gas estimates reported by the simulations.
+    pub gas: BigUint,
+}
+
+/// Why a route could not be replayed against a market state.
+#[derive(Debug, thiserror::Error)]
+pub enum ReplayError {
+    /// The route carries no swaps (only reachable via deserialization — [`Route::new`] rejects
+    /// an empty swap list).
+    #[error("route has no swaps")]
+    EmptyRoute,
+    /// The market state carries no simulation state for a pool in the route (removed by the feed
+    /// or filtered out since the route was built).
+    #[error("no simulation state for component {0}")]
+    MissingState(ComponentId),
+    /// A token in the route is missing from the market state's token registry.
+    #[error("token {0} missing from the market state")]
+    MissingToken(Address),
+    /// A pool simulation failed (e.g. the pool was paused or its liquidity vanished).
+    #[error("simulation failed on component {component_id}: {error}")]
+    Simulation {
+        /// The pool whose simulation failed.
+        component_id: ComponentId,
+        /// The underlying simulation error.
+        error: String,
+    },
+}
+
+/// Replay `route` against `market`, producing the output its swaps yield at that state.
+///
+/// Swaps execute in the route's emitted order, which is topological: every swap producing a token
+/// runs before any swap consuming it. Split fractions are interpreted exactly as routes encode
+/// them — within the swaps consuming one token, each positive `split` takes that fraction of the
+/// token's collected balance, and the final swap of the group (split `0.0`) takes the remainder.
+/// Post-swap pool states are threaded, so a pool shared by two swaps sees depleted reserves on
+/// the second. Each swap's embedded quote-time `protocol_state` is deliberately ignored: pools
+/// and tokens are resolved from `market`, the state being replayed against.
+///
+/// # Errors
+///
+/// Returns [`ReplayError`] when a pool's simulation state or a token is missing from `market`,
+/// or a pool simulation fails.
+pub fn replay_route(route: &Route, market: &MarketState) -> Result<RouteReplay, ReplayError> {
+    let swaps = route.swaps();
+    let (Some(input_token), Some(output_token)) = (route.input_token(), route.output_token())
+    else {
+        return Err(ReplayError::EmptyRoute);
+    };
+    let total_in: BigUint = swaps
+        .iter()
+        .filter(|swap| *swap.token_in() == input_token)
+        .map(Swap::amount_in)
+        .sum();
+
+    // Collected balance per token. A token's balance is complete before its first consuming swap
+    // runs (topological order), and `branch_totals` snapshots it at that moment: positive splits
+    // are fractions of that total, not of the running remainder.
+    let mut available: HashMap<Address, BigUint> = HashMap::new();
+    available.insert(input_token, total_in);
+    let mut branch_totals: HashMap<Address, BigUint> = HashMap::new();
+    let mut post_swap: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
+    let mut total_gas = BigUint::ZERO;
+
+    for swap in swaps {
+        let token_in = market
+            .get_token(swap.token_in())
+            .ok_or_else(|| ReplayError::MissingToken(swap.token_in().clone()))?;
+        let token_out = market
+            .get_token(swap.token_out())
+            .ok_or_else(|| ReplayError::MissingToken(swap.token_out().clone()))?;
+
+        let branch_total = branch_totals
+            .entry(swap.token_in().clone())
+            .or_insert_with(|| {
+                available
+                    .get(swap.token_in())
+                    .cloned()
+                    .unwrap_or_default()
+            })
+            .clone();
+        let remaining = available
+            .entry(swap.token_in().clone())
+            .or_default();
+        let amount_in = if *swap.split() > 0.0 {
+            // Flooring in split_amount keeps the sum of parts at or under the total, but cap at
+            // the remainder anyway so a malformed split can never underflow the balance.
+            let (part, _) = split_amount(&branch_total, *swap.split());
+            part.min(remaining.clone())
+        } else {
+            remaining.clone()
+        };
+        *remaining -= &amount_in;
+
+        let sim = post_swap
+            .get(swap.component_id())
+            .map(|state| state.as_ref())
+            .or_else(|| market.get_simulation_state(swap.component_id()))
+            .ok_or_else(|| ReplayError::MissingState(swap.component_id().to_string()))?;
+        let result = sim
+            .get_amount_out(amount_in, token_in, token_out)
+            .map_err(|e| ReplayError::Simulation {
+                component_id: swap.component_id().to_string(),
+                error: e.to_string(),
+            })?;
+
+        total_gas += &result.gas;
+        *available
+            .entry(swap.token_out().clone())
+            .or_default() += &result.amount;
+        post_swap.insert(swap.component_id().to_string(), result.new_state);
+    }
+
+    let amount_out = available
+        .remove(&output_token)
+        .unwrap_or_default();
+    Ok(RouteReplay { amount_out, gas: total_gas })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::test_utils::{component, token, ConstantProductSim, MockProtocolSim};
+
+    fn make_market(
+        pools: Vec<(
+            &str,
+            Vec<tycho_simulation::tycho_common::models::token::Token>,
+            Box<dyn ProtocolSim>,
+        )>,
+    ) -> MarketState {
+        let mut market = MarketState::new();
+        for (pool_id, tokens, sim) in pools {
+            market.upsert_components(std::iter::once(component(pool_id, &tokens)));
+            market.update_states([(pool_id.to_string(), sim)]);
+            market.upsert_tokens(tokens);
+        }
+        market
+    }
+
+    /// A swap as a route would carry it. The embedded protocol state is a decoy with an absurd
+    /// price so any test that accidentally simulates against it fails loudly.
+    fn route_swap(
+        pool_id: &str,
+        token_in: &tycho_simulation::tycho_common::models::token::Token,
+        token_out: &tycho_simulation::tycho_common::models::token::Token,
+        amount_in: u64,
+        split: f64,
+    ) -> Swap {
+        Swap::new(
+            pool_id.to_string(),
+            "mock".to_string(),
+            token_in.address.clone(),
+            token_out.address.clone(),
+            BigUint::from(amount_in),
+            BigUint::ZERO,
+            BigUint::ZERO,
+            component(pool_id, &[token_in.clone(), token_out.clone()]),
+            Box::new(MockProtocolSim::new(1_000_000.0)),
+        )
+        .with_split(split)
+    }
+
+    fn route(swaps: Vec<Swap>) -> Route {
+        Route::new(swaps, HashMap::new()).expect("test route must not be empty")
+    }
+
+    #[test]
+    fn sequential_route_threads_amounts_through_market_state() {
+        // A→B→C at market prices 2.0 then 3.0: 1000 → 2000 → 6000. The swaps embed a decoy
+        // state, so this also proves replay reads the market, not the route's quote-time states.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let token_c = token(0x0C, "C");
+        let market = make_market(vec![
+            (
+                "pool_ab",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0).with_gas(50_000)),
+            ),
+            (
+                "pool_bc",
+                vec![token_b.clone(), token_c.clone()],
+                Box::new(MockProtocolSim::new(3.0).with_gas(70_000)),
+            ),
+        ]);
+        let route = route(vec![
+            route_swap("pool_ab", &token_a, &token_b, 1_000, 0.0),
+            route_swap("pool_bc", &token_b, &token_c, 2_000, 0.0),
+        ]);
+
+        let replay = replay_route(&route, &market).unwrap();
+        assert_eq!(replay.amount_out, BigUint::from(6_000u64));
+        assert_eq!(replay.gas, BigUint::from(120_000u64));
+    }
+
+    #[test]
+    fn split_route_divides_by_fraction_with_remainder() {
+        // 1000 split 60/40 across two parallel pools: 600*2 + 400*3 = 2400. The second swap
+        // carries split 0.0 (remainder convention).
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![
+            ("pool_1", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("pool_2", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(3.0))),
+        ]);
+        let route = route(vec![
+            route_swap("pool_1", &token_a, &token_b, 600, 0.6),
+            route_swap("pool_2", &token_a, &token_b, 400, 0.0),
+        ]);
+
+        let replay = replay_route(&route, &market).unwrap();
+        assert_eq!(replay.amount_out, BigUint::from(2_400u64));
+    }
+
+    #[test]
+    fn splits_are_fractions_of_the_collected_total_not_the_remainder() {
+        // Three-way split 0.5 / 0.3 / remainder of 1000: 500, 300, 200 — the 0.3 applies to the
+        // full 1000, not to the 500 left after the first swap.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![
+            ("pool_1", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("pool_2", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("pool_3", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(4.0))),
+        ]);
+        let route = route(vec![
+            route_swap("pool_1", &token_a, &token_b, 500, 0.5),
+            route_swap("pool_2", &token_a, &token_b, 300, 0.3),
+            route_swap("pool_3", &token_a, &token_b, 200, 0.0),
+        ]);
+
+        // 500*1 + 300*2 + 200*4 = 1900.
+        let replay = replay_route(&route, &market).unwrap();
+        assert_eq!(replay.amount_out, BigUint::from(1_900u64));
+    }
+
+    #[test]
+    fn shared_pool_sees_depleted_reserves() {
+        // Two swaps through the same constant-product pool: the second must run on the first's
+        // post-swap reserves, matching one full-amount swap up to rounding.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let cp = ConstantProductSim {
+            reserve_0: BigUint::from(10_000u64),
+            reserve_1: BigUint::from(10_000u64),
+            gas: 50_000,
+        };
+        let market = make_market(vec![(
+            "pool",
+            vec![token_a.clone(), token_b.clone()],
+            Box::new(cp.clone()),
+        )]);
+        let route = route(vec![
+            route_swap("pool", &token_a, &token_b, 500, 0.5),
+            route_swap("pool", &token_a, &token_b, 500, 0.0),
+        ]);
+
+        let replay = replay_route(&route, &market).unwrap();
+        let full_swap = cp
+            .get_amount_out(BigUint::from(1_000u64), &token_a, &token_b)
+            .unwrap()
+            .amount;
+        let diff = if replay.amount_out > full_swap {
+            &replay.amount_out - &full_swap
+        } else {
+            &full_swap - &replay.amount_out
+        };
+        assert!(diff <= BigUint::from(2u32), "split through one pool must match one full swap");
+    }
+
+    #[test]
+    fn changed_market_state_changes_the_output() {
+        // The pool moved in the trade's favor between quote and replay: same route, more output.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![(
+            "pool",
+            vec![token_a.clone(), token_b.clone()],
+            Box::new(MockProtocolSim::new(2.5)),
+        )]);
+        // The route was quoted at price 2.0 (amount_out recorded then was 2000).
+        let route = route(vec![route_swap("pool", &token_a, &token_b, 1_000, 0.0)]);
+
+        let replay = replay_route(&route, &market).unwrap();
+        assert_eq!(replay.amount_out, BigUint::from(2_500u64));
+    }
+
+    #[test]
+    fn missing_simulation_state_errors() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let mut market = make_market(vec![]);
+        market.upsert_tokens(vec![token_a.clone(), token_b.clone()]);
+        let route = route(vec![route_swap("gone", &token_a, &token_b, 1_000, 0.0)]);
+
+        let err = replay_route(&route, &market).unwrap_err();
+        assert!(matches!(err, ReplayError::MissingState(id) if id == "gone"));
+    }
+
+    #[test]
+    fn missing_token_errors() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![(
+            "pool",
+            vec![token_a.clone(), token_b.clone()],
+            Box::new(MockProtocolSim::new(2.0)),
+        )]);
+        let unknown = token(0x42, "X");
+        let route = route(vec![route_swap("pool", &unknown, &token_b, 1_000, 0.0)]);
+
+        let err = replay_route(&route, &market).unwrap_err();
+        assert!(matches!(err, ReplayError::MissingToken(addr) if addr == unknown.address));
+    }
+}

--- a/fynd-core/src/replay.rs
+++ b/fynd-core/src/replay.rs
@@ -13,7 +13,7 @@ use num_bigint::BigUint;
 use tycho_simulation::tycho_common::{models::Address, simulation::protocol_sim::ProtocolSim};
 
 use crate::{
-    algorithm::split_primitives::split_amount,
+    algorithm::{sim_guard::GuardedProtocolSim, split_primitives::split_amount},
     feed::market_data::MarketState,
     types::{ComponentId, Route, Swap},
 };
@@ -122,7 +122,7 @@ pub fn replay_route(route: &Route, market: &MarketState) -> Result<RouteReplay, 
             .or_else(|| market.get_simulation_state(swap.component_id()))
             .ok_or_else(|| ReplayError::MissingState(swap.component_id().to_string()))?;
         let result = sim
-            .get_amount_out(amount_in, token_in, token_out)
+            .get_amount_out_guarded(amount_in, token_in, token_out)
             .map_err(|e| ReplayError::Simulation {
                 component_id: swap.component_id().to_string(),
                 error: e.to_string(),

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1153,6 +1153,18 @@ impl Route {
     pub(crate) fn tokens(&self) -> &HashMap<Bytes, Token> {
         &self.tokens
     }
+
+    /// Returns the symbol of `address`, resolved from this route's own token map (populated by
+    /// the algorithm that built the route). `None` if the route carries no entry for it — for
+    /// example a route built without a token map (tests, replays).
+    ///
+    /// Lets a caller outside this crate render a human-readable path (tokens and protocols
+    /// interleaved) without needing a separate, externally-sourced token table.
+    pub fn token_symbol(&self, address: &Address) -> Option<&str> {
+        self.tokens
+            .get(address)
+            .map(|token| token.symbol.as_str())
+    }
 }
 
 /// The result of a route-finding algorithm: a route plus its gas-adjusted net output.
@@ -1955,6 +1967,26 @@ mod tests {
             .map(|(a, b)| make_swap(a, b, 1000, 990))
             .collect();
         Route::new(swaps, HashMap::new()).unwrap()
+    }
+
+    #[test]
+    fn test_route_token_symbol_resolves_from_own_map() {
+        let token_in = token(0x01, "TIN");
+        let token_out = token(0x02, "TOUT");
+        let tokens = HashMap::from([
+            (token_in.address.clone(), token_in.clone()),
+            (token_out.address.clone(), token_out.clone()),
+        ]);
+        let route = Route::new(vec![make_swap(0x01, 0x02, 1000, 990)], tokens).unwrap();
+        assert_eq!(route.token_symbol(&make_address(0x01)), Some("TIN"));
+        assert_eq!(route.token_symbol(&make_address(0x02)), Some("TOUT"));
+    }
+
+    #[test]
+    fn test_route_token_symbol_missing_returns_none() {
+        // `make_route` builds with an empty token map: any address is unresolved.
+        let route = make_route(vec![(0x01, 0x02)]);
+        assert_eq!(route.token_symbol(&make_address(0x01)), None);
     }
 
     #[rstest]

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -62,9 +62,9 @@ Four subcommands via `cargo run -p hindsight --release --`:
   (max 1000 blocks), or defaults to the latest block.
 - **`verify`** — Diff decoded trades against Allium's `aggregator_trades` ground truth. Requires 
   `ALLIUM_API_KEY` and `ALLIUM_QUERY_ID`.
-- **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block, re-solving
-  each settled trade at top-of-block (N-1) and back-of-block (N). Emits JSONL and exposes
-  Prometheus metrics.
+- **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block, solving
+  each settled trade at top-of-block (N-1) and re-executing that route at back-of-block (N) to
+  measure slippage. Emits JSONL and exposes Prometheus metrics.
 - **`report`** — Offline: render a self-contained HTML report from a `monitor` run's comparison
   JSONL (`--comparisons-dir`). No chain or network access.
 

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -63,8 +63,8 @@ Four subcommands via `cargo run -p hindsight --release --`:
 - **`verify`** — Diff decoded trades against Allium's `aggregator_trades` ground truth. Requires 
   `ALLIUM_API_KEY` and `ALLIUM_QUERY_ID`.
 - **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block, solving
-  each settled trade at top-of-block (N-1) and re-executing that route at back-of-block (N) to
-  measure slippage. Emits JSONL and exposes Prometheus metrics.
+  each settled trade at top-of-block (N-1) and again at back-of-block (N), where the top route
+  is also re-executed to measure slippage. Emits JSONL and exposes Prometheus metrics.
 - **`report`** — Offline: render a self-contained HTML report from a `monitor` run's comparison
   JSONL (`--comparisons-dir`). No chain or network access.
 

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -118,9 +118,11 @@ unsolved states keep their coverage verdicts).
 `Slippage` measures how the top route's output moved between quote time (N-1) and execution time
 (N): re-executed output vs quoted output, signed, in bps (JSONL also carries USD valued at the
 back-of-block price snapshot). Positive slippage is the surplus we would keep if we charged it —
-Prometheus records the signed bps distribution (`hindsight_slippage_bps`) and a positive-only
-USD histogram (`hindsight_positive_slippage_usd`) whose sum is the running hypothetical revenue.
-Absent when the top was unsolved or the re-execution failed (e.g. a pool vanished at N).
+Prometheus records the signed bps distribution (`hindsight_slippage_bps`) and the signed USD
+value (`hindsight_slippage_usd`), both labeled by the trade's headline verdict, plus a
+positive-only USD histogram (`hindsight_positive_slippage_usd`) whose sum is the running
+hypothetical revenue. Absent when the top was unsolved or the re-execution failed (e.g. a pool
+vanished at N).
 
 ### Key types
 

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -23,10 +23,12 @@ and takes neither.
   `ALLIUM_API_KEY` and `ALLIUM_QUERY_ID`.
 
 - **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block. For each
-  block it decodes settled trades, re-solves each order at top-of-block (state N-1) then
-  back-of-block (state N), and emits `RangeComparison` JSONL records. Exposes a Prometheus
-  metrics endpoint (`--metrics-port`). `--max-lag-blocks` (default 100, ~20 min on mainnet)
-  bounds how far it may fall behind chain head before rebuilding the solver.
+  block it decodes settled trades, solves each order at top-of-block (state N-1), then
+  re-executes that same route at back-of-block (state N) via `fynd_core::replay_route` to
+  measure slippage between quote time and execution time, and emits `RangeComparison` JSONL
+  records. Exposes a Prometheus metrics endpoint (`--metrics-port`). `--max-lag-blocks` (default
+  100, ~20 min on mainnet) bounds how far it may fall behind chain head before rebuilding the
+  solver.
 
 - **`report`** — Offline: read the `comparisons-YYYY-MM-DD.jsonl` files a `monitor` run wrote
   (`--comparisons-dir`) and render a single self-contained HTML file (`-o`, defaults to
@@ -84,8 +86,8 @@ their solver in calldata — `solver_aliases`).
 
 | File | Purpose |
 |---|---|
-| `mod.rs` | `SteppingSolver` trait; `resolve_block_range` — solve all trades at top, advance, solve again at back |
-| `compare.rs` | `Verdict` / `Deltas` — bps diff, win/loss/coverage-miss classification |
+| `mod.rs` | `SteppingSolver` trait; `resolve_block_range` — solve all trades at top, advance, re-execute each top route at back |
+| `compare.rs` | `Verdict` / `Deltas` / `Slippage` — bps diff, win/loss/coverage-miss classification, quote-vs-re-execution slippage |
 | `monitor.rs` | Production `monitor` subcommand: in-process solver, block subscription, JSONL emission |
 | `jsonl.rs` | Append-only JSONL writer used by `monitor` |
 
@@ -103,17 +105,28 @@ self-contained HTML file.
 
 ### Verdict model
 
-Each re-solved trade produces a `top` (optimistic, state N-1) and `back` (pessimistic, state N)
-result. The headline `verdict` is top-of-block. Possible verdicts: `Win`, `Loss`,
-`CoverageMiss` (Fynd filled <50% of the settled size — `MIN_FILL_RATIO = 0.5`), `Unsolvable`,
-and `Sandwiched` (a solved comparison whose settled output was moved by MEV — excluded from the
-savings aggregates; unsolved states keep their coverage verdicts).
+Each trade produces a `top` result (optimistic, solved fresh at state N-1) and a `back` result
+(pessimistic: the top route re-executed at state N, after the block's swaps moved the pools).
+The headline `verdict` is top-of-block. Possible verdicts: `Win`, `Loss`, `CoverageMiss` (Fynd
+filled <50% of the settled size — `MIN_FILL_RATIO = 0.5`), `Unsolvable`, and `Sandwiched` (a
+solved comparison whose settled output was moved by MEV — excluded from the savings aggregates;
+unsolved states keep their coverage verdicts).
+
+### Slippage model
+
+`Slippage` measures how the top route's output moved between quote time (N-1) and execution time
+(N): re-executed output vs quoted output, signed, in bps (JSONL also carries USD valued at the
+back-of-block price snapshot). Positive slippage is the surplus we would keep if we charged it —
+Prometheus records the signed bps distribution (`hindsight_slippage_bps`) and a positive-only
+USD histogram (`hindsight_positive_slippage_usd`) whose sum is the running hypothetical revenue.
+Absent when the top was unsolved or the re-execution failed (e.g. a pool vanished at N).
 
 ### Key types
 
 - `DecodedTrade` — decoded on-chain trade; amounts are venue-fee-adjusted so re-solve compares
   like-for-like. Carries `sandwich` evidence when a bracket pair was found.
-- `RangeComparison` — a trade re-solved at both block states, including gas-netted settled output.
+- `RangeComparison` — a trade solved at top and re-executed at back, including gas-netted settled
+  output and the route's `Slippage` between the two states.
 - `Outcome` — `Solved`, `Partial`, or `Unsolvable`.
 - `RouteSummary` — which algorithm won a solved state and the path its route took. Carried on
   `SolvedAmount` as typed fields (not dug out of the serialized quote) so the metrics and the

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -131,14 +131,17 @@ vanished at N).
 - `RangeComparison` — a trade solved at top and back, including gas-netted settled output and
   the top route's `Slippage` between the two states (from its re-execution at back).
 - `Outcome` — `Solved`, `Partial`, or `Unsolvable`.
-- `RouteSummary` — which algorithm won a solved state and the path its route took. Carried on
-  `SolvedAmount` as typed fields (not dug out of the serialized quote) so the metrics and the
-  per-trade log line read it directly.
+- `SolvedAmount` — a solved state's amounts plus `algorithm` (which worker pool won the quote) and
+  `solved_route` (the full `fynd_core::types::Route`, kept in memory to replay at back-of-block).
+  The readable path is not stored: `resolve::render_route` derives it from `solved_route` at
+  serialization/log time, reading token symbols off the route's own token map via
+  `Route::token_symbol`.
 
 ### Route attribution
 
 A solved state records the algorithm whose route won the quote — the worker pool that beat the
-others on that order — and that route rendered as a readable path:
+others on that order — and, derived from its route at serialization time, that route rendered as
+a readable path:
 
 ```
 USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -23,9 +23,10 @@ and takes neither.
   `ALLIUM_API_KEY` and `ALLIUM_QUERY_ID`.
 
 - **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block. For each
-  block it decodes settled trades, solves each order at top-of-block (state N-1), then
-  re-executes that same route at back-of-block (state N) via `fynd_core::replay_route` to
-  measure slippage between quote time and execution time, and emits `RangeComparison` JSONL
+  block it decodes settled trades, solves each order at top-of-block (state N-1), then measures
+  twice at back-of-block (state N): the top route is re-executed via `fynd_core::replay_route`
+  to measure slippage between quote time and execution time, and the order is solved fresh to
+  show what routing at the block's end state would deliver. Emits `RangeComparison` JSONL
   records. Exposes a Prometheus metrics endpoint (`--metrics-port`). `--max-lag-blocks` (default
   100, ~20 min on mainnet) bounds how far it may fall behind chain head before rebuilding the
   solver.
@@ -86,7 +87,7 @@ their solver in calldata — `solver_aliases`).
 
 | File | Purpose |
 |---|---|
-| `mod.rs` | `SteppingSolver` trait; `resolve_block_range` — solve all trades at top, advance, re-execute each top route at back |
+| `mod.rs` | `SteppingSolver` trait; `resolve_block_range` — solve all trades at top, advance, then re-execute each top route and solve each trade fresh at back |
 | `compare.rs` | `Verdict` / `Deltas` / `Slippage` — bps diff, win/loss/coverage-miss classification, quote-vs-re-execution slippage |
 | `monitor.rs` | Production `monitor` subcommand: in-process solver, block subscription, JSONL emission |
 | `jsonl.rs` | Append-only JSONL writer used by `monitor` |
@@ -106,8 +107,8 @@ self-contained HTML file.
 ### Verdict model
 
 Each trade produces a `top` result (optimistic, solved fresh at state N-1) and a `back` result
-(pessimistic: the top route re-executed at state N, after the block's swaps moved the pools).
-The headline `verdict` is top-of-block. Possible verdicts: `Win`, `Loss`, `CoverageMiss` (Fynd
+(pessimistic: solved fresh at state N, after the block's swaps moved the pools). The headline
+`verdict` is top-of-block. Possible verdicts: `Win`, `Loss`, `CoverageMiss` (Fynd
 filled <50% of the settled size — `MIN_FILL_RATIO = 0.5`), `Unsolvable`, and `Sandwiched` (a
 solved comparison whose settled output was moved by MEV — excluded from the savings aggregates;
 unsolved states keep their coverage verdicts).
@@ -125,8 +126,8 @@ Absent when the top was unsolved or the re-execution failed (e.g. a pool vanishe
 
 - `DecodedTrade` — decoded on-chain trade; amounts are venue-fee-adjusted so re-solve compares
   like-for-like. Carries `sandwich` evidence when a bracket pair was found.
-- `RangeComparison` — a trade solved at top and re-executed at back, including gas-netted settled
-  output and the route's `Slippage` between the two states.
+- `RangeComparison` — a trade solved at top and back, including gas-netted settled output and
+  the top route's `Slippage` between the two states (from its re-execution at back).
 - `Outcome` — `Solved`, `Partial`, or `Unsolvable`.
 - `RouteSummary` — which algorithm won a solved state and the path its route took. Carried on
   `SolvedAmount` as typed fields (not dug out of the serialized quote) so the metrics and the

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -55,6 +55,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
 
+[dev-dependencies]
+# Test-only route fixtures (resolve::test_support): a throwaway ProtocolComponent's creation
+# timestamp needs a concrete NaiveDateTime.
+chrono = { workspace = true }
+
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 # Panic prevention

--- a/tools/hindsight/src/report/record.rs
+++ b/tools/hindsight/src/report/record.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use crate::{
         decoder::{AttributionSource, DecodedTrade, Registry},
-        resolve::{build_range, jsonl::write_comparisons, Outcome, RouteSummary, SolvedAmount},
+        resolve::{build_range, jsonl::write_comparisons, Outcome, SolvedAmount},
         usd::Prices,
     };
 
@@ -101,7 +101,7 @@ mod tests {
             amount_out: U256::from(1_010_000_000u64),
             amount_out_net_gas: U256::from(1_010_000_000u64),
             gas_estimate: U256::from(21_000u64),
-            route: RouteSummary::default(),
+            algorithm: String::new(),
             quote_json: None,
             solved_route: None,
         });

--- a/tools/hindsight/src/report/record.rs
+++ b/tools/hindsight/src/report/record.rs
@@ -103,9 +103,15 @@ mod tests {
             gas_estimate: U256::from(21_000u64),
             route: RouteSummary::default(),
             quote_json: None,
-            route: None,
+            solved_route: None,
         });
-        let range = build_range(&trade, &prices, top, Outcome::Unsolvable("x".into()));
+        let range = build_range(
+            &trade,
+            &prices,
+            top,
+            Outcome::Unsolvable("x".into()),
+            &Outcome::Unsolvable("x".into()),
+        );
 
         let mut buf = Vec::new();
         write_comparisons(&mut buf, std::slice::from_ref(&range), &prices, &prices);

--- a/tools/hindsight/src/report/record.rs
+++ b/tools/hindsight/src/report/record.rs
@@ -103,6 +103,7 @@ mod tests {
             gas_estimate: U256::from(21_000u64),
             route: RouteSummary::default(),
             quote_json: None,
+            route: None,
         });
         let range = build_range(&trade, &prices, top, Outcome::Unsolvable("x".into()));
 

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -144,14 +144,14 @@ pub(crate) fn verdict(outcome: &Outcome, deltas: &Deltas) -> Verdict {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resolve::{RouteSummary, SolvedAmount};
+    use crate::resolve::SolvedAmount;
 
     fn solved(amount_out: u64, net: u64) -> Outcome {
         Outcome::Solved(SolvedAmount {
             amount_out: U256::from(amount_out),
             amount_out_net_gas: U256::from(net),
             gas_estimate: U256::from(21_000),
-            route: RouteSummary::default(),
+            algorithm: String::new(),
             quote_json: None,
             solved_route: None,
         })

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -30,6 +30,34 @@ impl Deltas {
     const NONE: Self = Self { raw_bps: None, net_bps: None };
 }
 
+/// Slippage of the top-of-block route re-executed at back-of-block: how the route's output moved
+/// between quote time (N-1) and execution time (N). Positive = the route produced more than
+/// quoted — the surplus we would keep if we charged positive slippage.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+pub(crate) struct Slippage {
+    /// Re-executed output vs the quoted output, in bps (positive = surplus).
+    pub bps: f64,
+    /// The top-of-block quoted output the slippage is measured against.
+    pub quoted_amount_out: U256,
+    /// The same route's re-executed output at back-of-block.
+    pub reexecuted_amount_out: U256,
+}
+
+/// Slippage between the top-of-block quote and its re-execution at back-of-block. `None` when
+/// either side is unsolved (no route quoted, or the re-execution failed) or the quoted output
+/// is zero.
+pub(crate) fn slippage(top: &Outcome, back: &Outcome) -> Option<Slippage> {
+    let (Outcome::Solved(top), Outcome::Solved(back)) = (top, back) else {
+        return None;
+    };
+    let bps = raw_bps_diff(&to_biguint(back.amount_out), &to_biguint(top.amount_out))?;
+    Some(Slippage {
+        bps,
+        quoted_amount_out: top.amount_out,
+        reexecuted_amount_out: back.amount_out,
+    })
+}
+
 /// Win/loss classification for a single trade, judged at one block state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -125,6 +153,7 @@ mod tests {
             gas_estimate: U256::from(21_000),
             route: RouteSummary::default(),
             quote_json: None,
+            route: None,
         })
     }
 
@@ -229,5 +258,32 @@ mod tests {
             Outcome::Unsolvable(_)
         ));
         assert!(matches!(served(solved(1, 1), U256::ZERO), Outcome::Solved(_)));
+    }
+
+    #[test]
+    fn slippage_positive_when_reexecution_beats_the_quote() {
+        // Quoted 10_000 at top, re-executed to 10_050 at back → +50 bps surplus.
+        let s = slippage(&solved(10_000, 9_900), &solved(10_050, 9_950)).unwrap();
+        assert!((s.bps - 50.0).abs() < 0.01, "expected +50 bps, got {}", s.bps);
+        assert_eq!(s.quoted_amount_out, U256::from(10_000u64));
+        assert_eq!(s.reexecuted_amount_out, U256::from(10_050u64));
+    }
+
+    #[test]
+    fn slippage_negative_when_reexecution_underperforms() {
+        let s = slippage(&solved(10_000, 9_900), &solved(9_900, 9_800)).unwrap();
+        assert!((s.bps + 100.0).abs() < 0.01, "expected -100 bps, got {}", s.bps);
+    }
+
+    #[test]
+    fn slippage_none_when_either_side_unsolved() {
+        let failed = Outcome::Unsolvable("re-execution failed".into());
+        assert_eq!(slippage(&failed, &solved(10_000, 9_900)), None);
+        assert_eq!(slippage(&solved(10_000, 9_900), &failed), None);
+    }
+
+    #[test]
+    fn slippage_none_for_zero_quoted_output() {
+        assert_eq!(slippage(&solved(0, 0), &solved(10, 10)), None);
     }
 }

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -153,7 +153,7 @@ mod tests {
             gas_estimate: U256::from(21_000),
             route: RouteSummary::default(),
             quote_json: None,
-            route: None,
+            solved_route: None,
         })
     }
 

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -355,6 +355,7 @@ mod tests {
             &empty_prices(),
             Outcome::Unsolvable("x".into()),
             Outcome::Unsolvable("x".into()),
+            &Outcome::Unsolvable("x".into()),
         );
         let rec = comparison_record(&range, &empty_prices(), &empty_prices());
         assert_eq!(rec.pointer("/tx_index").unwrap(), 3);
@@ -435,14 +436,15 @@ mod tests {
             algorithm: "bellman_ford".to_string(),
             path: "WETH -[uniswap_v3]-> DAI -[vm:curve]-> USDC".to_string(),
         };
-        // Top: gross 1010 USDC → +$10. Back: gross 1002 USDC → +$2. Both win.
+        // Top: gross 1010 USDC → +$10. Back: gross 1002 USDC → +$2. Both win. The top route's
+        // re-execution matches the fresh back solve, so the slippage numbers read off `back`.
         let top = Outcome::Solved(SolvedAmount {
             amount_out: U256::from(1_010_000_000u64),
             amount_out_net_gas: U256::from(1_005_000_000u64),
             gas_estimate: U256::from(21_000u64),
             route: route.clone(),
             quote_json: quote.clone(),
-            route: None,
+            solved_route: None,
         });
         let back = Outcome::Solved(SolvedAmount {
             amount_out: U256::from(1_002_000_000u64),
@@ -450,9 +452,9 @@ mod tests {
             gas_estimate: U256::from(21_000u64),
             route,
             quote_json: quote,
-            route: None,
+            solved_route: None,
         });
-        let range = build_range(&trade, &prices, top, back);
+        let range = build_range(&trade, &prices, top, back.clone(), &back);
 
         let rec = comparison_record(&range, &prices, &prices);
         let top_usd = rec
@@ -540,6 +542,7 @@ mod tests {
             &empty_prices(),
             Outcome::Unsolvable("missing token in Tycho".into()),
             Outcome::Unsolvable("missing token in Tycho".into()),
+            &Outcome::Unsolvable("no top-of-block route to re-execute".into()),
         );
         let rec = comparison_record(&range, &empty_prices(), &empty_prices());
         assert_eq!(rec.pointer("/top/verdict").unwrap(), "unsolvable");
@@ -605,10 +608,11 @@ mod tests {
                 gas_estimate: U256::from(21_000u64),
                 route: RouteSummary::default(),
                 quote_json: None,
-                route: None,
+                solved_route: None,
             })
         };
-        let range = build_range(&trade, &empty_prices(), solved(1_100), solved(1_050));
+        let range =
+            build_range(&trade, &empty_prices(), solved(1_100), solved(1_050), &solved(1_050));
         let rec = comparison_record(&range, &empty_prices(), &empty_prices());
 
         assert_eq!(rec.pointer("/tx_index").unwrap(), 42);

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -139,14 +139,27 @@ pub(crate) fn write_comparisons<W: std::io::Write>(
     }
 }
 
-/// Build the JSON record for one re-solved trade: block, settled tx, decoded amounts, and a `top`
+/// Build the JSON record for one re-solved trade: block, settled tx, decoded amounts, a `top`
 /// and `back` state (each with its verdict, bps, USD delta, and slim route/calldata or unsolvable
-/// reason). Top is valued at N-1 prices, back at N prices, matching the state each was solved at.
+/// reason), and the top route's slippage between the two states. Top is valued at N-1 prices,
+/// back (and the slippage) at N prices, matching the state each was produced at.
 fn comparison_record(
     range: &RangeComparison,
     prices_top: &Prices,
     prices_back: &Prices,
 ) -> serde_json::Value {
+    // Signed in both directions; the positive records are the "revenue if we charged positive
+    // slippage" view, filtered downstream.
+    let slippage = range.slippage.map(|slippage| {
+        serde_json::json!({
+            "bps": slippage.bps,
+            "usd": prices_back.savings_usd(
+                range.token_out,
+                slippage.reexecuted_amount_out,
+                slippage.quoted_amount_out,
+            ),
+        })
+    });
     serde_json::json!({
         "block": range.block_number,
         "tx_index": range.tx_index,
@@ -165,6 +178,7 @@ fn comparison_record(
         "quote_source": range.quote.as_ref().and_then(|q| q.source.clone()),
         "quote_timestamp": range.quote.as_ref().and_then(|q| q.timestamp),
         "sandwich": range.sandwich,
+        "slippage": slippage,
         "top": state_record(&range.top, range, prices_top),
         "back": state_record(&range.back, range, prices_back),
     })
@@ -428,6 +442,7 @@ mod tests {
             gas_estimate: U256::from(21_000u64),
             route: route.clone(),
             quote_json: quote.clone(),
+            route: None,
         });
         let back = Outcome::Solved(SolvedAmount {
             amount_out: U256::from(1_002_000_000u64),
@@ -435,6 +450,7 @@ mod tests {
             gas_estimate: U256::from(21_000u64),
             route,
             quote_json: quote,
+            route: None,
         });
         let range = build_range(&trade, &prices, top, back);
 
@@ -451,6 +467,20 @@ mod tests {
             .unwrap();
         assert!((top_usd - 10.0).abs() < 1e-3, "top_usd={top_usd}");
         assert!((back_usd - 2.0).abs() < 1e-3, "back_usd={back_usd}");
+        // Slippage: the top route re-executed at back produced 1002 vs 1010 quoted → −8 USDC,
+        // ≈ −79.2 bps and −$8 (signed; positive records are the chargeable-surplus view).
+        let slippage_bps = rec
+            .pointer("/slippage/bps")
+            .unwrap()
+            .as_f64()
+            .unwrap();
+        assert!((slippage_bps + 79.2).abs() < 0.1, "slippage_bps={slippage_bps}");
+        let slippage_usd = rec
+            .pointer("/slippage/usd")
+            .unwrap()
+            .as_f64()
+            .unwrap();
+        assert!((slippage_usd + 8.0).abs() < 1e-3, "slippage_usd={slippage_usd}");
         assert!(
             rec.pointer("/back/net_bps")
                 .unwrap()
@@ -532,6 +562,11 @@ mod tests {
                 "{field} should be null on an unsolvable state"
             );
         }
+        // No top route means nothing was re-executed: slippage is null, not zero.
+        assert!(rec
+            .pointer("/slippage")
+            .unwrap()
+            .is_null());
     }
 
     #[test]
@@ -570,6 +605,7 @@ mod tests {
                 gas_estimate: U256::from(21_000u64),
                 route: RouteSummary::default(),
                 quote_json: None,
+                route: None,
             })
         };
         let range = build_range(&trade, &empty_prices(), solved(1_100), solved(1_050));

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -392,8 +392,9 @@ mod tests {
             .starts_with("0x"));
     }
 
-    #[test]
-    fn test_improvement_record_top_and_back() {
+    /// Shared fixture for the top/back improvement and route-attribution tests: a win at both
+    /// states, with the top route re-executing to the same output the fresh back solve finds.
+    fn improvement_record_top_and_back() -> serde_json::Value {
         let usdc: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
             .parse()
             .unwrap();
@@ -456,7 +457,12 @@ mod tests {
         });
         let range = build_range(&trade, &prices, top, back.clone(), &back);
 
-        let rec = comparison_record(&range, &prices, &prices);
+        comparison_record(&range, &prices, &prices)
+    }
+
+    #[test]
+    fn test_improvement_record_top_and_back() {
+        let rec = improvement_record_top_and_back();
         let top_usd = rec
             .pointer("/top/improvement_usd")
             .unwrap()
@@ -506,6 +512,11 @@ mod tests {
                 .unwrap(),
             "uniswap_v3"
         );
+    }
+
+    #[test]
+    fn test_improvement_record_attributes_the_winning_route() {
+        let rec = improvement_record_top_and_back();
         // Route attribution is flat on the state, so grouping by algorithm or protocol does not
         // have to walk the nested per-hop route.
         assert_eq!(rec.pointer("/top/algorithm").unwrap(), "bellman_ford");

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -16,7 +16,7 @@ use fynd_core::types::{OrderQuote, Swap, Transaction};
 use tracing::{info, warn};
 
 use crate::{
-    resolve::{Outcome, RangeComparison, StateResult},
+    resolve::{render_route, Outcome, RangeComparison, StateResult},
     usd::Prices,
 };
 
@@ -216,8 +216,8 @@ fn state_record(
         "gas_estimate": solved.map(|s| s.gas_estimate.to_string()),
         // Flat route attribution, so a jq pass can group by algorithm or read the path at a glance
         // without walking the nested per-hop route below.
-        "algorithm": solved.map(|s| s.route.algorithm.as_str()),
-        "route": solved.map(|s| s.route.path.as_str()),
+        "algorithm": solved.map(|s| s.algorithm.as_str()),
+        "route": solved.map(|s| s.solved_route.as_deref().map(render_route).unwrap_or_default()),
         "improvement_usd": improvement_usd,
         "fynd_value_usd": fynd_value_usd,
         "settled_value_usd": prices.value_usd(token_out, range.settled_amount_out),
@@ -282,7 +282,7 @@ mod tests {
     use super::*;
     use crate::{
         decoder::{AttributionSource, DecodedTrade, Registry, SandwichEvidence, SolverQuote},
-        resolve::{build_range, RouteSummary, SolvedAmount},
+        resolve::{build_range, test_support, SolvedAmount},
     };
 
     fn empty_prices() -> Prices {
@@ -433,27 +433,27 @@ mod tests {
                 "gas_estimate":"0","split":1.0}]}"#
                 .to_string(),
         );
-        let route = RouteSummary {
-            algorithm: "bellman_ford".to_string(),
-            path: "WETH -[uniswap_v3]-> DAI -[vm:curve]-> USDC".to_string(),
-        };
+        let solved_route = Box::new(test_support::route(&[
+            ("uniswap_v3", "WETH", "DAI"),
+            ("vm:curve", "DAI", "USDC"),
+        ]));
         // Top: gross 1010 USDC → +$10. Back: gross 1002 USDC → +$2. Both win. The top route's
         // re-execution matches the fresh back solve, so the slippage numbers read off `back`.
         let top = Outcome::Solved(SolvedAmount {
             amount_out: U256::from(1_010_000_000u64),
             amount_out_net_gas: U256::from(1_005_000_000u64),
             gas_estimate: U256::from(21_000u64),
-            route: route.clone(),
+            algorithm: "bellman_ford".to_string(),
             quote_json: quote.clone(),
-            solved_route: None,
+            solved_route: Some(solved_route.clone()),
         });
         let back = Outcome::Solved(SolvedAmount {
             amount_out: U256::from(1_002_000_000u64),
             amount_out_net_gas: U256::from(1_001_000_000u64),
             gas_estimate: U256::from(21_000u64),
-            route,
+            algorithm: "bellman_ford".to_string(),
             quote_json: quote,
-            solved_route: None,
+            solved_route: Some(solved_route),
         });
         let range = build_range(&trade, &prices, top, back.clone(), &back);
 
@@ -617,7 +617,7 @@ mod tests {
                 amount_out: U256::from(amount),
                 amount_out_net_gas: U256::from(amount),
                 gas_estimate: U256::from(21_000u64),
-                route: RouteSummary::default(),
+                algorithm: String::new(),
                 quote_json: None,
                 solved_route: None,
             })

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -4,8 +4,9 @@
 //! The `SteppingSolver` trait abstracts the solver so the two-state comparison pipeline is
 //! testable without a live Fynd instance. The production implementation (`monitor`) drives an
 //! in-process `fynd-core` solver one block at a time: each trade is solved at top-of-block (N-1),
-//! then that same route is re-executed at back-of-block (N) to measure the slippage between
-//! quote time and execution time.
+//! then measured twice at back-of-block (N) — the top route is re-executed to isolate the
+//! slippage between quote time and execution time, and the trade is solved fresh to show what
+//! routing at the block's end state would deliver.
 
 mod compare;
 pub(crate) mod jsonl;
@@ -57,7 +58,7 @@ pub(crate) struct SolvedAmount {
     /// projection in `quote_json` covers the JSONL) and excluded from equality (a route carries
     /// unserializable, incomparable protocol states).
     #[serde(skip)]
-    pub route: Option<Route>,
+    pub solved_route: Option<Route>,
 }
 
 impl PartialEq for SolvedAmount {
@@ -130,8 +131,8 @@ pub(crate) struct RangeComparison {
     pub sandwich: Option<SandwichEvidence>,
     /// Optimistic: solved at state N-1, before the block's swaps moved the pools.
     pub top: StateResult,
-    /// Pessimistic: the top-of-block route re-executed at state N, after the block's swaps moved
-    /// the pools.
+    /// Pessimistic: solved fresh at state N, after the block's swaps moved the pools — what
+    /// routing at the block's end state would deliver.
     pub back: StateResult,
     /// Headline verdict — top-of-block (the optimistic default).
     pub verdict: Verdict,
@@ -155,7 +156,9 @@ pub(crate) trait SteppingSolver {
     async fn reexecute(&self, top: &SolvedAmount) -> Outcome;
 }
 
-/// Build a `RangeComparison` from the two per-state outcomes of a trade.
+/// Build a `RangeComparison` from a trade's three outcomes: the top-of-block solve, the fresh
+/// back-of-block solve, and the top route's re-execution at back-of-block (which feeds only the
+/// `slippage` field).
 ///
 /// When the decoder isolated the gas the trader paid for the settled route, its cost is converted
 /// into `token_out` units at the `prices` snapshot (top-of-block — a fine approximation for a gas
@@ -173,6 +176,7 @@ pub(crate) fn build_range(
     prices: &Prices,
     top: Outcome,
     back: Outcome,
+    reexecuted: &Outcome,
 ) -> RangeComparison {
     let settled_net_gas = trade
         .settled_gas
@@ -180,7 +184,7 @@ pub(crate) fn build_range(
         .map_or(trade.amount_out, |gas_out| trade.amount_out.saturating_sub(gas_out));
     // Computed from the raw outcomes: the coverage-miss reclassification below discards the
     // solved amounts the slippage is measured from.
-    let slippage = compare::slippage(&top, &back);
+    let slippage = compare::slippage(&top, reexecuted);
     let mut top = StateResult::new(top, trade.amount_out, settled_net_gas);
     let mut back = StateResult::new(back, trade.amount_out, settled_net_gas);
     if trade.sandwich.is_some() {
@@ -214,10 +218,11 @@ pub(crate) fn build_range(
     }
 }
 
-/// Re-solve every trade in a held block at top-of-block, advance to back-of-block, then
-/// re-execute each top route against the pools as the block left them, and pair the results.
-/// Solving all trades at one state before advancing keeps each state's reads consistent and
-/// steps the chain only once per block.
+/// Re-solve every trade in a held block at top-of-block, advance to back-of-block, then measure
+/// each trade twice at the new state: re-execute its top route against the pools as the block
+/// left them (for the slippage), and solve it fresh (for the `back` comparison). Solving all
+/// trades at one state before advancing keeps each state's reads consistent and steps the chain
+/// only once per block.
 pub(crate) async fn resolve_block_range<S: SteppingSolver + ?Sized>(
     solver: &S,
     trades: &[DecodedTrade],
@@ -236,13 +241,16 @@ pub(crate) async fn resolve_block_range<S: SteppingSolver + ?Sized>(
 
     let mut ranges = Vec::with_capacity(trades.len());
     for (trade, top) in trades.iter().zip(tops) {
-        let back = match &top {
+        let reexecuted = match &top {
             Outcome::Solved(solved) => solver.reexecute(solved).await,
             Outcome::Partial(_) | Outcome::Unsolvable(_) => {
                 Outcome::Unsolvable("no top-of-block route to re-execute".to_string())
             }
         };
-        ranges.push(build_range(trade, prices, top, back));
+        let back = solver
+            .solve(trade.token_in, trade.token_out, trade.amount_in)
+            .await;
+        ranges.push(build_range(trade, prices, top, back, &reexecuted));
     }
     Ok(ranges)
 }
@@ -287,21 +295,30 @@ mod tests {
             gas_estimate: U256::from(21_000),
             route: RouteSummary::default(),
             quote_json: None,
-            route: None,
+            solved_route: None,
         })
     }
 
-    /// Stepping mock: `solve` returns `top`; `reexecute` returns `back` (the re-executed route).
+    /// Stepping mock: `solve` returns `top` before `advance()` and `back` after; `reexecute`
+    /// returns `reexecuted` (the top route replayed at the new state).
     struct MockStepping {
         advanced: std::sync::atomic::AtomicBool,
         top: Outcome,
         back: Outcome,
+        reexecuted: Outcome,
     }
 
     #[async_trait]
     impl SteppingSolver for MockStepping {
         async fn solve(&self, _: Address, _: Address, _: U256) -> Outcome {
-            self.top.clone()
+            if self
+                .advanced
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                self.back.clone()
+            } else {
+                self.top.clone()
+            }
         }
 
         async fn advance(&self) -> anyhow::Result<()> {
@@ -316,7 +333,7 @@ mod tests {
                     .load(std::sync::atomic::Ordering::Relaxed),
                 "reexecute must only run after advance()"
             );
-            self.back.clone()
+            self.reexecuted.clone()
         }
     }
 
@@ -327,6 +344,7 @@ mod tests {
             &empty_prices(),
             solved(10_200, 10_100),
             solved(10_010, 9_990),
+            &solved(10_010, 9_990),
         );
         assert_eq!(range.verdict, Verdict::Win); // top is the headline
         assert!(range.top.deltas.raw_bps.unwrap() > range.back.deltas.raw_bps.unwrap());
@@ -335,8 +353,13 @@ mod tests {
     #[test]
     fn test_build_range_partial_fill() {
         // Fynd fills only 10% of a 10_000 settled trade → reclassified as a coverage miss.
-        let range =
-            build_range(&trade(10_000), &empty_prices(), solved(1_000, 990), solved(1_000, 990));
+        let range = build_range(
+            &trade(10_000),
+            &empty_prices(),
+            solved(1_000, 990),
+            solved(1_000, 990),
+            &solved(1_000, 990),
+        );
         assert_eq!(range.verdict, Verdict::CoverageMiss);
         assert_eq!(range.top.deltas, Deltas { raw_bps: None, net_bps: None });
         assert!(matches!(range.top.outcome, Outcome::Partial(_)));
@@ -351,8 +374,13 @@ mod tests {
             attacker: Address::repeat_byte(0xcc),
             pools: vec![Address::repeat_byte(0xdd)],
         });
-        let range =
-            build_range(&sandwiched, &empty_prices(), solved(10_200, 10_100), solved(9_800, 9_700));
+        let range = build_range(
+            &sandwiched,
+            &empty_prices(),
+            solved(10_200, 10_100),
+            solved(9_800, 9_700),
+            &solved(9_800, 9_700),
+        );
 
         assert_eq!(range.verdict, Verdict::Sandwiched);
         assert_eq!(range.top.verdict, Verdict::Sandwiched);
@@ -378,6 +406,7 @@ mod tests {
             &empty_prices(),
             solved(10_200, 10_100),
             Outcome::Unsolvable("missing token in Tycho".into()),
+            &Outcome::Unsolvable("re-execution failed".into()),
         );
 
         assert_eq!(range.top.verdict, Verdict::Sandwiched);
@@ -394,7 +423,13 @@ mod tests {
         let mut prices = empty_prices();
         prices.insert(with_gas.token_out, 2.0);
 
-        let range = build_range(&with_gas, &prices, solved(10_050, 9_990), solved(10_050, 9_990));
+        let range = build_range(
+            &with_gas,
+            &prices,
+            solved(10_050, 9_990),
+            solved(10_050, 9_990),
+            &solved(10_050, 9_990),
+        );
         assert_eq!(range.settled_amount_out_net_gas, U256::from(9_800u64));
         assert_eq!(range.settled_amount_out, U256::from(10_000u64));
         assert_eq!(range.verdict, Verdict::Win);
@@ -407,20 +442,26 @@ mod tests {
         let mut with_gas = trade(10_000);
         with_gas.settled_gas = Some(U256::from(100u64));
 
-        let range =
-            build_range(&with_gas, &empty_prices(), solved(10_050, 9_990), solved(10_050, 9_990));
+        let range = build_range(
+            &with_gas,
+            &empty_prices(),
+            solved(10_050, 9_990),
+            solved(10_050, 9_990),
+            &solved(10_050, 9_990),
+        );
         assert_eq!(range.settled_amount_out_net_gas, U256::from(10_000u64));
         assert_eq!(range.verdict, Verdict::Win);
     }
 
     #[tokio::test]
-    async fn resolve_block_range_pairs_top_and_reexecution() {
-        // Two trades. The top solve wins; its route re-executed at back-of-block produces less
-        // than settled (a loss vs settled) and less than quoted (negative slippage).
+    async fn resolve_block_range_pairs_top_back_and_reexecution() {
+        // Two trades. The top solve wins; the fresh back solve loses vs settled; the top route
+        // re-executed at back-of-block produces less than quoted (negative slippage).
         let solver = MockStepping {
             advanced: std::sync::atomic::AtomicBool::new(false),
             top: solved(10_200, 10_100),
-            back: solved(9_900, 9_800),
+            back: solved(9_950, 9_850),
+            reexecuted: solved(9_900, 9_800),
         };
         let trades = [trade(10_000), trade(10_000)];
         let ranges = resolve_block_range(&solver, &trades, &empty_prices())
@@ -440,36 +481,52 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_block_range_skips_reexecution_without_top_route() {
-        // An unsolved top has no route to re-execute: the mock's reexecute is never reached
-        // (it would return a solved back), and the back state records why.
+    async fn resolve_block_range_back_solve_without_top_route() {
+        // An unsolved top has no route to re-execute, so there is no slippage — but the fresh
+        // back-of-block solve does not need a top route: back still carries a real comparison.
         let solver = MockStepping {
             advanced: std::sync::atomic::AtomicBool::new(false),
             top: Outcome::Unsolvable("missing token in Tycho".into()),
             back: solved(10_100, 10_000),
+            reexecuted: solved(10_100, 10_000),
         };
         let trades = [trade(10_000)];
         let ranges = resolve_block_range(&solver, &trades, &empty_prices())
             .await
             .unwrap();
 
-        assert_eq!(ranges[0].back.verdict, Verdict::Unsolvable);
-        assert!(matches!(
-            &ranges[0].back.outcome,
-            Outcome::Unsolvable(reason) if reason == "no top-of-block route to re-execute"
-        ));
+        assert_eq!(ranges[0].top.verdict, Verdict::Unsolvable);
+        assert_eq!(ranges[0].back.verdict, Verdict::Win);
         assert_eq!(ranges[0].slippage, None);
     }
 
     #[test]
     fn build_range_positive_slippage_from_raw_outcomes() {
-        // The route re-executed to more than quoted: the surplus we could charge.
+        // The route re-executed to more than quoted: the surplus we could charge. The fresh
+        // back solve is a different route and plays no part in the slippage.
         let range = build_range(
             &trade(10_000),
             &empty_prices(),
             solved(10_000, 9_900),
-            solved(10_050, 9_950),
+            solved(10_500, 10_400),
+            &solved(10_050, 9_950),
         );
+        let slippage = range.slippage.unwrap();
+        assert!((slippage.bps - 50.0).abs() < 0.01, "expected +50 bps, got {}", slippage.bps);
+    }
+
+    #[test]
+    fn build_range_slippage_survives_unsolved_back() {
+        // The fresh back solve failed (e.g. the pair lost its route at state N), but the top
+        // route still re-executed: the slippage must survive independently of `back`.
+        let range = build_range(
+            &trade(10_000),
+            &empty_prices(),
+            solved(10_000, 9_900),
+            Outcome::Unsolvable("no route at back-of-block".into()),
+            &solved(10_050, 9_950),
+        );
+        assert_eq!(range.back.verdict, Verdict::Unsolvable);
         let slippage = range.slippage.unwrap();
         assert!((slippage.bps - 50.0).abs() < 0.01, "expected +50 bps, got {}", slippage.bps);
     }
@@ -477,10 +534,15 @@ mod tests {
     #[test]
     fn build_range_slippage_survives_coverage_miss_reclassification() {
         // Both states cover only 10% of the settled size and are reclassified as coverage
-        // misses (losing their solved amounts) — the slippage between them must still be
-        // measured from the raw outcomes.
-        let range =
-            build_range(&trade(10_000), &empty_prices(), solved(1_000, 990), solved(1_010, 1_000));
+        // misses (losing their solved amounts) — the slippage between the top quote and its
+        // re-execution must still be measured from the raw outcomes.
+        let range = build_range(
+            &trade(10_000),
+            &empty_prices(),
+            solved(1_000, 990),
+            solved(1_010, 1_000),
+            &solved(1_010, 1_000),
+        );
         assert_eq!(range.verdict, Verdict::CoverageMiss);
         let slippage = range.slippage.unwrap();
         assert!((slippage.bps - 100.0).abs() < 0.01, "expected +100 bps, got {}", slippage.bps);

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -3,8 +3,9 @@
 //!
 //! The `SteppingSolver` trait abstracts the solver so the two-state comparison pipeline is
 //! testable without a live Fynd instance. The production implementation (`monitor`) drives an
-//! in-process `fynd-core` solver one block at a time, re-solving each trade at top-of-block (N-1)
-//! and back-of-block (N).
+//! in-process `fynd-core` solver one block at a time: each trade is solved at top-of-block (N-1),
+//! then that same route is re-executed at back-of-block (N) to measure the slippage between
+//! quote time and execution time.
 
 mod compare;
 pub(crate) mod jsonl;
@@ -12,7 +13,8 @@ pub(crate) mod monitor;
 
 use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
-pub(crate) use compare::{Deltas, Verdict};
+pub(crate) use compare::{Deltas, Slippage, Verdict};
+use fynd_core::types::Route;
 use serde::Serialize;
 
 use crate::{
@@ -38,7 +40,7 @@ pub(crate) struct RouteSummary {
 }
 
 /// A Fynd quote for the re-solved order.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct SolvedAmount {
     pub amount_out: U256,
     /// Output after Fynd's own estimated gas cost.
@@ -50,7 +52,24 @@ pub(crate) struct SolvedAmount {
     /// dumping improvements. `None` when not captured (e.g. the HTTP resolve path).
     #[serde(default)]
     pub quote_json: Option<String>,
+    /// The solved route, kept in memory so [`SteppingSolver::reexecute`] can replay it at
+    /// back-of-block. `None` for re-executed results and mocks. Not serialized (the slim
+    /// projection in `quote_json` covers the JSONL) and excluded from equality (a route carries
+    /// unserializable, incomparable protocol states).
+    #[serde(skip)]
+    pub route: Option<Route>,
 }
+
+impl PartialEq for SolvedAmount {
+    fn eq(&self, other: &Self) -> bool {
+        self.amount_out == other.amount_out &&
+            self.amount_out_net_gas == other.amount_out_net_gas &&
+            self.gas_estimate == other.gas_estimate &&
+            self.quote_json == other.quote_json
+    }
+}
+
+impl Eq for SolvedAmount {}
 
 /// The outcome of re-solving a trade.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -111,10 +130,14 @@ pub(crate) struct RangeComparison {
     pub sandwich: Option<SandwichEvidence>,
     /// Optimistic: solved at state N-1, before the block's swaps moved the pools.
     pub top: StateResult,
-    /// Pessimistic: solved at state N, after the block's swaps moved the pools.
+    /// Pessimistic: the top-of-block route re-executed at state N, after the block's swaps moved
+    /// the pools.
     pub back: StateResult,
     /// Headline verdict — top-of-block (the optimistic default).
     pub verdict: Verdict,
+    /// Slippage of the top route between quote time (N-1) and re-execution (N). `None` when the
+    /// top was unsolved or the re-execution failed.
+    pub slippage: Option<Slippage>,
 }
 
 /// Solves a sell order at the current block state and steps to the next block. The production
@@ -127,6 +150,9 @@ pub(crate) trait SteppingSolver {
     async fn solve(&self, token_in: Address, token_out: Address, amount_in: U256) -> Outcome;
     /// Release the held block and settle the solver onto the next block's state.
     async fn advance(&self) -> anyhow::Result<()>;
+    /// Re-execute `top`'s route at the solver's current block state — same pools, splits, and
+    /// input amount against the pools as the block left them.
+    async fn reexecute(&self, top: &SolvedAmount) -> Outcome;
 }
 
 /// Build a `RangeComparison` from the two per-state outcomes of a trade.
@@ -152,6 +178,9 @@ pub(crate) fn build_range(
         .settled_gas
         .and_then(|gas| prices.gas_in_token(gas, trade.token_out))
         .map_or(trade.amount_out, |gas_out| trade.amount_out.saturating_sub(gas_out));
+    // Computed from the raw outcomes: the coverage-miss reclassification below discards the
+    // solved amounts the slippage is measured from.
+    let slippage = compare::slippage(&top, &back);
     let mut top = StateResult::new(top, trade.amount_out, settled_net_gas);
     let mut back = StateResult::new(back, trade.amount_out, settled_net_gas);
     if trade.sandwich.is_some() {
@@ -181,12 +210,14 @@ pub(crate) fn build_range(
         top,
         back,
         verdict,
+        slippage,
     }
 }
 
-/// Re-solve every trade in a held block at top-of-block, advance to back-of-block, re-solve again,
-/// and pair the results. Solving all trades at one state before advancing keeps each state's reads
-/// consistent and steps the chain only once per block.
+/// Re-solve every trade in a held block at top-of-block, advance to back-of-block, then
+/// re-execute each top route against the pools as the block left them, and pair the results.
+/// Solving all trades at one state before advancing keeps each state's reads consistent and
+/// steps the chain only once per block.
 pub(crate) async fn resolve_block_range<S: SteppingSolver + ?Sized>(
     solver: &S,
     trades: &[DecodedTrade],
@@ -205,9 +236,12 @@ pub(crate) async fn resolve_block_range<S: SteppingSolver + ?Sized>(
 
     let mut ranges = Vec::with_capacity(trades.len());
     for (trade, top) in trades.iter().zip(tops) {
-        let back = solver
-            .solve(trade.token_in, trade.token_out, trade.amount_in)
-            .await;
+        let back = match &top {
+            Outcome::Solved(solved) => solver.reexecute(solved).await,
+            Outcome::Partial(_) | Outcome::Unsolvable(_) => {
+                Outcome::Unsolvable("no top-of-block route to re-execute".to_string())
+            }
+        };
         ranges.push(build_range(trade, prices, top, back));
     }
     Ok(ranges)
@@ -253,10 +287,11 @@ mod tests {
             gas_estimate: U256::from(21_000),
             route: RouteSummary::default(),
             quote_json: None,
+            route: None,
         })
     }
 
-    /// Stepping mock: returns `top` before `advance()`, `back` after.
+    /// Stepping mock: `solve` returns `top`; `reexecute` returns `back` (the re-executed route).
     struct MockStepping {
         advanced: std::sync::atomic::AtomicBool,
         top: Outcome,
@@ -266,20 +301,22 @@ mod tests {
     #[async_trait]
     impl SteppingSolver for MockStepping {
         async fn solve(&self, _: Address, _: Address, _: U256) -> Outcome {
-            if self
-                .advanced
-                .load(std::sync::atomic::Ordering::Relaxed)
-            {
-                self.back.clone()
-            } else {
-                self.top.clone()
-            }
+            self.top.clone()
         }
 
         async fn advance(&self) -> anyhow::Result<()> {
             self.advanced
                 .store(true, std::sync::atomic::Ordering::Relaxed);
             Ok(())
+        }
+
+        async fn reexecute(&self, _: &SolvedAmount) -> Outcome {
+            assert!(
+                self.advanced
+                    .load(std::sync::atomic::Ordering::Relaxed),
+                "reexecute must only run after advance()"
+            );
+            self.back.clone()
         }
     }
 
@@ -377,8 +414,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_block_range_top_and_back() {
-        // Two trades. Top-of-block is optimistic (better), back-of-block pessimistic (worse).
+    async fn resolve_block_range_pairs_top_and_reexecution() {
+        // Two trades. The top solve wins; its route re-executed at back-of-block produces less
+        // than settled (a loss vs settled) and less than quoted (negative slippage).
         let solver = MockStepping {
             advanced: std::sync::atomic::AtomicBool::new(false),
             top: solved(10_200, 10_100),
@@ -394,6 +432,57 @@ mod tests {
             assert_eq!(range.top.verdict, Verdict::Win);
             assert_eq!(range.back.verdict, Verdict::Loss);
             assert!(range.top.deltas.raw_bps.unwrap() > range.back.deltas.raw_bps.unwrap());
+            let slippage = range.slippage.unwrap();
+            assert!(slippage.bps < 0.0, "re-execution below quote must be negative slippage");
+            assert_eq!(slippage.quoted_amount_out, U256::from(10_200u64));
+            assert_eq!(slippage.reexecuted_amount_out, U256::from(9_900u64));
         }
+    }
+
+    #[tokio::test]
+    async fn resolve_block_range_skips_reexecution_without_top_route() {
+        // An unsolved top has no route to re-execute: the mock's reexecute is never reached
+        // (it would return a solved back), and the back state records why.
+        let solver = MockStepping {
+            advanced: std::sync::atomic::AtomicBool::new(false),
+            top: Outcome::Unsolvable("missing token in Tycho".into()),
+            back: solved(10_100, 10_000),
+        };
+        let trades = [trade(10_000)];
+        let ranges = resolve_block_range(&solver, &trades, &empty_prices())
+            .await
+            .unwrap();
+
+        assert_eq!(ranges[0].back.verdict, Verdict::Unsolvable);
+        assert!(matches!(
+            &ranges[0].back.outcome,
+            Outcome::Unsolvable(reason) if reason == "no top-of-block route to re-execute"
+        ));
+        assert_eq!(ranges[0].slippage, None);
+    }
+
+    #[test]
+    fn build_range_positive_slippage_from_raw_outcomes() {
+        // The route re-executed to more than quoted: the surplus we could charge.
+        let range = build_range(
+            &trade(10_000),
+            &empty_prices(),
+            solved(10_000, 9_900),
+            solved(10_050, 9_950),
+        );
+        let slippage = range.slippage.unwrap();
+        assert!((slippage.bps - 50.0).abs() < 0.01, "expected +50 bps, got {}", slippage.bps);
+    }
+
+    #[test]
+    fn build_range_slippage_survives_coverage_miss_reclassification() {
+        // Both states cover only 10% of the settled size and are reclassified as coverage
+        // misses (losing their solved amounts) — the slippage between them must still be
+        // measured from the raw outcomes.
+        let range =
+            build_range(&trade(10_000), &empty_prices(), solved(1_000, 990), solved(1_010, 1_000));
+        assert_eq!(range.verdict, Verdict::CoverageMiss);
+        let slippage = range.slippage.unwrap();
+        assert!((slippage.bps - 100.0).abs() < 0.01, "expected +100 bps, got {}", slippage.bps);
     }
 }

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -56,9 +56,10 @@ pub(crate) struct SolvedAmount {
     /// The solved route, kept in memory so [`SteppingSolver::reexecute`] can replay it at
     /// back-of-block. `None` for re-executed results and mocks. Not serialized (the slim
     /// projection in `quote_json` covers the JSONL) and excluded from equality (a route carries
-    /// unserializable, incomparable protocol states).
+    /// unserializable, incomparable protocol states). Boxed so a route-carrying `SolvedAmount`
+    /// doesn't blow up `Outcome`'s size relative to its other variants.
     #[serde(skip)]
-    pub solved_route: Option<Route>,
+    pub solved_route: Option<Box<Route>>,
 }
 
 impl PartialEq for SolvedAmount {

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -12,32 +12,145 @@ mod compare;
 pub(crate) mod jsonl;
 pub(crate) mod monitor;
 
+use std::collections::HashMap;
+
 use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
 pub(crate) use compare::{Deltas, Slippage, Verdict};
-use fynd_core::types::Route;
+use fynd_core::types::{Route, Swap};
 use serde::Serialize;
+use tycho_simulation::tycho_common::models::Address as CoreAddress;
 
 use crate::{
     decoder::{AttributionSource, DecodedTrade, SandwichEvidence, SolverQuote},
     usd::Prices,
 };
 
-/// What Fynd's winning route was: the worker-pool algorithm that produced it and the path it took.
-/// Kept as typed fields (not dug back out of `quote_json`) so the metrics and the per-trade log
-/// line can read them without parsing JSON.
+/// One route leg, reduced to what rendering needs. A `Swap` also carries a `ProtocolComponent`
+/// and a boxed `ProtocolSim` that a route string has no use for and that cannot be built outside
+/// `fynd-core`, so the rendering below works on this instead and stays unit-testable.
+struct Leg<'a> {
+    token_in: &'a CoreAddress,
+    token_out: &'a CoreAddress,
+    protocol: &'a str,
+    /// The leg's declared share of `token_in`. `0.0` means "all the remaining balance".
+    split: f64,
+}
+
+impl<'a> Leg<'a> {
+    fn from_swap(swap: &'a Swap) -> Self {
+        Self {
+            token_in: swap.token_in(),
+            token_out: swap.token_out(),
+            protocol: swap.protocol(),
+            split: *swap.split(),
+        }
+    }
+}
+
+/// Render a solved route as a readable path: `USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH`.
+/// Token symbols are resolved from the route's own token map (populated by the algorithm that
+/// built it, via [`fynd_core::types::Route::token_symbol`]); a token missing from that map falls
+/// back to a shortened address.
+pub(crate) fn render_route(route: &Route) -> String {
+    let legs: Vec<Leg<'_>> = Route::swaps(route)
+        .iter()
+        .map(Leg::from_swap)
+        .collect();
+    render_legs(&legs, &route_symbols(route))
+}
+
+/// Symbols for every token in `route`, resolved from the route's own token map.
+fn route_symbols(route: &Route) -> HashMap<CoreAddress, String> {
+    let mut symbols = HashMap::new();
+    for swap in Route::swaps(route) {
+        for token in [swap.token_in(), swap.token_out()] {
+            if let Some(symbol) = route.token_symbol(token) {
+                symbols.insert(token.clone(), symbol.to_string());
+            }
+        }
+    }
+    symbols
+}
+
+/// Render a route's legs as a readable path, given each token's symbol. Kept apart from
+/// [`render_route`] so the algorithm is unit-testable against plain `Leg`s and a symbol map,
+/// without building a real `Route`/`Swap`.
 ///
-/// `Default` means "no route detail" — both fields empty.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
-pub(crate) struct RouteSummary {
-    /// Name of the algorithm whose route won the quote: `bellman_ford`, `most_liquid`,
-    /// `path_frank_wolfe`, `water_fill`. Empty when the quote declared none.
-    pub algorithm: String,
-    /// The route as a readable path, tokens and protocols interleaved:
-    /// `USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH`. Split legs carry their share and are
-    /// joined with ` + `. Empty when the quote carried no route. Logged and serialized under the
-    /// name `route`.
-    pub path: String,
+/// Swaps that connect — one's output token is the next's input — chain into a single arrow path.
+/// A split fans several legs out of the same token, so its legs cannot share one chain: each
+/// becomes its own path carrying its share of the input, and the paths are joined with ` + `.
+/// Protocol ids are Tycho's own, so a newly integrated DEX reads correctly without a lookup table
+/// here.
+fn render_legs(legs: &[Leg<'_>], symbols: &HashMap<CoreAddress, String>) -> String {
+    let mut paths: Vec<String> = Vec::new();
+    let mut open = String::new();
+    let mut tip: Option<&CoreAddress> = None;
+    for (leg, share) in legs.iter().zip(split_shares(legs)) {
+        if tip != Some(leg.token_in) {
+            if !open.is_empty() {
+                paths.push(std::mem::take(&mut open));
+            }
+            open = token_label(leg.token_in, symbols);
+        }
+        open.push_str(&arrow(leg.protocol, share));
+        open.push_str(&token_label(leg.token_out, symbols));
+        tip = Some(leg.token_out);
+    }
+    if !open.is_empty() {
+        paths.push(open);
+    }
+    paths.join(" + ")
+}
+
+/// The arrow between two tokens: ` -[uniswap_v2]-> `, or ` -[vm:curve 40%]-> ` for one leg of a
+/// split, where the share tells you how much of the input took this leg.
+fn arrow(protocol: &str, share: Option<f64>) -> String {
+    match share {
+        Some(share) => format!(" -[{protocol} {:.0}%]-> ", share * 100.0),
+        None => format!(" -[{protocol}]-> "),
+    }
+}
+
+/// Each leg's share of its input token, or `None` when it is the only leg consuming that token.
+///
+/// A split's legs all consume the same token, and by `Route`'s split convention every leg but one
+/// declares an explicit fraction while the last declares `0.0`, meaning "all the remaining
+/// balance". Reconstruct that remainder so every leg of a split reads as a percentage.
+fn split_shares(legs: &[Leg<'_>]) -> Vec<Option<f64>> {
+    let mut consumers: HashMap<&CoreAddress, (usize, f64)> = HashMap::new();
+    for leg in legs {
+        let entry = consumers
+            .entry(leg.token_in)
+            .or_insert((0, 0.0));
+        entry.0 += 1;
+        entry.1 += leg.split;
+    }
+    legs.iter()
+        .map(|leg| {
+            let (count, declared) = consumers
+                .get(leg.token_in)
+                .copied()
+                .unwrap_or((1, 0.0));
+            if count < 2 {
+                return None;
+            }
+            Some(if leg.split == 0.0 { 1.0 - declared } else { leg.split })
+        })
+        .collect()
+}
+
+/// A token's symbol, or a shortened address when the route has no entry for it — an unknown token
+/// still has to read as a distinct hop rather than vanish from the path.
+fn token_label(token: &CoreAddress, symbols: &HashMap<CoreAddress, String>) -> String {
+    if let Some(symbol) = symbols.get(token) {
+        return symbol.clone();
+    }
+    let hex = token.to_string();
+    match hex.get(..8) {
+        Some(prefix) => format!("{prefix}…"),
+        None => hex,
+    }
 }
 
 /// A Fynd quote for the re-solved order.
@@ -47,17 +160,21 @@ pub(crate) struct SolvedAmount {
     /// Output after Fynd's own estimated gas cost.
     pub amount_out_net_gas: U256,
     pub gas_estimate: U256,
-    /// Which algorithm won and the path its route took.
-    pub route: RouteSummary,
+    /// Name of the algorithm whose route won the quote: `bellman_ford`, `most_liquid`,
+    /// `path_frank_wolfe`, `water_fill`. Empty when the quote declared none, or when this is a
+    /// re-executed outcome (it only feeds the slippage numbers and does not re-declare a route).
+    pub algorithm: String,
     /// The complete serialized Fynd quote (route, per-hop pools/amounts, encoded transaction) for
     /// dumping improvements. `None` when not captured (e.g. the HTTP resolve path).
     #[serde(default)]
     pub quote_json: Option<String>,
     /// The solved route, kept in memory so [`SteppingSolver::reexecute`] can replay it at
-    /// back-of-block. `None` for re-executed results and mocks. Not serialized (the slim
-    /// projection in `quote_json` covers the JSONL) and excluded from equality (a route carries
-    /// unserializable, incomparable protocol states). Boxed so a route-carrying `SolvedAmount`
-    /// doesn't blow up `Outcome`'s size relative to its other variants.
+    /// back-of-block and so [`render_route`] can derive the readable path at serialization time
+    /// (serialized under `route`, alongside `algorithm`). `None` for re-executed results and
+    /// mocks. Not serialized directly (the derived path and the slim projection in `quote_json`
+    /// cover the JSONL) and excluded from equality (a route carries unserializable, incomparable
+    /// protocol states). Boxed so a route-carrying `SolvedAmount` doesn't blow up `Outcome`'s size
+    /// relative to its other variants.
     #[serde(skip)]
     pub solved_route: Option<Box<Route>>,
 }
@@ -294,7 +411,7 @@ mod tests {
             amount_out: U256::from(amount_out),
             amount_out_net_gas: U256::from(net),
             gas_estimate: U256::from(21_000),
-            route: RouteSummary::default(),
+            algorithm: String::new(),
             quote_json: None,
             solved_route: None,
         })
@@ -547,5 +664,173 @@ mod tests {
         assert_eq!(range.verdict, Verdict::CoverageMiss);
         let slippage = range.slippage.unwrap();
         assert!((slippage.bps - 100.0).abs() < 0.01, "expected +100 bps, got {}", slippage.bps);
+    }
+
+    /// A token address keyed by its symbol's last byte — distinct across the symbols used below,
+    /// where the first byte is not (USDT and USDC share it) — so `symbols()` can name it back.
+    fn token(symbol: &str) -> CoreAddress {
+        let tag = symbol
+            .as_bytes()
+            .last()
+            .copied()
+            .unwrap_or(0);
+        CoreAddress::from(vec![tag; 20])
+    }
+
+    /// A symbol table for the symbols used below.
+    fn symbols() -> HashMap<CoreAddress, String> {
+        ["USDT", "DAI", "WETH", "USDC"]
+            .into_iter()
+            .map(|symbol| (token(symbol), symbol.to_string()))
+            .collect()
+    }
+
+    /// One route leg. `split` follows `Route`'s convention: an explicit fraction, or 0.0 for the
+    /// leg that takes whatever is left.
+    fn leg<'a>(
+        token_in: &'a CoreAddress,
+        token_out: &'a CoreAddress,
+        protocol: &'a str,
+        split: f64,
+    ) -> Leg<'a> {
+        Leg { token_in, token_out, protocol, split }
+    }
+
+    #[test]
+    fn test_render_legs_multi_hop() {
+        // Connecting legs chain into one arrow path; no percentages, since nothing is split.
+        let (usdt, dai, weth) = (token("USDT"), token("DAI"), token("WETH"));
+        let route = render_legs(
+            &[leg(&usdt, &dai, "uniswap_v2", 0.0), leg(&dai, &weth, "vm:balancer", 0.0)],
+            &symbols(),
+        );
+        assert_eq!(route, "USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH");
+    }
+
+    #[test]
+    fn test_render_legs_split() {
+        // Two legs out of USDC: the 0.6 leg is explicit, the 0.0 leg takes the remainder. They fan
+        // out of the same token so they cannot share one chain — each becomes its own path, joined
+        // by " + ", and both carry their share.
+        let (usdc, weth) = (token("USDC"), token("WETH"));
+        let route = render_legs(
+            &[leg(&usdc, &weth, "uniswap_v3", 0.6), leg(&usdc, &weth, "vm:curve", 0.0)],
+            &symbols(),
+        );
+        assert_eq!(route, "USDC -[uniswap_v3 60%]-> WETH + USDC -[vm:curve 40%]-> WETH");
+    }
+
+    #[test]
+    fn test_render_legs_split_then_common_hop() {
+        // A split that reconverges: both legs land on WETH, then one leg carries on to USDC. The
+        // continuation chains onto the path that ended at WETH rather than starting a third path.
+        let (usdt, dai, weth, usdc) = (token("USDT"), token("DAI"), token("WETH"), token("USDC"));
+        let route = render_legs(
+            &[
+                leg(&usdt, &weth, "uniswap_v3", 0.25),
+                leg(&usdt, &dai, "vm:curve", 0.0),
+                leg(&dai, &usdc, "uniswap_v2", 0.0),
+            ],
+            &symbols(),
+        );
+        assert_eq!(
+            route,
+            "USDT -[uniswap_v3 25%]-> WETH + USDT -[vm:curve 75%]-> DAI -[uniswap_v2]-> USDC"
+        );
+    }
+
+    #[test]
+    fn test_render_legs_unknown_token() {
+        // A long-tail token with no entry in the symbol table still has to read as a distinct
+        // hop, so it falls back to a shortened address rather than an empty string.
+        let (usdt, unknown) = (token("USDT"), CoreAddress::from(vec![0xab; 20]));
+        assert_eq!(
+            render_legs(&[leg(&usdt, &unknown, "uniswap_v2", 0.0)], &symbols()),
+            "USDT -[uniswap_v2]-> 0xababab…"
+        );
+    }
+
+    #[test]
+    fn test_render_legs_empty() {
+        assert_eq!(render_legs(&[], &symbols()), "");
+    }
+
+    #[test]
+    fn test_render_route_resolves_symbols_from_the_route_itself() {
+        // Unlike `render_legs` above (fed a hand-built symbol table), this exercises the glue
+        // that reads symbols directly off a real `Route`'s own token map.
+        let route =
+            test_support::route(&[("uniswap_v2", "USDT", "DAI"), ("vm:balancer", "DAI", "WETH")]);
+        assert_eq!(render_route(&route), "USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH");
+    }
+}
+
+/// Test-only route construction, shared by tests here and in sibling modules (`jsonl`) that need
+/// a real `Route` with resolvable token symbols — as opposed to the pure-rendering tests above,
+/// which build `Leg`s directly to stay decoupled from `Swap`'s heavier constructor.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::collections::HashMap;
+
+    use alloy::primitives::U256;
+    use chrono::NaiveDateTime;
+    use fynd_core::types::{Route, Swap};
+    use num_bigint::BigUint;
+    use tycho_simulation::{
+        evm::protocol::uniswap_v2::state::UniswapV2State,
+        tycho_common::{
+            models::{protocol::ProtocolComponent, token::Token, Chain, ChangeType},
+            Bytes,
+        },
+    };
+
+    /// Build a route from `(protocol, token_in_symbol, token_out_symbol)` hops, chained in order.
+    /// Each hop gets a throwaway `UniswapV2State` pool — real enough to satisfy `Swap::new`,
+    /// irrelevant to what the route-summary code reads (protocol id, token addresses, and the
+    /// route's own token map).
+    pub(crate) fn route(hops: &[(&str, &str, &str)]) -> Route {
+        let mut tokens: HashMap<Bytes, Token> = HashMap::new();
+        let mut swaps = Vec::with_capacity(hops.len());
+        for &(protocol, token_in_symbol, token_out_symbol) in hops {
+            let token_in = symbol_token(token_in_symbol);
+            let token_out = symbol_token(token_out_symbol);
+            let component = ProtocolComponent::new(
+                "test-pool",
+                protocol,
+                "swap",
+                Chain::Ethereum,
+                vec![token_in.address.clone(), token_out.address.clone()],
+                vec![],
+                HashMap::new(),
+                ChangeType::default(),
+                Bytes::default(),
+                NaiveDateTime::default(),
+            );
+            swaps.push(Swap::new(
+                "test-pool".to_string(),
+                protocol.to_string(),
+                token_in.address.clone(),
+                token_out.address.clone(),
+                BigUint::from(1_000u64),
+                BigUint::from(990u64),
+                BigUint::from(100_000u64),
+                component,
+                Box::new(UniswapV2State::new(U256::from(1_000_000u64), U256::from(1_000_000u64))),
+            ));
+            tokens.insert(token_in.address.clone(), token_in);
+            tokens.insert(token_out.address.clone(), token_out);
+        }
+        Route::new(swaps, tokens).expect("test route must not be empty")
+    }
+
+    /// A deterministic token keyed by its symbol's last byte, matching the address scheme the
+    /// pure-rendering tests use so both layers agree on the same token identity.
+    fn symbol_token(symbol: &str) -> Token {
+        let tag = symbol
+            .as_bytes()
+            .last()
+            .copied()
+            .unwrap_or(0);
+        Token::new(&Bytes::from(vec![tag; 20]), symbol, 18, 0, &[], Chain::Ethereum, 100)
     }
 }

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -10,7 +10,6 @@
 //! integration test in `tests/` (requires `TYCHO_URL` + `RPC_URL`).
 
 use std::{
-    collections::HashMap,
     future::Future,
     pin::Pin,
     time::{Duration, Instant},
@@ -24,7 +23,7 @@ use async_trait::async_trait;
 use fynd_core::{
     types::{
         parse_chain, EncodingOptions, Order, OrderQuote, OrderSide, QuoteOptions, QuoteRequest,
-        QuoteStatus, Route, Swap,
+        QuoteStatus,
     },
     BlockStepController, FyndBuilder, Solver,
 };
@@ -35,7 +34,7 @@ use tycho_simulation::tycho_common::models::{Address as CoreAddress, Chain};
 use crate::{
     decoder::{DecodedTrade, Decoder, Registry},
     provider_from,
-    resolve::{resolve_block_range, Outcome, RouteSummary, SolvedAmount, SteppingSolver},
+    resolve::{resolve_block_range, Outcome, SolvedAmount, SteppingSolver},
     telemetry,
     usd::Prices,
 };
@@ -138,25 +137,6 @@ impl StepAdapter<'_> {
             .last_updated()
             .map(fynd_core::BlockInfo::number)
     }
-
-    /// Symbols for every token on `quote`'s route, read under one market-data lock. A `Swap`
-    /// carries only addresses, so without this the rendered route would be a chain of hex.
-    async fn route_symbols(&self, quote: &OrderQuote) -> HashMap<CoreAddress, String> {
-        let mut symbols = HashMap::new();
-        let Some(route) = quote.route() else {
-            return symbols;
-        };
-        let market_data = self.solver.market_data();
-        let market = market_data.read().await;
-        for swap in Route::swaps(route) {
-            for token in [swap.token_in(), swap.token_out()] {
-                if let Some(found) = market.get_token(token) {
-                    symbols.insert(token.clone(), found.symbol.clone());
-                }
-            }
-        }
-        symbols
-    }
 }
 
 #[async_trait]
@@ -190,8 +170,7 @@ impl SteppingSolver for StepAdapter<'_> {
         let Some(order) = quote.orders().first() else {
             return Outcome::Unsolvable("solver returned no order quote".to_string());
         };
-        let symbols = self.route_symbols(order).await;
-        order_quote_to_outcome(order, &symbols)
+        order_quote_to_outcome(order)
     }
 
     async fn reexecute(&self, top: &SolvedAmount) -> Outcome {
@@ -213,8 +192,10 @@ impl SteppingSolver for StepAdapter<'_> {
                     amount_out,
                     amount_out_net_gas: amount_out.saturating_sub(gas_deduction),
                     gas_estimate: top.gas_estimate,
-                    // Same route re-executed: attribution carries over from the top quote.
-                    route: top.route.clone(),
+                    // Same route re-executed: attribution carries over from the top quote. The
+                    // route itself does not — nothing serializes a re-executed outcome's route
+                    // (it only feeds the slippage numbers via its amounts).
+                    algorithm: top.algorithm.clone(),
                     quote_json: top.quote_json.clone(),
                     solved_route: None,
                 })
@@ -267,7 +248,7 @@ impl SteppingSolver for StepAdapter<'_> {
     }
 }
 
-fn order_quote_to_outcome(quote: &OrderQuote, symbols: &HashMap<CoreAddress, String>) -> Outcome {
+fn order_quote_to_outcome(quote: &OrderQuote) -> Outcome {
     if quote.status() != QuoteStatus::Success {
         return Outcome::Unsolvable(format!("{:?}", quote.status()));
     }
@@ -280,127 +261,15 @@ fn order_quote_to_outcome(quote: &OrderQuote, symbols: &HashMap<CoreAddress, Str
         amount_out: biguint_to_u256(quote.amount_out()),
         amount_out_net_gas: biguint_to_u256(quote.amount_out_net_gas()),
         gas_estimate: biguint_to_u256(quote.gas_estimate()),
-        route: route_summary(quote, symbols),
+        // Which algorithm won the quote — the winning quote is the one the `WorkerPoolRouter`
+        // ranked first across every configured pool, so this is the pool that beat the others on
+        // this order. The readable path is derived from `solved_route` at serialization time
+        // (see `resolve::render_route`), not stored here.
+        algorithm: quote.algorithm().to_string(),
         quote_json,
         // Kept in memory so the route can be re-executed at back-of-block.
         solved_route: quote.route().cloned().map(Box::new),
     })
-}
-
-/// Which algorithm won the quote and the path its route took. The winning quote is the one the
-/// `WorkerPoolRouter` ranked first across every configured pool, so its algorithm is the pool that
-/// beat the others on this order.
-fn route_summary(quote: &OrderQuote, symbols: &HashMap<CoreAddress, String>) -> RouteSummary {
-    let legs: Vec<Leg<'_>> = quote
-        .route()
-        .map(|route| {
-            Route::swaps(route)
-                .iter()
-                .map(Leg::from_swap)
-                .collect()
-        })
-        .unwrap_or_default();
-    RouteSummary { algorithm: quote.algorithm().to_string(), path: render_route(&legs, symbols) }
-}
-
-/// One route leg, reduced to what rendering needs. A `Swap` also carries a `ProtocolComponent` and
-/// a boxed `ProtocolSim` that a route string has no use for and that cannot be built outside
-/// `fynd-core`, so the rendering below works on this instead and stays unit-testable.
-struct Leg<'a> {
-    token_in: &'a CoreAddress,
-    token_out: &'a CoreAddress,
-    protocol: &'a str,
-    /// The leg's declared share of `token_in`. `0.0` means "all the remaining balance".
-    split: f64,
-}
-
-impl<'a> Leg<'a> {
-    fn from_swap(swap: &'a Swap) -> Self {
-        Self {
-            token_in: swap.token_in(),
-            token_out: swap.token_out(),
-            protocol: swap.protocol(),
-            split: *swap.split(),
-        }
-    }
-}
-
-/// Render a route as a readable path: `USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH`.
-///
-/// Swaps that connect — one's output token is the next's input — chain into a single arrow path.
-/// A split fans several legs out of the same token, so its legs cannot share one chain: each
-/// becomes its own path carrying its share of the input, and the paths are joined with ` + `.
-/// Protocol ids are Tycho's own, so a newly integrated DEX reads correctly without a lookup table
-/// here.
-fn render_route(legs: &[Leg<'_>], symbols: &HashMap<CoreAddress, String>) -> String {
-    let mut paths: Vec<String> = Vec::new();
-    let mut open = String::new();
-    let mut tip: Option<&CoreAddress> = None;
-    for (leg, share) in legs.iter().zip(split_shares(legs)) {
-        if tip != Some(leg.token_in) {
-            if !open.is_empty() {
-                paths.push(std::mem::take(&mut open));
-            }
-            open = token_label(leg.token_in, symbols);
-        }
-        open.push_str(&arrow(leg.protocol, share));
-        open.push_str(&token_label(leg.token_out, symbols));
-        tip = Some(leg.token_out);
-    }
-    if !open.is_empty() {
-        paths.push(open);
-    }
-    paths.join(" + ")
-}
-
-/// The arrow between two tokens: ` -[uniswap_v2]-> `, or ` -[vm:curve 40%]-> ` for one leg of a
-/// split, where the share tells you how much of the input took this leg.
-fn arrow(protocol: &str, share: Option<f64>) -> String {
-    match share {
-        Some(share) => format!(" -[{protocol} {:.0}%]-> ", share * 100.0),
-        None => format!(" -[{protocol}]-> "),
-    }
-}
-
-/// Each leg's share of its input token, or `None` when it is the only leg consuming that token.
-///
-/// A split's legs all consume the same token, and by `Route`'s split convention every leg but one
-/// declares an explicit fraction while the last declares `0.0`, meaning "all the remaining
-/// balance". Reconstruct that remainder so every leg of a split reads as a percentage.
-fn split_shares(legs: &[Leg<'_>]) -> Vec<Option<f64>> {
-    let mut consumers: HashMap<&CoreAddress, (usize, f64)> = HashMap::new();
-    for leg in legs {
-        let entry = consumers
-            .entry(leg.token_in)
-            .or_insert((0, 0.0));
-        entry.0 += 1;
-        entry.1 += leg.split;
-    }
-    legs.iter()
-        .map(|leg| {
-            let (count, declared) = consumers
-                .get(leg.token_in)
-                .copied()
-                .unwrap_or((1, 0.0));
-            if count < 2 {
-                return None;
-            }
-            Some(if leg.split == 0.0 { 1.0 - declared } else { leg.split })
-        })
-        .collect()
-}
-
-/// A token's symbol, or a shortened address when the solver has no token entry for it — an
-/// unknown token still has to read as a distinct hop rather than vanish from the path.
-fn token_label(token: &CoreAddress, symbols: &HashMap<CoreAddress, String>) -> String {
-    if let Some(symbol) = symbols.get(token) {
-        return symbol.clone();
-    }
-    let hex = token.to_string();
-    match hex.get(..8) {
-        Some(prefix) => format!("{prefix}…"),
-        None => hex,
-    }
 }
 
 fn biguint_to_u256(value: &BigUint) -> U256 {
@@ -859,95 +728,6 @@ fn core_to_alloy(address: &CoreAddress) -> Option<Address> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// A token address keyed by its symbol's last byte — distinct across the symbols used below,
-    /// where the first byte is not (USDT and USDC share it) — so `symbols()` can name it back.
-    fn token(symbol: &str) -> CoreAddress {
-        let tag = symbol
-            .as_bytes()
-            .last()
-            .copied()
-            .unwrap_or(0);
-        CoreAddress::from(vec![tag; 20])
-    }
-
-    /// The solver's token table for the symbols used below.
-    fn symbols() -> HashMap<CoreAddress, String> {
-        ["USDT", "DAI", "WETH", "USDC"]
-            .into_iter()
-            .map(|symbol| (token(symbol), symbol.to_string()))
-            .collect()
-    }
-
-    /// One route leg. `split` follows `Route`'s convention: an explicit fraction, or 0.0 for the
-    /// leg that takes whatever is left.
-    fn leg<'a>(
-        token_in: &'a CoreAddress,
-        token_out: &'a CoreAddress,
-        protocol: &'a str,
-        split: f64,
-    ) -> Leg<'a> {
-        Leg { token_in, token_out, protocol, split }
-    }
-
-    #[test]
-    fn test_render_route_multi_hop() {
-        // Connecting legs chain into one arrow path; no percentages, since nothing is split.
-        let (usdt, dai, weth) = (token("USDT"), token("DAI"), token("WETH"));
-        let route = render_route(
-            &[leg(&usdt, &dai, "uniswap_v2", 0.0), leg(&dai, &weth, "vm:balancer", 0.0)],
-            &symbols(),
-        );
-        assert_eq!(route, "USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH");
-    }
-
-    #[test]
-    fn test_render_route_split() {
-        // Two legs out of USDC: the 0.6 leg is explicit, the 0.0 leg takes the remainder. They fan
-        // out of the same token so they cannot share one chain — each becomes its own path, joined
-        // by " + ", and both carry their share.
-        let (usdc, weth) = (token("USDC"), token("WETH"));
-        let route = render_route(
-            &[leg(&usdc, &weth, "uniswap_v3", 0.6), leg(&usdc, &weth, "vm:curve", 0.0)],
-            &symbols(),
-        );
-        assert_eq!(route, "USDC -[uniswap_v3 60%]-> WETH + USDC -[vm:curve 40%]-> WETH");
-    }
-
-    #[test]
-    fn test_render_route_split_then_common_hop() {
-        // A split that reconverges: both legs land on WETH, then one leg carries on to USDC. The
-        // continuation chains onto the path that ended at WETH rather than starting a third path.
-        let (usdt, dai, weth, usdc) = (token("USDT"), token("DAI"), token("WETH"), token("USDC"));
-        let route = render_route(
-            &[
-                leg(&usdt, &weth, "uniswap_v3", 0.25),
-                leg(&usdt, &dai, "vm:curve", 0.0),
-                leg(&dai, &usdc, "uniswap_v2", 0.0),
-            ],
-            &symbols(),
-        );
-        assert_eq!(
-            route,
-            "USDT -[uniswap_v3 25%]-> WETH + USDT -[vm:curve 75%]-> DAI -[uniswap_v2]-> USDC"
-        );
-    }
-
-    #[test]
-    fn test_render_route_unknown_token() {
-        // A long-tail token with no entry in the solver's token table still has to read as a
-        // distinct hop, so it falls back to a shortened address rather than an empty string.
-        let (usdt, unknown) = (token("USDT"), CoreAddress::from(vec![0xab; 20]));
-        assert_eq!(
-            render_route(&[leg(&usdt, &unknown, "uniswap_v2", 0.0)], &symbols()),
-            "USDT -[uniswap_v2]-> 0xababab…"
-        );
-    }
-
-    #[test]
-    fn test_render_route_empty() {
-        assert_eq!(render_route(&[], &symbols()), "");
-    }
 
     #[test]
     fn test_default_lag_blocks_scales_with_block_time() {

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -283,7 +283,7 @@ fn order_quote_to_outcome(quote: &OrderQuote, symbols: &HashMap<CoreAddress, Str
         route: route_summary(quote, symbols),
         quote_json,
         // Kept in memory so the route can be re-executed at back-of-block.
-        solved_route: quote.route().cloned(),
+        solved_route: quote.route().cloned().map(Box::new),
     })
 }
 

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -1,6 +1,7 @@
 //! Live two-state monitor: drive an in-process `fynd-core` solver one block at a time, solving
-//! each block's settled trades at top-of-block (N-1) and re-executing each top route at
-//! back-of-block (N) to measure slippage between quote time and execution time.
+//! each block's settled trades at top-of-block (N-1) and measuring twice at back-of-block (N) —
+//! each top route is re-executed to isolate slippage between quote time and execution time, and
+//! each trade is solved fresh to show what routing at the block's end state would deliver.
 //!
 //! The block barrier is deterministic: after releasing a block via
 //! `BlockStepController::trigger_next_block`, we wait until the solver's `MarketData` reports the
@@ -194,7 +195,7 @@ impl SteppingSolver for StepAdapter<'_> {
     }
 
     async fn reexecute(&self, top: &SolvedAmount) -> Outcome {
-        let Some(route) = top.route.as_ref() else {
+        let Some(route) = top.solved_route.as_ref() else {
             return Outcome::Unsolvable("top-of-block quote carried no route".to_string());
         };
         let market = self.solver.market_data();
@@ -212,8 +213,10 @@ impl SteppingSolver for StepAdapter<'_> {
                     amount_out,
                     amount_out_net_gas: amount_out.saturating_sub(gas_deduction),
                     gas_estimate: top.gas_estimate,
+                    // Same route re-executed: attribution carries over from the top quote.
+                    route: top.route.clone(),
                     quote_json: top.quote_json.clone(),
-                    route: None,
+                    solved_route: None,
                 })
             }
             Err(e) => Outcome::Unsolvable(format!("re-execution failed: {e}")),
@@ -280,7 +283,7 @@ fn order_quote_to_outcome(quote: &OrderQuote, symbols: &HashMap<CoreAddress, Str
         route: route_summary(quote, symbols),
         quote_json,
         // Kept in memory so the route can be re-executed at back-of-block.
-        route: quote.route().cloned(),
+        solved_route: quote.route().cloned(),
     })
 }
 

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -1,5 +1,6 @@
-//! Live two-state monitor: drive an in-process `fynd-core` solver one block at a time, re-solving
-//! each block's settled trades at top-of-block (N-1) and back-of-block (N).
+//! Live two-state monitor: drive an in-process `fynd-core` solver one block at a time, solving
+//! each block's settled trades at top-of-block (N-1) and re-executing each top route at
+//! back-of-block (N) to measure slippage between quote time and execution time.
 //!
 //! The block barrier is deterministic: after releasing a block via
 //! `BlockStepController::trigger_next_block`, we wait until the solver's `MarketData` reports the
@@ -192,6 +193,33 @@ impl SteppingSolver for StepAdapter<'_> {
         order_quote_to_outcome(order, &symbols)
     }
 
+    async fn reexecute(&self, top: &SolvedAmount) -> Outcome {
+        let Some(route) = top.route.as_ref() else {
+            return Outcome::Unsolvable("top-of-block quote carried no route".to_string());
+        };
+        let market = self.solver.market_data();
+        let view = market.read().await;
+        match fynd_core::replay_route(route, view.base_market_state()) {
+            Ok(replay) => {
+                let amount_out = biguint_to_u256(&replay.amount_out);
+                // Same route ⇒ same gas: reuse the top quote's gas deduction (in token_out
+                // units) and its encoding-refined gas estimate instead of re-deriving gas
+                // prices at the new block state.
+                let gas_deduction = top
+                    .amount_out
+                    .saturating_sub(top.amount_out_net_gas);
+                Outcome::Solved(SolvedAmount {
+                    amount_out,
+                    amount_out_net_gas: amount_out.saturating_sub(gas_deduction),
+                    gas_estimate: top.gas_estimate,
+                    quote_json: top.quote_json.clone(),
+                    route: None,
+                })
+            }
+            Err(e) => Outcome::Unsolvable(format!("re-execution failed: {e}")),
+        }
+    }
+
     async fn advance(&self) -> anyhow::Result<()> {
         let before = self.current_block().await;
         self.controller
@@ -251,6 +279,8 @@ fn order_quote_to_outcome(quote: &OrderQuote, symbols: &HashMap<CoreAddress, Str
         gas_estimate: biguint_to_u256(quote.gas_estimate()),
         route: route_summary(quote, symbols),
         quote_json,
+        // Kept in memory so the route can be re-executed at back-of-block.
+        route: quote.route().cloned(),
     })
 }
 

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -592,7 +592,7 @@ mod tests {
                 path: "USDC -[uniswap_v3]-> WETH".to_string(),
             },
             quote_json: None,
-            route: None,
+            solved_route: None,
         })
     }
 
@@ -625,6 +625,7 @@ mod tests {
             &empty_prices(),
             solved_by("path_frank_wolfe", 1_010_000_000, 1_005_000_000),
             solved_by("path_frank_wolfe", 1_010_000_000, 1_005_000_000),
+            &Outcome::Unsolvable("x".into()),
         );
         let mut prices = empty_prices();
         prices.insert(usdc, 2e-9);
@@ -665,6 +666,7 @@ mod tests {
             &empty_prices(),
             Outcome::Unsolvable("missing token in Tycho".into()),
             Outcome::Unsolvable("missing token in Tycho".into()),
+            &Outcome::Unsolvable("no top-of-block route to re-execute".into()),
         );
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
@@ -721,6 +723,7 @@ mod tests {
             &empty_prices(),
             solved(1_010_000_000, 1_005_000_000),
             solved(998_000_000, 995_000_000),
+            &solved(998_000_000, 995_000_000),
         );
         // USDC priced at 2e-9 native-units per ETH-wei (ETH = $2000) anchors ETH→USD.
         let mut prices = empty_prices();
@@ -775,6 +778,7 @@ mod tests {
             &empty_prices(),
             solved(1_000_000_000, 995_000_000),
             solved(1_005_000_000, 1_000_000_000),
+            &solved(1_005_000_000, 1_000_000_000),
         );
         let mut prices = empty_prices();
         prices.insert(usdc, 2e-9);
@@ -812,6 +816,7 @@ mod tests {
             &empty_prices(),
             solved(1_000_000_000, 995_000_000),
             solved(995_000_000, 990_000_000),
+            &solved(995_000_000, 990_000_000),
         );
         let mut prices = empty_prices();
         prices.insert(usdc, 2e-9);
@@ -835,11 +840,13 @@ mod tests {
     #[test]
     fn failed_reexecution_emits_no_slippage_metrics() {
         let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        // The fresh back solve succeeded — slippage must come from the re-execution alone.
         let range = build_range(
             &trade(usdc, 1_000_000_000),
             &empty_prices(),
             solved(1_000_000_000, 995_000_000),
-            Outcome::Unsolvable("re-execution failed: no simulation state".into()),
+            solved(1_002_000_000, 997_000_000),
+            &Outcome::Unsolvable("re-execution failed: no simulation state".into()),
         );
         let mut prices = empty_prices();
         prices.insert(usdc, 2e-9);
@@ -884,7 +891,13 @@ mod tests {
         let mut t = trade(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 1_000);
         t.venue = "0xD720183DdA64a8CDb424B5c13aF73baf713521f8".to_string();
         t.solver = "0xB6F54cAed61C318027c022c47B94BAF139a99Dab".to_string();
-        let range = build_range(&t, &empty_prices(), solved(1_100, 1_050), solved(1_100, 1_050));
+        let range = build_range(
+            &t,
+            &empty_prices(),
+            solved(1_100, 1_050),
+            solved(1_100, 1_050),
+            &solved(1_100, 1_050),
+        );
 
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
@@ -911,7 +924,13 @@ mod tests {
         let mut t = trade(address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"), 1_000);
         t.solver = "relay".to_string();
         t.solver_source = AttributionSource::Fallback;
-        let range = build_range(&t, &empty_prices(), solved(1_100, 1_050), solved(1_100, 1_050));
+        let range = build_range(
+            &t,
+            &empty_prices(),
+            solved(1_100, 1_050),
+            solved(1_100, 1_050),
+            &solved(1_100, 1_050),
+        );
 
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
@@ -943,6 +962,7 @@ mod tests {
             &empty_prices(),
             Outcome::Unsolvable("no route".into()),
             Outcome::Unsolvable("no route".into()),
+            &Outcome::Unsolvable("no top-of-block route to re-execute".into()),
         );
         let mut prices = empty_prices();
         prices.insert(usdc, 2e-9);
@@ -969,6 +989,7 @@ mod tests {
             &empty_prices(),
             Outcome::Unsolvable("x".into()),
             Outcome::Unsolvable("x".into()),
+            &Outcome::Unsolvable("x".into()),
         );
         let recorder = PrometheusBuilder::new().build_recorder();
         let handle = recorder.handle();
@@ -1005,6 +1026,7 @@ mod tests {
             &prices,
             solved(1_100_000_000, 1_090_000_000),
             solved(1_100_000_000, 1_090_000_000),
+            &solved(1_100_000_000, 1_090_000_000),
         );
         assert_eq!(range.verdict, Verdict::Sandwiched);
 
@@ -1036,6 +1058,7 @@ mod tests {
             &empty_prices(),
             solved(1_005_000, 1_005_000),
             solved(1_005_000, 1_005_000),
+            &solved(1_005_000, 1_005_000),
         );
         let mut prices = empty_prices();
         prices.insert(usdc, 2e-9);
@@ -1066,6 +1089,7 @@ mod tests {
             &empty_prices(),
             solved(1_100, 1_050),
             solved(1_100, 1_050),
+            &solved(1_100, 1_050),
         );
         let recorder = configure_buckets(PrometheusBuilder::new())
             .unwrap()

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -21,6 +21,7 @@ const SAVINGS_BPS: &str = "hindsight_savings_bps";
 const SAVINGS_USD: &str = "hindsight_savings_usd";
 const IMPROVEMENT_USD: &str = "hindsight_improvement_usd";
 const SLIPPAGE_BPS: &str = "hindsight_slippage_bps";
+const SLIPPAGE_USD: &str = "hindsight_slippage_usd";
 const POSITIVE_SLIPPAGE_USD: &str = "hindsight_positive_slippage_usd";
 const VOLUME_USD: &str = "hindsight_volume_usd";
 const BLOCK_SECONDS: &str = "hindsight_block_processing_seconds";
@@ -140,7 +141,14 @@ pub(crate) fn describe() {
         SLIPPAGE_BPS,
         Unit::Count,
         "Signed bps move of the top-of-block route re-executed at back-of-block (positive = the \
-         route produced more than quoted), labeled by venue / solver / chain"
+         route produced more than quoted), labeled by venue / solver / chain / outcome (headline \
+         verdict)"
+    );
+    describe_histogram!(
+        SLIPPAGE_USD,
+        "Signed per-trade slippage USD (positive = the route produced more than quoted), labeled \
+         by venue / solver / chain / outcome (headline verdict). The positive-only revenue \
+         aggregate stays in POSITIVE_SLIPPAGE_USD"
     );
     describe_histogram!(
         POSITIVE_SLIPPAGE_USD,
@@ -376,20 +384,23 @@ fn record_state(
 }
 
 /// Record the top route's slippage between quote time (N-1) and re-execution (N): the signed bps
-/// move always, and the USD surplus only when positive — its histogram sum is the running
-/// "revenue if we charged positive slippage" aggregate, mirroring how [`IMPROVEMENT_USD`] sums
-/// uplift. Valued at `prices_back`, the state the surplus is realized at. Sandwiched trades are
-/// not skipped: the comparison is Fynd-quote vs Fynd-re-execution, so the settled trade's MEV
-/// does not enter it, and block N's pool moves are real either way.
+/// move and the signed USD value always (both labeled with the range's headline verdict), and
+/// additionally the USD surplus alone when positive — its histogram sum is the running "revenue
+/// if we charged positive slippage" aggregate, mirroring how [`IMPROVEMENT_USD`] sums uplift.
+/// Valued at `prices_back`, the state the surplus is realized at. Sandwiched trades are not
+/// skipped: the comparison is Fynd-quote vs Fynd-re-execution, so the settled trade's MEV does
+/// not enter it, and block N's pool moves are real either way.
 fn record_slippage(range: &RangeComparison, labels: &MetricLabels<'_>, prices: &Prices) {
     let Some(slippage) = range.slippage else {
         return;
     };
+    let outcome = outcome_label(range.verdict).to_string();
     histogram!(
         SLIPPAGE_BPS,
         "venue" => labels.venue.to_string(),
         "solver" => labels.solver.to_string(),
         "chain" => labels.chain.to_string(),
+        "outcome" => outcome.clone(),
     )
     .record(slippage.bps);
 
@@ -400,6 +411,15 @@ fn record_slippage(range: &RangeComparison, labels: &MetricLabels<'_>, prices: &
     ) else {
         return;
     };
+    histogram!(
+        SLIPPAGE_USD,
+        "venue" => labels.venue.to_string(),
+        "solver" => labels.solver.to_string(),
+        "chain" => labels.chain.to_string(),
+        "outcome" => outcome,
+    )
+    .record(usd);
+
     if usd <= 0.0 {
         return;
     }
@@ -530,6 +550,7 @@ fn configure_buckets(
         .set_buckets_for_metric(Matcher::Full(SAVINGS_USD.into()), SAVINGS_USD_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(IMPROVEMENT_USD.into()), SAVINGS_USD_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(SLIPPAGE_BPS.into()), SAVINGS_BPS_BUCKETS)?
+        .set_buckets_for_metric(Matcher::Full(SLIPPAGE_USD.into()), SAVINGS_USD_BUCKETS)?
         .set_buckets_for_metric(
             Matcher::Full(POSITIVE_SLIPPAGE_USD.into()),
             POSITIVE_SLIPPAGE_USD_BUCKETS,
@@ -792,7 +813,12 @@ mod tests {
         });
         let rendered = handle.render();
 
-        assert!(rendered.contains("hindsight_slippage_bps_bucket"), "rendered: {rendered}");
+        let slippage_bps_line = rendered
+            .lines()
+            .find(|line| line.starts_with("hindsight_slippage_bps_bucket"))
+            .expect("slippage bps histogram rendered");
+        assert!(slippage_bps_line.contains("outcome="), "rendered: {slippage_bps_line}");
+        assert!(rendered.contains("hindsight_slippage_usd_bucket"), "rendered: {rendered}");
         let surplus_sum = rendered
             .lines()
             .find(|line| line.starts_with("hindsight_positive_slippage_usd_sum"))
@@ -831,6 +857,17 @@ mod tests {
         let rendered = handle.render();
 
         assert!(rendered.contains("hindsight_slippage_bps_bucket"), "rendered: {rendered}");
+        let slippage_usd_sum = rendered
+            .lines()
+            .find(|line| line.starts_with("hindsight_slippage_usd_sum"))
+            .expect("signed slippage USD recorded regardless of sign");
+        let value: f64 = slippage_usd_sum
+            .rsplit(' ')
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!(value < 0.0, "expected a negative signed slippage USD, got {slippage_usd_sum}");
         assert!(
             !rendered.contains("hindsight_positive_slippage_usd"),
             "negative slippage must not count as chargeable surplus: {rendered}"
@@ -861,6 +898,7 @@ mod tests {
         let rendered = handle.render();
 
         assert!(!rendered.contains("hindsight_slippage_bps"), "rendered: {rendered}");
+        assert!(!rendered.contains("hindsight_slippage_usd"), "rendered: {rendered}");
         assert!(!rendered.contains("hindsight_positive_slippage_usd"));
     }
 

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -12,7 +12,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     decoder::Registry,
-    resolve::{Outcome, RangeComparison, StateResult, Verdict},
+    resolve::{render_route, Outcome, RangeComparison, StateResult, Verdict},
     usd::Prices,
 };
 
@@ -91,7 +91,7 @@ struct MetricLabels<'a> {
 /// `algorithm` names must resolve in the algorithm registry for the pool to spawn at all.
 fn algorithm_label(outcome: &Outcome) -> &str {
     match outcome {
-        Outcome::Solved(solved) if !solved.route.algorithm.is_empty() => &solved.route.algorithm,
+        Outcome::Solved(solved) if !solved.algorithm.is_empty() => &solved.algorithm,
         Outcome::Solved(_) | Outcome::Partial(_) | Outcome::Unsolvable(_) => ALGORITHM_NONE,
     }
 }
@@ -276,7 +276,7 @@ pub(crate) fn record_range(
             fynd_usd = priced(solved.amount_out),
             quoted_usd = range.quote.as_ref().map_or(0.0, |quote| priced(quote.amount_out)),
             savings_usd,
-            route = %solved.route.path,
+            route = %solved.solved_route.as_deref().map(render_route).unwrap_or_default(),
             "trade comparison"
         );
     }
@@ -569,7 +569,7 @@ mod tests {
     use super::*;
     use crate::{
         decoder::{AttributionSource, DecodedTrade, SandwichEvidence},
-        resolve::{build_range, RouteSummary, SolvedAmount},
+        resolve::{build_range, SolvedAmount},
     };
 
     fn empty_prices() -> Prices {
@@ -608,10 +608,7 @@ mod tests {
             amount_out: U256::from(amount_out),
             amount_out_net_gas: U256::from(net),
             gas_estimate: U256::from(21_000),
-            route: RouteSummary {
-                algorithm: algorithm.to_string(),
-                path: "USDC -[uniswap_v3]-> WETH".to_string(),
-            },
+            algorithm: algorithm.to_string(),
             quote_json: None,
             solved_route: None,
         })

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -20,6 +20,8 @@ const TRADES_TOTAL: &str = "hindsight_trades_total";
 const SAVINGS_BPS: &str = "hindsight_savings_bps";
 const SAVINGS_USD: &str = "hindsight_savings_usd";
 const IMPROVEMENT_USD: &str = "hindsight_improvement_usd";
+const SLIPPAGE_BPS: &str = "hindsight_slippage_bps";
+const POSITIVE_SLIPPAGE_USD: &str = "hindsight_positive_slippage_usd";
 const VOLUME_USD: &str = "hindsight_volume_usd";
 const BLOCK_SECONDS: &str = "hindsight_block_processing_seconds";
 const HEAD_LAG_BLOCKS: &str = "hindsight_chain_head_lag_blocks";
@@ -135,6 +137,18 @@ pub(crate) fn describe() {
          adding Fynd; count = improving trades"
     );
     describe_histogram!(
+        SLIPPAGE_BPS,
+        Unit::Count,
+        "Signed bps move of the top-of-block route re-executed at back-of-block (positive = the \
+         route produced more than quoted), labeled by venue / solver / chain"
+    );
+    describe_histogram!(
+        POSITIVE_SLIPPAGE_USD,
+        "USD surplus of the re-executed route over its top-of-block quote, recorded only when \
+         positive. Sum = hypothetical revenue if positive slippage were charged; count = trades \
+         with a surplus. Signed per-trade values stay in the JSONL records"
+    );
+    describe_histogram!(
         VOLUME_USD,
         "Observed settled trade volume in USD, labeled by venue / solver / outcome (headline \
          verdict). Valued from the output leg, falling back to the input leg when the output \
@@ -223,6 +237,7 @@ pub(crate) fn record_range(
 
     let savings_top = record_state(range, &range.top, "top", &labels, prices_top, above_floor);
     record_state(range, &range.back, "back", &labels, prices_back, above_floor);
+    record_slippage(range, &labels, prices_back);
 
     // One structured line per priced comparison, on the headline basis (top-of-block, gross).
     // Loki ingests pod stdout, so this line feeds the dashboard's top-trades table; keep the
@@ -360,6 +375,57 @@ fn record_state(
     Some(usd)
 }
 
+/// Record the top route's slippage between quote time (N-1) and re-execution (N): the signed bps
+/// move always, and the USD surplus only when positive — its histogram sum is the running
+/// "revenue if we charged positive slippage" aggregate, mirroring how [`IMPROVEMENT_USD`] sums
+/// uplift. Valued at `prices_back`, the state the surplus is realized at. Sandwiched trades are
+/// not skipped: the comparison is Fynd-quote vs Fynd-re-execution, so the settled trade's MEV
+/// does not enter it, and block N's pool moves are real either way.
+fn record_slippage(range: &RangeComparison, labels: &MetricLabels<'_>, prices: &Prices) {
+    let Some(slippage) = range.slippage else {
+        return;
+    };
+    histogram!(
+        SLIPPAGE_BPS,
+        "venue" => labels.venue.to_string(),
+        "solver" => labels.solver.to_string(),
+        "chain" => labels.chain.to_string(),
+    )
+    .record(slippage.bps);
+
+    let Some(usd) = prices.savings_usd(
+        range.token_out,
+        slippage.reexecuted_amount_out,
+        slippage.quoted_amount_out,
+    ) else {
+        return;
+    };
+    if usd <= 0.0 {
+        return;
+    }
+    if is_usd_outlier(usd) {
+        warn!(
+            tx = %range.tx_hash,
+            block = range.block_number,
+            venue = %range.venue,
+            solver = %range.solver,
+            token_out = %range.token_out,
+            quoted_out = %slippage.quoted_amount_out,
+            reexecuted_out = %slippage.reexecuted_amount_out,
+            token_out_price = ?prices.get(range.token_out),
+            usd,
+            "positive slippage USD outlier — inspect for token mispricing vs a genuine pool move"
+        );
+    }
+    histogram!(
+        POSITIVE_SLIPPAGE_USD,
+        "venue" => labels.venue.to_string(),
+        "solver" => labels.solver.to_string(),
+        "chain" => labels.chain.to_string(),
+    )
+    .record(usd);
+}
+
 pub(crate) fn record_block_seconds(seconds: f64) {
     histogram!(BLOCK_SECONDS).record(seconds);
 }
@@ -404,6 +470,10 @@ async fn metrics_handler(handle: PrometheusHandle) -> impl Responder {
 const SAVINGS_BPS_BUCKETS: &[f64] =
     &[-1000.0, -300.0, -100.0, -30.0, -10.0, -3.0, 0.0, 3.0, 10.0, 30.0, 100.0, 300.0, 1000.0];
 const SAVINGS_USD_BUCKETS: &[f64] = &[-3000.0, -300.0, -30.0, -3.0, 0.0, 3.0, 30.0, 300.0, 3000.0];
+/// Positive-only by construction, so the edges start near zero; most per-trade surpluses are
+/// well under a dollar.
+const POSITIVE_SLIPPAGE_USD_BUCKETS: &[f64] =
+    &[0.01, 0.1, 0.3, 1.0, 3.0, 10.0, 30.0, 100.0, 300.0, 3000.0];
 const VOLUME_USD_BUCKETS: &[f64] = &[10.0, 100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0];
 const BLOCK_SECONDS_BUCKETS: &[f64] = &[0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0];
 /// One block is the floor (the monitor solves block N against state N-1), so the low edges are
@@ -459,6 +529,11 @@ fn configure_buckets(
         .set_buckets_for_metric(Matcher::Full(SAVINGS_BPS.into()), SAVINGS_BPS_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(SAVINGS_USD.into()), SAVINGS_USD_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(IMPROVEMENT_USD.into()), SAVINGS_USD_BUCKETS)?
+        .set_buckets_for_metric(Matcher::Full(SLIPPAGE_BPS.into()), SAVINGS_BPS_BUCKETS)?
+        .set_buckets_for_metric(
+            Matcher::Full(POSITIVE_SLIPPAGE_USD.into()),
+            POSITIVE_SLIPPAGE_USD_BUCKETS,
+        )?
         .set_buckets_for_metric(Matcher::Full(VOLUME_USD.into()), VOLUME_USD_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(BLOCK_SECONDS.into()), BLOCK_SECONDS_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(HEAD_LAG_BLOCKS.into()), HEAD_LAG_BLOCKS_BUCKETS)?
@@ -517,6 +592,7 @@ mod tests {
                 path: "USDC -[uniswap_v3]-> WETH".to_string(),
             },
             quote_json: None,
+            route: None,
         })
     }
 
@@ -688,6 +764,97 @@ mod tests {
         );
         assert!(rendered.contains("hindsight_savings_usd_bucket"));
         assert!(rendered.contains("le=\"3\""));
+    }
+
+    #[test]
+    fn record_range_emits_slippage_metrics() {
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        // Quoted 1000 USDC at top, re-executed to 1005 USDC at back → +50 bps, +$5 surplus.
+        let range = build_range(
+            &trade(usdc, 1_000_000_000),
+            &empty_prices(),
+            solved(1_000_000_000, 995_000_000),
+            solved(1_005_000_000, 1_000_000_000),
+        );
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
+
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(&range, "ethereum", &prices, &prices, &Registry::ethereum());
+        });
+        let rendered = handle.render();
+
+        assert!(rendered.contains("hindsight_slippage_bps_bucket"), "rendered: {rendered}");
+        let surplus_sum = rendered
+            .lines()
+            .find(|line| line.starts_with("hindsight_positive_slippage_usd_sum"))
+            .expect("positive slippage surplus recorded");
+        let value: f64 = surplus_sum
+            .rsplit(' ')
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap();
+        assert!((value - 5.0).abs() < 1e-3, "expected ~$5 surplus, got {surplus_sum}");
+    }
+
+    #[test]
+    fn negative_slippage_records_bps_but_no_positive_usd() {
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        // Re-execution underperforms the quote: the signed bps histogram still records, the
+        // positive-only USD surplus does not.
+        let range = build_range(
+            &trade(usdc, 1_000_000_000),
+            &empty_prices(),
+            solved(1_000_000_000, 995_000_000),
+            solved(995_000_000, 990_000_000),
+        );
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
+
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(&range, "ethereum", &prices, &prices, &Registry::ethereum());
+        });
+        let rendered = handle.render();
+
+        assert!(rendered.contains("hindsight_slippage_bps_bucket"), "rendered: {rendered}");
+        assert!(
+            !rendered.contains("hindsight_positive_slippage_usd"),
+            "negative slippage must not count as chargeable surplus: {rendered}"
+        );
+    }
+
+    #[test]
+    fn failed_reexecution_emits_no_slippage_metrics() {
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        let range = build_range(
+            &trade(usdc, 1_000_000_000),
+            &empty_prices(),
+            solved(1_000_000_000, 995_000_000),
+            Outcome::Unsolvable("re-execution failed: no simulation state".into()),
+        );
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
+
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(&range, "ethereum", &prices, &prices, &Registry::ethereum());
+        });
+        let rendered = handle.render();
+
+        assert!(!rendered.contains("hindsight_slippage_bps"), "rendered: {rendered}");
+        assert!(!rendered.contains("hindsight_positive_slippage_usd"));
     }
 
     #[test]


### PR DESCRIPTION
## What

The hindsight monitor now measures each trade twice at back-of-block. The fresh re-solve at state N stays (the `back` comparison keeps its original meaning: what routing at the block's end state would deliver), and the top-of-block route is additionally re-executed against state N — same pools, split fractions, and input amount — to record the slippage between quote time and execution time, in bps and USD.

## Changes

- **`fynd_core::replay_route` (new public API)**: re-executes an already-built `Route` against a given `MarketState`. Swaps run in the route's topological order; positive `split` fractions apply to the token's collected balance with the `0.0` remainder convention; post-swap states are threaded so shared pools see depleted reserves. Pool simulations run through `get_amount_out_guarded`, so pool-math panics become per-trade `ReplayError`s instead of unwinding the caller. Pools and tokens resolve from the market state, not the route's embedded quote-time states.
- **Monitor**: the top solve keeps its `Route` in memory; `SteppingSolver` gains `reexecute`. After `advance()`, each trade is re-executed (for slippage) and solved fresh (for `back`). An unsolvable top records "no top-of-block route to re-execute" as the slippage side; a failed replay (e.g. pool gone at N) records the error.
- **Route attribution derived, not stored**: `SolvedAmount` carries `algorithm` plus the solved `Route` (boxed, serde-skipped); the readable path in JSONL/logs is rendered from the route at record time via a new `fynd_core::Route::token_symbol` accessor. The stored `RouteSummary` type and the monitor's token-symbols plumbing are removed; JSONL keys (`algorithm`, `route`) are unchanged.
- **JSONL**: new top-level `"slippage": {"bps", "usd"}` field, signed in both directions, USD valued at the back-of-block price snapshot. Null when nothing was replayed.
- **Prometheus**: `hindsight_slippage_bps` (signed histogram, venue/solver/chain/outcome labels — outcome is the trade's headline verdict), `hindsight_slippage_usd` (signed histogram, same labels), and `hindsight_positive_slippage_usd` (positive-only; its `_sum` is the running revenue if positive slippage were charged). Positive outliers ≥ $1000 get the same mispricing-inspection warn log as savings.

## Notes

- Slippage is computed from the raw outcomes before the coverage-miss reclassification, and survives independently of the `back` solve.
- The re-executed side reuses the top quote's gas deduction (same route ⇒ same gas) instead of re-deriving gas prices at N.
- Sandwiched trades are not excluded from slippage metrics: the comparison is Fynd-quote vs Fynd-re-execution, so the settled trade's MEV does not enter it.

## Testing

- Unit tests for `replay_route` (sequential, split fractions, shared-pool depletion, market-state divergence, missing state/token errors) and `Route::token_symbol`
- Tests for slippage math, verdict-labeled metrics rendering, JSONL fields, the re-execution flow, the back solve running without a top route, and route-path derivation (245 hindsight tests pass)
- `cargo +nightly clippy --all-targets --all-features` clean; fmt and doc build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
