### PR TITLE
ci(release): restore workflow_dispatch with a required tag input

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,16 @@ name: Release
 on:
   release:
     types: [created]
+  # Manual escape hatch: (re)publish an existing tag with the CURRENT workflow from
+  # main. Release-event runs pin the workflow file at the tag's commit, so a workflow
+  # fix can never reach an already-tagged release any other way. Publishing is
+  # idempotent, so re-dispatching a fully published tag is a no-op.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)publish, e.g. 0.97.2"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -23,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +76,7 @@ jobs:
     name: Publish TypeScript packages to npm
     # Pre-releases build a Docker image only; registry publishing happens on
     # full releases (or manual dispatch).
-    if: github.event_name == 'workflow_dispatch' || !github.event.release.prerelease
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -74,7 +86,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ github.event.release.tag_name || github.sha }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@9fd676a19091d4595eefd76e4bd31c97133911f1 # v4.2.0
@@ -96,9 +108,10 @@ jobs:
         run: pnpm --dir clients/typescript install --frozen-lockfile
 
       - name: Set client version from release tag
-        if: ${{ github.event.release.tag_name != '' }}
         working-directory: clients/typescript/client
-        run: npm version "${{ github.event.release.tag_name }}" --no-git-tag-version --allow-same-version
+        env:
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: npm version "$TAG" --no-git-tag-version --allow-same-version
 
       - name: Build client
         run: pnpm --dir clients/typescript --filter @kayibal/fynd-client run build


### PR DESCRIPTION
## What

Restores the manual trigger on `release.yaml` — this time functional: a **required `tag` input** is used for checkout and the npm version step in both jobs, so a dispatch publishes the tag's content while running the **current workflow from main**.

## Why (reverses #309's removal, with new information)

Release-event runs pin the workflow file **at the tag's commit**. That means the idempotent-publish fix (#343) can never reach the already-tagged v0.97.2: re-running the failed run *and* deleting/recreating the Release both execute the old workflow, which dies on the crates that already published. Verified on [run 30004711614](https://github.com/propeller-heads/fynd/actions/runs/30004711614).

So the earlier reasoning "re-run covers all recovery" holds for flakes, but not for the one case where the workflow itself is broken at the tagged commit — that's exactly what a dispatch-from-main covers (as suggested in [#309's review](https://github.com/propeller-heads/fynd/pull/309#issuecomment-thread)).

Publishing is idempotent since #343, so dispatching an already-published tag is a safe no-op.

## After merge

Dispatch with `tag=0.97.2` → skips `fynd-core` + npm (already published), publishes the four missing crates → crates.io reaches 0.97.2 → release-plz unblocks and opens the 0.98.0 release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)