### PR TITLE
feat: add aerodrome_v1 protocol and update tycho crates to 0.341.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7830,9 +7830,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.341.6"
+version = "0.341.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce699ebb29bbb24678dca6cd587b32996511dfead148590c1d95b078c0af24fc"
+checksum = "ec5b494641dbd47b2c6687b42ff32252ca2602180d95c02199010124b757f2a5"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7860,9 +7860,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.341.6"
+version = "0.341.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72be78297ef2771dfc92682e9ac5758997d971550658cee460c5636e7e64129"
+checksum = "31252c175d9f0805dd8487b731b1a7aecb2492cca853acc575cf8817045c44a4"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7889,9 +7889,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.341.6"
+version = "0.341.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0599e7343794b6df97241b4383ffae3157c123fe8dd78dacfc2f2dde747f811f"
+checksum = "73e426b26ce1030dce5c790f2f20f5c9fce82847b9f326ba544139237e671320"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7911,9 +7911,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.341.6"
+version = "0.341.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95bf300f33ed2a766ee2800ae5cec19bb16ceb2df1ad4025eef1a8e0c1a83870"
+checksum = "042b2817bdbbd5fae7179750ccdffe733628cc43708bcd5e058ce758c28ad322"
 dependencies = [
  "alloy",
  "chrono",
@@ -7932,9 +7932,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.341.6"
+version = "0.341.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c86a66b28de88ab7d5ed4df47876ac36c203dd809720ce0d1705783c677c21"
+checksum = "6feb98ceb7b96e34e035c8039c6d394f9a3dbc5612051a183c107e54429f6247"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-tycho-execution = ">=0.341.6"
-tycho-simulation = ">=0.341.6"
+tycho-execution = ">=0.341.7"
+tycho-simulation = ">=0.341.7"
 typetag = "0.2"
 
 # Compression

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -6,6 +6,7 @@ use tycho_simulation::{
         engine_db::tycho_db::PreCachedDB,
         protocol::{
             aerodrome_slipstreams::state::AerodromeSlipstreamsState,
+            aerodrome_v1::state::AerodromeV1State,
             curve::CurveState,
             ekubo::state::EkuboState,
             ekubo_v3::{self, state::EkuboV3State},
@@ -140,6 +141,10 @@ pub(crate) fn register_exchanges(
                     tvl_filter.clone(),
                     Some(fluid_v1_paused_pools_filter),
                 );
+            }
+            "aerodrome_v1" => {
+                builder =
+                    builder.exchange::<AerodromeV1State>("aerodrome_v1", tvl_filter.clone(), None);
             }
             "aerodrome_slipstreams" => {
                 builder = builder.exchange::<AerodromeSlipstreamsState>(


### PR DESCRIPTION
## Summary

- Register `AerodromeV1State` for the `aerodrome_v1` protocol in the protocol registry, so it can be indexed on Base. tycho-execution already ships an `aerodrome_v1` swap encoder, so encoding works out of the box.
- Update tycho crates to 0.341.7 and enforce `>=0.341.7` in the workspace manifest. This release includes propeller-heads/tycho#1239 (slipstream pools fall back to their static fee when the dynamic-fee module marker is absent), so downstream users pick up the fix on their next `cargo update`.

## Testing

- `cargo +nightly fmt` — clean
- `cargo +nightly clippy --workspace --all-targets --all-features` — no warnings
- `cargo test --workspace --all-targets --all-features` — 1085 passed, 0 failed, 10 ignored (includes the fynd-core integration suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)