### PR TITLE
fix(hindsight): log terminal errors so stdout log pipelines show them

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,14 @@ fn main() -> Result<(), anyhow::Error> {
             Ok(())
         }
         Commands::Serve(serve_args) => {
-            run_solver(*serve_args).map_err(|e| anyhow!("{}", e))?;
+            // Log the failure before returning it: the fmt layer writes to stdout, whereas a
+            // `main` that returns `Err` prints only to stderr, so log pipelines that follow stdout
+            // show a run that stops mid-startup with no reason. Returning the error too keeps the
+            // exit code.
+            run_solver(*serve_args).map_err(|e| {
+                error!(error = %e, "Fynd exited with an error");
+                anyhow!("{}", e)
+            })?;
             Ok(())
         }
         Commands::DeriveConnectorTokens(args) => tokio::runtime::Runtime::new()

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use alloy::providers::{Provider, ProviderBuilder};
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
 use crate::{
@@ -129,11 +129,19 @@ async fn main() -> anyhow::Result<()> {
         .with_ansi(std::io::IsTerminal::is_terminal(&std::io::stdout()))
         .init();
 
-    match Cli::parse().command {
+    let result = match Cli::parse().command {
         Command::Decode(args) => run_decode(args).await,
         Command::Verify(args) => run_verify(args).await,
         Command::Monitor(args) => resolve::monitor::run(args).await,
+    };
+
+    // Log the failure before returning it: the fmt subscriber above writes to stdout, whereas a
+    // `main` that returns `Err` prints only to stderr, so log pipelines that follow stdout show a
+    // run that stops mid-startup with no reason. Returning the error too keeps the exit code.
+    if let Err(error) = &result {
+        error!(error = format!("{error:#}"), "hindsight exited with an error");
     }
+    result
 }
 
 #[expect(clippy::print_stdout)]


### PR DESCRIPTION
The fmt subscriber writes to stdout, while a main that returns Err prints only to stderr. Collectors that follow stdout showed a run that stopped mid-startup with no reason.

Log the error through tracing before returning it. Returning it too keeps the exit code and the stderr fallback for the subcommands that install no subscriber.