### PR TITLE
ci(release): make crate and npm publishing idempotent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,8 @@ jobs:
   publish-crates:
     name: Publish Crates
     # Pre-releases build a Docker image only; registry publishing happens on
-    # full releases (or manual dispatch).
-    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    # full releases.
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -32,20 +32,33 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Publish fynd-core
-        run: cargo publish --locked --verbose --package fynd-core
-
-      - name: Publish fynd-rpc-types
-        run: cargo publish --locked --verbose --package fynd-rpc-types
-
-      - name: Publish fynd-client
-        run: cargo publish --locked --verbose --package fynd-client
-
-      - name: Publish fynd-rpc
-        run: cargo publish --locked --verbose --package fynd-rpc
-
-      - name: Publish fynd
-        run: cargo publish --locked --verbose --package fynd
+      # Publishes in dependency order, skipping versions already on crates.io so a
+      # partially failed release run can be recovered by re-running the job. A single
+      # retry (with an index re-check) covers crates.io index propagation lag between
+      # consecutive publishes.
+      - name: Publish crates
+        run: |
+          set -euo pipefail
+          version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "fynd") | .version')"
+          published() {
+            curl -sf "https://crates.io/api/v1/crates/$1/${version}" \
+              -H "User-Agent: fynd-ci (github.com/propeller-heads/fynd)" >/dev/null
+          }
+          for crate in fynd-core fynd-rpc-types fynd-client fynd-rpc fynd; do
+            if published "${crate}"; then
+              echo "${crate} ${version} already on crates.io, skipping"
+              continue
+            fi
+            if cargo publish --locked --package "${crate}"; then
+              continue
+            fi
+            echo "publish of ${crate} failed, re-checking index and retrying in 30s"
+            sleep 30
+            if ! published "${crate}"; then
+              cargo publish --locked --package "${crate}"
+            fi
+          done
 
   publish-npm:
     name: Publish TypeScript packages to npm
@@ -90,6 +103,16 @@ jobs:
       - name: Build client
         run: pnpm --dir clients/typescript --filter @kayibal/fynd-client run build
 
+      # Skip when this version is already on npm so a recovered/re-fired release
+      # event doesn't fail the job on a duplicate publish.
       - name: Publish client
-        run: npm publish --provenance --access public
         working-directory: clients/typescript/client
+        run: |
+          set -euo pipefail
+          name="$(jq -r .name package.json)"
+          version="$(jq -r .version package.json)"
+          if npm view "${name}@${version}" version >/dev/null 2>&1; then
+            echo "${name}@${version} already on npm, skipping"
+            exit 0
+          fi
+          npm publish --provenance --access public


### PR DESCRIPTION
## What

The v0.97.2 publish run ([30002836579](https://github.com/propeller-heads/fynd/actions/runs/30002836579)) died mid-sequence: `fynd-core` reached crates.io, then `fynd-rpc-types` failed to resolve `fynd-core ^0.97.2` because the registry index hadn't propagated between the two publishes. A plain re-run cannot recover: `cargo publish` errors on already-uploaded versions, so the first step (`fynd-core`) would now fail.

## Changes

- Replace the five crate publish steps with one loop that **skips crates already on crates.io** at the target version and **retries once** (after re-checking the index) to absorb propagation lag.
- **Guard the npm publish the same way** (skip when the version is already on npm).
- Drop the dead `workflow_dispatch` check from the `publish-crates` condition (the trigger was removed in #309).

Partial publish failures are now recoverable with a plain job re-run, and re-firing the release event doesn't fail on the parts that already succeeded.

## Recovery of v0.97.2 (after merge)

Re-runs pin the workflow version from the original event, so the fix needs a fresh `release` event: **delete and recreate the 0.97.2 GitHub Release** (tag untouched). The new run skips `fynd-core` + npm (both already published) and publishes the remaining four crates — which unblocks release-plz to open the 0.98.0 release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)