### PR TITLE
feat: log the no-route reason on quote_failure lines

### DIFF
--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -48,7 +48,8 @@ pub mod worker_pool_router;
 
 // Re-export commonly used types for convenience
 pub use algorithm::{
-    Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgorithm, PathFrankWolfeAlgorithm,
+    Algorithm, AlgorithmConfig, AlgorithmError, MostLiquidAlgorithm, NoPathReason,
+    PathFrankWolfeAlgorithm,
 };
 // Required for implementing the Algorithm trait externally
 pub use derived::computation::ComputationRequirements;

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -7,6 +7,7 @@ use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use super::{quote::SolveParams, Order, SingleOrderQuote};
+use crate::algorithm::NoPathReason;
 
 /// Unique identifier for a solve task.
 pub type TaskId = Uuid;
@@ -78,6 +79,8 @@ pub enum SolveError {
     NoRouteFound {
         /// ID of the order for which no route was found.
         order_id: String,
+        /// Why no route was found, when the algorithm reported it.
+        reason: Option<NoPathReason>,
     },
 
     /// Insufficient liquidity for the requested amount.
@@ -161,7 +164,12 @@ impl SolveError {
 
     /// Creates a [`SolveError::NoRouteFound`] for the given order ID.
     pub fn no_route_found(order_id: impl Into<String>) -> Self {
-        Self::NoRouteFound { order_id: order_id.into() }
+        Self::NoRouteFound { order_id: order_id.into(), reason: None }
+    }
+
+    /// Creates a [`SolveError::NoRouteFound`] carrying the algorithm's [`NoPathReason`].
+    pub fn no_route_found_with_reason(order_id: impl Into<String>, reason: NoPathReason) -> Self {
+        Self::NoRouteFound { order_id: order_id.into(), reason: Some(reason) }
     }
 
     /// Creates a [`SolveError::InsufficientLiquidity`] with the required and available amounts.

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -29,6 +29,7 @@ use tycho_simulation::tycho_common::{
 use uuid::Uuid;
 
 use super::primitives::ComponentId;
+use crate::algorithm::NoPathReason;
 use crate::{feed::market_data::StateLabel, price_guard::config::PriceGuardConfig, AlgorithmError};
 
 // ============================================================================
@@ -752,6 +753,9 @@ pub struct OrderQuote {
     /// The state overlay this quote was computed against.
     /// When no overlay was requested this is the block number of the base state at solve time.
     solved_against: StateLabel,
+    /// Why no route was found (internal use only; only set for `NoRouteFound`).
+    #[serde(skip)]
+    no_route_reason: Option<NoPathReason>,
 }
 
 impl OrderQuote {
@@ -786,6 +790,7 @@ impl OrderQuote {
             sender,
             receiver,
             solved_against,
+            no_route_reason: None,
         }
     }
 
@@ -914,6 +919,16 @@ impl OrderQuote {
     /// Returns the state overlay this quote was computed against.
     pub fn solved_against(&self) -> &StateLabel {
         &self.solved_against
+    }
+
+    /// Records why no route was found. Internal; skipped during serialization.
+    pub(crate) fn set_no_route_reason(&mut self, reason: Option<NoPathReason>) {
+        self.no_route_reason = reason;
+    }
+
+    /// Returns the recorded no-route reason, if any.
+    pub fn no_route_reason(&self) -> Option<NoPathReason> {
+        self.no_route_reason
     }
 }
 

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -29,8 +29,10 @@ use tycho_simulation::tycho_common::{
 use uuid::Uuid;
 
 use super::primitives::ComponentId;
-use crate::algorithm::NoPathReason;
-use crate::{feed::market_data::StateLabel, price_guard::config::PriceGuardConfig, AlgorithmError};
+use crate::{
+    algorithm::NoPathReason, feed::market_data::StateLabel, price_guard::config::PriceGuardConfig,
+    AlgorithmError,
+};
 
 // ============================================================================
 // REQUEST TYPES

--- a/fynd-core/src/worker_pool/task_queue.rs
+++ b/fynd-core/src/worker_pool/task_queue.rs
@@ -275,7 +275,7 @@ mod tests {
                 .recv()
                 .await
                 .expect("should receive task");
-            task.respond(Err(SolveError::NoRouteFound { order_id: "test".to_string() }));
+            task.respond(Err(SolveError::no_route_found("test")));
         });
 
         let result = handle

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -260,7 +260,7 @@ where
                                 order_id = %order.id(),
                                 "route missing first swap for buy order"
                             );
-                            SolveError::NoRouteFound { order_id: order.id().to_string() }
+                            SolveError::no_route_found(order.id())
                         })?
                 };
                 let amount_out = if order.is_sell() {
@@ -269,7 +269,7 @@ where
                             order_id = %order.id(),
                             "route missing swaps for sell order"
                         );
-                        SolveError::NoRouteFound { order_id: order.id().to_string() }
+                        SolveError::no_route_found(order.id())
                     })?;
                     route
                         .swaps()
@@ -314,13 +314,13 @@ where
             }
             Err(err) => {
                 let solve_error = match err {
-                    crate::AlgorithmError::NoPath { .. } => {
+                    crate::AlgorithmError::NoPath { reason, .. } => {
                         debug!(
                             order_id = %order.id(),
                             error = %err,
                             "no route found"
                         );
-                        SolveError::NoRouteFound { order_id: order.id().to_string() }
+                        SolveError::no_route_found_with_reason(order.id(), reason)
                     }
                     crate::AlgorithmError::Timeout { elapsed_ms } => {
                         warn!(
@@ -1125,6 +1125,30 @@ mod tests {
             closed_warns, 1,
             "closed channel must be handled once, not spun on ({closed_warns} warns)"
         );
+    }
+
+    #[test]
+    fn no_route_found_with_reason_carries_reason() {
+        use crate::algorithm::NoPathReason;
+        let err = SolveError::no_route_found_with_reason(
+            "order-1",
+            NoPathReason::DestinationTokenNotInGraph,
+        );
+        match err {
+            SolveError::NoRouteFound { order_id, reason } => {
+                assert_eq!(order_id, "order-1");
+                assert_eq!(reason, Some(NoPathReason::DestinationTokenNotInGraph));
+            }
+            other => panic!("expected NoRouteFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_route_found_defaults_to_no_reason() {
+        match SolveError::no_route_found("order-1") {
+            SolveError::NoRouteFound { reason, .. } => assert_eq!(reason, None),
+            other => panic!("expected NoRouteFound, got {other:?}"),
+        }
     }
 
     #[test]

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -496,7 +496,7 @@ fn aggregate_no_route_reason(
                 NoPathReason::SourceTokenNotInGraph | NoPathReason::DestinationTokenNotInGraph => {
                     return Some(*reason)
                 }
-                _ => {
+                NoPathReason::NoGraphPath | NoPathReason::NoScorablePaths => {
                     if first.is_none() {
                         first = Some(*reason);
                     }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -839,11 +839,8 @@ mod tests {
     #[tokio::test]
     async fn test_router_captures_solver_errors() {
         // Pool that returns an error
-        let (pool, worker) = create_mock_pool(
-            "error_pool",
-            Err(SolveError::NoRouteFound { order_id: "test-order".to_string() }),
-            0,
-        );
+        let (pool, worker) =
+            create_mock_pool("error_pool", Err(SolveError::no_route_found("test-order")), 0);
 
         let worker_router =
             WorkerPoolRouter::new(vec![pool], WorkerPoolRouterConfig::default(), default_encoder());
@@ -887,7 +884,7 @@ mod tests {
             quotes: vec![],
             failed_solvers: vec![
                 ("pool_a".to_string(), SolveError::Timeout { elapsed_ms: 100 }),
-                ("pool_b".to_string(), SolveError::NoRouteFound { order_id: "test".to_string() }),
+                ("pool_b".to_string(), SolveError::no_route_found("test")),
             ],
         };
 

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -399,7 +399,7 @@ impl WorkerPoolRouter {
 
         // No valid quote found - return a NoRouteFound response
         // Try to get any response to extract block info, or create a placeholder
-        let fallback = if let Some((_, any_q)) = responses.quotes.first() {
+        let mut fallback = if let Some((_, any_q)) = responses.quotes.first() {
             counter!("worker_router_orders_total", "status" => "no_route").increment(1);
             OrderQuote::new(
                 responses.order_id.clone(),
@@ -466,6 +466,9 @@ impl WorkerPoolRouter {
                 label,
             )
         };
+        if fallback.status() == QuoteStatus::NoRouteFound {
+            fallback.set_no_route_reason(aggregate_no_route_reason(&responses.failed_solvers));
+        }
         vec![fallback]
     }
 
@@ -476,6 +479,32 @@ impl WorkerPoolRouter {
             .map(Duration::from_millis)
             .unwrap_or(self.config.default_timeout())
     }
+}
+
+/// Picks the most informative no-route reason across the failed pools.
+///
+/// A token-not-in-graph reason is a shared-graph fact and wins over any
+/// path-specific reason; otherwise the first reason present is used.
+fn aggregate_no_route_reason(
+    failed_solvers: &[(String, SolveError)],
+) -> Option<crate::algorithm::NoPathReason> {
+    use crate::algorithm::NoPathReason;
+    let mut first = None;
+    for (_, error) in failed_solvers {
+        if let SolveError::NoRouteFound { reason: Some(reason), .. } = error {
+            match reason {
+                NoPathReason::SourceTokenNotInGraph | NoPathReason::DestinationTokenNotInGraph => {
+                    return Some(*reason)
+                }
+                _ => {
+                    if first.is_none() {
+                        first = Some(*reason);
+                    }
+                }
+            }
+        }
+    }
+    first
 }
 
 fn refine_gas_estimates(
@@ -907,6 +936,52 @@ mod tests {
 
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status(), QuoteStatus::NoRouteFound);
+    }
+
+    #[test]
+    fn rank_quotes_attaches_no_route_reason() {
+        use crate::algorithm::NoPathReason;
+        let responses = OrderResponses {
+            order_id: "test".to_string(),
+            quotes: vec![],
+            failed_solvers: vec![
+                (
+                    "pool_a".to_string(),
+                    SolveError::no_route_found_with_reason("test", NoPathReason::NoGraphPath),
+                ),
+                (
+                    "pool_b".to_string(),
+                    SolveError::no_route_found_with_reason(
+                        "test",
+                        NoPathReason::DestinationTokenNotInGraph,
+                    ),
+                ),
+            ],
+        };
+        let worker_router =
+            WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
+        let result = worker_router.rank_quotes(&responses, &QuoteOptions::default());
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].status(), QuoteStatus::NoRouteFound);
+        // Token-not-in-graph wins over no_graph_path regardless of pool order.
+        assert_eq!(result[0].no_route_reason(), Some(NoPathReason::DestinationTokenNotInGraph));
+    }
+
+    #[test]
+    fn rank_quotes_no_route_reason_falls_back_to_first() {
+        use crate::algorithm::NoPathReason;
+        let responses = OrderResponses {
+            order_id: "test".to_string(),
+            quotes: vec![],
+            failed_solvers: vec![(
+                "pool_a".to_string(),
+                SolveError::no_route_found_with_reason("test", NoPathReason::NoGraphPath),
+            )],
+        };
+        let worker_router =
+            WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
+        let result = worker_router.rank_quotes(&responses, &QuoteOptions::default());
+        assert_eq!(result[0].no_route_reason(), Some(NoPathReason::NoGraphPath));
     }
 
     #[test]

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -13,7 +13,9 @@ use crate::api::prices::{
 };
 use crate::api::{
     error::{solve_error_code, ErrorResponse},
-    request_capture::{self, log_request_capture, quote_status_code, RequestOutcome},
+    request_capture::{
+        self, log_request_capture, no_route_reason_code, quote_status_code, RequestOutcome,
+    },
 };
 
 /// Configures API routes under /v1 namespace.
@@ -90,6 +92,11 @@ pub(crate) async fn quote(
                 .orders()
                 .iter()
                 .map(|order_quote| quote_status_code(order_quote.status()))
+                .collect(),
+            no_route_reasons: core_quote
+                .orders()
+                .iter()
+                .map(|order_quote| no_route_reason_code(order_quote.no_route_reason()))
                 .collect(),
         },
         Err(error) => RequestOutcome::Failed { code: solve_error_code(error) },

--- a/fynd-rpc/src/api/request_capture.rs
+++ b/fynd-rpc/src/api/request_capture.rs
@@ -1,7 +1,7 @@
 //! Builds the routing-essential representation of a quote request for the
 //! replay-capture log emitted by the `/v1/quote` handler.
 
-use fynd_core::QuoteStatus;
+use fynd_core::{NoPathReason, QuoteStatus};
 use fynd_rpc_types::{Address, OrderSide, QuoteRequest};
 use serde::Serialize;
 use tracing::info;
@@ -92,6 +92,19 @@ pub(crate) fn quote_status_code(status: QuoteStatus) -> &'static str {
     }
 }
 
+/// Stable snake_case code for a no-route [`NoPathReason`]. `""` when absent;
+/// wildcard guards the `#[non_exhaustive]` enum.
+pub(crate) fn no_route_reason_code(reason: Option<NoPathReason>) -> &'static str {
+    match reason {
+        None => "",
+        Some(NoPathReason::SourceTokenNotInGraph) => "source_token_not_in_graph",
+        Some(NoPathReason::DestinationTokenNotInGraph) => "destination_token_not_in_graph",
+        Some(NoPathReason::NoGraphPath) => "no_graph_path",
+        Some(NoPathReason::NoScorablePaths) => "no_scorable_paths",
+        Some(_) => "unknown",
+    }
+}
+
 /// Recorded outcome of a solved request, for the replay-capture log.
 pub(crate) enum RequestOutcome {
     /// Solve returned a quote; per-order status codes in request order.
@@ -100,6 +113,9 @@ pub(crate) enum RequestOutcome {
         solve_time_ms: u64,
         /// One [`quote_status_code`] per order, in request order.
         order_statuses: Vec<&'static str>,
+        /// One [`no_route_reason_code`] per order, aligned with `order_statuses`
+        /// (`""` for non-`no_route_found` orders).
+        no_route_reasons: Vec<&'static str>,
     },
     /// Solve failed; carries the [`crate::api::error::solve_error_code`].
     Failed {
@@ -129,12 +145,13 @@ impl RequestOutcome {
 /// `event="quote_failure"`.
 pub(crate) fn log_request_capture(num_orders: usize, request_json: &str, outcome: &RequestOutcome) {
     match outcome {
-        RequestOutcome::Solved { solve_time_ms, order_statuses } => info!(
+        RequestOutcome::Solved { solve_time_ms, order_statuses, no_route_reasons } => info!(
             event = "quote_failure",
             num_orders,
             solve_time_ms = *solve_time_ms,
             outcome = "ok",
             order_statuses = ?order_statuses,
+            no_route_reasons = ?no_route_reasons,
             request = %request_json,
             "quote failure captured"
         ),
@@ -349,6 +366,7 @@ mod tests {
                 &RequestOutcome::Solved {
                     solve_time_ms: 12,
                     order_statuses: vec!["success", "no_route_found"],
+                    no_route_reasons: vec!["", "no_graph_path"],
                 },
             );
         });
@@ -358,6 +376,39 @@ mod tests {
         assert!(logs.contains("ok"), "logs were: {logs}");
         assert!(logs.contains("no_route_found"), "logs were: {logs}");
         assert!(logs.contains("num_orders"), "logs were: {logs}");
+    }
+
+    #[test]
+    fn no_route_reason_code_maps_variants() {
+        use fynd_core::NoPathReason;
+        assert_eq!(no_route_reason_code(None), "");
+        assert_eq!(
+            no_route_reason_code(Some(NoPathReason::SourceTokenNotInGraph)),
+            "source_token_not_in_graph"
+        );
+        assert_eq!(
+            no_route_reason_code(Some(NoPathReason::DestinationTokenNotInGraph)),
+            "destination_token_not_in_graph"
+        );
+        assert_eq!(no_route_reason_code(Some(NoPathReason::NoGraphPath)), "no_graph_path");
+        assert_eq!(no_route_reason_code(Some(NoPathReason::NoScorablePaths)), "no_scorable_paths");
+    }
+
+    #[test]
+    fn logs_ok_outcome_with_no_route_reasons() {
+        let logs = capture_logs(|| {
+            log_request_capture(
+                1,
+                r#"{"orders":[]}"#,
+                &RequestOutcome::Solved {
+                    solve_time_ms: 5,
+                    order_statuses: vec!["no_route_found"],
+                    no_route_reasons: vec!["destination_token_not_in_graph"],
+                },
+            );
+        });
+        assert!(logs.contains("no_route_reasons"), "logs were: {logs}");
+        assert!(logs.contains("destination_token_not_in_graph"), "logs were: {logs}");
     }
 
     #[test]
@@ -376,8 +427,11 @@ mod tests {
 
     #[test]
     fn is_failure_false_when_all_orders_succeed() {
-        let outcome =
-            RequestOutcome::Solved { solve_time_ms: 5, order_statuses: vec!["success", "success"] };
+        let outcome = RequestOutcome::Solved {
+            solve_time_ms: 5,
+            order_statuses: vec!["success", "success"],
+            no_route_reasons: vec!["", ""],
+        };
         assert!(!outcome.is_failure());
     }
 
@@ -386,6 +440,7 @@ mod tests {
         let outcome = RequestOutcome::Solved {
             solve_time_ms: 5,
             order_statuses: vec!["success", "no_route_found"],
+            no_route_reasons: vec!["", "no_graph_path"],
         };
         assert!(outcome.is_failure());
     }


### PR DESCRIPTION
## What

Adds the **reason a quote found no route** to the `quote_failure` capture log, so a `no_route_found` order shows *why* — e.g. the requested token isn't in any tracked pool vs. no connecting path.

New per-order field on the capture line, positionally aligned with `order_statuses`:
```
order_statuses=["no_route_found"] no_route_reasons=["destination_token_not_in_graph"]
```
Reason codes: `source_token_not_in_graph`, `destination_token_not_in_graph`, `no_graph_path`, `no_scorable_paths` (and `""` for orders that didn't fail with no-route).

> **Stacked on #331** (`bg/add-replay-logs`). Base this on / merge #331 first. The diff here is only the no-route-reason commits.

## Why

The solver already computes *why* a route wasn't found (`AlgorithmError::NoPath { reason }`), but it was discarded before anything could observe it — every `no_route_found` looked identical. This surfaces the distinction, most usefully "the token isn't tracked at all" vs. "tracked but unroutable."

## How it threads through (all fynd-core / fynd-rpc internal)

1. **`SolveError::NoRouteFound`** gains `reason: Option<NoPathReason>`; the worker captures it at the `NoPath` arm instead of dropping it.
2. **`OrderQuote`** carries it as an internal `#[serde(skip)]` field; `WorkerPoolRouter::rank_quotes` aggregates across pools (a token-not-in-graph reason wins over path-specific ones, since it's a shared-graph fact; otherwise the first reason).
3. **Handler** emits `no_route_reasons` on the existing `quote_failure` line, built from the same `orders()` iterator as `order_statuses` (1:1 alignment).

**No wire change:** the `OrderQuote` field is `#[serde(skip)]` — the OpenAPI drift check is a no-op, no TS-client regen. The failures-only gate (`is_failure`) and `event="quote_failure"` from #331 are untouched.

## Testing

- `cargo nextest run --workspace --locked --all-features`: **1029 passed / 0 failed / 10 skipped**.
- Unit tests cover: the constructor plumbing, the cross-pool aggregation rule (incl. token-not-in-graph winning regardless of pool order), the reason-code mapping, and the emitted log field.
- OpenAPI drift: **none**. Doc build (`-D warnings`): clean. `cargo +nightly fmt --check`: clean.

## Note for review

`cargo +nightly clippy` currently ICEs inside the `tycho-simulation` dependency (rustc 1.98.0-nightly, unrelated to this diff). Gated via **stable** `cargo clippy -p fynd-core -p fynd-rpc --all-features --all-targets -- -D warnings`, which is clean over the changed crates. (Same known issue flagged on #331.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
