### PR TITLE
feat(rpc): serve a hosted-gateway Swagger UI at /docs/hosted/

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -108,6 +108,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 | `BLOCKLIST_CONFIG` | Blocklist config file |
 | `RUST_LOG` | Tracing filter (e.g. `info,fynd=debug`) |
 | `METRICS_PORT` | Prometheus metrics server port (default: `9898`, requires `metrics` feature) |
+| `FYND_HOSTED_SWAGGER_URL` | Server URL advertised by the hosted OpenAPI spec (default: `https://fynd-api.propellerheads.xyz`) |
 
 ### CLI Commands
 

--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -108,7 +108,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 | `BLOCKLIST_CONFIG` | Blocklist config file |
 | `RUST_LOG` | Tracing filter (e.g. `info,fynd=debug`) |
 | `METRICS_PORT` | Prometheus metrics server port (default: `9898`, requires `metrics` feature) |
-| `FYND_HOSTED_SWAGGER_URL` | Server URL advertised by the hosted OpenAPI spec (default: `https://fynd-api.propellerheads.xyz`) |
+| `FYND_HOSTED_SWAGGER_URL` | Server URL advertised by the hosted OpenAPI spec. When unset, the hosted Swagger UI (`/docs/hosted/`) is not served — only the self-hosted `/docs/` |
 
 ### CLI Commands
 

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -27,11 +27,24 @@ infrastructure.
 | `GET /v1/info` | `handlers::info` | Static metadata about this Fynd instance (version, chain, spender address) |
 | `GET /v1/prices` | `handlers::get_prices` | Token prices, spot prices, pool depths (experimental feature only) |
 
+## API Documentation
+
+Two Swagger UIs are served, both built from the same `ApiDoc` annotations:
+
+| Path | Spec | Describes |
+|---|---|---|
+| `/docs/` | `/api-docs/openapi.json` | Self-hosted deployments: `/v1/quote` on the origin it is reached at, no authentication |
+| `/docs/hosted/` | `/api-docs/hosted/openapi.json` | The hosted gateway: `/v1/{chain}/quote` with a `chain` path parameter, bearer auth, and a server URL from `FYND_HOSTED_SWAGGER_URL` (default `https://fynd-api.propellerheads.xyz`) |
+
+`api/docs.rs` derives the hosted spec from the self-hosted one at startup, so endpoint
+annotations live in one place.
+
 ## API Module (`api/`)
 
 | File | Purpose |
 |---|---|
 | `mod.rs` | `configure_app()`, `AppState`, `HealthTracker`, `ApiDoc` (utoipa OpenAPI) |
+| `docs.rs` | Builds the self-hosted and hosted OpenAPI specs and registers both Swagger UIs |
 | `handlers.rs` | Request handlers for `/v1/quote`, `/v1/health`, and `/v1/info` |
 | `dto.rs` | Re-exports wire types from `fynd-rpc-types` (conversions to `fynd-core` types live in `fynd-rpc-types` via the `core` feature) |
 | `error.rs` | `ApiError` type with HTTP status code mapping |

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -29,12 +29,12 @@ infrastructure.
 
 ## API Documentation
 
-Two Swagger UIs are served, both built from the same `ApiDoc` annotations:
+Up to two Swagger UIs are served, both built from the same `ApiDoc` annotations:
 
 | Path | Spec | Describes |
 |---|---|---|
-| `/docs/` | `/api-docs/openapi.json` | Self-hosted deployments: `/v1/quote` on the origin it is reached at, no authentication |
-| `/docs/hosted/` | `/api-docs/hosted/openapi.json` | The hosted gateway: `/v1/{chain}/quote` with a `chain` path parameter, an API key sent as the raw `Authorization` header value, and a server URL from `FYND_HOSTED_SWAGGER_URL` (default `https://fynd-api.propellerheads.xyz`) |
+| `/docs/` | `/api-docs/openapi.json` | Self-hosted deployments: `/v1/quote` on the origin it is reached at, no authentication. Always served |
+| `/docs/hosted/` | `/api-docs/hosted/openapi.json` | The hosted gateway: `/v1/{chain}/quote` with a `chain` path parameter and an API key sent as the raw `Authorization` header value. Only served when a gateway URL is set via `--hosted-swagger-url` / `FYND_HOSTED_SWAGGER_URL` |
 
 `api/docs.rs` derives the hosted spec from the self-hosted one at startup, so endpoint
 annotations live in one place.

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -34,7 +34,7 @@ Two Swagger UIs are served, both built from the same `ApiDoc` annotations:
 | Path | Spec | Describes |
 |---|---|---|
 | `/docs/` | `/api-docs/openapi.json` | Self-hosted deployments: `/v1/quote` on the origin it is reached at, no authentication |
-| `/docs/hosted/` | `/api-docs/hosted/openapi.json` | The hosted gateway: `/v1/{chain}/quote` with a `chain` path parameter, bearer auth, and a server URL from `FYND_HOSTED_SWAGGER_URL` (default `https://fynd-api.propellerheads.xyz`) |
+| `/docs/hosted/` | `/api-docs/hosted/openapi.json` | The hosted gateway: `/v1/{chain}/quote` with a `chain` path parameter, an API key sent as the raw `Authorization` header value, and a server URL from `FYND_HOSTED_SWAGGER_URL` (default `https://fynd-api.propellerheads.xyz`) |
 
 `api/docs.rs` derives the hosted spec from the self-hosted one at startup, so endpoint
 annotations live in one place.

--- a/fynd-rpc/src/api/docs.rs
+++ b/fynd-rpc/src/api/docs.rs
@@ -1,0 +1,309 @@
+//! OpenAPI spec construction and Swagger UI registration.
+//!
+//! Two specs are served from the same binary:
+//!
+//! - `/docs/` + `/api-docs/openapi.json` — self-hosted deployments, describing the paths this
+//!   process routes (`/v1/quote`) on the origin it is reached at, with no authentication.
+//! - `/docs/hosted/` + `/api-docs/hosted/openapi.json` — the hosted gateway, which routes per chain
+//!   (`/v1/{chain}/quote`) and authenticates requests with a bearer token.
+
+use std::env;
+
+use actix_web::web;
+use serde_json::json;
+use utoipa::{
+    openapi::{
+        path::{Operation, Parameter, ParameterBuilder, ParameterIn},
+        security::{Http, HttpAuthScheme, SecurityScheme},
+        Components, ObjectBuilder, OpenApi, PathItem, Required, SecurityRequirement, Server, Type,
+    },
+    OpenApi as _,
+};
+use utoipa_swagger_ui::SwaggerUi;
+
+use crate::api::ApiDoc;
+#[cfg(feature = "experimental")]
+use crate::api::ExperimentalApiDoc;
+
+/// Environment variable overriding the server URL advertised by the hosted spec.
+const HOSTED_SERVER_URL_ENV: &str = "FYND_HOSTED_SWAGGER_URL";
+
+/// Server URL advertised by the hosted spec when [`HOSTED_SERVER_URL_ENV`] is unset.
+const DEFAULT_HOSTED_SERVER_URL: &str = "https://fynd-api.propellerheads.xyz";
+
+/// Name of the bearer security scheme declared by the hosted spec.
+const BEARER_SCHEME_NAME: &str = "BearerAuth";
+
+/// Registers both Swagger UIs and the specs they load.
+///
+/// The hosted UI is registered first because actix matches resources in registration order:
+/// `/docs/{_:.*}` also matches `/docs/hosted/index.html` and would serve a 404 for it.
+pub(crate) fn configure_docs(cfg: &mut web::ServiceConfig) {
+    let hosted = SwaggerUi::new("/docs/hosted/{_:.*}")
+        .url("/api-docs/hosted/openapi.json", hosted_spec(&hosted_server_url()));
+    let self_hosted =
+        SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", self_hosted_spec());
+    cfg.service(hosted).service(self_hosted);
+}
+
+/// Builds the spec describing the endpoints this process routes.
+fn self_hosted_spec() -> OpenApi {
+    #[allow(unused_mut)]
+    let mut openapi = ApiDoc::openapi();
+    #[cfg(feature = "experimental")]
+    openapi.merge(ExperimentalApiDoc::openapi());
+    openapi
+}
+
+/// Builds the spec describing the endpoints as exposed by the hosted gateway.
+///
+/// The gateway picks a backend from a chain segment in the path, so every `/v1/<endpoint>` becomes
+/// `/v1/{chain}/<endpoint>` and gains a `chain` path parameter. It also authenticates every
+/// request; declaring the bearer scheme is what gives Swagger UI its "Authorize" button, without
+/// which "Try it out" can only produce 401s.
+fn hosted_spec(server_url: &str) -> OpenApi {
+    let mut openapi = self_hosted_spec();
+
+    let routed_paths = std::mem::take(&mut openapi.paths.paths);
+    for (path, mut path_item) in routed_paths {
+        let Some(endpoint) = path.strip_prefix("/v1/") else {
+            openapi
+                .paths
+                .paths
+                .insert(path, path_item);
+            continue
+        };
+        for operation in operations_mut(&mut path_item) {
+            operation
+                .parameters
+                .get_or_insert_with(Vec::new)
+                .push(chain_parameter())
+        }
+        openapi
+            .paths
+            .paths
+            .insert(format!("/v1/{{chain}}/{endpoint}"), path_item);
+    }
+
+    openapi
+        .components
+        .get_or_insert_with(Components::new)
+        .add_security_scheme(
+            BEARER_SCHEME_NAME,
+            SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)),
+        );
+    openapi.security =
+        Some(vec![SecurityRequirement::new(BEARER_SCHEME_NAME, Vec::<String>::new())]);
+    openapi.servers = Some(vec![Server::new(server_url)]);
+
+    openapi
+}
+
+/// Returns the server URL the hosted spec points "Try it out" requests at.
+fn hosted_server_url() -> String {
+    env::var(HOSTED_SERVER_URL_ENV).unwrap_or_else(|_| DEFAULT_HOSTED_SERVER_URL.to_string())
+}
+
+/// Path parameter naming the chain the hosted gateway routes to.
+fn chain_parameter() -> Parameter {
+    ParameterBuilder::new()
+        .name("chain")
+        .parameter_in(ParameterIn::Path)
+        .required(Required::True)
+        .description(Some("Chain to route the request to."))
+        .schema(Some(ObjectBuilder::new().schema_type(Type::String)))
+        .example(Some(json!("ethereum")))
+        .build()
+}
+
+/// Every operation defined on a path item, whichever HTTP methods it declares.
+fn operations_mut(path_item: &mut PathItem) -> impl Iterator<Item = &mut Operation> {
+    [
+        path_item.get.as_mut(),
+        path_item.put.as_mut(),
+        path_item.post.as_mut(),
+        path_item.delete.as_mut(),
+        path_item.options.as_mut(),
+        path_item.head.as_mut(),
+        path_item.patch.as_mut(),
+        path_item.trace.as_mut(),
+    ]
+    .into_iter()
+    .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    // Aliased: an unqualified `test` import shadows the built-in `#[test]` attribute with
+    // actix-web's, which rejects non-async test functions.
+    use actix_web::{test as actix_test, App};
+    use serde_json::Value;
+
+    use super::*;
+
+    const TEST_SERVER_URL: &str = "https://fynd.test";
+
+    /// The hosted spec as Swagger UI receives it.
+    fn hosted_spec_json(server_url: &str) -> Value {
+        serde_json::to_value(hosted_spec(server_url)).expect("spec serializes")
+    }
+
+    #[test]
+    fn self_hosted_spec_paths() {
+        let spec = self_hosted_spec();
+        let paths: Vec<&str> = spec
+            .paths
+            .paths
+            .keys()
+            .map(String::as_str)
+            .collect();
+
+        assert!(paths.contains(&"/v1/quote"), "{paths:?}");
+        assert!(paths.contains(&"/v1/health"), "{paths:?}");
+        assert!(paths.contains(&"/v1/info"), "{paths:?}");
+        assert!(
+            paths
+                .iter()
+                .all(|path| !path.contains("{chain}")),
+            "{paths:?}"
+        )
+    }
+
+    #[test]
+    fn self_hosted_spec_has_no_security() {
+        let spec = self_hosted_spec();
+
+        assert!(spec.security.is_none());
+        assert!(spec.servers.is_none());
+        assert!(spec
+            .components
+            .expect("schemas are declared")
+            .security_schemes
+            .is_empty())
+    }
+
+    #[test]
+    fn hosted_spec_paths_carry_chain_segment() {
+        let spec = hosted_spec(TEST_SERVER_URL);
+        let paths: Vec<&str> = spec
+            .paths
+            .paths
+            .keys()
+            .map(String::as_str)
+            .collect();
+
+        assert!(paths.contains(&"/v1/{chain}/quote"), "{paths:?}");
+        assert!(paths.contains(&"/v1/{chain}/health"), "{paths:?}");
+        assert!(paths.contains(&"/v1/{chain}/info"), "{paths:?}");
+        assert!(
+            paths
+                .iter()
+                .all(|path| path.starts_with("/v1/{chain}/")),
+            "{paths:?}"
+        )
+    }
+
+    #[cfg(feature = "experimental")]
+    #[test]
+    fn hosted_spec_includes_experimental_paths() {
+        let spec = hosted_spec(TEST_SERVER_URL);
+
+        assert!(spec
+            .paths
+            .paths
+            .contains_key("/v1/{chain}/prices"))
+    }
+
+    #[test]
+    fn hosted_spec_operations_declare_chain_parameter() {
+        let spec = hosted_spec_json(TEST_SERVER_URL);
+
+        let paths = spec["paths"]
+            .as_object()
+            .expect("paths are an object");
+        for (path, path_item) in paths {
+            for (method, operation) in path_item
+                .as_object()
+                .expect("path items are an object")
+            {
+                let parameters = operation["parameters"]
+                    .as_array()
+                    .unwrap_or_else(|| panic!("{method} {path} declares no parameters"));
+                let chain = parameters
+                    .iter()
+                    .find(|parameter| parameter["name"] == "chain")
+                    .unwrap_or_else(|| panic!("{method} {path} declares no chain parameter"));
+                assert_eq!(chain["in"], "path", "{method} {path}");
+                assert_eq!(chain["required"], true, "{method} {path}")
+            }
+        }
+    }
+
+    #[test]
+    fn hosted_spec_declares_bearer_auth() {
+        let spec = hosted_spec_json(TEST_SERVER_URL);
+
+        assert_eq!(
+            spec["components"]["securitySchemes"]["BearerAuth"],
+            json!({"type": "http", "scheme": "bearer"})
+        );
+        assert_eq!(spec["security"], json!([{"BearerAuth": []}]))
+    }
+
+    #[test]
+    fn hosted_spec_server_url() {
+        let spec = hosted_spec(TEST_SERVER_URL);
+
+        let servers = spec.servers.expect("server is set");
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].url, TEST_SERVER_URL)
+    }
+
+    #[test]
+    fn hosted_server_url_defaults() {
+        if env::var(HOSTED_SERVER_URL_ENV).is_ok() {
+            return
+        }
+
+        assert_eq!(hosted_server_url(), DEFAULT_HOSTED_SERVER_URL)
+    }
+
+    /// Both UIs must resolve: `/docs/{_:.*}` matches `/docs/hosted/...` too, so registration order
+    /// decides whether the hosted UI is reachable at all.
+    #[actix_web::test]
+    async fn both_swagger_uis_are_reachable() {
+        let app = actix_test::init_service(App::new().configure(configure_docs)).await;
+
+        for path in ["/docs/", "/docs/hosted/"] {
+            let request = actix_test::TestRequest::get()
+                .uri(path)
+                .to_request();
+            let response = actix_test::call_service(&app, request).await;
+            assert!(response.status().is_success(), "{path}: {}", response.status())
+        }
+    }
+
+    #[actix_web::test]
+    async fn spec_endpoints_serve_their_own_paths() {
+        let app = actix_test::init_service(App::new().configure(configure_docs)).await;
+
+        let self_hosted: Value = actix_test::call_and_read_body_json(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/api-docs/openapi.json")
+                .to_request(),
+        )
+        .await;
+        assert!(self_hosted["paths"]["/v1/quote"].is_object(), "{self_hosted}");
+
+        let hosted: Value = actix_test::call_and_read_body_json(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/api-docs/hosted/openapi.json")
+                .to_request(),
+        )
+        .await;
+        assert!(hosted["paths"]["/v1/{chain}/quote"].is_object(), "{hosted}");
+        assert!(hosted["components"]["securitySchemes"][BEARER_SCHEME_NAME].is_object(), "{hosted}")
+    }
+}

--- a/fynd-rpc/src/api/docs.rs
+++ b/fynd-rpc/src/api/docs.rs
@@ -5,7 +5,8 @@
 //! - `/docs/` + `/api-docs/openapi.json` — self-hosted deployments, describing the paths this
 //!   process routes (`/v1/quote`) on the origin it is reached at, with no authentication.
 //! - `/docs/hosted/` + `/api-docs/hosted/openapi.json` — the hosted gateway, which routes per chain
-//!   (`/v1/{chain}/quote`) and authenticates requests with a bearer token.
+//!   (`/v1/{chain}/quote`) and authenticates requests with an API key sent as the raw
+//!   `Authorization` header value.
 
 use std::env;
 
@@ -14,7 +15,7 @@ use serde_json::json;
 use utoipa::{
     openapi::{
         path::{Operation, Parameter, ParameterBuilder, ParameterIn},
-        security::{Http, HttpAuthScheme, SecurityScheme},
+        security::{ApiKey, ApiKeyValue, SecurityScheme},
         Components, ObjectBuilder, OpenApi, PathItem, Required, SecurityRequirement, Server, Type,
     },
     OpenApi as _,
@@ -31,8 +32,8 @@ const HOSTED_SERVER_URL_ENV: &str = "FYND_HOSTED_SWAGGER_URL";
 /// Server URL advertised by the hosted spec when [`HOSTED_SERVER_URL_ENV`] is unset.
 const DEFAULT_HOSTED_SERVER_URL: &str = "https://fynd-api.propellerheads.xyz";
 
-/// Name of the bearer security scheme declared by the hosted spec.
-const BEARER_SCHEME_NAME: &str = "BearerAuth";
+/// Name of the API key security scheme declared by the hosted spec.
+const API_KEY_SCHEME_NAME: &str = "ApiKeyAuth";
 
 /// Registers both Swagger UIs and the specs they load.
 ///
@@ -59,8 +60,10 @@ fn self_hosted_spec() -> OpenApi {
 ///
 /// The gateway picks a backend from a chain segment in the path, so every `/v1/<endpoint>` becomes
 /// `/v1/{chain}/<endpoint>` and gains a `chain` path parameter. It also authenticates every
-/// request; declaring the bearer scheme is what gives Swagger UI its "Authorize" button, without
-/// which "Try it out" can only produce 401s.
+/// request; declaring the security scheme is what gives Swagger UI its "Authorize" button, without
+/// which "Try it out" can only produce 401s. The gateway matches the entire `Authorization`
+/// header value against its key store, so the scheme is an API key in that header — an HTTP
+/// bearer scheme would add a `Bearer ` prefix the gateway rejects.
 fn hosted_spec(server_url: &str) -> OpenApi {
     let mut openapi = self_hosted_spec();
 
@@ -89,11 +92,14 @@ fn hosted_spec(server_url: &str) -> OpenApi {
         .components
         .get_or_insert_with(Components::new)
         .add_security_scheme(
-            BEARER_SCHEME_NAME,
-            SecurityScheme::Http(Http::new(HttpAuthScheme::Bearer)),
+            API_KEY_SCHEME_NAME,
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::with_description(
+                "Authorization",
+                "Fynd API key, sent as the raw header value (no `Bearer ` prefix).",
+            ))),
         );
     openapi.security =
-        Some(vec![SecurityRequirement::new(BEARER_SCHEME_NAME, Vec::<String>::new())]);
+        Some(vec![SecurityRequirement::new(API_KEY_SCHEME_NAME, Vec::<String>::new())]);
     openapi.servers = Some(vec![Server::new(server_url)]);
 
     openapi
@@ -239,15 +245,17 @@ mod tests {
         }
     }
 
+    /// The gateway matches the raw `Authorization` header value, so the scheme must make
+    /// Swagger UI send the key without a `Bearer ` prefix.
     #[test]
-    fn hosted_spec_declares_bearer_auth() {
+    fn hosted_spec_declares_api_key_auth() {
         let spec = hosted_spec_json(TEST_SERVER_URL);
 
-        assert_eq!(
-            spec["components"]["securitySchemes"]["BearerAuth"],
-            json!({"type": "http", "scheme": "bearer"})
-        );
-        assert_eq!(spec["security"], json!([{"BearerAuth": []}]))
+        let scheme = &spec["components"]["securitySchemes"]["ApiKeyAuth"];
+        assert_eq!(scheme["type"], "apiKey", "{scheme}");
+        assert_eq!(scheme["in"], "header", "{scheme}");
+        assert_eq!(scheme["name"], "Authorization", "{scheme}");
+        assert_eq!(spec["security"], json!([{"ApiKeyAuth": []}]))
     }
 
     #[test]
@@ -304,6 +312,9 @@ mod tests {
         )
         .await;
         assert!(hosted["paths"]["/v1/{chain}/quote"].is_object(), "{hosted}");
-        assert!(hosted["components"]["securitySchemes"][BEARER_SCHEME_NAME].is_object(), "{hosted}")
+        assert!(
+            hosted["components"]["securitySchemes"][API_KEY_SCHEME_NAME].is_object(),
+            "{hosted}"
+        )
     }
 }

--- a/fynd-rpc/src/api/docs.rs
+++ b/fynd-rpc/src/api/docs.rs
@@ -6,9 +6,7 @@
 //!   process routes (`/v1/quote`) on the origin it is reached at, with no authentication.
 //! - `/docs/hosted/` + `/api-docs/hosted/openapi.json` — the hosted gateway, which routes per chain
 //!   (`/v1/{chain}/quote`) and authenticates requests with an API key sent as the raw
-//!   `Authorization` header value.
-
-use std::env;
+//!   `Authorization` header value. Only served when a gateway URL is configured.
 
 use actix_web::web;
 use serde_json::json;
@@ -26,25 +24,24 @@ use crate::api::ApiDoc;
 #[cfg(feature = "experimental")]
 use crate::api::ExperimentalApiDoc;
 
-/// Environment variable overriding the server URL advertised by the hosted spec.
-const HOSTED_SERVER_URL_ENV: &str = "FYND_HOSTED_SWAGGER_URL";
-
-/// Server URL advertised by the hosted spec when [`HOSTED_SERVER_URL_ENV`] is unset.
-const DEFAULT_HOSTED_SERVER_URL: &str = "https://fynd-api.propellerheads.xyz";
-
 /// Name of the API key security scheme declared by the hosted spec.
 const API_KEY_SCHEME_NAME: &str = "ApiKeyAuth";
 
-/// Registers both Swagger UIs and the specs they load.
+/// Registers the Swagger UIs and the specs they load.
+///
+/// The self-hosted UI is always served. The hosted one describes a gateway this process knows
+/// nothing about, so it is only served when `hosted_url` names that gateway.
 ///
 /// The hosted UI is registered first because actix matches resources in registration order:
 /// `/docs/{_:.*}` also matches `/docs/hosted/index.html` and would serve a 404 for it.
-pub(crate) fn configure_docs(cfg: &mut web::ServiceConfig) {
-    let hosted = SwaggerUi::new("/docs/hosted/{_:.*}")
-        .url("/api-docs/hosted/openapi.json", hosted_spec(&hosted_server_url()));
-    let self_hosted =
-        SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", self_hosted_spec());
-    cfg.service(hosted).service(self_hosted);
+pub(crate) fn configure_docs(cfg: &mut web::ServiceConfig, hosted_url: Option<&str>) {
+    if let Some(hosted_url) = hosted_url {
+        cfg.service(
+            SwaggerUi::new("/docs/hosted/{_:.*}")
+                .url("/api-docs/hosted/openapi.json", hosted_spec(hosted_url)),
+        );
+    }
+    cfg.service(SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", self_hosted_spec()));
 }
 
 /// Builds the spec describing the endpoints this process routes.
@@ -105,11 +102,6 @@ fn hosted_spec(server_url: &str) -> OpenApi {
     openapi
 }
 
-/// Returns the server URL the hosted spec points "Try it out" requests at.
-fn hosted_server_url() -> String {
-    env::var(HOSTED_SERVER_URL_ENV).unwrap_or_else(|_| DEFAULT_HOSTED_SERVER_URL.to_string())
-}
-
 /// Path parameter naming the chain the hosted gateway routes to.
 fn chain_parameter() -> Parameter {
     ParameterBuilder::new()
@@ -142,7 +134,7 @@ fn operations_mut(path_item: &mut PathItem) -> impl Iterator<Item = &mut Operati
 mod tests {
     // Aliased: an unqualified `test` import shadows the built-in `#[test]` attribute with
     // actix-web's, which rejects non-async test functions.
-    use actix_web::{test as actix_test, App};
+    use actix_web::{http::StatusCode, test as actix_test, App};
     use serde_json::Value;
 
     use super::*;
@@ -267,20 +259,14 @@ mod tests {
         assert_eq!(servers[0].url, TEST_SERVER_URL)
     }
 
-    #[test]
-    fn hosted_server_url_defaults() {
-        if env::var(HOSTED_SERVER_URL_ENV).is_ok() {
-            return
-        }
-
-        assert_eq!(hosted_server_url(), DEFAULT_HOSTED_SERVER_URL)
-    }
-
     /// Both UIs must resolve: `/docs/{_:.*}` matches `/docs/hosted/...` too, so registration order
     /// decides whether the hosted UI is reachable at all.
     #[actix_web::test]
     async fn both_swagger_uis_are_reachable() {
-        let app = actix_test::init_service(App::new().configure(configure_docs)).await;
+        let app = actix_test::init_service(
+            App::new().configure(|cfg| configure_docs(cfg, Some(TEST_SERVER_URL))),
+        )
+        .await;
 
         for path in ["/docs/", "/docs/hosted/"] {
             let request = actix_test::TestRequest::get()
@@ -291,9 +277,37 @@ mod tests {
         }
     }
 
+    /// Self-hosted deployments get no hosted UI, so nothing points them at a gateway they have
+    /// no key for.
+    #[actix_web::test]
+    async fn hosted_swagger_ui_needs_a_url() {
+        let app =
+            actix_test::init_service(App::new().configure(|cfg| configure_docs(cfg, None))).await;
+
+        let self_hosted = actix_test::call_service(
+            &app,
+            actix_test::TestRequest::get()
+                .uri("/docs/")
+                .to_request(),
+        )
+        .await;
+        assert!(self_hosted.status().is_success(), "{}", self_hosted.status());
+
+        for path in ["/docs/hosted/", "/api-docs/hosted/openapi.json"] {
+            let request = actix_test::TestRequest::get()
+                .uri(path)
+                .to_request();
+            let response = actix_test::call_service(&app, request).await;
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}")
+        }
+    }
+
     #[actix_web::test]
     async fn spec_endpoints_serve_their_own_paths() {
-        let app = actix_test::init_service(App::new().configure(configure_docs)).await;
+        let app = actix_test::init_service(
+            App::new().configure(|cfg| configure_docs(cfg, Some(TEST_SERVER_URL))),
+        )
+        .await;
 
         let self_hosted: Value = actix_test::call_and_read_body_json(
             &app,

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -1,5 +1,7 @@
 //! HTTP API layer: endpoint handlers, OpenAPI docs, and shared application state.
 
+/// OpenAPI spec construction and Swagger UI registration.
+mod docs;
 /// Re-exports of wire-format DTO types from `fynd-rpc-types`.
 pub mod dto;
 /// [`ApiError`] type with HTTP status code mapping.
@@ -31,7 +33,6 @@ use handlers::configure_routes;
 use tycho_simulation::tycho_common::models::Address;
 use tycho_simulation::tycho_common::Bytes;
 use utoipa::OpenApi;
-use utoipa_swagger_ui::SwaggerUi;
 
 use crate::api::error::ErrorResponse;
 
@@ -232,17 +233,10 @@ pub(crate) fn configure_error_handlers(cfg: &mut web::ServiceConfig) {
 
 /// Configures the Actix Web application with routes and state.
 pub(crate) fn configure_app(cfg: &mut web::ServiceConfig, state: AppState) {
-    #[allow(unused_mut)]
-    let mut openapi = ApiDoc::openapi();
-    #[cfg(feature = "experimental")]
-    {
-        let experimental = ExperimentalApiDoc::openapi();
-        openapi.merge(experimental);
-    }
     cfg.configure(configure_error_handlers)
         .app_data(web::Data::new(state))
         .configure(configure_routes)
-        .service(SwaggerUi::new("/docs/{_:.*}").url("/api-docs/openapi.json", openapi))
+        .configure(docs::configure_docs)
         .default_service(web::to(|| async {
             let body = ErrorResponse::new("not found".into(), "NOT_FOUND".into());
             HttpResponse::NotFound().json(body)

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -232,11 +232,18 @@ pub(crate) fn configure_error_handlers(cfg: &mut web::ServiceConfig) {
 }
 
 /// Configures the Actix Web application with routes and state.
-pub(crate) fn configure_app(cfg: &mut web::ServiceConfig, state: AppState) {
+///
+/// `hosted_swagger_url` names the hosted gateway the `/docs/hosted/` UI points at; when it is
+/// `None` that UI is not served.
+pub(crate) fn configure_app(
+    cfg: &mut web::ServiceConfig,
+    state: AppState,
+    hosted_swagger_url: Option<String>,
+) {
     cfg.configure(configure_error_handlers)
         .app_data(web::Data::new(state))
         .configure(configure_routes)
-        .configure(docs::configure_docs)
+        .configure(|cfg| docs::configure_docs(cfg, hosted_swagger_url.as_deref()))
         .default_service(web::to(|| async {
             let body = ErrorResponse::new("not found".into(), "NOT_FOUND".into());
             HttpResponse::NotFound().json(body)

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -28,6 +28,9 @@ pub struct FyndRPCBuilder {
     http_port: u16,
     /// Gas price staleness threshold. Health returns 503 when exceeded. Disabled by default.
     gas_price_stale_threshold: Option<Duration>,
+    /// Hosted gateway URL advertised by the `/docs/hosted/` Swagger UI. Unset by default, which
+    /// leaves that UI unregistered.
+    hosted_swagger_url: Option<String>,
 }
 
 impl FyndRPCBuilder {
@@ -67,6 +70,7 @@ impl FyndRPCBuilder {
             http_host: defaults::HTTP_HOST.to_owned(),
             http_port: defaults::HTTP_PORT,
             gas_price_stale_threshold: None,
+            hosted_swagger_url: None,
         })
     }
 
@@ -187,6 +191,15 @@ impl FyndRPCBuilder {
         self
     }
 
+    /// Sets the hosted gateway URL the `/docs/hosted/` Swagger UI sends requests to.
+    ///
+    /// Leaving it unset (the default) leaves that UI unregistered, so self-hosted deployments
+    /// only serve `/docs/`.
+    pub fn hosted_swagger_url(mut self, url: Option<String>) -> Self {
+        self.hosted_swagger_url = url;
+        self
+    }
+
     /// Enables or disables the price guard.
     ///
     /// When enabled, default providers are auto-registered if none were added
@@ -272,13 +285,14 @@ impl FyndRPCBuilder {
             gas_token,
         );
 
+        let hosted_swagger_url = self.hosted_swagger_url;
         let server = HttpServer::new(move || {
             App::new()
                 .wrap(tracing_actix_web::TracingLogger::default())
                 .wrap(actix_web::middleware::from_fn(
                     crate::api::middleware::http_metrics_middleware,
                 ))
-                .configure(|cfg| configure_app(cfg, app_state.clone()))
+                .configure(|cfg| configure_app(cfg, app_state.clone(), hosted_swagger_url.clone()))
         })
         .bind((self.http_host.as_str(), self.http_port))
         .context("failed to bind HTTP server")?

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,6 +136,12 @@ pub struct ServeArgs {
     #[arg(long)]
     pub enable_price_guard: bool,
 
+    /// URL of the hosted gateway fronting this instance. When set, a second Swagger UI is served
+    /// at /docs/hosted/, describing the gateway's per-chain paths and API-key auth. When unset,
+    /// only the self-hosted /docs/ is served.
+    #[arg(long, env = "FYND_HOSTED_SWAGGER_URL")]
+    pub hosted_swagger_url: Option<String>,
+
     /// Port for the Prometheus metrics HTTP server (requires `metrics` feature).
     #[cfg(feature = "metrics")]
     #[arg(long, default_value_t = METRICS_PORT, env)]
@@ -175,6 +181,8 @@ mod cli_tests {
             "20.0",
             "--worker-pools-config",
             "new_worker_pools.toml",
+            "--hosted-swagger-url",
+            "https://gateway.example.com",
         ])
         .expect("parse errored");
 
@@ -191,6 +199,7 @@ mod cli_tests {
         assert_eq!(args.min_tvl, Some(20.0));
         assert_eq!(args.worker_pools_config, PathBuf::from("new_worker_pools.toml"));
         assert_eq!(args.blocklist_config, None);
+        assert_eq!(args.hosted_swagger_url, Some("https://gateway.example.com".to_string()));
     }
 
     #[test]
@@ -201,6 +210,7 @@ mod cli_tests {
         std::env::remove_var("TYCHO_URL");
         std::env::remove_var("HTTP_HOST");
         std::env::remove_var("HTTP_PORT");
+        std::env::remove_var("FYND_HOSTED_SWAGGER_URL");
         let cli = Cli::try_parse_from(vec!["fynd", "serve"]).expect("parse errored");
 
         let Commands::Serve(args) = cli.command else {
@@ -220,6 +230,7 @@ mod cli_tests {
         assert_eq!(args.worker_router_timeout_ms, 100);
         assert_eq!(args.worker_router_min_responses, 0);
         assert_eq!(args.blocklist_config, None);
+        assert_eq!(args.hosted_swagger_url, None);
         assert!(!args.partial_blocks);
         #[cfg(feature = "metrics")]
         assert_eq!(args.metrics_port, METRICS_PORT);

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,7 +314,8 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
             .gas_price_stale_threshold(
                 args.gas_price_stale_threshold_secs
                     .map(Duration::from_secs),
-            );
+            )
+            .hosted_swagger_url(args.hosted_swagger_url.clone());
 
     if args.disable_tls {
         builder = builder.disable_tls();


### PR DESCRIPTION
## What

Serves a **second** Swagger UI from the fynd backend, describing the hosted-gateway API (per-chain routing + bearer auth) alongside the existing self-hosted UI.

| | `/docs/` (self-hosted, unchanged) | `/docs/hosted/` (new) |
|---|---|---|
| Spec | `/api-docs/openapi.json` | `/api-docs/hosted/openapi.json` |
| Paths | `/v1/quote`, `/v1/health`, `/v1/info` | `/v1/{chain}/quote`, `/v1/{chain}/health`, `/v1/{chain}/info` |
| Auth | None | `ApiKeyAuth` security scheme (API key as raw `Authorization` header value, no `Bearer ` prefix) — Swagger UI shows "Authorize" button |
| Server URL | Relative (same origin) | `FYND_HOSTED_SWAGGER_URL` env var (default `https://fynd-api.propellerheads.xyz`) |

## Why

The hosted gateway at `fynd-api.propellerheads.xyz` routes per chain (`/v1/{chain}/quote`) and authenticates every request. But the Swagger UI it proxies shows the wrong paths (`/v1/quote`), has no "Authorize" button, and "Try it out" only produces 401s/404s. Users have no usable interactive docs for the hosted API.

The hosted spec is built **programmatically** from the self-hosted one (`api/docs.rs`) — no duplicate `#[derive(OpenApi)]` annotations, so endpoint docs stay in one place and can't drift. Every `/v1/<endpoint>` path is rewritten to `/v1/{chain}/<endpoint>` with a required `chain` path parameter, a bearer security scheme is declared and required globally, and `servers[0].url` is set from the env var.

## Backward compatibility

`/docs/` and `/api-docs/openapi.json` are **unchanged** — self-hosted deployments see zero behavior change. The hosted UI is registered first (actix matches resources in registration order; `/docs/{_:.*}` would otherwise swallow `/docs/hosted/...`) — a test asserts both UIs stay reachable.

OpenAPI drift check: **no drift** — `ApiDoc` is untouched, so `clients/openapi.json` stays in sync.

## Validation

| Gate | Result |
|---|---|
| `cargo +nightly fmt --all --check` | pass |
| `cargo +nightly clippy --locked --all --all-features --all-targets -- -D warnings` | pass, 0 warnings |
| `cargo doc` (RUSTDOCFLAGS=-D warnings) | pass |
| `cargo test -p fynd-rpc --all-features --lib` | 10 passed (api::docs), 0 failed |
| `cargo nextest run --workspace` (non-integration) | 1031 pass, 0 fail |
| OpenAPI drift check (`cargo run -- openapi` vs `clients/openapi.json`) | NO DRIFT |

New tests cover: self-hosted paths unchanged, no security on self-hosted, hosted paths carry `{chain}`, experimental paths included, chain parameter on every operation, bearer auth scheme, server URL, default URL, both UIs reachable (registration-order regression test), and both spec endpoints serve the right paths.

## Follow-up (separate PR, ph-nginx-auth)

Follow-up PRs are open: [ph-nginx-auth#34](https://github.com/propeller-heads/ph-nginx-auth/pull/34) routes the gateway's `/docs/` → backend's `/docs/hosted/` and `/api-docs/openapi.json` → `/api-docs/hosted/openapi.json` — unauthenticated, not `access_by_lua_file` as originally planned: Swagger UI fetches assets and specs without an `Authorization` header, and `/api-docs/openapi.json` is the documented unauthenticated version-discovery endpoint. [helm-configuration#805](https://github.com/propeller-heads/helm-configuration/pull/805) (draft) rolls out the v14 gateway image and sets `FYND_HOSTED_SWAGGER_URL` on the staging backends. The self-hosted `/docs/` on the backend stays available for private deployments.

