### PR TITLE
ci(semver): declare breaking changes with the ! marker

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -34,23 +34,18 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # Breaking changes are declared with the conventional `!` marker (e.g. feat!:).
+          # release-plz derives the bump from it: minor on 0.x.x, major on v1+.
           MAJOR=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\([0-9]*\)\.[0-9]*\.[0-9]*".*/\1/')
           if [ "$MAJOR" = "0" ]; then
-            # 0.x.x: breaking changes bump the minor version, declared with feat:
             echo "pre_v1=true" >> "$GITHUB_OUTPUT"
-            if echo "$TITLE" | grep -qE '^feat(\(.+\))?:'; then
-              echo "declared=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "declared=false" >> "$GITHUB_OUTPUT"
-            fi
           else
-            # v1+: breaking changes bump the major version, declared with breaking: type
             echo "pre_v1=false" >> "$GITHUB_OUTPUT"
-            if echo "$TITLE" | grep -qE '^breaking(\(.+\))?:'; then
-              echo "declared=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "declared=false" >> "$GITHUB_OUTPUT"
-            fi
+          fi
+          if echo "$TITLE" | grep -qE '^[a-z]+(\(.+\))?!:'; then
+            echo "declared=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "declared=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup toolchain
@@ -183,12 +178,14 @@ jobs:
                 : raw;
               const hint = preV1
                 ? [
-                    'Either fix the breaking changes, or update the PR title to signal intent:',
-                    '- Use `feat: ...` to bump the minor version (breaking changes on 0.x.x)',
+                    'Either fix the breaking changes, or declare them:',
+                    '- Append `!` to the PR title type (e.g. `feat!: ...`) and make sure a `!`-marked commit',
+                    '  lands on main — release-plz bumps the minor version for breaking changes on 0.x.x.',
                   ]
                 : [
-                    'Either fix the breaking changes, or update the PR title to signal intent:',
-                    '- Use `breaking: ...` to declare a major version bump',
+                    'Either fix the breaking changes, or declare them:',
+                    '- Append `!` to the PR title type (e.g. `feat!: ...`) and make sure a `!`-marked commit',
+                    '  lands on main — release-plz bumps the major version for breaking changes.',
                   ];
               body = [
                 marker,
@@ -212,8 +209,8 @@ jobs:
                 ? raw.slice(0, MAX_OUTPUT) + '\n\n[output truncated]'
                 : raw;
               const versionNote = preV1
-                ? 'Ensure the minor version is bumped before merging (breaking changes on 0.x.x bump the minor).'
-                : 'Ensure the major version is bumped before merging.';
+                ? 'release-plz derives the bump from commits: verify a `!`-marked commit is in this PR so the release PR shows a minor bump (breaking changes on 0.x.x bump the minor).'
+                : 'release-plz derives the bump from commits: verify a `!`-marked commit is in this PR so the release PR shows a major bump.';
               body = [
                 marker,
                 '## Breaking API Changes (Intentional)',
@@ -231,9 +228,7 @@ jobs:
               ].join('\n');
             } else {
               // !breaking && declared
-              const titleHint = preV1
-                ? 'Otherwise, consider using `fix:` instead of `feat:` in the PR title.'
-                : 'Otherwise, consider removing the `breaking` type from the PR title.';
+              const titleHint = 'Otherwise, consider removing the `!` marker from the PR title.';
               body = [
                 marker,
                 '## No API Breaking Changes Detected',


### PR DESCRIPTION
## What

Updates the API semver check to the release-plz versioning convention (kept as-is per the 0.97.3 discussion — cargo semver for 0.x).

| | before (semantic-release) | after (release-plz) |
|---|---|---|
| feature on 0.x | `feat:` → **minor** bump | `feat:` → **patch** bump |
| breaking on 0.x | declared via `feat:` (= the minor bump) | declared via `!` (e.g. `feat!:`) → **minor** bump |
| breaking on v1+ | declared via custom `breaking:` type | declared via `!` → **major** bump |

The check previously accepted a plain `feat:` title as "breaking change declared" on 0.x — under release-plz that would ship a breaking change in a **patch** release (violating `^0.97`-style ranges). Now the declaration is the conventional `!` marker, which is exactly what makes release-plz produce the correct bump. The custom `breaking:` type is dropped from the v1+ path since release-plz treats unknown types as patch bumps.

PR comment hints updated to match, including a reminder that release-plz derives the bump from **commits**, so the `!` must land on a commit in the branch, not just the PR title.

The title validator (`amannn/action-semantic-pull-request`) accepts `!` markers as standard conventional-commit syntax, so `feat!: ...` titles pass validation unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)