### PR TITLE
fix: contain pool simulation panics in solver algorithms

### DIFF
--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -41,7 +41,7 @@ use super::{
     split_primitives::MarketOverrides, Algorithm, AlgorithmConfig, AlgorithmError, NoPathReason,
 };
 use crate::{
-    algorithm::sim_guard::get_amount_out_guarded,
+    algorithm::sim_guard::GuardedProtocolSim,
     derived::{
         computation::ComputationRequirements,
         types::{SpotPrices, TokenGasPrices},
@@ -405,22 +405,18 @@ impl BellmanFordAlgorithm {
                             continue;
                         };
 
-                    let result = match get_amount_out_guarded(
-                        sim,
-                        amount[u_idx].clone(),
-                        token_u,
-                        token_v,
-                    ) {
-                        Ok(r) => r,
-                        Err(e) => {
-                            trace!(
-                                component_id,
-                                error = %e,
-                                "simulation failed, skipping edge"
-                            );
-                            continue;
-                        }
-                    };
+                    let result =
+                        match sim.get_amount_out_guarded(amount[u_idx].clone(), token_u, token_v) {
+                            Ok(r) => r,
+                            Err(e) => {
+                                trace!(
+                                    component_id,
+                                    error = %e,
+                                    "simulation failed, skipping edge"
+                                );
+                                continue;
+                            }
+                        };
 
                     let candidate_cumul_gas = &cumul_gas[u_idx] + &result.gas;
 

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -41,6 +41,7 @@ use super::{
     split_primitives::MarketOverrides, Algorithm, AlgorithmConfig, AlgorithmError, NoPathReason,
 };
 use crate::{
+    algorithm::sim_guard::get_amount_out_guarded,
     derived::{
         computation::ComputationRequirements,
         types::{SpotPrices, TokenGasPrices},
@@ -404,7 +405,12 @@ impl BellmanFordAlgorithm {
                             continue;
                         };
 
-                    let result = match sim.get_amount_out(amount[u_idx].clone(), token_u, token_v) {
+                    let result = match get_amount_out_guarded(
+                        sim,
+                        amount[u_idx].clone(),
+                        token_u,
+                        token_v,
+                    ) {
                         Ok(r) => r,
                         Err(e) => {
                             trace!(

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -21,7 +21,7 @@
 pub mod bellman_ford;
 pub mod most_liquid;
 pub mod path_frank_wolfe;
-#[allow(dead_code)]
+pub(crate) mod sim_guard;
 pub(crate) mod split_primitives;
 
 #[cfg(test)]

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -24,7 +24,7 @@ use tycho_simulation::{
 
 use super::{Algorithm, AlgorithmConfig, NoPathReason};
 use crate::{
-    algorithm::sim_guard::get_amount_out_guarded,
+    algorithm::sim_guard::GuardedProtocolSim,
     derived::{computation::ComputationRequirements, types::TokenGasPrices, SharedDerivedDataRef},
     feed::market_data::{MarketData, MarketState, StateLabel},
     graph::{petgraph::StableDiGraph, Path, PetgraphStableDiGraphManager},
@@ -396,7 +396,8 @@ impl MostLiquidAlgorithm {
                 .unwrap_or(component_state);
 
             // Simulate the swap
-            let result = get_amount_out_guarded(state, current_amount.clone(), token_in, token_out)
+            let result = state
+                .get_amount_out_guarded(current_amount.clone(), token_in, token_out)
                 .map_err(|e| AlgorithmError::Other(format!("simulation error: {:?}", e)))?;
 
             // Record the swap

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -24,6 +24,7 @@ use tycho_simulation::{
 
 use super::{Algorithm, AlgorithmConfig, NoPathReason};
 use crate::{
+    algorithm::sim_guard::get_amount_out_guarded,
     derived::{computation::ComputationRequirements, types::TokenGasPrices, SharedDerivedDataRef},
     feed::market_data::{MarketData, MarketState, StateLabel},
     graph::{petgraph::StableDiGraph, Path, PetgraphStableDiGraphManager},
@@ -395,8 +396,7 @@ impl MostLiquidAlgorithm {
                 .unwrap_or(component_state);
 
             // Simulate the swap
-            let result = state
-                .get_amount_out(current_amount.clone(), token_in, token_out)
+            let result = get_amount_out_guarded(state, current_amount.clone(), token_in, token_out)
                 .map_err(|e| AlgorithmError::Other(format!("simulation error: {:?}", e)))?;
 
             // Record the swap

--- a/fynd-core/src/algorithm/sim_guard.rs
+++ b/fynd-core/src/algorithm/sim_guard.rs
@@ -18,42 +18,57 @@ use tycho_simulation::tycho_common::{
     },
 };
 
-/// Calls `sim.get_amount_out`, converting a panic into a `SimulationError::FatalError`.
+/// Extension trait adding panic-guarded simulation calls to every [`ProtocolSim`].
 ///
-/// On a contained panic, logs the input that triggered it (amount and token pair) so the
-/// offending pool/quote can be tracked down from the logs.
-pub(crate) fn get_amount_out_guarded(
-    sim: &dyn ProtocolSim,
-    amount_in: BigUint,
-    token_in: &Token,
-    token_out: &Token,
-) -> Result<GetAmountOutResult, SimulationError> {
-    // `amount_in` is cloned into the call so the original stays available for the panic log.
-    let outcome = catch_unwind(AssertUnwindSafe(|| {
-        sim.get_amount_out(amount_in.clone(), token_in, token_out)
-    }));
+/// Crate-private: solver code calls the guarded variants; the raw `ProtocolSim` methods
+/// remain untouched for callers that manage panics themselves.
+pub(crate) trait GuardedProtocolSim {
+    /// Calls `get_amount_out`, converting a panic into a `SimulationError::FatalError`.
+    ///
+    /// On a contained panic, logs the input that triggered it (amount and token pair) so
+    /// the offending pool/quote can be tracked down from the logs.
+    fn get_amount_out_guarded(
+        &self,
+        amount_in: BigUint,
+        token_in: &Token,
+        token_out: &Token,
+    ) -> Result<GetAmountOutResult, SimulationError>;
+}
 
-    outcome.unwrap_or_else(|panic_payload| {
-        let message = panic_payload
-            .downcast_ref::<&str>()
-            .copied()
-            .or_else(|| {
-                panic_payload
-                    .downcast_ref::<String>()
-                    .map(String::as_str)
-            })
-            .unwrap_or("<non-string panic payload>");
-        warn!(
-            %amount_in,
-            token_in = %token_in.address,
-            token_out = %token_out.address,
-            token_in_symbol = %token_in.symbol,
-            token_out_symbol = %token_out.symbol,
-            panic = message,
-            "pool simulation panicked; skipping pool"
-        );
-        Err(SimulationError::FatalError(format!("get_amount_out panicked: {message}")))
-    })
+impl<T: ProtocolSim + ?Sized> GuardedProtocolSim for T {
+    fn get_amount_out_guarded(
+        &self,
+        amount_in: BigUint,
+        token_in: &Token,
+        token_out: &Token,
+    ) -> Result<GetAmountOutResult, SimulationError> {
+        // `amount_in` is cloned into the call so the original stays available for the panic log.
+        let outcome = catch_unwind(AssertUnwindSafe(|| {
+            self.get_amount_out(amount_in.clone(), token_in, token_out)
+        }));
+
+        outcome.unwrap_or_else(|panic_payload| {
+            let message = panic_payload
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| {
+                    panic_payload
+                        .downcast_ref::<String>()
+                        .map(String::as_str)
+                })
+                .unwrap_or("<non-string panic payload>");
+            warn!(
+                %amount_in,
+                token_in = %token_in.address,
+                token_out = %token_out.address,
+                token_in_symbol = %token_in.symbol,
+                token_out_symbol = %token_out.symbol,
+                panic = message,
+                "pool simulation panicked; skipping pool"
+            );
+            Err(SimulationError::FatalError(format!("get_amount_out panicked: {message}")))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -67,7 +82,7 @@ mod tests {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
 
-        let result = get_amount_out_guarded(&sim, BigUint::from(1000u64), &token_a, &token_b);
+        let result = sim.get_amount_out_guarded(BigUint::from(1000u64), &token_a, &token_b);
 
         match result {
             Err(SimulationError::FatalError(message)) => {
@@ -87,7 +102,8 @@ mod tests {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
 
-        let result = get_amount_out_guarded(&sim, BigUint::from(1000u64), &token_a, &token_b)
+        let result = sim
+            .get_amount_out_guarded(BigUint::from(1000u64), &token_a, &token_b)
             .expect("mock simulation should succeed");
         assert_eq!(result.amount, BigUint::from(2000u64));
     }

--- a/fynd-core/src/algorithm/sim_guard.rs
+++ b/fynd-core/src/algorithm/sim_guard.rs
@@ -1,0 +1,77 @@
+//! Panic containment for pool simulation calls.
+//!
+//! `ProtocolSim` implementations run third-party pool math that can panic on degenerate
+//! inputs (e.g. a U256 division by zero when quoting an absurdly large amount). Left
+//! uncaught, such a panic unwinds through the solver worker thread and permanently kills
+//! it. Simulation calls made while solving therefore go through this guard, which turns
+//! a panic into a `SimulationError` so the algorithm skips the pool and keeps solving.
+
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use num_bigint::BigUint;
+use tycho_simulation::tycho_common::{
+    models::token::Token,
+    simulation::{
+        errors::SimulationError,
+        protocol_sim::{GetAmountOutResult, ProtocolSim},
+    },
+};
+
+/// Calls `sim.get_amount_out`, converting a panic into a `SimulationError::FatalError`.
+pub(crate) fn get_amount_out_guarded(
+    sim: &dyn ProtocolSim,
+    amount_in: BigUint,
+    token_in: &Token,
+    token_out: &Token,
+) -> Result<GetAmountOutResult, SimulationError> {
+    catch_unwind(AssertUnwindSafe(|| sim.get_amount_out(amount_in, token_in, token_out)))
+        .unwrap_or_else(|panic_payload| {
+            let message = panic_payload
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| {
+                    panic_payload
+                        .downcast_ref::<String>()
+                        .map(String::as_str)
+                })
+                .unwrap_or("<non-string panic payload>");
+            Err(SimulationError::FatalError(format!("get_amount_out panicked: {message}")))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::test_utils::{token, DivByZeroSim, MockProtocolSim};
+
+    #[test]
+    fn test_get_amount_out_guarded_converts_panic_to_error() {
+        let sim = DivByZeroSim::default();
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+
+        let result = get_amount_out_guarded(&sim, BigUint::from(1000u64), &token_a, &token_b);
+
+        match result {
+            Err(SimulationError::FatalError(message)) => {
+                assert!(
+                    message.contains("panicked") && message.contains("divide by zero"),
+                    "unexpected message: {message}"
+                );
+            }
+            Err(other) => panic!("expected FatalError, got {other:?}"),
+            Ok(_) => panic!("expected FatalError, got Ok"),
+        }
+    }
+
+    #[test]
+    fn test_get_amount_out_guarded_passes_through_success() {
+        let sim = MockProtocolSim::new(2.0);
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+
+        let result = get_amount_out_guarded(&sim, BigUint::from(1000u64), &token_a, &token_b)
+            .expect("mock simulation should succeed");
+        assert_eq!(result.amount, BigUint::from(2000u64));
+    }
+}

--- a/fynd-core/src/algorithm/sim_guard.rs
+++ b/fynd-core/src/algorithm/sim_guard.rs
@@ -9,6 +9,7 @@
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use num_bigint::BigUint;
+use tracing::warn;
 use tycho_simulation::tycho_common::{
     models::token::Token,
     simulation::{
@@ -18,25 +19,41 @@ use tycho_simulation::tycho_common::{
 };
 
 /// Calls `sim.get_amount_out`, converting a panic into a `SimulationError::FatalError`.
+///
+/// On a contained panic, logs the input that triggered it (amount and token pair) so the
+/// offending pool/quote can be tracked down from the logs.
 pub(crate) fn get_amount_out_guarded(
     sim: &dyn ProtocolSim,
     amount_in: BigUint,
     token_in: &Token,
     token_out: &Token,
 ) -> Result<GetAmountOutResult, SimulationError> {
-    catch_unwind(AssertUnwindSafe(|| sim.get_amount_out(amount_in, token_in, token_out)))
-        .unwrap_or_else(|panic_payload| {
-            let message = panic_payload
-                .downcast_ref::<&str>()
-                .copied()
-                .or_else(|| {
-                    panic_payload
-                        .downcast_ref::<String>()
-                        .map(String::as_str)
-                })
-                .unwrap_or("<non-string panic payload>");
-            Err(SimulationError::FatalError(format!("get_amount_out panicked: {message}")))
-        })
+    // `amount_in` is cloned into the call so the original stays available for the panic log.
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        sim.get_amount_out(amount_in.clone(), token_in, token_out)
+    }));
+
+    outcome.unwrap_or_else(|panic_payload| {
+        let message = panic_payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| {
+                panic_payload
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+            })
+            .unwrap_or("<non-string panic payload>");
+        warn!(
+            %amount_in,
+            token_in = %token_in.address,
+            token_out = %token_out.address,
+            token_in_symbol = %token_in.symbol,
+            token_out_symbol = %token_out.symbol,
+            panic = message,
+            "pool simulation panicked; skipping pool"
+        );
+        Err(SimulationError::FatalError(format!("get_amount_out panicked: {message}")))
+    })
 }
 
 #[cfg(test)]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -13,7 +13,7 @@ use tycho_simulation::tycho_common::{
 };
 
 use crate::{
-    algorithm::AlgorithmError,
+    algorithm::{sim_guard::get_amount_out_guarded, AlgorithmError},
     feed::market_data::MarketState,
     types::{ComponentId, Order, Route, Swap},
 };
@@ -95,8 +95,6 @@ impl PathAllocation {
 /// Output of simulating one path at a given input amount.
 pub(crate) struct SimResult {
     pub(crate) amount_out: BigUint,
-    /// Raw per-hop sum; use only via `evaluate_total_output`.
-    pub(crate) gas: u64,
     pub(crate) marginal_price_product: f64,
     /// Per-hop `(amount_out, gas)` in path order.
     pub(crate) hop_results: Vec<(BigUint, BigUint)>,
@@ -399,8 +397,8 @@ pub(crate) fn compute_marginal_price_product(
 ///
 /// For each hop, the path's own post-swap states are checked first, then
 /// `overrides`, then the live market state. Returns the final output amount,
-/// raw gas sum, marginal price product (spot prices at the state each hop
-/// executed against), and the post-swap pool states.
+/// marginal price product (spot prices at the state each hop executed
+/// against), per-hop results, and the post-swap pool states.
 pub(crate) fn simulate_path(
     hops: &[HopDescriptor],
     amount_in: &BigUint,
@@ -408,7 +406,6 @@ pub(crate) fn simulate_path(
     overrides: &MarketOverrides,
 ) -> Result<SimResult, AlgorithmError> {
     let mut current_amount = amount_in.clone();
-    let mut total_gas: u64 = 0;
     let mut hop_results = Vec::with_capacity(hops.len());
     let mut post_swap_states: Vec<(ComponentId, Box<dyn ProtocolSim>)> =
         Vec::with_capacity(hops.len());
@@ -437,15 +434,12 @@ pub(crate) fn simulate_path(
             })?;
         marginal_price_product *= price;
 
-        let result = sim
-            .get_amount_out(current_amount, &hop.token_in, &hop.token_out)
+        let result = get_amount_out_guarded(sim, current_amount, &hop.token_in, &hop.token_out)
             .map_err(|e| AlgorithmError::SimulationFailed {
                 component_id: hop.component_id.clone(),
                 error: e.to_string(),
             })?;
 
-        // Cap at u64::MAX instead of panicking on overflow.
-        total_gas = total_gas.saturating_add(result.gas.to_u64().unwrap_or(u64::MAX));
         hop_results.push((result.amount.clone(), result.gas));
         current_amount = result.amount;
         post_swap_states.push((hop.component_id.clone(), result.new_state));
@@ -453,7 +447,6 @@ pub(crate) fn simulate_path(
 
     Ok(SimResult {
         amount_out: current_amount,
-        gas: total_gas,
         marginal_price_product,
         hop_results,
         post_swap_states,
@@ -683,16 +676,16 @@ fn execute_split_plan(
                     id: Some(split_swap.hop.component_id.clone()),
                 })?;
 
-            let result = sim
-                .get_amount_out(
-                    split_swap.amount_in.clone(),
-                    &split_swap.hop.token_in,
-                    &split_swap.hop.token_out,
-                )
-                .map_err(|e| AlgorithmError::SimulationFailed {
-                    component_id: split_swap.hop.component_id.clone(),
-                    error: e.to_string(),
-                })?;
+            let result = get_amount_out_guarded(
+                sim,
+                split_swap.amount_in.clone(),
+                &split_swap.hop.token_in,
+                &split_swap.hop.token_out,
+            )
+            .map_err(|e| AlgorithmError::SimulationFailed {
+                component_id: split_swap.hop.component_id.clone(),
+                error: e.to_string(),
+            })?;
 
             let out_addr = split_swap.hop.token_out.address.clone();
             *available
@@ -933,7 +926,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        algorithm::test_utils::{component, order, token, ConstantProductSim, MockProtocolSim},
+        algorithm::test_utils::{
+            component, order, token, ConstantProductSim, DivByZeroSim, MockProtocolSim,
+        },
         types::OrderSide,
     };
 
@@ -1235,6 +1230,32 @@ mod tests {
     }
 
     #[test]
+    fn test_simulate_path_contains_simulation_panic() {
+        // Pool math that panics (e.g. U256 division by zero on degenerate amounts) must
+        // surface as a SimulationFailed error, not unwind through the solver thread.
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let market = make_market(vec![(
+            "pool_ab",
+            vec![token_a.clone(), token_b.clone()],
+            Box::new(DivByZeroSim::default()),
+        )]);
+
+        let hops = [HopDescriptor::new("pool_ab".to_string(), token_a, token_b)];
+        let result =
+            simulate_path(&hops, &BigUint::from(1000u64), &market, &MarketOverrides::empty());
+
+        match result {
+            Err(AlgorithmError::SimulationFailed { component_id, error }) => {
+                assert_eq!(component_id, "pool_ab");
+                assert!(error.contains("panic"), "error should mention the panic: {error}");
+            }
+            Err(other) => panic!("expected SimulationFailed, got {other:?}"),
+            Ok(_) => panic!("expected SimulationFailed, got Ok"),
+        }
+    }
+
+    #[test]
     fn test_market_overrides_with_zero_gas() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
@@ -1256,17 +1277,32 @@ mod tests {
         let hops_bc = [HopDescriptor::new("pool_bc".to_string(), token_b, token_c)];
         let amount_in = BigUint::from(1000u64);
 
+        let hop_gas_sum = |sim: &SimResult| -> BigUint {
+            sim.hop_results
+                .iter()
+                .map(|(_, gas)| gas)
+                .sum()
+        };
+
         let normal_ab =
             simulate_path(&hops_ab, &amount_in, &market, &MarketOverrides::empty()).unwrap();
         let zero_gas_ab = simulate_path(&hops_ab, &amount_in, &market, &overrides).unwrap();
 
         assert_eq!(normal_ab.amount_out, zero_gas_ab.amount_out);
-        assert!(normal_ab.gas > 0, "normal gas should be non-zero");
-        assert_eq!(zero_gas_ab.gas, 0, "zero-gas override should report gas=0");
+        assert!(hop_gas_sum(&normal_ab) > BigUint::ZERO, "normal gas should be non-zero");
+        assert_eq!(
+            hop_gas_sum(&zero_gas_ab),
+            BigUint::ZERO,
+            "zero-gas override should report gas=0"
+        );
 
         // pool_bc is a normal override — its gas should be unaffected.
         let result_bc = simulate_path(&hops_bc, &amount_in, &market, &overrides).unwrap();
-        assert_eq!(result_bc.gas, 70_000, "non-zero-gas override should keep its gas");
+        assert_eq!(
+            hop_gas_sum(&result_bc),
+            BigUint::from(70_000u64),
+            "non-zero-gas override should keep its gas"
+        );
     }
 
     #[test]

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -13,7 +13,7 @@ use tycho_simulation::tycho_common::{
 };
 
 use crate::{
-    algorithm::{sim_guard::get_amount_out_guarded, AlgorithmError},
+    algorithm::{sim_guard::GuardedProtocolSim, AlgorithmError},
     feed::market_data::MarketState,
     types::{ComponentId, Order, Route, Swap},
 };
@@ -434,7 +434,8 @@ pub(crate) fn simulate_path(
             })?;
         marginal_price_product *= price;
 
-        let result = get_amount_out_guarded(sim, current_amount, &hop.token_in, &hop.token_out)
+        let result = sim
+            .get_amount_out_guarded(current_amount, &hop.token_in, &hop.token_out)
             .map_err(|e| AlgorithmError::SimulationFailed {
                 component_id: hop.component_id.clone(),
                 error: e.to_string(),
@@ -676,16 +677,16 @@ fn execute_split_plan(
                     id: Some(split_swap.hop.component_id.clone()),
                 })?;
 
-            let result = get_amount_out_guarded(
-                sim,
-                split_swap.amount_in.clone(),
-                &split_swap.hop.token_in,
-                &split_swap.hop.token_out,
-            )
-            .map_err(|e| AlgorithmError::SimulationFailed {
-                component_id: split_swap.hop.component_id.clone(),
-                error: e.to_string(),
-            })?;
+            let result = sim
+                .get_amount_out_guarded(
+                    split_swap.amount_in.clone(),
+                    &split_swap.hop.token_in,
+                    &split_swap.hop.token_out,
+                )
+                .map_err(|e| AlgorithmError::SimulationFailed {
+                    component_id: split_swap.hop.component_id.clone(),
+                    error: e.to_string(),
+                })?;
 
             let out_addr = split_swap.hop.token_out.address.clone();
             *available

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -251,6 +251,77 @@ impl ProtocolSim for MockProtocolSim {
     }
 }
 
+// ==================== DivByZeroSim ====================
+
+/// ProtocolSim whose `get_amount_out` performs a real U256 division by zero.
+///
+/// Reproduces pool math panicking inside a simulation call instead of returning a
+/// `SimulationError`, so tests can assert that callers contain the panic. All other
+/// methods delegate to a [`MockProtocolSim`].
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct DivByZeroSim {
+    inner: MockProtocolSim,
+}
+
+#[typetag::serde]
+impl ProtocolSim for DivByZeroSim {
+    fn fee(&self) -> f64 {
+        self.inner.fee()
+    }
+
+    fn spot_price(&self, base: &Token, quote: &Token) -> Result<f64, SimulationError> {
+        self.inner.spot_price(base, quote)
+    }
+
+    fn get_amount_out(
+        &self,
+        _amount_in: BigUint,
+        _token_in: &Token,
+        _token_out: &Token,
+    ) -> Result<GetAmountOutResult, SimulationError> {
+        use alloy::primitives::U256;
+        let _ = U256::from(1u64) / U256::ZERO;
+        unreachable!("U256 division by zero panics");
+    }
+
+    fn get_limits(
+        &self,
+        sell_token: Bytes,
+        buy_token: Bytes,
+    ) -> Result<(BigUint, BigUint), SimulationError> {
+        self.inner
+            .get_limits(sell_token, buy_token)
+    }
+
+    fn delta_transition(
+        &mut self,
+        _delta: ProtocolStateDelta,
+        _tokens: &HashMap<Bytes, Token>,
+        _balances: &Balances,
+    ) -> Result<(), TransitionError> {
+        unimplemented!("delta_transition not implemented in DivByZeroSim")
+    }
+
+    fn clone_box(&self) -> Box<dyn ProtocolSim> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn eq(&self, other: &dyn ProtocolSim) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some()
+    }
+}
+
 // ==================== ConstantProductSim ====================
 
 /// xy=k AMM simulator for testing. Uses pure `BigUint` arithmetic; No fees — pure constant-product

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -25,6 +25,7 @@ use tycho_simulation::{
 };
 
 use crate::{
+    algorithm::sim_guard::get_amount_out_guarded,
     derived::{
         computation::{
             ComputationId, ComputationOutput, ComputationRequirements, DerivedComputation,
@@ -305,11 +306,17 @@ impl DerivedComputation for PoolDepthComputation {
                         succeeded += 1;
                     }
                     Err(e) => {
-                        // Diagnostic: probe with 1 unit to understand why depth search failed
-                        let probe_info = sim_state
-                            .get_amount_out(BigUint::from(1u32), token_in, token_out)
-                            .map(|r| format!("amount_out={}", r.amount))
-                            .unwrap_or_else(|e| format!("sim_error={e}"));
+                        // Diagnostic: probe with 1 unit to understand why depth search failed.
+                        // Guarded so a panicking pool degrades to a diagnostic string instead of
+                        // killing the computation worker.
+                        let probe_info = get_amount_out_guarded(
+                            sim_state,
+                            BigUint::from(1u32),
+                            token_in,
+                            token_out,
+                        )
+                        .map(|r| format!("amount_out={}", r.amount))
+                        .unwrap_or_else(|e| format!("sim_error={e}"));
                         let limits_info = sim_state
                             .get_limits(token_in.address.clone(), token_out.address.clone())
                             .map(|(max_in, max_out)| format!("max_in={max_in}, max_out={max_out}"))

--- a/fynd-core/src/derived/computations/pool_depth.rs
+++ b/fynd-core/src/derived/computations/pool_depth.rs
@@ -25,7 +25,7 @@ use tycho_simulation::{
 };
 
 use crate::{
-    algorithm::sim_guard::get_amount_out_guarded,
+    algorithm::sim_guard::GuardedProtocolSim,
     derived::{
         computation::{
             ComputationId, ComputationOutput, ComputationRequirements, DerivedComputation,
@@ -309,14 +309,10 @@ impl DerivedComputation for PoolDepthComputation {
                         // Diagnostic: probe with 1 unit to understand why depth search failed.
                         // Guarded so a panicking pool degrades to a diagnostic string instead of
                         // killing the computation worker.
-                        let probe_info = get_amount_out_guarded(
-                            sim_state,
-                            BigUint::from(1u32),
-                            token_in,
-                            token_out,
-                        )
-                        .map(|r| format!("amount_out={}", r.amount))
-                        .unwrap_or_else(|e| format!("sim_error={e}"));
+                        let probe_info = sim_state
+                            .get_amount_out_guarded(BigUint::from(1u32), token_in, token_out)
+                            .map(|r| format!("amount_out={}", r.amount))
+                            .unwrap_or_else(|e| format!("sim_error={e}"));
                         let limits_info = sim_state
                             .get_limits(token_in.address.clone(), token_out.address.clone())
                             .map(|(max_in, max_out)| format!("max_in={max_in}, max_out={max_out}"))


### PR DESCRIPTION
## What

Routes all solver-side `ProtocolSim::get_amount_out` calls (bellman_ford, path_frank_wolfe/split_primitives, most_liquid) through `get_amount_out_guarded`, which wraps the call in `catch_unwind` and converts a panic into a `SimulationError::FatalError`. The algorithms already treat simulation errors as "skip this pool", so a panicking pool no longer kills the worker thread. On a contained panic the guard logs the triggering amount and token pair (address + symbol) so the offending pool/quote can be tracked down.

The diagnostic `get_amount_out` probe in `derived/computations/pool_depth.rs` is routed through the same guard, so a panicking pool degrades to a diagnostic string instead of killing the computation-manager worker.

Also removes `SimResult.gas`, which was written but never read outside tests (gas totals flow through `SplitExecution.total_gas`); the zero-gas override test now sums per-hop gas from `hop_results`.

## Why

Prod incident 2026-07-23 (~10:22–12:02 UTC): a quote for ~7.9e28 USDC triggered `attempt to divide by zero` in ruint (U256 math inside tycho-simulation pool code). Each occurrence killed one solver worker thread; after all workers on both ethereum pods had panicked, every quote returned `no_route_found` (100% no_route on the Quote outcomes panel) until the pods were manually recreated ~1.5h later.

With this change the poison request fails with a simulation error for the affected pool/path and the workers stay alive.

## Tests

- `sim_guard`: panic → `FatalError` with the panic message; success passes through
- `split_primitives::test_simulate_path_contains_simulation_panic`: a `ProtocolSim` performing a real U256 division by zero surfaces as `AlgorithmError::SimulationFailed` instead of unwinding

🤖 Generated with [Claude Code](https://claude.com/claude-code)
