### PR TITLE
ci(release-plz): title GitHub Releases with the bare version

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,6 +13,9 @@ changelog_update = false
 # release run fails with "Reference already exists".
 git_tag_enable = false
 git_tag_name = "{{ version }}"
+# Title the GitHub Release with the bare version too: the default is inconsistent
+# (0.97.1/0.97.2 got "{version}", 0.97.3 got "fynd-v{version}").
+git_release_name = "{{ version }}"
 git_release_enable = false
 semver_check = false
 publish = false


### PR DESCRIPTION
Sets `git_release_name = "{{ version }}"` so release titles match the tag (e.g. `0.97.4`). The default was inconsistent: 0.97.1/0.97.2 were titled with the bare version, 0.97.3 with `fynd-v0.97.3`. The existing 0.97.3 release has been renamed by hand.

Merge before release PR #349 so 0.97.4 gets the right title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)