### PR TITLE
ci: create the release tag only once per workspace release

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,6 +8,10 @@
 # version-bumped via the shared workspace version, but excluded from changelog/tag/publish.
 [workspace]
 changelog_update = false
+# All crates share the workspace version, so they all resolve to the same bare tag name.
+# Only `fynd` creates it (git_tag_enable below); a second crate creating the same tag in one
+# release run fails with "Reference already exists".
+git_tag_enable = false
 git_tag_name = "{{ version }}"
 git_release_enable = false
 semver_check = false
@@ -17,6 +21,7 @@ pr_labels = ["release"]
 [[package]]
 name = "fynd"
 changelog_update = true
+git_tag_enable = true
 git_release_enable = true
 changelog_include = ["fynd-core", "fynd-rpc", "fynd-rpc-types", "fynd-client"]
 


### PR DESCRIPTION
## What

The v0.97.2 release job failed ([run 29995568636](https://github.com/propeller-heads/fynd/actions/runs/29995568636/job/89168344313)): every released crate shares the workspace version and the bare `{{ version }}` tag name, so the first crate released (`fynd-core`) created tag `0.97.2` and the next crate's attempt to create the same tag failed with `Reference already exists`, aborting the job.

This sets `git_tag_enable = false` at the `[workspace]` level and enables it only on `fynd`, so exactly one tag is created per release — matching the config's stated intent ("one shared bare tag + one GitHub Release on `fynd`"). `git_tag_name` stays at the workspace level so version detection keeps resolving against the shared tag for every crate.

## Note on the stuck v0.97.2

Tag `0.97.2` exists (created for `fynd-core` before the failure) but the GitHub Release was never created, so `release.yaml` (crates/npm publish) never triggered. This PR prevents recurrence but does not repair v0.97.2 — that needs the Release created manually against the existing tag, e.g.:

```
gh release create 0.97.2 --title 0.97.2 --notes "see CHANGELOG.md"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)