### PR TITLE
feat: distinguish amount_too_small from no_graph_path in route failures

### DIFF
--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -462,20 +462,28 @@ impl BellmanFordAlgorithm {
                         // (input stays large) nor a too-large amount (huge input); those fail via
                         // other paths. Catches dust at token_in and amounts that decay below a
                         // hop's gas mid-route.
-                        let u_price = Self::resolve_token_price(
-                            ctx.node_address.get(&u),
-                            ctx.token_prices.as_ref(),
-                            spot_product[u_idx],
-                            ctx.node_address.get(&ctx.token_in_node),
-                        );
-                        if Self::gas_adjusted_amount(
-                            &amount[u_idx],
-                            &result.gas,
-                            ctx.gas_price_wei.as_ref().unwrap(),
-                            u_price.as_ref(),
-                        ) <= BigInt::ZERO
-                        {
-                            input_below_hop_gas = true;
+                        //
+                        // Probe the input-side dust signal only on uneconomic edges: an input
+                        // below this hop's gas implies net_candidate <= 0 (output value <=
+                        // input value < hop gas <= cumulative gas), so economic relaxing edges
+                        // can never trip it — gating keeps the extra price lookup and BigInt
+                        // math off the hot path (measured ~3-4% of quote time when unguarded).
+                        if !input_below_hop_gas && net_candidate <= BigInt::ZERO {
+                            let u_price = Self::resolve_token_price(
+                                ctx.node_address.get(&u),
+                                ctx.token_prices.as_ref(),
+                                spot_product[u_idx],
+                                ctx.node_address.get(&ctx.token_in_node),
+                            );
+                            if Self::gas_adjusted_amount(
+                                &amount[u_idx],
+                                &result.gas,
+                                ctx.gas_price_wei.as_ref().unwrap(),
+                                u_price.as_ref(),
+                            ) <= BigInt::ZERO
+                            {
+                                input_below_hop_gas = true;
+                            }
                         }
                         let net_existing = Self::gas_adjusted_amount(
                             &amount[v_idx],

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -100,11 +100,8 @@ struct SPFAResult {
     edge_gas: Vec<BigUint>,
     /// Cumulative spot-price product from token_in to each node (for gas fallback).
     spot_product: Vec<f64>,
-    /// True if some hop's own input amount couldn't cover that single hop's gas cost
-    /// (gas-aware) or a literal zero output was produced (gas-unaware). Input-side and
-    /// single-hop, so it never trips for a healthy or too-large order (input stays
-    /// large); it catches dust at token_in and amounts that decay below a hop's gas
-    /// mid-route. Distinguishes a too-small amount from a genuinely missing route.
+    /// True if some hop's input couldn't cover that hop's own gas (gas-aware) or a sim
+    /// produced a literal zero output (gas-unaware) — i.e. the amount is dust, not unroutable.
     input_below_hop_gas: bool,
 }
 
@@ -272,13 +269,9 @@ impl BellmanFordAlgorithm {
 
         let out_idx = ctx.token_out_node.index();
         if spfa.amount[out_idx].is_zero() {
-            // amount[out] == 0. If some hop's own input amount couldn't cover that single
-            // hop's gas cost (gas-aware), or a successful simulation produced a literal zero
-            // output (gas-unaware), the requested amount is too small to route to a usable
-            // output at some hop -> AmountTooSmall (dust or gas-unprofitable, mid-route
-            // included). A too-large amount instead fails by simulation error, so it never
-            // sets the flag. Anything else (unreachable, connector/forbid-revisits excluded,
-            // sim error, missing state, timeout) -> NoGraphPath.
+            // Dust (a hop's input below its own gas) -> AmountTooSmall; everything else
+            // (unreachable, filtered, sim error incl. too-large, missing state, timeout)
+            // -> NoGraphPath.
             let reason = if spfa.input_below_hop_gas {
                 NoPathReason::AmountTooSmall
             } else {
@@ -457,17 +450,10 @@ impl BellmanFordAlgorithm {
                             ctx.gas_price_wei.as_ref().unwrap(),
                             v_price.as_ref(),
                         );
-                        // Amount-too-small: the amount ENTERING this hop can't cover THIS hop's
-                        // own gas. Input-side + single-hop, so it never trips for a healthy order
-                        // (input stays large) nor a too-large amount (huge input); those fail via
-                        // other paths. Catches dust at token_in and amounts that decay below a
-                        // hop's gas mid-route.
-                        //
-                        // Probe the input-side dust signal only on uneconomic edges: an input
-                        // below this hop's gas implies net_candidate <= 0 (output value <=
-                        // input value < hop gas <= cumulative gas), so economic relaxing edges
-                        // can never trip it — gating keeps the extra price lookup and BigInt
-                        // math off the hot path (measured ~3-4% of quote time when unguarded).
+                        // Dust signal: this hop's input can't cover its own gas. Input-side, so
+                        // healthy and too-large orders (large inputs) never trip it. Gated on
+                        // net_candidate <= 0 (implied by input < hop gas) to keep the extra
+                        // price lookup off the hot path.
                         if !input_below_hop_gas && net_candidate <= BigInt::ZERO {
                             let u_price = Self::resolve_token_price(
                                 ctx.node_address.get(&u),
@@ -1113,10 +1099,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_amount_too_small_when_dust_occurs_mid_route() {
-        // A->B floors 1*0.5 to 0: that successful sim produced a zero output, so
-        // input_below_hop_gas is set even though the dust occurs one hop before
-        // token_out. This must be AmountTooSmall, not NoGraphPath (catching dust
-        // anywhere along the route, not just on edges landing directly on token_out).
+        // A->B floors 1*0.5 to 0 one hop before token_out: dust mid-route must still
+        // be AmountTooSmall.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
@@ -1138,11 +1122,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_graph_path_when_amount_too_large_for_liquidity() {
-        // pool_ab has liquidity=500; a 1000-unit input at rate 2.0 would produce 2000
-        // output, which exceeds liquidity, so get_amount_out returns Err and the edge is
-        // skipped without ever setting input_below_hop_gas. This is the key guard: a
-        // too-large amount must fail by simulation error, not by an economic comparison,
-        // so it is never mislabeled AmountTooSmall.
+        // Output 2000 exceeds liquidity 500, so the sim errors: a too-large amount must
+        // never be mislabeled AmountTooSmall.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let (market, manager) = setup_market_bf(vec![(
@@ -1187,10 +1168,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_graph_path_when_connector_tokens_exclude_intermediate() {
-        // A->B->C is topologically reachable (get_subgraph doesn't consult
-        // connector_tokens), but B is excluded from the allowlist and isn't an
-        // endpoint, so SPFA skips every edge into B: no edge simulation ever runs,
-        // so input_below_hop_gas stays false and this correctly reports NoGraphPath.
+        // B is not in the connector allowlist, so SPFA never simulates into it:
+        // policy exclusion reads as NoGraphPath, not AmountTooSmall.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
@@ -1660,12 +1639,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_amount_too_small_when_net_uneconomic_after_gas() {
-        // The 1-unit input entering the only hop is worth 1 (price 1:1), but that hop's
-        // own gas cost is 10 units * gas_price=100 * price 1:1 = 1000, deeply exceeding
-        // it. The input-side check sets input_below_hop_gas, and since the resulting
-        // net_candidate (2 - 1000) does not beat the existing net (0), B is never
-        // relaxed -> amount[B] stays 0 -> AmountTooSmall via the gas-aware branch, not
-        // the gross-zero fallback.
+        // Gas-aware branch: the 1-unit input (worth 1 at 1:1) is far below the hop's
+        // gas cost of 1000 -> AmountTooSmall.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
@@ -1692,13 +1667,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_graph_path_when_output_uneconomic_but_input_economic() {
-        // Single-hop A->B (B=token_out), gas-aware. The pool's low rate (0.05) makes the
-        // OUTPUT value (10_000 * 0.05 = 500) fall below the hop's gas cost (10 * 100 * 1/1
-        // = 1000), so B is never relaxed and amount[B] stays 0. But the INPUT (10_000)
-        // comfortably covers that same gas cost, so the input-side check must not flag
-        // this as AmountTooSmall. The old output-side/cumulative check would have set the
-        // flag here (net_candidate = 500 - 1000 <= 0), mislabeling a healthy-sized order
-        // whose pool simply has a low rate as AmountTooSmall.
+        // Output value (500) is below the hop's gas (1000) so the solve fails, but the
+        // input (10_000) covers it: a healthy-sized order on a low-rate pool must read
+        // NoGraphPath, not AmountTooSmall.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -100,6 +100,12 @@ struct SPFAResult {
     edge_gas: Vec<BigUint>,
     /// Cumulative spot-price product from token_in to each node (for gas fallback).
     spot_product: Vec<f64>,
+    /// True if some hop's own input amount couldn't cover that single hop's gas cost
+    /// (gas-aware) or a literal zero output was produced (gas-unaware). Input-side and
+    /// single-hop, so it never trips for a healthy or too-large order (input stays
+    /// large); it catches dust at token_in and amounts that decay below a hop's gas
+    /// mid-route. Distinguishes a too-small amount from a genuinely missing route.
+    input_below_hop_gas: bool,
 }
 
 /// Bellman-Ford algorithm with SPFA optimisation for simulation-driven DEX routing.
@@ -266,10 +272,22 @@ impl BellmanFordAlgorithm {
 
         let out_idx = ctx.token_out_node.index();
         if spfa.amount[out_idx].is_zero() {
+            // amount[out] == 0. If some hop's own input amount couldn't cover that single
+            // hop's gas cost (gas-aware), or a successful simulation produced a literal zero
+            // output (gas-unaware), the requested amount is too small to route to a usable
+            // output at some hop -> AmountTooSmall (dust or gas-unprofitable, mid-route
+            // included). A too-large amount instead fails by simulation error, so it never
+            // sets the flag. Anything else (unreachable, connector/forbid-revisits excluded,
+            // sim error, missing state, timeout) -> NoGraphPath.
+            let reason = if spfa.input_below_hop_gas {
+                NoPathReason::AmountTooSmall
+            } else {
+                NoPathReason::NoGraphPath
+            };
             return Err(AlgorithmError::NoPath {
                 from: order.token_in().clone(),
                 to: order.token_out().clone(),
-                reason: NoPathReason::NoGraphPath,
+                reason,
             });
         }
 
@@ -340,6 +358,8 @@ impl BellmanFordAlgorithm {
         let mut spot_product: Vec<f64> = vec![0.0; ctx.max_idx];
         spot_product[ctx.token_in_node.index()] = 1.0;
 
+        let mut input_below_hop_gas = false;
+
         let gas_aware = matches!(ctx.scoring, RouteScoringMode::NetOutput) &&
             ctx.gas_price_wei.is_some() &&
             ctx.token_prices.is_some();
@@ -382,15 +402,8 @@ impl BellmanFordAlgorithm {
 
                     // Skip disallowed connector tokens. Endpoints (token_in / token_out) are
                     // always permitted regardless of the allowlist.
-                    if let (Some(tokens), Some(v_addr)) =
-                        (&self.connector_tokens, ctx.node_address.get(v))
-                    {
-                        if v_addr != order.token_in() &&
-                            v_addr != order.token_out() &&
-                            !tokens.contains(v_addr)
-                        {
-                            continue;
-                        }
+                    if !self.connector_allows(ctx, order, *v) {
+                        continue;
                     }
 
                     let Some(token_v) = ctx.token_map.get(v) else { continue };
@@ -444,6 +457,26 @@ impl BellmanFordAlgorithm {
                             ctx.gas_price_wei.as_ref().unwrap(),
                             v_price.as_ref(),
                         );
+                        // Amount-too-small: the amount ENTERING this hop can't cover THIS hop's
+                        // own gas. Input-side + single-hop, so it never trips for a healthy order
+                        // (input stays large) nor a too-large amount (huge input); those fail via
+                        // other paths. Catches dust at token_in and amounts that decay below a
+                        // hop's gas mid-route.
+                        let u_price = Self::resolve_token_price(
+                            ctx.node_address.get(&u),
+                            ctx.token_prices.as_ref(),
+                            spot_product[u_idx],
+                            ctx.node_address.get(&ctx.token_in_node),
+                        );
+                        if Self::gas_adjusted_amount(
+                            &amount[u_idx],
+                            &result.gas,
+                            ctx.gas_price_wei.as_ref().unwrap(),
+                            u_price.as_ref(),
+                        ) <= BigInt::ZERO
+                        {
+                            input_below_hop_gas = true;
+                        }
                         let net_existing = Self::gas_adjusted_amount(
                             &amount[v_idx],
                             &cumul_gas[v_idx],
@@ -452,6 +485,9 @@ impl BellmanFordAlgorithm {
                         );
                         net_candidate > net_existing
                     } else {
+                        if result.amount.is_zero() {
+                            input_below_hop_gas = true;
+                        }
                         result.amount > amount[v_idx]
                     };
 
@@ -474,7 +510,17 @@ impl BellmanFordAlgorithm {
             active_nodes.sort_unstable();
         }
 
-        SPFAResult { amount, predecessor, edge_gas, spot_product }
+        SPFAResult { amount, predecessor, edge_gas, spot_product, input_below_hop_gas }
+    }
+
+    /// Whether the connector-token allowlist permits routing *into* node `v`.
+    /// Endpoints (token_in / token_out) are always permitted. No allowlist => all allowed.
+    fn connector_allows(&self, ctx: &BellmanFordContext, order: &Order, v: NodeIndex) -> bool {
+        let (Some(tokens), Some(v_addr)) = (&self.connector_tokens, ctx.node_address.get(&v))
+        else {
+            return true;
+        };
+        v_addr == order.token_in() || v_addr == order.token_out() || tokens.contains(v_addr)
     }
 
     /// Constructs a [`Route`] from a reconstructed path and SPFA output arrays.
@@ -1039,6 +1085,130 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_amount_too_small_when_reachable_but_zero_output() {
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        // Reachable pool, but rate 0.5 on a 1-unit input floors to 0 output.
+        let (market, manager) =
+            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(0.5))]);
+        let algo = bf_algorithm(3, 1000);
+        let ord = order(&token_a, &token_b, 1, OrderSide::Sell);
+
+        let result = algo
+            .find_best_route(manager.graph(), market, None, None, &ord)
+            .await;
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::AmountTooSmall, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_amount_too_small_when_dust_occurs_mid_route() {
+        // A->B floors 1*0.5 to 0: that successful sim produced a zero output, so
+        // input_below_hop_gas is set even though the dust occurs one hop before
+        // token_out. This must be AmountTooSmall, not NoGraphPath (catching dust
+        // anywhere along the route, not just on edges landing directly on token_out).
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let token_c = token(0x03, "C");
+        let (market, manager) = setup_market_bf(vec![
+            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(0.5)),
+            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
+        ]);
+        let algo = bf_algorithm(3, 1000);
+        let ord = order(&token_a, &token_c, 1, OrderSide::Sell);
+
+        let result = algo
+            .find_best_route(manager.graph(), market, None, None, &ord)
+            .await;
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::AmountTooSmall, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_no_graph_path_when_amount_too_large_for_liquidity() {
+        // pool_ab has liquidity=500; a 1000-unit input at rate 2.0 would produce 2000
+        // output, which exceeds liquidity, so get_amount_out returns Err and the edge is
+        // skipped without ever setting input_below_hop_gas. This is the key guard: a
+        // too-large amount must fail by simulation error, not by an economic comparison,
+        // so it is never mislabeled AmountTooSmall.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let (market, manager) = setup_market_bf(vec![(
+            "pool_ab",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0).with_liquidity(500),
+        )]);
+        let algo = bf_algorithm(2, 1000);
+        let ord = order(&token_a, &token_b, 1000, OrderSide::Sell);
+
+        let result = algo
+            .find_best_route(manager.graph(), market, None, None, &ord)
+            .await;
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::NoGraphPath, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_no_graph_path_when_unreachable_within_hops() {
+        // A->B->C exists, but max_hops=1 leaves C out of the subgraph.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let token_c = token(0x03, "C");
+        let (market, manager) = setup_market_bf(vec![
+            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
+        ]);
+        let algo = bf_algorithm(1, 1000);
+        let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
+
+        let result = algo
+            .find_best_route(manager.graph(), market, None, None, &ord)
+            .await;
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::NoGraphPath, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_no_graph_path_when_connector_tokens_exclude_intermediate() {
+        // A->B->C is topologically reachable (get_subgraph doesn't consult
+        // connector_tokens), but B is excluded from the allowlist and isn't an
+        // endpoint, so SPFA skips every edge into B: no edge simulation ever runs,
+        // so input_below_hop_gas stays false and this correctly reports NoGraphPath.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+        let token_c = token(0x03, "C");
+
+        let (market, manager) = setup_market_bf(vec![
+            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
+        ]);
+
+        let algo = BellmanFordAlgorithm::with_config(
+            AlgorithmConfig::new(1, 3, Duration::from_millis(1000), None)
+                .unwrap()
+                .with_connector_tokens(HashSet::new()),
+        );
+        let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
+
+        let result = algo
+            .find_best_route(manager.graph(), market, None, None, &ord)
+            .await;
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::NoGraphPath, .. })
+        ));
+    }
+
+    #[tokio::test]
     async fn test_destination_not_in_graph() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1478,6 +1648,71 @@ mod tests {
         assert_eq!(result.route().swaps().len(), 2);
         assert_eq!(result.route().swaps()[0].component_id(), "pool_ab");
         assert_eq!(result.route().swaps()[1].component_id(), "pool_bd");
+    }
+
+    #[tokio::test]
+    async fn test_amount_too_small_when_net_uneconomic_after_gas() {
+        // The 1-unit input entering the only hop is worth 1 (price 1:1), but that hop's
+        // own gas cost is 10 units * gas_price=100 * price 1:1 = 1000, deeply exceeding
+        // it. The input-side check sets input_below_hop_gas, and since the resulting
+        // net_candidate (2 - 1000) does not beat the existing net (0), B is never
+        // relaxed -> amount[B] stays 0 -> AmountTooSmall via the gas-aware branch, not
+        // the gross-zero fallback.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+
+        let (market, manager) = setup_market_bf(vec![(
+            "pool_ab",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0).with_gas(10),
+        )]);
+
+        let algo = bf_algorithm(2, 1000);
+        let ord = order(&token_a, &token_b, 1, OrderSide::Sell);
+        let derived =
+            setup_derived_with_token_prices(&[token_a.address.clone(), token_b.address.clone()]);
+
+        let result = algo
+            .find_best_route(manager.graph(), market, None, Some(derived), &ord)
+            .await;
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::AmountTooSmall, .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_no_graph_path_when_output_uneconomic_but_input_economic() {
+        // Single-hop A->B (B=token_out), gas-aware. The pool's low rate (0.05) makes the
+        // OUTPUT value (10_000 * 0.05 = 500) fall below the hop's gas cost (10 * 100 * 1/1
+        // = 1000), so B is never relaxed and amount[B] stays 0. But the INPUT (10_000)
+        // comfortably covers that same gas cost, so the input-side check must not flag
+        // this as AmountTooSmall. The old output-side/cumulative check would have set the
+        // flag here (net_candidate = 500 - 1000 <= 0), mislabeling a healthy-sized order
+        // whose pool simply has a low rate as AmountTooSmall.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+
+        let (market, manager) = setup_market_bf(vec![(
+            "pool_ab",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(0.05).with_gas(10),
+        )]);
+
+        let algo = bf_algorithm(1, 1000);
+        let ord = order(&token_a, &token_b, 10_000, OrderSide::Sell);
+        let derived =
+            setup_derived_with_token_prices(&[token_a.address.clone(), token_b.address.clone()]);
+
+        let result = algo
+            .find_best_route(manager.graph(), market, None, Some(derived), &ord)
+            .await;
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::NoGraphPath, .. })
+        ));
     }
 
     // ==================== Connector token tests ====================

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -311,6 +311,9 @@ pub enum NoPathReason {
     NoGraphPath,
     /// Paths exist but none could be scored (e.g., missing edge weights).
     NoScorablePaths,
+    /// A path exists, but the requested amount is too small to produce a
+    /// non-zero output (dust).
+    AmountTooSmall,
 }
 
 impl std::fmt::Display for NoPathReason {
@@ -320,6 +323,7 @@ impl std::fmt::Display for NoPathReason {
             Self::DestinationTokenNotInGraph => write!(f, "destination token not in graph"),
             Self::NoGraphPath => write!(f, "no connecting path in graph"),
             Self::NoScorablePaths => write!(f, "no paths with valid scores"),
+            Self::AmountTooSmall => write!(f, "output amount too small to route"),
         }
     }
 }

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -311,8 +311,12 @@ pub enum NoPathReason {
     NoGraphPath,
     /// Paths exist but none could be scored (e.g., missing edge weights).
     NoScorablePaths,
-    /// A path exists, but the requested amount is too small to produce a
-    /// non-zero output (dust).
+    /// The requested amount is too small to route (dust). Detection depends
+    /// on scoring mode: gas-unaware scoring reports this when an explored
+    /// hop's output floors to zero; gas-aware scoring reports it when an
+    /// explored hop's input cannot cover that hop's gas cost. The signal
+    /// latches on any explored edge, so a usable path to the destination may
+    /// not have existed.
     AmountTooSmall,
 }
 
@@ -323,7 +327,7 @@ impl std::fmt::Display for NoPathReason {
             Self::DestinationTokenNotInGraph => write!(f, "destination token not in graph"),
             Self::NoGraphPath => write!(f, "no connecting path in graph"),
             Self::NoScorablePaths => write!(f, "no paths with valid scores"),
-            Self::AmountTooSmall => write!(f, "output amount too small to route"),
+            Self::AmountTooSmall => write!(f, "amount too small to route"),
         }
     }
 }

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -744,7 +744,7 @@ mod tests {
                 order, setup_market_unweighted, token, token_with_decimals, ConstantProductSim,
                 MockProtocolSim,
             },
-            AlgorithmConfig,
+            AlgorithmConfig, NoPathReason,
         },
         derived::{types::TokenGasPrices, DerivedData, SharedDerivedDataRef},
         graph::GraphManager,
@@ -1416,6 +1416,34 @@ mod tests {
             AlgorithmConfig::new(1, max_hops, StdDuration::from_millis(5000), None).unwrap(),
             pfw_config,
         )
+    }
+
+    #[tokio::test]
+    async fn test_amount_too_small_surfaces_from_inner_bf() {
+        // Reachable pool, but rate 0.5 on a 1-unit input floors to 0 output.
+        // find_best_route propagates the inner BF error with `?`, so
+        // AmountTooSmall reaches the caller unchanged.
+        let token_a = token(0x01, "A");
+        let token_b = token(0x02, "B");
+
+        let (market, graph_manager) = setup_market_unweighted(vec![(
+            "pool_ab",
+            &token_a,
+            &token_b,
+            Box::new(MockProtocolSim::new(0.5)) as Box<dyn ProtocolSim>,
+        )]);
+
+        let algo = pfw_algo(3);
+        let ord = order(&token_a, &token_b, 1, OrderSide::Sell);
+
+        let result = algo
+            .find_best_route(graph_manager.graph(), market, None, None, &ord)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(AlgorithmError::NoPath { reason: NoPathReason::AmountTooSmall, .. })
+        ));
     }
 
     #[tokio::test]

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -496,7 +496,9 @@ fn aggregate_no_route_reason(
                 NoPathReason::SourceTokenNotInGraph | NoPathReason::DestinationTokenNotInGraph => {
                     return Some(*reason)
                 }
-                NoPathReason::NoGraphPath | NoPathReason::NoScorablePaths => {
+                NoPathReason::NoGraphPath
+                | NoPathReason::NoScorablePaths
+                | NoPathReason::AmountTooSmall => {
                     if first.is_none() {
                         first = Some(*reason);
                     }
@@ -982,6 +984,26 @@ mod tests {
             WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
         let result = worker_router.rank_quotes(&responses, &QuoteOptions::default());
         assert_eq!(result[0].no_route_reason(), Some(NoPathReason::NoGraphPath));
+    }
+
+    #[test]
+    fn aggregate_no_route_reason_surfaces_amount_too_small() {
+        use crate::algorithm::NoPathReason;
+        let failed = vec![(
+            "bf".to_string(),
+            SolveError::no_route_found_with_reason("o1", NoPathReason::AmountTooSmall),
+        )];
+        assert_eq!(aggregate_no_route_reason(&failed), Some(NoPathReason::AmountTooSmall));
+    }
+
+    #[test]
+    fn aggregate_token_not_in_graph_wins_over_amount_too_small() {
+        use crate::algorithm::NoPathReason;
+        let failed = vec![
+            ("bf".to_string(), SolveError::no_route_found_with_reason("o1", NoPathReason::AmountTooSmall)),
+            ("ml".to_string(), SolveError::no_route_found_with_reason("o2", NoPathReason::DestinationTokenNotInGraph)),
+        ];
+        assert_eq!(aggregate_no_route_reason(&failed), Some(NoPathReason::DestinationTokenNotInGraph));
     }
 
     #[test]

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -483,30 +483,31 @@ impl WorkerPoolRouter {
 
 /// Picks the most informative no-route reason across the failed pools.
 ///
-/// A token-not-in-graph reason is a shared-graph fact and wins over any
-/// path-specific reason; otherwise the first reason present is used.
+/// Reasons are ranked into tiers so the result does not depend on pool
+/// completion order: token-not-in-graph reasons are shared-graph facts and
+/// rank highest, then `AmountTooSmall`, `NoScorablePaths`, `NoGraphPath`.
 fn aggregate_no_route_reason(
     failed_solvers: &[(String, SolveError)],
 ) -> Option<crate::algorithm::NoPathReason> {
-    use crate::algorithm::NoPathReason;
-    let mut first = None;
+    let mut best = None;
     for (_, error) in failed_solvers {
         if let SolveError::NoRouteFound { reason: Some(reason), .. } = error {
-            match reason {
-                NoPathReason::SourceTokenNotInGraph | NoPathReason::DestinationTokenNotInGraph => {
-                    return Some(*reason)
-                }
-                NoPathReason::NoGraphPath |
-                NoPathReason::NoScorablePaths |
-                NoPathReason::AmountTooSmall => {
-                    if first.is_none() {
-                        first = Some(*reason);
-                    }
-                }
+            if best.is_none_or(|b| reason_tier(b) < reason_tier(*reason)) {
+                best = Some(*reason);
             }
         }
     }
-    first
+    best
+}
+
+fn reason_tier(reason: crate::algorithm::NoPathReason) -> u8 {
+    use crate::algorithm::NoPathReason;
+    match reason {
+        NoPathReason::SourceTokenNotInGraph | NoPathReason::DestinationTokenNotInGraph => 3,
+        NoPathReason::AmountTooSmall => 2,
+        NoPathReason::NoScorablePaths => 1,
+        NoPathReason::NoGraphPath => 0,
+    }
 }
 
 fn refine_gas_estimates(
@@ -970,7 +971,7 @@ mod tests {
     }
 
     #[test]
-    fn rank_quotes_no_route_reason_falls_back_to_first() {
+    fn test_rank_quotes_no_route_reason_single_failure() {
         use crate::algorithm::NoPathReason;
         let responses = OrderResponses {
             order_id: "test".to_string(),
@@ -994,6 +995,17 @@ mod tests {
             SolveError::no_route_found_with_reason("o1", NoPathReason::AmountTooSmall),
         )];
         assert_eq!(aggregate_no_route_reason(&failed), Some(NoPathReason::AmountTooSmall));
+    }
+
+    #[test]
+    fn test_aggregate_no_route_reason_independent_of_pool_order() {
+        use crate::algorithm::NoPathReason;
+        let dust = || SolveError::no_route_found_with_reason("o1", NoPathReason::AmountTooSmall);
+        let no_path = || SolveError::no_route_found_with_reason("o1", NoPathReason::NoGraphPath);
+        let forward = vec![("bf1".to_string(), no_path()), ("bf3".to_string(), dust())];
+        let reversed = vec![("bf3".to_string(), dust()), ("bf1".to_string(), no_path())];
+        assert_eq!(aggregate_no_route_reason(&forward), Some(NoPathReason::AmountTooSmall));
+        assert_eq!(aggregate_no_route_reason(&reversed), Some(NoPathReason::AmountTooSmall));
     }
 
     #[test]

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -496,9 +496,9 @@ fn aggregate_no_route_reason(
                 NoPathReason::SourceTokenNotInGraph | NoPathReason::DestinationTokenNotInGraph => {
                     return Some(*reason)
                 }
-                NoPathReason::NoGraphPath
-                | NoPathReason::NoScorablePaths
-                | NoPathReason::AmountTooSmall => {
+                NoPathReason::NoGraphPath |
+                NoPathReason::NoScorablePaths |
+                NoPathReason::AmountTooSmall => {
                     if first.is_none() {
                         first = Some(*reason);
                     }
@@ -1000,10 +1000,22 @@ mod tests {
     fn aggregate_token_not_in_graph_wins_over_amount_too_small() {
         use crate::algorithm::NoPathReason;
         let failed = vec![
-            ("bf".to_string(), SolveError::no_route_found_with_reason("o1", NoPathReason::AmountTooSmall)),
-            ("ml".to_string(), SolveError::no_route_found_with_reason("o2", NoPathReason::DestinationTokenNotInGraph)),
+            (
+                "bf".to_string(),
+                SolveError::no_route_found_with_reason("o1", NoPathReason::AmountTooSmall),
+            ),
+            (
+                "ml".to_string(),
+                SolveError::no_route_found_with_reason(
+                    "o2",
+                    NoPathReason::DestinationTokenNotInGraph,
+                ),
+            ),
         ];
-        assert_eq!(aggregate_no_route_reason(&failed), Some(NoPathReason::DestinationTokenNotInGraph));
+        assert_eq!(
+            aggregate_no_route_reason(&failed),
+            Some(NoPathReason::DestinationTokenNotInGraph)
+        );
     }
 
     #[test]

--- a/fynd-rpc/src/api/request_capture.rs
+++ b/fynd-rpc/src/api/request_capture.rs
@@ -101,6 +101,7 @@ pub(crate) fn no_route_reason_code(reason: Option<NoPathReason>) -> &'static str
         Some(NoPathReason::DestinationTokenNotInGraph) => "destination_token_not_in_graph",
         Some(NoPathReason::NoGraphPath) => "no_graph_path",
         Some(NoPathReason::NoScorablePaths) => "no_scorable_paths",
+        Some(NoPathReason::AmountTooSmall) => "amount_too_small",
         Some(_) => "unknown",
     }
 }
@@ -392,6 +393,7 @@ mod tests {
         );
         assert_eq!(no_route_reason_code(Some(NoPathReason::NoGraphPath)), "no_graph_path");
         assert_eq!(no_route_reason_code(Some(NoPathReason::NoScorablePaths)), "no_scorable_paths");
+        assert_eq!(no_route_reason_code(Some(NoPathReason::AmountTooSmall)), "amount_too_small",);
     }
 
     #[test]

--- a/fynd-rpc/src/api/request_capture.rs
+++ b/fynd-rpc/src/api/request_capture.rs
@@ -393,7 +393,7 @@ mod tests {
         );
         assert_eq!(no_route_reason_code(Some(NoPathReason::NoGraphPath)), "no_graph_path");
         assert_eq!(no_route_reason_code(Some(NoPathReason::NoScorablePaths)), "no_scorable_paths");
-        assert_eq!(no_route_reason_code(Some(NoPathReason::AmountTooSmall)), "amount_too_small",);
+        assert_eq!(no_route_reason_code(Some(NoPathReason::AmountTooSmall)), "amount_too_small");
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds `NoPathReason::AmountTooSmall` so dust quotes stop being reported as `no_graph_path`.

Bellman-Ford reported every zero routed-output as `NoGraphPath`, conflating "no route exists" with "the amount is too small to route." During SPFA, each successful hop simulation now checks whether the amount entering the hop covers that hop's own gas; if not, the failure is labeled `amount_too_small` instead. Input-side and single-hop, so healthy and too-large orders never trip it (too-large fails via simulation error). PathFrankWolfe inherits the behavior; the reason flows through aggregation into the `quote_failure` log.

Motivation: steady ETH↔USDC `no_graph_path` failures on Base turned out to be dust-sized requests (confirmed by replay), indistinguishable in the logs from real routing gaps.

Scope: Bellman-Ford + PathFrankWolfe. MostLiquid already reports dust as `insufficient_liquidity` and is unchanged.

## Compatibility

Reason label only: order status stays `NoRouteFound`, wire `QuoteStatus` unchanged, no OpenAPI drift.

## Performance

The check is gated on the already-computed `net_candidate <= 0`, keeping it off the hot path. A/B replay benchmark (recorded market, interleaved runs): ungated cost was ~4% per quote; gated is within measurement noise of main. Details in the PR comment.

## Caveats

- Gas-aware `amount_too_small` requires `token_in` to be priced; unpriced dust falls back to `no_graph_path` (under-report, never a mislabel).
- The flag is per-solve: a no-path solve that also contains a dust hop on some branch can be labeled `amount_too_small`. Rare, label-only.

## Testing

608 tests pass (clippy / fmt / doc / OpenAPI drift clean). Key cases: direct + mid-route dust → `amount_too_small`; too-large revert, low-rate pool with healthy input, connector-excluded, unreachable → `no_graph_path`; gas-aware tiny input → `amount_too_small`.