### PR TITLE
feat: add lunarbase to the protocol registry

### DIFF
--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -14,6 +14,7 @@ use tycho_simulation::{
                 balancer_v2_pool_filter, curve_filter, erc4626_filter, fluid_v1_paused_pools_filter,
             },
             fluid::FluidV1,
+            lunarbase::state::LunarBaseState,
             pancakeswap_v2::state::PancakeswapV2State,
             uniswap_v2::state::UniswapV2State,
             uniswap_v3::state::UniswapV3State,
@@ -171,6 +172,9 @@ pub(crate) fn register_exchanges(
             "quickswap_v2" => {
                 builder =
                     builder.exchange::<UniswapV2State>("quickswap_v2", tvl_filter.clone(), None);
+            }
+            "lunarbase" => {
+                builder = builder.exchange::<LunarBaseState>("lunarbase", tvl_filter.clone(), None);
             }
             p if p.starts_with("rfq:") => {
                 // RFQ protocols are handled in register_rfq


### PR DESCRIPTION
## What

Adds `lunarbase` to the protocol registry match block in `fynd-core/src/feed/protocol_registry.rs`, registering the native `LunarBaseState` decoder from tycho-simulation. Pools are now indexed when the protocol is requested via `--protocols` or auto-fetched from Tycho RPC.

## Notes

- `LunarBaseState` (native PMM math, no VM simulation) and its snapshot decoder ship in tycho-simulation 0.340.0, which fynd already depends on.
- Swap encoding is already handled by `LunarBaseSwapEncoder` in tycho-execution 0.340.0, so no encoding changes are needed.

## Testing

- `cargo +nightly fmt` — clean
- `cargo +nightly clippy --workspace --all-targets --all-features` — clean
- `cargo test --workspace --all-targets --all-features` — 1023 passed; the 8 fynd-core integration-test failures are environmental (git-lfs fixture unavailable on the dev machine) and unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)