### PR TITLE
feat(hindsight): add offline HTML report subcommand

### DIFF
--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -55,7 +55,7 @@ See [`docs/guides/swap-cli.md`](../docs/guides/swap-cli.md) for usage instructio
 
 See [`tools/hindsight/CLAUDE.md`](hindsight/CLAUDE.md) for the full module overview.
 
-Three subcommands via `cargo run -p hindsight --release --`:
+Four subcommands via `cargo run -p hindsight --release --`:
 
 - **`decode`** — Fetch block receipts, match and trace solver transactions, emit decoded trades
   (token in/out, amounts, client, solver, settled gas). Accepts `--block N`, `--range START-END`
@@ -65,6 +65,8 @@ Three subcommands via `cargo run -p hindsight --release --`:
 - **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block, re-solving
   each settled trade at top-of-block (N-1) and back-of-block (N). Emits JSONL and exposes
   Prometheus metrics.
+- **`report`** — Offline: render a self-contained HTML report from a `monitor` run's comparison
+  JSONL (`--comparisons-dir`). No chain or network access.
 
 ---
 

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -8,9 +8,10 @@ actually settled.
 
 ## Commands
 
-Three subcommands via `cargo run -p hindsight --release --`. All of them take `--chain`
-(default `ethereum`), which selects the decoder's address book, and `--registry <path>` /
-`HINDSIGHT_REGISTRY` to load a custom address book.
+Four subcommands via `cargo run -p hindsight --release --`. The on-chain ones (`decode`,
+`verify`, `monitor`) take `--chain` (default `ethereum`), which selects the decoder's address book,
+and `--registry <path>` / `HINDSIGHT_REGISTRY` to load a custom address book. `report` is offline
+and takes neither.
 
 - **`decode`** — Fetch block receipts, match solver transactions, trace each one, and emit decoded
   trades (token in/out, amounts, venue, solver, gas, sandwich evidence). Accepts `--block N`,
@@ -26,6 +27,13 @@ Three subcommands via `cargo run -p hindsight --release --`. All of them take `-
   back-of-block (state N), and emits `RangeComparison` JSONL records. Exposes a Prometheus
   metrics endpoint (`--metrics-port`). `--max-lag-blocks` (default 100, ~20 min on mainnet)
   bounds how far it may fall behind chain head before rebuilding the solver.
+
+- **`report`** — Offline: read the `comparisons-YYYY-MM-DD.jsonl` files a `monitor` run wrote
+  (`--comparisons-dir`) and render a single self-contained HTML file (`-o`, defaults to
+  `<dir>/report.html`) with the dashboard's value views — the headline Fynd savings, win rate, and
+  median savings bps; the verdict split by trade count and by volume; per-solver/venue breakdowns;
+  top-saving trades; and the unsolved token tail. `--venue <name>` (repeatable, case-insensitive)
+  restricts the report to those venues. No chain, Tycho, or network access.
 
 ## Environment
 
@@ -80,6 +88,18 @@ their solver in calldata — `solver_aliases`).
 | `compare.rs` | `Verdict` / `Deltas` — bps diff, win/loss/coverage-miss classification |
 | `monitor.rs` | Production `monitor` subcommand: in-process solver, block subscription, JSONL emission |
 | `jsonl.rs` | Append-only JSONL writer used by `monitor` |
+
+### Report (`src/report/`)
+
+The offline `report` subcommand — reads a `monitor` run's comparison JSONL and writes one
+self-contained HTML file.
+
+| File | Purpose |
+|---|---|
+| `mod.rs` | `ReportArgs`; reads every `.jsonl` in the dir, skipping malformed lines |
+| `record.rs` | The subset of the JSONL record the report deserializes; round-trip tested against `jsonl::write_comparisons` |
+| `aggregate.rs` | Pure aggregations over the records (verdicts, coverage, savings, per-group, movers) |
+| `html.rs` | Renders the aggregates to a self-contained HTML file (inline CSS, `<div>` bars, no assets) |
 
 ### Verdict model
 

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -1,4 +1,5 @@
 mod decoder;
+mod report;
 mod resolve;
 mod telemetry;
 mod usd;
@@ -14,6 +15,7 @@ use tracing_subscriber::EnvFilter;
 
 use crate::{
     decoder::{DecodedTrade, Decoder, Registry},
+    report::ReportArgs,
     resolve::monitor::MonitorArgs,
     verify::allium::AlliumClient,
 };
@@ -34,6 +36,8 @@ enum Command {
     /// Live monitor: drive an in-process solver block-by-block, re-solving each block's settled
     /// trades at top-of-block (N-1) and back-of-block (N).
     Monitor(MonitorArgs),
+    /// Render an offline HTML report from a monitor run's comparison JSONL.
+    Report(ReportArgs),
 }
 
 /// Chain selection shared by every subcommand: which chain to operate on and how to reach it.
@@ -133,6 +137,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Decode(args) => run_decode(args).await,
         Command::Verify(args) => run_verify(args).await,
         Command::Monitor(args) => resolve::monitor::run(args).await,
+        Command::Report(args) => report::run(args),
     };
 
     // Log the failure before returning it: the fmt subscriber above writes to stdout, whereas a

--- a/tools/hindsight/src/report/aggregate.rs
+++ b/tools/hindsight/src/report/aggregate.rs
@@ -50,20 +50,16 @@ pub(crate) struct VerdictStat {
     pub notional_usd: f64,
 }
 
-/// Routing-quality view over scored (win/loss) trades. USD figures are signed gross Fynd-vs-settled
-/// deltas (the `hindsight_savings_usd` metric): `net` is the headline, `won`/`lost` its two sides.
+/// Routing-quality view over scored (win/loss) trades. The losses are not summarised here — the
+/// report lists each one instead, so a single bad-liquidity snapshot cannot pass for a trend.
 pub(crate) struct Savings {
     pub scored: usize,
     pub wins: usize,
-    pub losses: usize,
     /// Median net bps over winning trades — the typical savings when Fynd wins.
     pub median_win_bps: Option<f64>,
-    /// Net USD savings across scored trades — wins minus losses.
-    pub net_usd: f64,
-    /// USD gained on winning trades (positive).
+    /// USD gained on winning trades, the signed gross Fynd-vs-settled delta on wins (the
+    /// `hindsight_savings_usd` metric).
     pub won_usd: f64,
-    /// USD given up on losing trades (negative).
-    pub lost_usd: f64,
 }
 
 /// Per-solver or per-venue breakdown row.
@@ -149,29 +145,18 @@ fn savings(records: &[Comparison]) -> Savings {
         .filter(|r| r.top.verdict == "win")
         .filter_map(|r| r.top.net_bps)
         .collect();
-    let savings_usd = |verdict: &str| -> f64 {
-        scored
-            .iter()
-            .filter(|r| r.top.verdict == verdict)
-            .filter_map(|r| r.top.improvement_usd)
-            .sum()
-    };
-    let won_usd = savings_usd("win");
-    let lost_usd = savings_usd("loss");
     Savings {
         scored: scored.len(),
         wins: scored
             .iter()
             .filter(|r| r.top.verdict == "win")
             .count(),
-        losses: scored
-            .iter()
-            .filter(|r| r.top.verdict == "loss")
-            .count(),
         median_win_bps: median(&mut win_bps),
-        net_usd: won_usd + lost_usd,
-        won_usd,
-        lost_usd,
+        won_usd: scored
+            .iter()
+            .filter(|r| r.top.verdict == "win")
+            .filter_map(|r| r.top.improvement_usd)
+            .sum(),
     }
 }
 
@@ -356,15 +341,13 @@ mod tests {
             record(3, "relay", "1inch", "sandwiched", Some(500.0)),
         ];
         let savings = savings(&records);
+        // The loss is scored, the sandwiched trade is not.
         assert_eq!(savings.scored, 2);
         assert_eq!(savings.wins, 1);
-        assert_eq!(savings.losses, 1);
         // Median over wins only: [20]; the loss and sandwiched are excluded.
         assert!((savings.median_win_bps.unwrap() - 20.0).abs() < 1e-6);
-        // Won +2.0, lost -1.0, net +1.0; sandwiched excluded.
+        // Won +2.0 on the one win; the loss and the sandwiched 500 bps do not enter it.
         assert!((savings.won_usd - 2.0).abs() < 1e-6);
-        assert!((savings.lost_usd + 1.0).abs() < 1e-6);
-        assert!((savings.net_usd - 1.0).abs() < 1e-6);
     }
 
     #[test]

--- a/tools/hindsight/src/report/aggregate.rs
+++ b/tools/hindsight/src/report/aggregate.rs
@@ -12,8 +12,11 @@ const TOP_TRADES: usize = 10;
 /// Number of tokens listed in the unsolvable-tail table.
 const TOP_UNSOLVABLE_TOKENS: usize = 15;
 
-/// Verdicts in display order; only those present in the data are rendered.
-const VERDICT_ORDER: &[&str] = &["win", "loss", "coverage_miss", "unsolvable", "sandwiched"];
+/// Verdicts in display order — the order of the legend, the stacked columns (top down), and the
+/// table. Win, unsolvable, then loss, so the win green and the loss red are never adjacent
+/// segments: the two are indistinguishable under deuteranopia. Only verdicts present in the data
+/// are rendered.
+const VERDICT_ORDER: &[&str] = &["win", "unsolvable", "loss", "coverage_miss", "sandwiched"];
 
 /// The fully aggregated report, ready to render.
 pub(crate) struct Report {
@@ -39,7 +42,7 @@ pub(crate) struct Count {
 }
 
 /// One verdict, counted two ways: by trade count and by settled USD notional (volume). Both feed a
-/// pie, so the split can be read by number of trades and by dollars — a long tail of tiny
+/// stacked bar, so the split can be read by number of trades and by dollars — a long tail of tiny
 /// unsolvable trades is many trades but little volume.
 pub(crate) struct VerdictStat {
     pub label: String,
@@ -339,7 +342,7 @@ mod tests {
             .iter()
             .map(|c| c.label.as_str())
             .collect();
-        assert_eq!(labels, vec!["win", "loss", "unsolvable"]);
+        assert_eq!(labels, vec!["win", "unsolvable", "loss"]);
         assert_eq!(stats[0].count, 2);
         // Each record's settled_value_usd is 1000; two wins → 2000 volume.
         assert!((stats[0].notional_usd - 2000.0).abs() < 1e-6);

--- a/tools/hindsight/src/report/aggregate.rs
+++ b/tools/hindsight/src/report/aggregate.rs
@@ -1,0 +1,404 @@
+//! Aggregate parsed comparison records into the numbers the report renders.
+//!
+//! Everything here is a pure function of `&[Comparison]`, judged on the headline (top-of-block)
+//! state, so the aggregates match the monitor's headline verdict and are straightforward to test.
+
+use std::collections::HashMap;
+
+use crate::report::record::Comparison;
+
+/// Number of trades listed in the biggest-wins and biggest-losses tables.
+const TOP_TRADES: usize = 10;
+/// Number of tokens listed in the unsolvable-tail table.
+const TOP_UNSOLVABLE_TOKENS: usize = 15;
+
+/// Verdicts in display order; only those present in the data are rendered.
+const VERDICT_ORDER: &[&str] = &["win", "loss", "coverage_miss", "unsolvable", "sandwiched"];
+
+/// The fully aggregated report, ready to render.
+pub(crate) struct Report {
+    pub summary: Summary,
+    pub verdicts: Vec<VerdictStat>,
+    pub savings: Savings,
+    pub by_solver: Vec<GroupStats>,
+    pub by_venue: Vec<GroupStats>,
+    pub top_wins: Vec<TradeRow>,
+    pub top_losses: Vec<TradeRow>,
+    pub unsolvable_tokens: Vec<Count>,
+}
+
+pub(crate) struct Summary {
+    pub total: usize,
+    pub distinct_blocks: usize,
+}
+
+/// A labelled count, for the token-tail table.
+pub(crate) struct Count {
+    pub label: String,
+    pub count: usize,
+}
+
+/// One verdict, counted two ways: by trade count and by settled USD notional (volume). Both feed a
+/// pie, so the split can be read by number of trades and by dollars — a long tail of tiny
+/// unsolvable trades is many trades but little volume.
+pub(crate) struct VerdictStat {
+    pub label: String,
+    pub count: usize,
+    pub notional_usd: f64,
+}
+
+/// Routing-quality view over scored (win/loss) trades. USD figures are signed gross Fynd-vs-settled
+/// deltas (the `hindsight_savings_usd` metric): `net` is the headline, `won`/`lost` its two sides.
+pub(crate) struct Savings {
+    pub scored: usize,
+    pub wins: usize,
+    pub losses: usize,
+    /// Median net bps over winning trades — the typical savings when Fynd wins.
+    pub median_win_bps: Option<f64>,
+    /// Net USD savings across scored trades — wins minus losses.
+    pub net_usd: f64,
+    /// USD gained on winning trades (positive).
+    pub won_usd: f64,
+    /// USD given up on losing trades (negative).
+    pub lost_usd: f64,
+}
+
+/// Per-solver or per-venue breakdown row.
+pub(crate) struct GroupStats {
+    pub name: String,
+    pub count: usize,
+    pub wins: usize,
+    pub losses: usize,
+    pub unsolved: usize,
+    pub median_net_bps: Option<f64>,
+    pub total_improvement_usd: f64,
+}
+
+/// One row in the biggest-wins or biggest-losses table.
+pub(crate) struct TradeRow {
+    pub settled_tx: String,
+    pub venue: String,
+    pub solver: String,
+    pub net_bps: Option<f64>,
+    pub improvement_usd: f64,
+}
+
+/// Aggregate every view from the parsed records.
+pub(crate) fn build(records: &[Comparison]) -> Report {
+    Report {
+        summary: summary(records),
+        verdicts: verdict_stats(records),
+        savings: savings(records),
+        by_solver: group_stats(records, |r| &r.solver),
+        by_venue: group_stats(records, |r| &r.venue),
+        top_wins: top_wins(records),
+        top_losses: top_losses(records),
+        unsolvable_tokens: unsolvable_tokens(records),
+    }
+}
+
+fn summary(records: &[Comparison]) -> Summary {
+    let mut blocks: Vec<u64> = records
+        .iter()
+        .map(|r| r.block)
+        .collect();
+    blocks.sort_unstable();
+    blocks.dedup();
+    Summary { total: records.len(), distinct_blocks: blocks.len() }
+}
+
+fn verdict_stats(records: &[Comparison]) -> Vec<VerdictStat> {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    let mut notional: HashMap<&str, f64> = HashMap::new();
+    for record in records {
+        let verdict = record.top.verdict.as_str();
+        *counts.entry(verdict).or_default() += 1;
+        *notional.entry(verdict).or_default() += record
+            .top
+            .settled_value_usd
+            .unwrap_or(0.0);
+    }
+    let mut ordered = Vec::new();
+    for &verdict in VERDICT_ORDER {
+        if let Some(&count) = counts.get(verdict) {
+            ordered.push(VerdictStat {
+                label: verdict.to_string(),
+                count,
+                notional_usd: notional
+                    .get(verdict)
+                    .copied()
+                    .unwrap_or(0.0),
+            });
+        }
+    }
+    ordered
+}
+
+fn savings(records: &[Comparison]) -> Savings {
+    let scored: Vec<&Comparison> = records
+        .iter()
+        .filter(|r| r.top.is_scored())
+        .collect();
+    // The savings-bps headline is over wins only — how much better Fynd was when it won, not
+    // diluted by the losses.
+    let mut win_bps: Vec<f64> = scored
+        .iter()
+        .filter(|r| r.top.verdict == "win")
+        .filter_map(|r| r.top.net_bps)
+        .collect();
+    let savings_usd = |verdict: &str| -> f64 {
+        scored
+            .iter()
+            .filter(|r| r.top.verdict == verdict)
+            .filter_map(|r| r.top.improvement_usd)
+            .sum()
+    };
+    let won_usd = savings_usd("win");
+    let lost_usd = savings_usd("loss");
+    Savings {
+        scored: scored.len(),
+        wins: scored
+            .iter()
+            .filter(|r| r.top.verdict == "win")
+            .count(),
+        losses: scored
+            .iter()
+            .filter(|r| r.top.verdict == "loss")
+            .count(),
+        median_win_bps: median(&mut win_bps),
+        net_usd: won_usd + lost_usd,
+        won_usd,
+        lost_usd,
+    }
+}
+
+fn group_stats(records: &[Comparison], key: impl Fn(&Comparison) -> &String) -> Vec<GroupStats> {
+    let mut groups: HashMap<&String, Vec<&Comparison>> = HashMap::new();
+    for record in records {
+        groups
+            .entry(key(record))
+            .or_default()
+            .push(record);
+    }
+    let mut stats: Vec<GroupStats> = groups
+        .into_iter()
+        .map(|(name, group)| {
+            let mut net_bps: Vec<f64> = group
+                .iter()
+                .filter(|r| r.top.is_scored())
+                .filter_map(|r| r.top.net_bps)
+                .collect();
+            GroupStats {
+                name: name.clone(),
+                count: group.len(),
+                wins: group
+                    .iter()
+                    .filter(|r| r.top.verdict == "win")
+                    .count(),
+                losses: group
+                    .iter()
+                    .filter(|r| r.top.verdict == "loss")
+                    .count(),
+                unsolved: group
+                    .iter()
+                    .filter(|r| !r.top.is_served())
+                    .count(),
+                median_net_bps: median(&mut net_bps),
+                total_improvement_usd: group
+                    .iter()
+                    .filter(|r| r.top.is_scored())
+                    .filter_map(|r| r.top.improvement_usd)
+                    .sum(),
+            }
+        })
+        .collect();
+    stats.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    stats
+}
+
+fn top_wins(records: &[Comparison]) -> Vec<TradeRow> {
+    let mut wins: Vec<TradeRow> = trade_rows(records, "win");
+    wins.sort_by(|a, b| {
+        b.improvement_usd
+            .total_cmp(&a.improvement_usd)
+    });
+    wins.truncate(TOP_TRADES);
+    wins
+}
+
+fn top_losses(records: &[Comparison]) -> Vec<TradeRow> {
+    let mut losses: Vec<TradeRow> = trade_rows(records, "loss");
+    losses.sort_by(|a, b| {
+        a.improvement_usd
+            .total_cmp(&b.improvement_usd)
+    });
+    losses.truncate(TOP_TRADES);
+    losses
+}
+
+fn trade_rows(records: &[Comparison], verdict: &str) -> Vec<TradeRow> {
+    records
+        .iter()
+        .filter(|r| r.top.verdict == verdict)
+        .filter_map(|r| {
+            r.top
+                .improvement_usd
+                .map(|usd| TradeRow {
+                    settled_tx: r.settled_tx.clone(),
+                    venue: r.venue.clone(),
+                    solver: r.solver.clone(),
+                    net_bps: r.top.net_bps,
+                    improvement_usd: usd,
+                })
+        })
+        .collect()
+}
+
+fn unsolvable_tokens(records: &[Comparison]) -> Vec<Count> {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for record in records
+        .iter()
+        .filter(|r| !r.top.is_served())
+    {
+        *counts
+            .entry(record.token_in.as_str())
+            .or_default() += 1;
+        *counts
+            .entry(record.token_out.as_str())
+            .or_default() += 1;
+    }
+    let mut ranked: Vec<Count> = counts
+        .into_iter()
+        .map(|(token, count)| Count { label: token.to_string(), count })
+        .collect();
+    ranked.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.label.cmp(&b.label))
+    });
+    ranked.truncate(TOP_UNSOLVABLE_TOKENS);
+    ranked
+}
+
+/// Median of `values`, sorting in place. `None` when empty.
+fn median(values: &mut [f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    values.sort_by(f64::total_cmp);
+    let mid = values.len() / 2;
+    if values.len().is_multiple_of(2) {
+        Some(f64::midpoint(values[mid - 1], values[mid]))
+    } else {
+        Some(values[mid])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(
+        block: u64,
+        venue: &str,
+        solver: &str,
+        verdict: &str,
+        bps: Option<f64>,
+    ) -> Comparison {
+        serde_json::from_value(serde_json::json!({
+            "block": block,
+            "settled_tx": format!("0x{block:064x}"),
+            "venue": venue,
+            "solver": solver,
+            "token_in": "0xaaa",
+            "token_out": "0xbbb",
+            "top": {
+                "verdict": verdict,
+                "net_bps": bps,
+                "improvement_usd": bps.map(|b| b / 10.0),
+                "settled_value_usd": 1000.0,
+            },
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_verdict_stats_in_display_order_with_volume() {
+        let records = vec![
+            record(1, "relay", "1inch", "unsolvable", None),
+            record(2, "relay", "1inch", "win", Some(20.0)),
+            record(3, "relay", "0x", "win", Some(5.0)),
+            record(4, "relay", "0x", "loss", Some(-8.0)),
+        ];
+        let stats = verdict_stats(&records);
+        let labels: Vec<&str> = stats
+            .iter()
+            .map(|c| c.label.as_str())
+            .collect();
+        assert_eq!(labels, vec!["win", "loss", "unsolvable"]);
+        assert_eq!(stats[0].count, 2);
+        // Each record's settled_value_usd is 1000; two wins → 2000 volume.
+        assert!((stats[0].notional_usd - 2000.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_savings_median_is_wins_only_and_excludes_sandwiched() {
+        let records = vec![
+            record(1, "relay", "1inch", "win", Some(20.0)),
+            record(2, "relay", "1inch", "loss", Some(-10.0)),
+            record(3, "relay", "1inch", "sandwiched", Some(500.0)),
+        ];
+        let savings = savings(&records);
+        assert_eq!(savings.scored, 2);
+        assert_eq!(savings.wins, 1);
+        assert_eq!(savings.losses, 1);
+        // Median over wins only: [20]; the loss and sandwiched are excluded.
+        assert!((savings.median_win_bps.unwrap() - 20.0).abs() < 1e-6);
+        // Won +2.0, lost -1.0, net +1.0; sandwiched excluded.
+        assert!((savings.won_usd - 2.0).abs() < 1e-6);
+        assert!((savings.lost_usd + 1.0).abs() < 1e-6);
+        assert!((savings.net_usd - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_top_wins_and_losses_ordered_by_usd() {
+        let records = vec![
+            record(1, "relay", "1inch", "win", Some(10.0)),
+            record(2, "relay", "0x", "win", Some(80.0)),
+            record(3, "relay", "0x", "loss", Some(-90.0)),
+            record(4, "relay", "1inch", "loss", Some(-5.0)),
+        ];
+        let wins = top_wins(&records);
+        assert_eq!(wins[0].solver, "0x");
+        assert!(wins[0].improvement_usd > wins[1].improvement_usd);
+        let losses = top_losses(&records);
+        assert!(losses[0].improvement_usd < 0.0);
+        assert!(losses[0].improvement_usd < losses[1].improvement_usd);
+    }
+
+    #[test]
+    fn test_group_stats_sorted_by_count() {
+        let records = vec![
+            record(1, "relay", "1inch", "win", Some(10.0)),
+            record(2, "relay", "1inch", "loss", Some(-5.0)),
+            record(3, "metamask", "0x", "unsolvable", None),
+        ];
+        let by_venue = group_stats(&records, |r| &r.venue);
+        assert_eq!(by_venue[0].name, "relay");
+        assert_eq!(by_venue[0].count, 2);
+        assert_eq!(by_venue[0].wins, 1);
+        assert_eq!(by_venue[1].name, "metamask");
+        assert_eq!(by_venue[1].unsolved, 1);
+    }
+
+    #[test]
+    fn test_median_even_and_odd() {
+        assert_eq!(median(&mut [3.0, 1.0, 2.0]), Some(2.0));
+        assert_eq!(median(&mut [4.0, 1.0, 3.0, 2.0]), Some(2.5));
+        assert_eq!(median(&mut []), None);
+    }
+}

--- a/tools/hindsight/src/report/html.rs
+++ b/tools/hindsight/src/report/html.rs
@@ -1,0 +1,386 @@
+//! Render an aggregated [`Report`] to a single self-contained HTML file.
+//!
+//! No external assets or network: the verdict pie is a CSS `conic-gradient`, styling is one inline
+//! stylesheet, so the file opens offline. The panels mirror the Grafana dashboard's value views —
+//! the headline Fynd savings (`hindsight_savings_usd`), the verdict split, coverage by notional,
+//! per-solver/venue breakdowns, and the top-saving trades — and skip the block/latency health
+//! panels the JSONL does not carry.
+
+use std::fmt::Write as _;
+
+use crate::report::aggregate::{
+    Count, GroupStats, Report, Savings, Summary, TradeRow, VerdictStat,
+};
+
+/// Colours for each verdict, shared by the pie segments and their legend swatches.
+fn verdict_color(verdict: &str) -> &'static str {
+    match verdict {
+        "win" => "#43a047",
+        "loss" => "#e53935",
+        "unsolvable" => "#fbc02d",
+        "coverage_miss" => "#fb8c00",
+        "sandwiched" => "#8e24aa",
+        _ => "#9e9e9e",
+    }
+}
+
+/// Render the whole report to an HTML document. `filter` names the active venue filter, if any, so
+/// the report says which slice of trades it covers.
+pub(crate) fn render(report: &Report, filter: Option<&str>) -> String {
+    let mut html = String::from(HEAD);
+    html.push_str(&hero_section(&report.savings, &report.summary, filter));
+    html.push_str(&verdict_section(&report.verdicts));
+    html.push_str(&trades_section("Top savings", &report.top_wins));
+    html.push_str(&trades_section("Biggest losses", &report.top_losses));
+    html.push_str(&group_section("By solver", &report.by_solver));
+    html.push_str(&group_section("By venue", &report.by_venue));
+    html.push_str(&token_section(&report.unsolvable_tokens));
+    html.push_str(FOOT);
+    html
+}
+
+/// The headline: Fynd's savings as the uplift on trades it wins (`hindsight_improvement_usd`), one
+/// number, no charts. The loss drag and net are on the sub-line for context — kept off the headline
+/// because a single bad-liquidity snapshot can dominate the signed net — and each loss is listed in
+/// the biggest-losses table.
+fn hero_section(savings: &Savings, summary: &Summary, filter: Option<&str>) -> String {
+    let scope = filter.map_or_else(
+        || "<span class=\"chip\">all venues</span>".to_string(),
+        |venue| format!("<span class=\"chip on\">venue: {}</span>", escape(venue)),
+    );
+    let big = |value: &str, label: &str, cls: &str| {
+        format!(
+            "<div class=\"herostat\"><div class=\"heronum {cls}\">{value}</div>\
+             <div class=\"herolab\">{label}</div></div>"
+        )
+    };
+    format!(
+        "<section class=\"hero\">\
+           <div class=\"heroscope\">hindsight report {scope}</div>\
+           <div class=\"herostats\">{}{}{}</div>\
+           <div class=\"herosub\">Fynd savings is the uplift on trades Fynd wins \
+             (hindsight_improvement_usd). Across {} wins · {} given up on {} losses · \
+             net {} · {} scored · {} comparisons / {} blocks</div>\
+         </section>",
+        big(&fmt_usd(savings.won_usd), "Fynd savings (wins uplift)", "pos big"),
+        big(&pct(savings.wins, savings.scored), "win rate", "pos"),
+        big(&fmt_bps_signed(savings.median_win_bps), "median savings bps (wins)", "pos"),
+        savings.wins,
+        fmt_usd(savings.lost_usd),
+        savings.losses,
+        fmt_usd(savings.net_usd),
+        savings.scored,
+        summary.total,
+        summary.distinct_blocks,
+    )
+}
+
+/// The verdict split as two `conic-gradient` pies — one weighted by trade count, one by settled USD
+/// volume — each with a legend, mirroring the dashboard's outcome-by-count and outcome-by-volume
+/// panels.
+fn verdict_section(verdicts: &[VerdictStat]) -> String {
+    let by_count: Vec<(&str, f64)> = verdicts
+        .iter()
+        .map(|v| (v.label.as_str(), ratio(v.count, 1)))
+        .collect();
+    let by_volume: Vec<(&str, f64)> = verdicts
+        .iter()
+        .map(|v| (v.label.as_str(), v.notional_usd))
+        .collect();
+    let body = format!(
+        "<div class=\"pies\">\
+           <div class=\"piecol\"><h3>by trade count</h3>{}</div>\
+           <div class=\"piecol\"><h3>by volume (settled USD)</h3>{}</div>\
+         </div>",
+        pie(&by_count, |v| format!("{v:.0}")),
+        pie(&by_volume, fmt_usd),
+    );
+    section("Verdicts (top-of-block)", &body)
+}
+
+/// A `conic-gradient` pie with a legend, from `(verdict, value)` slices. `fmt_val` formats each
+/// legend value (a count or a USD amount). Colours come from [`verdict_color`].
+fn pie(entries: &[(&str, f64)], fmt_val: impl Fn(f64) -> String) -> String {
+    let total: f64 = entries.iter().map(|(_, v)| v).sum();
+    if total <= 0.0 {
+        return "<p>no data</p>".to_string();
+    }
+    let mut segments = String::new();
+    let mut legend = String::new();
+    let mut acc = 0.0;
+    for &(label, value) in entries {
+        let color = verdict_color(label);
+        let start = acc;
+        acc += value / total * 100.0;
+        if !segments.is_empty() {
+            segments.push(',');
+        }
+        let _ = write!(segments, "{color} {start:.3}% {acc:.3}%");
+        let _ = write!(
+            legend,
+            "<li><span class=\"swatch\" style=\"background:{color}\"></span>\
+             <span class=\"legname\">{}</span>\
+             <span class=\"legval\">{} ({:.1}%)</span></li>",
+            escape(label),
+            fmt_val(value),
+            value / total * 100.0,
+        );
+    }
+    format!(
+        "<div class=\"pie-wrap\">\
+           <div class=\"pie\" style=\"background:conic-gradient({segments})\"></div>\
+           <ul class=\"legend\">{legend}</ul>\
+         </div>",
+    )
+}
+
+fn group_section(title: &str, groups: &[GroupStats]) -> String {
+    let mut table = String::from(
+        "<table><thead><tr><th>name</th><th>trades</th><th>wins</th><th>losses</th>\
+         <th>unsolved</th><th>win% (scored)</th><th>median bps</th><th>savings</th>\
+         </tr></thead><tbody>",
+    );
+    for group in groups {
+        let scored = group.wins + group.losses;
+        let _ = write!(
+            table,
+            "<tr><td>{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td>\
+             <td class=\"num\">{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td>\
+             <td class=\"num\">{}</td><td class=\"num\">{}</td></tr>",
+            escape(&group.name),
+            group.count,
+            group.wins,
+            group.losses,
+            group.unsolved,
+            pct(group.wins, scored),
+            fmt_bps(group.median_net_bps),
+            fmt_usd(group.total_improvement_usd),
+        );
+    }
+    table.push_str("</tbody></table>");
+    section(title, &table)
+}
+
+fn trades_section(title: &str, trades: &[TradeRow]) -> String {
+    let mut table = String::from(
+        "<table><thead><tr><th>settled tx</th><th>venue</th><th>solver</th>\
+         <th>net bps</th><th>savings</th></tr></thead><tbody>",
+    );
+    for trade in trades {
+        let _ = write!(
+            table,
+            "<tr><td class=\"mono\">{}</td><td>{}</td><td>{}</td>\
+             <td class=\"num\">{}</td><td class=\"num\">{}</td></tr>",
+            escape(&short_hash(&trade.settled_tx)),
+            escape(&trade.venue),
+            escape(&trade.solver),
+            fmt_bps(trade.net_bps),
+            fmt_usd(trade.improvement_usd),
+        );
+    }
+    table.push_str("</tbody></table>");
+    section(title, &table)
+}
+
+fn token_section(tokens: &[Count]) -> String {
+    let mut table = String::from(
+        "<table><thead><tr><th>token</th><th>appearances in unsolved</th></tr></thead><tbody>",
+    );
+    for token in tokens {
+        let _ = write!(
+            table,
+            "<tr><td class=\"mono\">{}</td><td class=\"num\">{}</td></tr>",
+            escape(&token.label),
+            token.count,
+        );
+    }
+    table.push_str("</tbody></table>");
+    section("Unsolved token tail", &table)
+}
+
+fn section(title: &str, body: &str) -> String {
+    format!("<section><h2>{}</h2>{body}</section>", escape(title))
+}
+
+/// `part / whole` as `f64`, `0.0` when `whole` is zero.
+#[expect(clippy::cast_precision_loss, reason = "trade counts are far below f64's mantissa")]
+fn ratio(part: usize, whole: usize) -> f64 {
+    if whole == 0 {
+        return 0.0;
+    }
+    part as f64 / whole as f64
+}
+
+/// `count` as a percentage of `whole`, one decimal; em dash when `whole` is zero.
+fn pct(count: usize, whole: usize) -> String {
+    if whole == 0 {
+        return "—".to_string();
+    }
+    format!("{:.1}%", ratio(count, whole) * 100.0)
+}
+
+fn fmt_bps(bps: Option<f64>) -> String {
+    bps.map_or_else(|| "—".to_string(), |b| format!("{b:.1}"))
+}
+
+/// Basis points with an explicit sign, for a headline stat (e.g. `+12.3`); em dash when absent.
+fn fmt_bps_signed(bps: Option<f64>) -> String {
+    bps.map_or_else(|| "—".to_string(), |b| format!("{b:+.1}"))
+}
+
+/// A signed USD amount with a thousands-separated integer part, e.g. `-$1,234.56`.
+fn fmt_usd(value: f64) -> String {
+    let sign = if value < 0.0 { "-$" } else { "$" };
+    let rounded = format!("{:.2}", value.abs());
+    let (int_part, frac) = rounded
+        .split_once('.')
+        .unwrap_or((rounded.as_str(), "00"));
+    format!("{sign}{}.{frac}", group_thousands(int_part))
+}
+
+fn group_thousands(digits: &str) -> String {
+    let len = digits.len();
+    let mut out = String::with_capacity(len + len / 3);
+    for (i, ch) in digits.chars().enumerate() {
+        if i > 0 && (len - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+/// Shorten a hex hash to `0x1234abcd…9abc` for a table cell.
+fn short_hash(hash: &str) -> String {
+    if hash.len() <= 18 {
+        return hash.to_string();
+    }
+    format!("{}…{}", &hash[..10], &hash[hash.len() - 6..])
+}
+
+fn escape(text: &str) -> String {
+    text.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+const HEAD: &str = r#"<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>hindsight report</title>
+<style>
+:root { color-scheme: dark; }
+body { margin: 0; padding: 2rem; background: #17111f; color: #ece7f2;
+  font: 14px/1.5 -apple-system, Segoe UI, Roboto, sans-serif; }
+h2 { margin: 0 0 1rem; font-size: 1.15rem; color: #c9b6ef; }
+h3 { margin: 0 0 .75rem; font-size: .9rem; color: #9a8bbf; text-transform: uppercase; letter-spacing: .04em; }
+section { background: #211a30; border: 1px solid #362b4a; border-radius: 8px;
+  padding: 1.25rem 1.5rem; margin-bottom: 1.25rem; }
+.hero { }
+.heroscope { color: #9a8bbf; font-size: .85rem; margin-bottom: 1rem; }
+.chip { display: inline-block; padding: .1rem .55rem; border-radius: 999px; background: #17111f;
+  border: 1px solid #362b4a; margin-left: .35rem; font-size: .8rem; }
+.chip.on { color: #c9b6ef; border-color: #5a4680; }
+.herostats { display: flex; flex-wrap: wrap; gap: 1.5rem; }
+.herostat { flex: 1 1 0; min-width: 11rem; }
+.heronum { font-size: 3.5rem; font-weight: 700; line-height: 1.05; letter-spacing: -0.02em; }
+.heronum.big { font-size: 4.25rem; }
+.heronum.pos { color: #66bb6a; }
+.heronum.neg { color: #ef5350; }
+.herolab { color: #9a8bbf; font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; margin-top: .3rem; }
+.herosub { color: #b9aecf; font-size: .9rem; margin-top: 1.25rem; }
+.pies { display: flex; flex-wrap: wrap; gap: 2.5rem; }
+.piecol { flex: 1 1 0; min-width: 20rem; }
+.pie-wrap { display: flex; flex-wrap: wrap; align-items: center; gap: 1.5rem; }
+.pie { width: 180px; height: 180px; border-radius: 50%; flex: 0 0 auto;
+  box-shadow: inset 0 0 0 1px #362b4a; }
+.legend { list-style: none; margin: 0; padding: 0; min-width: 14rem; }
+.legend li { display: flex; align-items: center; gap: .6rem; padding: .25rem 0; }
+.swatch { width: .85rem; height: .85rem; border-radius: 2px; flex: 0 0 auto; }
+.legname { flex: 1; text-transform: capitalize; }
+.legval { color: #b9aecf; font-variant-numeric: tabular-nums; }
+table { border-collapse: collapse; width: 100%; }
+th, td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid #362b4a; }
+th { color: #9a8bbf; font-weight: 600; font-size: .8rem; text-transform: uppercase; }
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+td.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+</style></head><body>
+"#;
+
+const FOOT: &str = "</body></html>\n";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::report::{
+        aggregate::{build, Report},
+        record::Comparison,
+    };
+
+    fn sample_report() -> Report {
+        let records: Vec<Comparison> = vec![
+            serde_json::json!({
+                "block": 1, "settled_tx": "0xabc0000000000000000000000000000000000000000000000000000000000001",
+                "venue": "relay", "solver": "1inch", "token_in": "0xaaa", "token_out": "0xbbb",
+                "top": {"verdict": "win", "net_bps": 20.0, "improvement_usd": 12.0, "settled_value_usd": 1000.0}
+            }),
+            serde_json::json!({
+                "block": 2, "settled_tx": "0xdef0000000000000000000000000000000000000000000000000000000000002",
+                "venue": "relay", "solver": "0x", "token_in": "0xccc", "token_out": "0xddd",
+                "top": {"verdict": "unsolvable", "net_bps": null, "improvement_usd": null, "settled_value_usd": 50.0}
+            }),
+        ]
+        .into_iter()
+        .map(|v| serde_json::from_value(v).unwrap())
+        .collect();
+        build(&records)
+    }
+
+    #[test]
+    fn test_render_is_self_contained_and_covers_sections() {
+        let html = render(&sample_report(), None);
+        assert!(html.starts_with("<!doctype html>"));
+        assert!(html.trim_end().ends_with("</html>"));
+        // No external assets: the file must open offline.
+        assert!(!html.contains("http://"));
+        assert!(!html.contains("https://"));
+        assert!(!html.contains("src="));
+        for heading in ["Fynd savings", "Verdicts", "Top savings", "By solver"] {
+            assert!(html.contains(heading), "missing content: {heading}");
+        }
+        // Verdicts render as two pies — by trade count and by volume — not bars, and not a
+        // separate coverage table.
+        assert!(html.contains("conic-gradient"));
+        assert!(html.contains("by trade count") && html.contains("by volume"));
+        assert!(!html.contains(">Coverage<"));
+    }
+
+    #[test]
+    fn test_render_shows_savings_and_top_trades() {
+        let html = render(&sample_report(), None);
+        // Net savings headline and the win in the top-savings table.
+        assert!(html.contains("$12.00"));
+        assert!(html.contains("0xabc00000…000001")); // shortened hash
+        assert!(html.contains("all venues"));
+    }
+
+    #[test]
+    fn test_render_names_the_active_venue_filter() {
+        let html = render(&sample_report(), Some("relay"));
+        assert!(html.contains("venue: relay"));
+        assert!(!html.contains("all venues"));
+    }
+
+    #[test]
+    fn test_fmt_usd_groups_and_signs() {
+        assert_eq!(fmt_usd(1_234_567.5), "$1,234,567.50");
+        assert_eq!(fmt_usd(-260.03), "-$260.03");
+        assert_eq!(fmt_usd(0.0), "$0.00");
+    }
+
+    #[test]
+    fn test_escape_replaces_markup() {
+        assert_eq!(escape("<a>&\"x\""), "&lt;a&gt;&amp;&quot;x&quot;");
+    }
+}

--- a/tools/hindsight/src/report/html.rs
+++ b/tools/hindsight/src/report/html.rs
@@ -62,10 +62,9 @@ pub(crate) fn render(report: &Report, filter: Option<&str>) -> String {
     html
 }
 
-/// The headline: Fynd's savings as the uplift on trades it wins (`hindsight_improvement_usd`), one
-/// number, no charts. The loss drag and net are on the sub-line for context — kept off the headline
-/// because a single bad-liquidity snapshot can dominate the signed net — and each loss is listed in
-/// the biggest-losses table.
+/// The headline: Fynd's savings as the uplift on trades it wins (`hindsight_improvement_usd`), its
+/// win rate, and its median savings when it wins. Underneath, the size of the run as plain counts.
+/// The losses are not summarised here — each one is listed in the biggest-losses table.
 fn hero_section(savings: &Savings, summary: &Summary, filter: Option<&str>) -> String {
     let scope = filter.map_or_else(
         || "<span class=\"chip\">all venues</span>".to_string(),
@@ -77,24 +76,24 @@ fn hero_section(savings: &Savings, summary: &Summary, filter: Option<&str>) -> S
              <div class=\"herolab\">{label}</div></div>"
         )
     };
+    let mini = |value: &str, label: &str| {
+        format!(
+            "<div class=\"ministat\"><div class=\"mininum\">{value}</div>\
+             <div class=\"minilab\">{label}</div></div>"
+        )
+    };
     format!(
         "<section class=\"hero\">\
            <div class=\"heroscope\">hindsight report {scope}</div>\
            <div class=\"herostats\">{}{}{}</div>\
-           <div class=\"herosub\">Fynd savings is the uplift on trades Fynd wins \
-             (hindsight_improvement_usd). Across {} wins · {} given up on {} losses · \
-             net {} · {} scored · {} comparisons / {} blocks</div>\
+           <div class=\"herofoot\">{}{}{}</div>\
          </section>",
         big(&fmt_usd(savings.won_usd), "Fynd savings (wins uplift)", "pos big"),
         big(&pct(savings.wins, savings.scored), "win rate", "pos"),
         big(&fmt_bps_signed(savings.median_win_bps), "median savings bps (wins)", "pos"),
-        savings.wins,
-        fmt_usd(savings.lost_usd),
-        savings.losses,
-        fmt_usd(savings.net_usd),
-        savings.scored,
-        summary.total,
-        summary.distinct_blocks,
+        mini(&fmt_count(summary.distinct_blocks), "blocks"),
+        mini(&fmt_count(summary.total), "comparisons"),
+        mini(&fmt_count(savings.scored), "scored"),
     )
 }
 
@@ -322,6 +321,11 @@ fn fmt_usd(value: f64) -> String {
     format!("{sign}{}{frac}", group_thousands(int_part))
 }
 
+/// A count with thousands separators, e.g. `4,433`.
+fn fmt_count(count: usize) -> String {
+    group_thousands(&count.to_string())
+}
+
 fn group_thousands(digits: &str) -> String {
     let len = digits.len();
     let mut out = String::with_capacity(len + len / 3);
@@ -368,12 +372,14 @@ section { background: #211a30; border: 1px solid #362b4a; border-radius: 8px;
 .chip.on { color: #c9b6ef; border-color: #5a4680; }
 .herostats { display: flex; flex-wrap: wrap; gap: 1.5rem; }
 .herostat { flex: 1 1 0; min-width: 11rem; }
-.heronum { font-size: 3.5rem; font-weight: 700; line-height: 1.05; letter-spacing: -0.02em; }
-.heronum.big { font-size: 4.25rem; }
+.heronum { font-size: 4.5rem; font-weight: 700; line-height: 1.05; letter-spacing: -0.02em; }
+.heronum.big { font-size: 5.5rem; }
 .heronum.pos { color: #66bb6a; }
 .heronum.neg { color: #ef5350; }
 .herolab { color: #9a8bbf; font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; margin-top: .3rem; }
-.herosub { color: #b9aecf; font-size: .9rem; margin-top: 1.25rem; }
+.herofoot { display: flex; flex-wrap: wrap; gap: 2.5rem; margin-top: 1.75rem; }
+.mininum { font-size: 1.4rem; font-weight: 600; line-height: 1.2; }
+.minilab { color: #9a8bbf; font-size: .75rem; text-transform: uppercase; letter-spacing: .04em; }
 .legend { list-style: none; margin: 0; padding: 0; }
 .legend li { display: flex; align-items: center; gap: .6rem; padding: .25rem 0; }
 .legend.row { display: flex; flex-wrap: wrap; gap: 1.25rem; margin-bottom: 1.25rem; }
@@ -504,6 +510,21 @@ mod tests {
         assert!(html.contains("$12.00"));
         assert!(html.contains("0xabc00000…000001")); // shortened hash
         assert!(html.contains("all venues"));
+    }
+
+    #[test]
+    fn test_render_states_the_run_size_as_counts() {
+        let html = render(&sample_report(), None);
+        // Two records over two blocks, one of them scored — plain counts, no sentence.
+        for (value, label) in [("2", "blocks"), ("2", "comparisons"), ("1", "scored")] {
+            assert!(
+                html.contains(&format!(">{value}</div><div class=\"minilab\">{label}<")),
+                "{label}"
+            );
+        }
+        // The prose summary of the loss drag and net is gone.
+        assert!(!html.contains("given up on"), "{html}");
+        assert!(!html.contains("herosub"), "{html}");
     }
 
     #[test]

--- a/tools/hindsight/src/report/html.rs
+++ b/tools/hindsight/src/report/html.rs
@@ -228,14 +228,19 @@ fn fmt_bps_signed(bps: Option<f64>) -> String {
     bps.map_or_else(|| "—".to_string(), |b| format!("{b:+.1}"))
 }
 
-/// A signed USD amount with a thousands-separated integer part, e.g. `-$1,234.56`.
+/// A signed USD amount with a thousands-separated integer part, e.g. `-$1,234.56`. A non-finite
+/// amount — an overflowed sum, or a `null` the aggregates turned into a NaN — has no digits to
+/// group and renders as an em dash.
 fn fmt_usd(value: f64) -> String {
+    if !value.is_finite() {
+        return "—".to_string();
+    }
     let sign = if value < 0.0 { "-$" } else { "$" };
     let rounded = format!("{:.2}", value.abs());
-    let (int_part, frac) = rounded
-        .split_once('.')
-        .unwrap_or((rounded.as_str(), "00"));
-    format!("{sign}{}.{frac}", group_thousands(int_part))
+    // `{:.2}` on a finite value always emits `<digits>.<2 digits>`, so the last three bytes are the
+    // fraction and everything before them is the integer part. Both are ASCII.
+    let (int_part, frac) = rounded.split_at(rounded.len() - 3);
+    format!("{sign}{}{frac}", group_thousands(int_part))
 }
 
 fn group_thousands(digits: &str) -> String {
@@ -377,6 +382,14 @@ mod tests {
         assert_eq!(fmt_usd(1_234_567.5), "$1,234,567.50");
         assert_eq!(fmt_usd(-260.03), "-$260.03");
         assert_eq!(fmt_usd(0.0), "$0.00");
+    }
+
+    #[test]
+    fn test_fmt_usd_non_finite() {
+        // `{:.2}` renders these without a decimal point, so they have no integer part to group.
+        assert_eq!(fmt_usd(f64::INFINITY), "—");
+        assert_eq!(fmt_usd(f64::NEG_INFINITY), "—");
+        assert_eq!(fmt_usd(f64::NAN), "—");
     }
 
     #[test]

--- a/tools/hindsight/src/report/html.rs
+++ b/tools/hindsight/src/report/html.rs
@@ -1,7 +1,7 @@
 //! Render an aggregated [`Report`] to a single self-contained HTML file.
 //!
-//! No external assets or network: the verdict pie is a CSS `conic-gradient`, styling is one inline
-//! stylesheet, so the file opens offline. The panels mirror the Grafana dashboard's value views —
+//! No external assets or network: the verdict split is a flexbox stacked column, styling is one
+//! inline stylesheet, so the file opens offline. The panels mirror the dashboard's value views —
 //! the headline Fynd savings (`hindsight_savings_usd`), the verdict split, coverage by notional,
 //! per-solver/venue breakdowns, and the top-saving trades — and skip the block/latency health
 //! panels the JSONL does not carry.
@@ -12,16 +12,39 @@ use crate::report::aggregate::{
     Count, GroupStats, Report, Savings, Summary, TradeRow, VerdictStat,
 };
 
-/// Colours for each verdict, shared by the pie segments and their legend swatches.
+/// Shortest share of a stacked column that gets an inline `12.3%` label. Below it the segment is
+/// not tall enough to hold a line of text with padding above and below, so the value stays in the
+/// hover title and the table.
+const MIN_LABELLED_SHARE: f64 = 8.0;
+
+/// Colours for each verdict, shared by the stacked-column segments and their legend swatches. These
+/// are status colours, not series identity: they carry good → critical in the same hues the Grafana
+/// dashboard uses, so the report reads like the dashboard it mirrors. Green and red are
+/// indistinguishable under deuteranopia, which is why every segment is also named in the legend and
+/// listed in the table.
 fn verdict_color(verdict: &str) -> &'static str {
     match verdict {
         "win" => "#43a047",
         "loss" => "#e53935",
         "unsolvable" => "#fbc02d",
         "coverage_miss" => "#fb8c00",
-        "sandwiched" => "#8e24aa",
+        "sandwiched" => "#ab47bc",
         _ => "#9e9e9e",
     }
+}
+
+/// Ink for a label sitting inside a verdict's fill, picked by the fill's luminance so the text
+/// clears contrast against it.
+fn verdict_ink(verdict: &str) -> &'static str {
+    match verdict {
+        "win" | "loss" | "sandwiched" => "#ffffff",
+        _ => "#17111f",
+    }
+}
+
+/// A verdict's display name: the JSONL's `coverage_miss` reads as `coverage miss`.
+fn verdict_name(verdict: &str) -> String {
+    verdict.replace('_', " ")
 }
 
 /// Render the whole report to an HTML document. `filter` names the active venue filter, if any, so
@@ -75,9 +98,10 @@ fn hero_section(savings: &Savings, summary: &Summary, filter: Option<&str>) -> S
     )
 }
 
-/// The verdict split as two `conic-gradient` pies — one weighted by trade count, one by settled USD
-/// volume — each with a legend, mirroring the dashboard's outcome-by-count and outcome-by-volume
-/// panels.
+/// The verdict split as two 100% stacked columns — one weighted by trade count, one by settled USD
+/// volume — sharing one legend, mirroring the dashboard's outcome-by-count and outcome-by-volume
+/// panels. Both columns are stated again as a table, so every value is readable without reading a
+/// colour.
 fn verdict_section(verdicts: &[VerdictStat]) -> String {
     let by_count: Vec<(&str, f64)> = verdicts
         .iter()
@@ -88,50 +112,97 @@ fn verdict_section(verdicts: &[VerdictStat]) -> String {
         .map(|v| (v.label.as_str(), v.notional_usd))
         .collect();
     let body = format!(
-        "<div class=\"pies\">\
-           <div class=\"piecol\"><h3>by trade count</h3>{}</div>\
-           <div class=\"piecol\"><h3>by volume (settled USD)</h3>{}</div>\
-         </div>",
-        pie(&by_count, |v| format!("{v:.0}")),
-        pie(&by_volume, fmt_usd),
+        "{}<div class=\"cols\">{}{}</div>{}",
+        verdict_legend(verdicts),
+        stacked_column("by trade count", &by_count, |v| format!("{v:.0}")),
+        stacked_column("by volume (USD)", &by_volume, fmt_usd),
+        verdict_table(verdicts),
     );
     section("Verdicts (top-of-block)", &body)
 }
 
-/// A `conic-gradient` pie with a legend, from `(verdict, value)` slices. `fmt_val` formats each
-/// legend value (a count or a USD amount). Colours come from [`verdict_color`].
-fn pie(entries: &[(&str, f64)], fmt_val: impl Fn(f64) -> String) -> String {
-    let total: f64 = entries.iter().map(|(_, v)| v).sum();
-    if total <= 0.0 {
-        return "<p>no data</p>".to_string();
-    }
-    let mut segments = String::new();
-    let mut legend = String::new();
-    let mut acc = 0.0;
-    for &(label, value) in entries {
-        let color = verdict_color(label);
-        let start = acc;
-        acc += value / total * 100.0;
-        if !segments.is_empty() {
-            segments.push(',');
-        }
-        let _ = write!(segments, "{color} {start:.3}% {acc:.3}%");
+/// The legend both columns share: identity never rests on colour alone, so every verdict present in
+/// the data is named beside its swatch.
+fn verdict_legend(verdicts: &[VerdictStat]) -> String {
+    let mut items = String::new();
+    for verdict in verdicts {
         let _ = write!(
-            legend,
-            "<li><span class=\"swatch\" style=\"background:{color}\"></span>\
-             <span class=\"legname\">{}</span>\
-             <span class=\"legval\">{} ({:.1}%)</span></li>",
-            escape(label),
-            fmt_val(value),
-            value / total * 100.0,
+            items,
+            "<li><span class=\"swatch\" style=\"background:{}\"></span>\
+             <span class=\"legname\">{}</span></li>",
+            verdict_color(&verdict.label),
+            escape(&verdict_name(&verdict.label)),
         );
     }
-    format!(
-        "<div class=\"pie-wrap\">\
-           <div class=\"pie\" style=\"background:conic-gradient({segments})\"></div>\
-           <ul class=\"legend\">{legend}</ul>\
-         </div>",
-    )
+    format!("<ul class=\"legend row\">{items}</ul>")
+}
+
+/// One 100% stacked column from `(verdict, value)` segments, captioned underneath. `fmt_val`
+/// formats a segment's value for its hover title. Segments stack top down in the verdict order and
+/// are separated by a 2px gap in the surface colour rather than a border; only a segment at least
+/// [`MIN_LABELLED_SHARE`] tall carries an inline share label, so no label is ever clipped by its
+/// own segment.
+fn stacked_column(title: &str, entries: &[(&str, f64)], fmt_val: impl Fn(f64) -> String) -> String {
+    let total: f64 = entries.iter().map(|(_, v)| v).sum();
+    let group = |body: &str| {
+        let caption = escape(title);
+        format!("<div class=\"colgroup\">{body}<div class=\"collab\">{caption}</div></div>")
+    };
+    if total <= 0.0 {
+        return group("<p class=\"nodata\">no data</p>");
+    }
+    let mut segments = String::new();
+    for &(label, value) in entries {
+        if value <= 0.0 {
+            continue;
+        }
+        let share = value / total * 100.0;
+        let inline = if share >= MIN_LABELLED_SHARE {
+            format!(
+                "<span class=\"seglab\" style=\"color:{}\">{share:.1}%</span>",
+                verdict_ink(label),
+            )
+        } else {
+            String::new()
+        };
+        let _ = write!(
+            segments,
+            "<div class=\"seg\" style=\"flex:{share:.4} 1 0;background:{}\" \
+             title=\"{} · {} ({share:.1}%)\">{inline}</div>",
+            verdict_color(label),
+            escape(&verdict_name(label)),
+            escape(&fmt_val(value)),
+        );
+    }
+    group(&format!("<div class=\"col\">{segments}</div>"))
+}
+
+/// The table view of the same split: every count, volume, and share in text, so the columns are a
+/// summary rather than the only way to read the numbers.
+fn verdict_table(verdicts: &[VerdictStat]) -> String {
+    let total_count: usize = verdicts.iter().map(|v| v.count).sum();
+    let total_volume: f64 = verdicts
+        .iter()
+        .map(|v| v.notional_usd)
+        .sum();
+    let mut table = String::from(
+        "<table><thead><tr><th>verdict</th><th>trades</th><th>share</th><th>volume</th>\
+         <th>share</th></tr></thead><tbody>",
+    );
+    for verdict in verdicts {
+        let _ = write!(
+            table,
+            "<tr><td>{}</td><td class=\"num\">{}</td><td class=\"num\">{}</td>\
+             <td class=\"num\">{}</td><td class=\"num\">{}</td></tr>",
+            escape(&verdict_name(&verdict.label)),
+            verdict.count,
+            pct(verdict.count, total_count),
+            fmt_usd(verdict.notional_usd),
+            share_pct(verdict.notional_usd, total_volume),
+        );
+    }
+    table.push_str("</tbody></table>");
+    table
 }
 
 fn group_section(title: &str, groups: &[GroupStats]) -> String {
@@ -219,6 +290,14 @@ fn pct(count: usize, whole: usize) -> String {
     format!("{:.1}%", ratio(count, whole) * 100.0)
 }
 
+/// `part` as a percentage of a USD `whole`, one decimal; em dash when there is no volume to divide.
+fn share_pct(part: f64, whole: f64) -> String {
+    if whole <= 0.0 {
+        return "—".to_string();
+    }
+    format!("{:.1}%", part / whole * 100.0)
+}
+
 fn fmt_bps(bps: Option<f64>) -> String {
     bps.map_or_else(|| "—".to_string(), |b| format!("{b:.1}"))
 }
@@ -295,16 +374,26 @@ section { background: #211a30; border: 1px solid #362b4a; border-radius: 8px;
 .heronum.neg { color: #ef5350; }
 .herolab { color: #9a8bbf; font-size: .8rem; text-transform: uppercase; letter-spacing: .04em; margin-top: .3rem; }
 .herosub { color: #b9aecf; font-size: .9rem; margin-top: 1.25rem; }
-.pies { display: flex; flex-wrap: wrap; gap: 2.5rem; }
-.piecol { flex: 1 1 0; min-width: 20rem; }
-.pie-wrap { display: flex; flex-wrap: wrap; align-items: center; gap: 1.5rem; }
-.pie { width: 180px; height: 180px; border-radius: 50%; flex: 0 0 auto;
-  box-shadow: inset 0 0 0 1px #362b4a; }
-.legend { list-style: none; margin: 0; padding: 0; min-width: 14rem; }
+.legend { list-style: none; margin: 0; padding: 0; }
 .legend li { display: flex; align-items: center; gap: .6rem; padding: .25rem 0; }
+.legend.row { display: flex; flex-wrap: wrap; gap: 1.25rem; margin-bottom: 1.25rem; }
+.legend.row li { padding: 0; }
 .swatch { width: .85rem; height: .85rem; border-radius: 2px; flex: 0 0 auto; }
-.legname { flex: 1; text-transform: capitalize; }
-.legval { color: #b9aecf; font-variant-numeric: tabular-nums; }
+.legname { text-transform: capitalize; }
+/* The columns are the panel's focus: centred, and wide enough to read at a glance. The table below
+   restates their values. */
+.cols { display: flex; justify-content: center; gap: 2rem; margin: .5rem 0 2rem; }
+.colgroup { display: flex; flex-direction: column; gap: .6rem; flex: 0 1 15rem; }
+/* Segments stack top down in verdict order, so the win green caps the column. A 2px gap in the
+   surface colour separates them — never a border. */
+.col { display: flex; flex-direction: column; gap: 2px; height: 17rem; }
+.seg { min-height: 2px; display: flex; align-items: center; justify-content: center; }
+.seg:first-child { border-radius: 4px 4px 0 0; }
+.seg:last-child { border-radius: 0 0 4px 4px; }
+.seglab { font-size: .8rem; font-weight: 600; font-variant-numeric: tabular-nums; }
+.collab { color: #9a8bbf; font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;
+  text-align: center; }
+.nodata { color: #9a8bbf; margin: 0; }
 table { border-collapse: collapse; width: 100%; }
 th, td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid #362b4a; }
 th { color: #9a8bbf; font-weight: 600; font-size: .8rem; text-transform: uppercase; }
@@ -354,11 +443,58 @@ mod tests {
         for heading in ["Fynd savings", "Verdicts", "Top savings", "By solver"] {
             assert!(html.contains(heading), "missing content: {heading}");
         }
-        // Verdicts render as two pies — by trade count and by volume — not bars, and not a
-        // separate coverage table.
-        assert!(html.contains("conic-gradient"));
+        // Verdicts render as two stacked columns — by trade count and by volume — not pies, and
+        // not a separate coverage section.
+        assert!(!html.contains("conic-gradient"));
+        assert!(html.contains("class=\"col\""));
         assert!(html.contains("by trade count") && html.contains("by volume"));
         assert!(!html.contains(">Coverage<"));
+    }
+
+    #[test]
+    fn test_stacked_column_labels_only_segments_tall_enough_to_hold_one() {
+        let entries = [("win", 95.0), ("loss", 5.0)];
+        let html = stacked_column("by trade count", &entries, |v| format!("{v:.0}"));
+        // The 95% segment carries its share inline; the 5% one would clip it, so its value lives
+        // in the hover title instead.
+        assert!(html.contains(">95.0%<"), "{html}");
+        assert!(!html.contains(">5.0%<"), "{html}");
+        assert!(html.contains("title=\"loss · 5 (5.0%)\""), "{html}");
+        // Segments grow proportionally and are separated by the surface gap, not a border.
+        assert!(html.contains("flex:95.0000 1 0"), "{html}");
+        assert!(!html.contains("border"), "{html}");
+    }
+
+    #[test]
+    fn test_stacked_column_stacks_the_first_verdict_at_the_top() {
+        let entries = [("win", 50.0), ("loss", 50.0)];
+        let html = stacked_column("by trade count", &entries, |v| format!("{v:.0}"));
+        // Plain `column` renders markup order top down, so the win green caps the column.
+        let win = html
+            .find("title=\"win")
+            .expect("win segment");
+        let loss = html
+            .find("title=\"loss")
+            .expect("loss segment");
+        assert!(win < loss, "{html}");
+    }
+
+    #[test]
+    fn test_stacked_column_without_volume_says_so() {
+        let html = stacked_column("by volume (settled USD)", &[("win", 0.0)], fmt_usd);
+        assert!(html.contains("no data"));
+        assert!(!html.contains("class=\"col\""));
+        // The caption still says which view is empty.
+        assert!(html.contains("by volume (settled USD)"));
+    }
+
+    #[test]
+    fn test_verdict_table_states_every_share() {
+        let html = render(&sample_report(), None);
+        // Two trades, one of each verdict: 50% by count, and the win holds 1000 of 1050 volume.
+        assert!(html.contains("<td>win</td>"), "{html}");
+        assert!(html.contains("95.2%"), "{html}");
+        assert!(html.contains("50.0%"), "{html}");
     }
 
     #[test]

--- a/tools/hindsight/src/report/mod.rs
+++ b/tools/hindsight/src/report/mod.rs
@@ -1,0 +1,219 @@
+//! Offline HTML report from a monitor run's comparison JSONL.
+//!
+//! Reads the `comparisons-YYYY-MM-DD.jsonl` files a `monitor --comparisons-dir` run wrote (all of
+//! them, so a rotated multi-day run aggregates into one report), computes the same analytical views
+//! as the Grafana dashboard, and writes a single self-contained HTML file. It touches no chain, no
+//! Tycho, and no network — jsonl in, html out.
+
+mod aggregate;
+mod html;
+mod record;
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{bail, Context};
+use tracing::{info, warn};
+
+use crate::report::record::Comparison;
+
+/// Inputs for the `report` subcommand.
+#[derive(clap::Args)]
+pub(crate) struct ReportArgs {
+    /// Directory of `comparisons-YYYY-MM-DD.jsonl` files written by `monitor --comparisons-dir`
+    #[arg(long)]
+    pub comparisons_dir: PathBuf,
+
+    /// Output HTML path (defaults to `<comparisons-dir>/report.html`)
+    #[arg(long, short)]
+    pub output: Option<PathBuf>,
+
+    /// Only report trades from these venues (repeatable, case-insensitive). Omit for all venues.
+    #[arg(long)]
+    pub venue: Vec<String>,
+}
+
+/// Read the comparisons, aggregate them, and write the HTML report.
+pub(crate) fn run(args: ReportArgs) -> anyhow::Result<()> {
+    let all = read_comparisons(&args.comparisons_dir)?;
+    if all.is_empty() {
+        bail!("no comparison records found in {}", args.comparisons_dir.display());
+    }
+    let records = filter_by_venue(all, &args.venue)?;
+    let report = aggregate::build(&records);
+    let filter = (!args.venue.is_empty()).then(|| args.venue.join(", "));
+    let html = html::render(&report, filter.as_deref());
+    let output = args
+        .output
+        .unwrap_or_else(|| args.comparisons_dir.join("report.html"));
+    fs::write(&output, html)
+        .with_context(|| format!("failed to write report to {}", output.display()))?;
+    info!(records = records.len(), venue = ?args.venue, path = %output.display(), "wrote report");
+    Ok(())
+}
+
+/// Keep only the records whose venue is in `venues` (case-insensitive); all records when `venues`
+/// is empty. Errors with the available venue list when the filter matches nothing, so a typo is
+/// obvious rather than yielding a blank report.
+fn filter_by_venue(records: Vec<Comparison>, venues: &[String]) -> anyhow::Result<Vec<Comparison>> {
+    if venues.is_empty() {
+        return Ok(records);
+    }
+    let wanted: Vec<String> = venues
+        .iter()
+        .map(|v| v.to_lowercase())
+        .collect();
+    let filtered: Vec<Comparison> = records
+        .iter()
+        .filter(|r| wanted.contains(&r.venue.to_lowercase()))
+        .cloned()
+        .collect();
+    if filtered.is_empty() {
+        // List the named venues, the sensible filter targets; unknown venues appear only as raw
+        // addresses and would just be noise.
+        let mut named: Vec<&str> = records
+            .iter()
+            .map(|r| r.venue.as_str())
+            .filter(|venue| !venue.starts_with("0x"))
+            .collect();
+        named.sort_unstable();
+        named.dedup();
+        bail!("no trades match venue {venues:?}; available venues: {}", named.join(", "));
+    }
+    Ok(filtered)
+}
+
+/// Read and parse every `.jsonl` file in `dir` into comparison records. Malformed lines are
+/// counted and skipped rather than failing the whole report — a truncated final line from an
+/// interrupted run should not lose the rest of the data.
+fn read_comparisons(dir: &Path) -> anyhow::Result<Vec<Comparison>> {
+    let mut files: Vec<PathBuf> = fs::read_dir(dir)
+        .with_context(|| format!("failed to read comparisons directory {}", dir.display()))?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|ext| ext == "jsonl")
+        })
+        .collect();
+    files.sort();
+    if files.is_empty() {
+        bail!("no .jsonl files in {}", dir.display());
+    }
+
+    let mut records = Vec::new();
+    let mut skipped = 0usize;
+    for file in &files {
+        let content = fs::read_to_string(file)
+            .with_context(|| format!("failed to read {}", file.display()))?;
+        for line in content.lines() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Comparison>(line) {
+                Ok(record) => records.push(record),
+                Err(_) => skipped += 1,
+            }
+        }
+    }
+    if skipped > 0 {
+        warn!(skipped, files = files.len(), "skipped malformed comparison lines");
+    }
+    info!(files = files.len(), records = records.len(), "read comparisons");
+    Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_dir(name: &str, files: &[(&str, &str)]) -> PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("hindsight-report-{name}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        for (file, content) in files {
+            fs::write(dir.join(file), content).unwrap();
+        }
+        dir
+    }
+
+    fn line(block: u64, verdict: &str) -> String {
+        serde_json::json!({
+            "block": block, "settled_tx": format!("0x{block:064x}"),
+            "venue": "relay", "solver": "1inch", "token_in": "0xaaa", "token_out": "0xbbb",
+            "top": {"verdict": verdict, "net_bps": 1.0, "improvement_usd": 1.0, "settled_value_usd": 1.0},
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn test_reads_all_jsonl_files_and_skips_malformed_lines() {
+        let dir = write_dir(
+            "multi",
+            &[
+                (
+                    "comparisons-2026-07-20.jsonl",
+                    &format!("{}\n{}\n", line(1, "win"), line(2, "loss")),
+                ),
+                // A blank line, a good line, and a truncated one.
+                (
+                    "comparisons-2026-07-21.jsonl",
+                    &format!("\n{}\n{{\"block\":3", line(3, "unsolvable")),
+                ),
+                ("report.html", "<html></html>"), // ignored: not .jsonl
+            ],
+        );
+        let records = read_comparisons(&dir).unwrap();
+        assert_eq!(records.len(), 3);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn test_empty_dir_is_an_error() {
+        let dir = write_dir("empty", &[]);
+        assert!(read_comparisons(&dir).is_err());
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    fn venue_record(venue: &str) -> Comparison {
+        serde_json::from_value(serde_json::json!({
+            "block": 1, "settled_tx": "0x1", "venue": venue, "solver": "1inch",
+            "token_in": "0xaaa", "token_out": "0xbbb",
+            "top": {"verdict": "win", "net_bps": 1.0, "improvement_usd": 1.0, "settled_value_usd": 1.0},
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn test_filter_by_venue() {
+        let records = vec![venue_record("relay"), venue_record("metamask"), venue_record("relay")];
+        // No filter keeps everything.
+        assert_eq!(
+            filter_by_venue(records.clone(), &[])
+                .unwrap()
+                .len(),
+            3
+        );
+        // Case-insensitive match on the named venue(s).
+        assert_eq!(
+            filter_by_venue(records.clone(), &["RELAY".into()])
+                .unwrap()
+                .len(),
+            2
+        );
+        assert_eq!(
+            filter_by_venue(records.clone(), &["relay".into(), "metamask".into()])
+                .unwrap()
+                .len(),
+            3
+        );
+        // An unmatched venue errors with the available list, not a blank report.
+        let err = filter_by_venue(records, &["cow".into()])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("metamask") && err.contains("relay"), "{err}");
+    }
+}

--- a/tools/hindsight/src/report/record.rs
+++ b/tools/hindsight/src/report/record.rs
@@ -1,0 +1,122 @@
+//! The subset of the monitor's JSONL comparison record the report reads.
+//!
+//! `monitor --comparisons-dir` writes one JSON object per re-solved trade (see
+//! `resolve::jsonl`). The report only needs the headline fields, so these structs deserialize a
+//! subset; serde ignores the rest (the slim quote, per-hop route, back-state amounts). The
+//! round-trip test in this module writes a record through the monitor's own writer and parses it
+//! back, so a rename on the writer side is caught here rather than silently reading `None`.
+
+use serde::Deserialize;
+
+/// One re-solved trade: the settled trade's identity plus Fynd's result at each block state.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Comparison {
+    pub block: u64,
+    pub settled_tx: String,
+    pub venue: String,
+    pub solver: String,
+    pub token_in: String,
+    pub token_out: String,
+    /// Optimistic state (N-1); the report's headline, matching the monitor's headline verdict.
+    pub top: State,
+}
+
+/// Fynd's result at one block state.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct State {
+    pub verdict: String,
+    #[serde(default)]
+    pub net_bps: Option<f64>,
+    /// Signed USD delta of Fynd's output vs the settled output — negative on a loss. Present only
+    /// for a solved state.
+    #[serde(default)]
+    pub improvement_usd: Option<f64>,
+    /// The settled trade's gross notional in USD — present whenever the output (or input) token is
+    /// priced, including for unsolvable trades, so coverage can be weighed by dollars.
+    #[serde(default)]
+    pub settled_value_usd: Option<f64>,
+}
+
+impl State {
+    /// Fynd produced a full-size quote and it was scored against the settled trade (win or loss),
+    /// or it was scored but discounted as sandwiched. These are the "served" trades — the ones
+    /// where routing quality, not coverage, is the question.
+    pub(crate) fn is_served(&self) -> bool {
+        self.verdict == "win" || self.verdict == "loss" || self.verdict == "sandwiched"
+    }
+
+    /// A fair win/loss comparison: served and not discounted by MEV. Savings aggregates are taken
+    /// over these, matching the dashboard (which excludes sandwiched trades from the value view).
+    pub(crate) fn is_scored(&self) -> bool {
+        self.verdict == "win" || self.verdict == "loss"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, TxHash, U256};
+
+    use super::*;
+    use crate::{
+        decoder::{AttributionSource, DecodedTrade, Registry},
+        resolve::{build_range, jsonl::write_comparisons, Outcome, SolvedAmount},
+        usd::Prices,
+    };
+
+    /// A record written by the monitor's own writer parses back into `Comparison` with the headline
+    /// fields populated — guards against the writer and this reader drifting apart.
+    #[test]
+    fn test_parses_a_record_from_the_monitor_writer() {
+        let usdc: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+            .parse()
+            .unwrap();
+        let weth: Address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+            .parse()
+            .unwrap();
+        let mut prices = Prices::new(&Registry::ethereum());
+        prices.insert(usdc, 2e-9);
+        prices.insert(weth, 1.0);
+
+        let trade = DecodedTrade {
+            tx_hash: TxHash::repeat_byte(0x42),
+            block_number: 25_000_000,
+            tx_index: 0,
+            venue: "relay".into(),
+            solver: "1inch".into(),
+            solver_source: AttributionSource::TraceMatch,
+            decoder: "sender-netting",
+            sender: Address::ZERO,
+            token_in: weth,
+            token_out: usdc,
+            amount_in: U256::from(1_000u64),
+            amount_out: U256::from(1_000_000_000u64), // settled 1000 USDC
+            venue_fee_in: None,
+            venue_fee_out: None,
+            settled_gas: None,
+            quote: None,
+            sandwich: None,
+        };
+        // Top solved above settled → a win with a positive USD improvement.
+        let top = Outcome::Solved(SolvedAmount {
+            amount_out: U256::from(1_010_000_000u64),
+            amount_out_net_gas: U256::from(1_010_000_000u64),
+            gas_estimate: U256::from(21_000u64),
+            quote_json: None,
+        });
+        let range = build_range(&trade, &prices, top, Outcome::Unsolvable("x".into()));
+
+        let mut buf = Vec::new();
+        write_comparisons(&mut buf, std::slice::from_ref(&range), &prices, &prices);
+        let line = String::from_utf8(buf).unwrap();
+
+        let record: Comparison = serde_json::from_str(line.trim()).unwrap();
+        assert_eq!(record.block, 25_000_000);
+        assert_eq!(record.venue, "relay");
+        assert_eq!(record.solver, "1inch");
+        assert_eq!(record.top.verdict, "win");
+        assert!(record.top.is_scored());
+        assert!(record.top.net_bps.unwrap() > 0.0);
+        assert!((record.top.improvement_usd.unwrap() - 10.0).abs() < 1e-3);
+        assert_eq!(record.token_out, format!("{usdc:#x}"));
+    }
+}

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -118,7 +118,7 @@ fn date_from_unix(secs: u64) -> String {
 /// filter to wins for the improvement view or to unsolvables for the coverage worklist (where Fynd
 /// needs to improve). Losses keep their route (what path Fynd took and lost on); unsolvables keep
 /// the reason.
-pub(super) fn write_comparisons<W: std::io::Write>(
+pub(crate) fn write_comparisons<W: std::io::Write>(
     writer: &mut W,
     ranges: &[RangeComparison],
     prices_top: &Prices,

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -7,7 +7,7 @@
 //! and back-of-block (N).
 
 mod compare;
-mod jsonl;
+pub(crate) mod jsonl;
 pub(crate) mod monitor;
 
 use alloy::primitives::{Address, TxHash, U256};


### PR DESCRIPTION
Adds a `report` subcommand that turns a `monitor` run's comparison JSONL into a single
self-contained HTML file. It reads the data the monitor already writes — no chain, Tycho, or
network access.

```
hindsight report --comparisons-dir ./out [--venue relay] [-o report.html]
```
<img width="1682" height="947" alt="Screenshot 2026-07-28 at 11 14 19" src="https://github.com/user-attachments/assets/6c4648ff-4452-4739-93b4-47d6b06b7bc8" />


Note: The unsolvable was because I set TVL too high in that particular run.