### PR TITLE
fix(hindsight): New client follow-ups 

### DIFF
--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -59,7 +59,7 @@ All take `--chain` (selects the address book) and `--registry` /
            ┌─────────────────┐  embedded_quote  ┌─────────────────┐
            │ post-processing │ ───────────────▶ │ SolverKnowledge │
            └────────┬────────┘                  └─────────────────┘
-                    │  veto → client attribution → solver attribution → gas → quote → sandwich scan
+                    │  veto → venue attribution → solver attribution → gas → quote → sandwich scan
                     ▼
               DecodedTrade
 ```
@@ -176,24 +176,24 @@ trait SolverKnowledge {
 }
 ```
 
-### Client attribution (`clients.rs`)
+### Venue attribution (`venue_attribution.rs`)
 
-The venue is normally the contract the trader entered through (`tx.to`). Some order-flow clients own
+The venue is normally the contract the trader entered through (`tx.to`). Some order-flow venues own
 the flow without being that contract, so after a flow is decoded one step can override the venue from
-a registry fingerprint. Nothing in `clients.rs` names a specific client — it reads four maps from
-the address book:
+a registry fingerprint. Nothing in `venue_attribution.rs` names a specific venue — it reads four maps
+from the address book:
 
-- **owning trader** (`[client_owners]`) — the flow was read from a known client address (kpk's Safes,
+- **owning trader** (`[venue_owners]`) — the flow was read from a known venue address (kpk's Safes,
   surfaced from the CoW decoder's owner).
-- **CoW appData tag** (`[client_appdata]`) — the settled order committed a frontend tag (`appCode`)
-  whose appData hash maps to a client (LlamaSwap). The hash is read from the settle calldata by
-  `intents::client_tag`, so `clients.rs` stays protocol-agnostic.
-- **fee wallet** (`[client_fees]`) — a known client fee wallet took the output-token fee (Phantom,
+- **CoW appData tag** (`[venue_appdata]`) — the settled order committed a frontend tag (`appCode`)
+  whose appData hash maps to a venue (LlamaSwap). The hash is read from the settle calldata by
+  `intents::venue_tag`, so `venue_attribution.rs` stays protocol-agnostic.
+- **fee wallet** (`[venue_fees]`) — a known venue fee wallet took the output-token fee (Phantom,
   Robinhood); the fee is grossed back. Only inside an already-matched trade, so a dust spray to a
   fee wallet is not mistaken for flow.
-- **provider integrator tag** (`[client_integrators]`) — a provider's event carried an integrator
-  string mapped to a client (LiFi frontends). The tag is read by that provider's
-  `SolverKnowledge::integrator`, so `clients.rs` stays provider-agnostic.
+- **provider integrator tag** (`[venue_integrators]`) — a provider's event carried an integrator
+  string mapped to a venue (LiFi frontends). The tag is read by that provider's
+  `SolverKnowledge::integrator`, so `venue_attribution.rs` stays provider-agnostic.
 
 ### Per protocol, not per chain
 
@@ -217,8 +217,8 @@ collectors are re-verified on every chain a venue is added on.
 | Skip a solver's non-swap orders | A `solver_veto` method on its `SolverKnowledge` impl | Those orders decode as trades that never happened, with absurd rates |
 | Add a venue | A `[venues.<name>]` section in the address book, a `TradeDecoder` in `venues/`, one arm in `venues::decoders_for` | The venue's trades are missed: with no entry-point match they only surface when a known solver logs inside them, and intent decoding then excludes the trader |
 | Extend what Hindsight knows about a venue | That venue's module in `venues/` — never anywhere else | Decoding degrades silently |
-| Decode an intent settler (CoW-style) | A `TradeDecoder` in `intents/`, listed in `intents::decoders_for` ahead of the netting fallback | The settler's trades decode by net flow, losing exact amounts and (for contract owners) the client |
-| Attribute a new client (owner / appData tag / fee wallet / integrator tag) | The matching address-book map (`[client_owners]` / `[client_appdata]` / `[client_fees]` / `[client_integrators]`); a provider's integrator tag also needs `SolverKnowledge::integrator` | The client's trades are attributed to the underlying router or settler, not the client |
+| Decode an intent settler (CoW-style) | A `TradeDecoder` in `intents/`, listed in `intents::decoders_for` ahead of the netting fallback | The settler's trades decode by net flow, losing exact amounts and (for contract owners) the venue |
+| Attribute a new venue (owner / appData tag / fee wallet / integrator tag) | The matching address-book map (`[venue_owners]` / `[venue_appdata]` / `[venue_fees]` / `[venue_integrators]`); a provider's integrator tag also needs `SolverKnowledge::integrator` | The venue's trades are attributed to the underlying router or settler, not the venue |
 | Add a new decode method | A `TradeDecoder` (a `netting`/`calldata` toolkit function behind it), listed for the entities that use it | Transactions the existing decoders cannot read stay undecoded |
 | Reject decodes that are not real trades (an NFT purchase's payment leg, a mis-paired wrap) | A check in `veto.rs` | Records that are not trades enter the comparison |
 | Support a new chain | A `registry/<chain>.toml` address book (all sections required), plus decoders for its venues and `SolverKnowledge` for its solvers that have none yet | The chain has no built-in book and must be passed via `--registry` |

--- a/tools/hindsight/src/decoder/decode.rs
+++ b/tools/hindsight/src/decoder/decode.rs
@@ -177,6 +177,17 @@ impl TraderFlow {
             gas_scope: GasScope::NotCharged,
         }
     }
+
+    /// Record `fee` as an output-token venue fee and gross it back into `swap.amount_out`, so the
+    /// settled output stays comparable to Fynd's gross re-solve. A no-op when an output fee was
+    /// already accounted, so a second matching fee leg cannot double-count.
+    pub(crate) fn gross_output_fee(&mut self, fee: U256) {
+        if self.venue_fee_out.is_some() {
+            return;
+        }
+        self.venue_fee_out = Some(fee);
+        self.swap.amount_out = self.swap.amount_out.saturating_add(fee);
+    }
 }
 
 #[cfg(test)]

--- a/tools/hindsight/src/decoder/intents/mod.rs
+++ b/tools/hindsight/src/decoder/intents/mod.rs
@@ -21,11 +21,11 @@ pub(crate) fn decoders_for<P: Provider>() -> Vec<Box<dyn TradeDecoder<P>>> {
     vec![Box::new(cow::CowSettlement), Box::new(netting::IntentNetting)]
 }
 
-/// The order-flow tag a batch settlement carries for client attribution: `CoW`'s per-order
+/// The order-flow tag a batch settlement carries for venue attribution: `CoW`'s per-order
 /// `appData` hash, read from the settle calldata. `None` for entries that are not batch settlers
 /// and for multi-order batches. Mirrors `solvers::integrator` — the orchestrator asks for a tag
 /// without knowing which intent protocol produced it.
-pub(crate) fn client_tag(registry: &Registry, entry_point: Address, input: &[u8]) -> Option<B256> {
+pub(crate) fn venue_tag(registry: &Registry, entry_point: Address, input: &[u8]) -> Option<B256> {
     registry
         .is_batch_settler(entry_point)
         .then(|| cow::order_app_data(input))

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -14,7 +14,6 @@
 //! entity), `transfer_ledger` answers all value-flow questions, `veto` rejects shapes that are not
 //! comparable trades, and `registry` is the address book behind matching.
 
-mod clients;
 mod decode;
 mod intents;
 mod matching;
@@ -24,6 +23,7 @@ mod sandwich;
 mod solvers;
 mod trace;
 mod transfer_ledger;
+mod venue_attribution;
 pub(crate) mod venues;
 mod veto;
 
@@ -262,13 +262,13 @@ impl<P: Provider> Decoder<P> {
             return None;
         }
 
-        // A client fingerprint (owning trader, CoW appData tag, fee wallet, or integrator tag — see
-        // `clients`) overrides the entry-point label, backing any client fee out before the quote
-        // check reads the grossed output. The appData tag is read from a batch settler's calldata;
-        // other transactions carry none.
+        // A venue fingerprint (owning trader, CoW appData tag, fee wallet, or integrator tag — see
+        // `venue_attribution`) overrides the entry-point label, backing any venue fee out before
+        // the quote check reads the grossed output. The appData tag is read from a batch settler's
+        // calldata; other transactions carry none.
         let integrator = solvers::integrator(logs);
-        let app_data = intents::client_tag(registry, entry_point, &root.input);
-        let venue = clients::attribute(
+        let app_data = intents::venue_tag(registry, entry_point, &root.input);
+        let venue = venue_attribution::attribute(
             registry,
             &mut flow,
             &transfer_ledger,

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -33,24 +33,24 @@ struct AddressBook {
     solvers: HashMap<Address, String>,
     venues: HashMap<String, VenueAddresses>,
     labels: HashMap<Address, String>,
-    /// Trader addresses that identify an order-flow client (e.g. kpk's Safes on `CoW`). Absent in
-    /// books that have no owner-identified clients.
+    /// Trader addresses that identify an order-flow venue (e.g. kpk's Safes on `CoW`). Absent in
+    /// books that have no owner-identified venues.
     #[serde(default)]
-    client_owners: HashMap<Address, String>,
-    /// Fee-wallet address → client, for clients that route through a shared router and are only
+    venue_owners: HashMap<Address, String>,
+    /// Fee-wallet address → venue, for venues that route through a shared router and are only
     /// identified by the fee transferred to their wallet (Phantom, Robinhood). Absent in books
-    /// with no fee-identified clients.
+    /// with no fee-identified venues.
     #[serde(default)]
-    client_fees: HashMap<Address, String>,
-    /// Provider integrator tag → client, for clients identified by the integrator string in a
+    venue_fees: HashMap<Address, String>,
+    /// Provider integrator tag → venue, for venues identified by the integrator string in a
     /// provider's event (`LiFi` frontends: Infinex, Robinhood). Keys are lowercase. Absent in
-    /// books with no integrator-identified clients.
+    /// books with no integrator-identified venues.
     #[serde(default)]
-    client_integrators: HashMap<String, String>,
-    /// `CoW` order `appData` hash → client, for clients identified by the frontend tag (`appCode`)
-    /// committed into an order (`LlamaSwap`). Absent in books with no appData-identified clients.
+    venue_integrators: HashMap<String, String>,
+    /// `CoW` order `appData` hash → venue, for venues identified by the frontend tag (`appCode`)
+    /// committed into an order (`LlamaSwap`). Absent in books with no appData-identified venues.
     #[serde(default)]
-    client_appdata: HashMap<B256, String>,
+    venue_appdata: HashMap<B256, String>,
 }
 
 /// A venue's address-book section on one chain: the contracts users enter through, the
@@ -114,18 +114,18 @@ pub(crate) struct Registry {
     usd_stablecoins: Vec<(Address, u32)>,
     /// Venue address sets, keyed by the venue name from the address book.
     venues: HashMap<String, VenueAddresses>,
-    /// Trader address → order-flow client name, for clients identified by who owns the order
+    /// Trader address → order-flow venue name, for venues identified by who owns the order
     /// rather than by the entry point (e.g. kpk's Safes settling through `CoW`).
-    client_owners: HashMap<Address, String>,
-    /// Fee-wallet address → client name, for clients identified by the fee they take on a shared
+    venue_owners: HashMap<Address, String>,
+    /// Fee-wallet address → venue name, for venues identified by the fee they take on a shared
     /// router rather than by the entry point (Phantom, Robinhood).
-    client_fees: HashMap<Address, String>,
-    /// Provider integrator tag (lowercase) → client name, for clients identified by the integrator
+    venue_fees: HashMap<Address, String>,
+    /// Provider integrator tag (lowercase) → venue name, for venues identified by the integrator
     /// string a provider records in its event (`LiFi` frontends: Infinex, Robinhood).
-    client_integrators: HashMap<String, String>,
-    /// `CoW` order `appData` hash → client name, for clients identified by the frontend tag
+    venue_integrators: HashMap<String, String>,
+    /// `CoW` order `appData` hash → venue name, for venues identified by the frontend tag
     /// (`appCode`) committed into an order (`LlamaSwap`).
-    client_appdata: HashMap<B256, String>,
+    venue_appdata: HashMap<B256, String>,
 }
 
 impl Registry {
@@ -205,14 +205,14 @@ impl Registry {
             infrastructure: book.infrastructure,
             usd_stablecoins,
             venues: book.venues,
-            client_owners: book.client_owners,
-            client_fees: book.client_fees,
-            client_integrators: book
-                .client_integrators
+            venue_owners: book.venue_owners,
+            venue_fees: book.venue_fees,
+            venue_integrators: book
+                .venue_integrators
                 .into_iter()
-                .map(|(tag, client)| (tag.to_lowercase(), client))
+                .map(|(tag, venue)| (tag.to_lowercase(), venue))
                 .collect(),
-            client_appdata: book.client_appdata,
+            venue_appdata: book.venue_appdata,
         })
     }
 
@@ -268,32 +268,32 @@ impl Registry {
         self.venues.get(name)
     }
 
-    /// The order-flow client that owns trades from this trader address, if any. Used to attribute
-    /// clients identified by who owns the order (e.g. kpk's Safes) rather than by `tx.to`.
-    pub(crate) fn client_for_owner(&self, address: Address) -> Option<&str> {
-        self.client_owners
+    /// The order-flow venue that owns trades from this trader address, if any. Used to attribute
+    /// venues identified by who owns the order (e.g. kpk's Safes) rather than by `tx.to`.
+    pub(crate) fn venue_for_owner(&self, address: Address) -> Option<&str> {
+        self.venue_owners
             .get(&address)
             .map(String::as_str)
     }
 
-    /// Fee-wallet → client map, for attributing clients identified only by their fee leg on a
-    /// shared router (see `crate::decoder::clients`).
-    pub(crate) fn client_fees(&self) -> &HashMap<Address, String> {
-        &self.client_fees
+    /// Fee-wallet → venue map, for attributing venues identified only by their fee leg on a
+    /// shared router (see `crate::decoder::venue_attribution`).
+    pub(crate) fn venue_fees(&self) -> &HashMap<Address, String> {
+        &self.venue_fees
     }
 
-    /// The client for a provider integrator tag (case-insensitive), if one is registered. Used to
+    /// The venue for a provider integrator tag (case-insensitive), if one is registered. Used to
     /// attribute `LiFi` frontends by the integrator string in the swap event.
-    pub(crate) fn client_for_integrator(&self, integrator: &str) -> Option<&str> {
-        self.client_integrators
+    pub(crate) fn venue_for_integrator(&self, integrator: &str) -> Option<&str> {
+        self.venue_integrators
             .get(&integrator.to_lowercase())
             .map(String::as_str)
     }
 
-    /// The client for a `CoW` order `appData` hash, if one is registered. Used to attribute
+    /// The venue for a `CoW` order `appData` hash, if one is registered. Used to attribute
     /// frontends by the `appCode` tag committed into the order (`LlamaSwap`).
-    pub(crate) fn client_for_appdata(&self, app_data: B256) -> Option<&str> {
-        self.client_appdata
+    pub(crate) fn venue_for_appdata(&self, app_data: B256) -> Option<&str> {
+        self.venue_appdata
             .get(&app_data)
             .map(String::as_str)
     }

--- a/tools/hindsight/src/decoder/registry/base.toml
+++ b/tools/hindsight/src/decoder/registry/base.toml
@@ -97,12 +97,12 @@ fee_collectors = []
 
 # LiFi frontends identified by the integrator tag in the LiFi swap event (Infinex's volume is
 # heavier on Base than on mainnet). Keys are lowercase.
-[client_integrators]
+[venue_integrators]
 "infinex" = "infinex"
 
-# Clients identified by the appData hash a CoW order carries (appCode names the frontend). CoW
+# Venues identified by the appData hash a CoW order carries (appCode names the frontend). CoW
 # settles on Base too, and the hash is the same across chains. Keyed by the 32-byte appData hash.
-[client_appdata]
+[venue_appdata]
 # LlamaSwap (DefiLlama): appCode "DefiLlama".
 "0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422" = "llamaswap"
 

--- a/tools/hindsight/src/decoder/registry/ethereum.toml
+++ b/tools/hindsight/src/decoder/registry/ethereum.toml
@@ -154,19 +154,19 @@ fee_collectors = ["0x382ffce2287252f930e1c8dc9328dac5bf282ba1"]
 entry_points = ["0x00000000009726632680fb29d3f7a9734e3010e2"]
 fee_collectors = []
 
-# Order-flow clients identified by the trader address that owns the order, not by tx.to. kpk is a
-# treasury manager whose Safes trade through CoW: tx.from is the CoW solver, so the client is only
+# Order-flow venues identified by the trader address that owns the order, not by tx.to. kpk is a
+# treasury manager whose Safes trade through CoW: tx.from is the CoW solver, so the venue is only
 # visible as the Safe owning the settled order. Addresses from docs.kpk.io / karpatkey.
-[client_owners]
+[venue_owners]
 "0x4f2083f5fbede34c2714affb3105539775f7fe64" = "kpk" # ENS Endowment
 "0x38f6a1b46144faee6a6d9f79d8de264c18e23848" = "kpk" # USD Alpha
 "0x99b9f5f24205cb88e33b1cc72008f644fc23768b" = "kpk" # ETH Alpha
 
-# Clients identified by the fee they take on a shared router (0x): the entry point is 0x's shared
-# AllowanceHolder, so the only fingerprint is the fee transfer to the client's wallet. Recognized
+# Venues identified by the fee they take on a shared router (0x): the entry point is 0x's shared
+# AllowanceHolder, so the only fingerprint is the fee transfer to the venue's wallet. Recognized
 # inside a matched solver trade (never a bare transfer), so the dust-spray gotcha does not apply.
 # The fee is taken from the output (buy) token and backed out so the settled output is gross.
-[client_fees]
+[venue_fees]
 # Phantom: 0.85% buy-token fee. Current wallet confirmed 2026-07-17; earlier wallet retired
 # 2025-07-25 — both kept so either window decodes.
 "0x2cffed5d56eb6a17662756ca0fdf350e732c9818" = "phantom"
@@ -175,17 +175,17 @@ fee_collectors = []
 # never the bundler sender).
 "0xad01c20d5886137e056775af56915de824c8fce5" = "robinhood"
 
-# Clients identified by the integrator tag a provider records in its swap event. LiFi frontends
+# Venues identified by the integrator tag a provider records in its swap event. LiFi frontends
 # route through the shared LiFi Diamond, so the integrator string in LiFiGenericSwapCompleted /
 # LiFiSwappedGeneric is the only fingerprint. Keys are lowercase (matched case-insensitively).
-[client_integrators]
+[venue_integrators]
 "infinex" = "infinex"
 "robinhood" = "robinhood"
 
-# Clients identified by the appData hash a CoW order carries: appCode names the frontend that
+# Venues identified by the appData hash a CoW order carries: appCode names the frontend that
 # built the order. CoW commits this hash into each order; it appears in the settle calldata, not
 # the Trade event. Keyed by the 32-byte appData hash.
-[client_appdata]
+[venue_appdata]
 # LlamaSwap (DefiLlama): appCode "DefiLlama". A low-frequency, fee-free frontend whose other legs
 # (0x, Kyber) tag it only off-chain, so this CoW hash is its one on-chain fingerprint.
 "0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422" = "llamaswap"

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -56,8 +56,8 @@ pub(crate) trait SolverKnowledge: Send + Sync {
 
     /// The order-flow integrator tag this solver records in its logs, when it exposes one. A
     /// solver that fronts other apps (`LiFi`'s Diamond) carries the frontend's integrator string in
-    /// its swap event; client attribution maps that tag to a client (see
-    /// `crate::decoder::clients`).
+    /// its swap event; venue attribution maps that tag to a venue (see
+    /// `crate::decoder::venue_attribution`).
     fn integrator(&self, _logs: &[Log]) -> Option<String> {
         None
     }

--- a/tools/hindsight/src/decoder/venue_attribution.rs
+++ b/tools/hindsight/src/decoder/venue_attribution.rs
@@ -1,23 +1,22 @@
-//! Order-flow client attribution.
+//! Order-flow venue attribution.
 //!
-//! A trade's venue is normally the contract the trader entered through (`tx.to`). Some clients own
+//! A trade's venue is normally the contract the trader entered through (`tx.to`). Some venues own
 //! the order flow without being that contract, and are recognized here from the decoded flow —
-//! overriding the venue label. Every fingerprint is registry-driven; nothing here knows about a
-//! specific client or provider.
+//! overriding the entry-point label. Every fingerprint is registry-driven; nothing here knows
+//! about a specific venue or provider.
 //!
 //! Four fingerprints, tried in order:
-//! - **owning trader** — the swap's net flow was read from a known client address
-//!   (`[client_owners]`).
+//! - **owning trader** — the swap's net flow was read from a known venue address
+//!   (`[venue_owners]`).
 //! - **`CoW` appData tag** — the settled order committed a frontend tag (`appCode`) whose appData
-//!   hash maps to a client (`[client_appdata]`). The hash is extracted by the caller (it is
+//!   hash maps to a venue (`[venue_appdata]`). The hash is extracted by the caller (it is
 //!   `CoW`-specific; see `crate::decoder::intents::cow::order_app_data`), so this module stays
 //!   generic.
-//! - **fee wallet** — a known client fee wallet received the output-token fee (`[client_fees]`);
-//!   the fee is backed out so the settled output stays gross. Checked only inside an
-//!   already-matched solver trade, so a bare dust transfer to a fee wallet is not mistaken for
-//!   flow.
+//! - **fee wallet** — a known venue fee wallet received the output-token fee (`[venue_fees]`); the
+//!   fee is backed out so the settled output stays gross. Checked only inside an already-matched
+//!   solver trade, so a bare dust transfer to a fee wallet is not mistaken for flow.
 //! - **provider integrator tag** — a provider's event carried an integrator string mapped to a
-//!   client (`[client_integrators]`). The tag is extracted by the caller (it is provider-specific;
+//!   venue (`[venue_integrators]`). The tag is extracted by the caller (it is provider-specific;
 //!   see `crate::decoder::solvers::integrator`), so this module stays generic.
 
 use std::collections::HashSet;
@@ -26,8 +25,8 @@ use alloy::primitives::{Address, B256, U256};
 
 use crate::decoder::{decode::TraderFlow, registry::Registry, transfer_ledger::TransferLedger};
 
-/// The order-flow client for a decoded flow, when a fingerprint matches. On a fee-wallet match the
-/// client's fee is backed out of `flow` (added to the gross output) unless a venue decoder already
+/// The order-flow venue for a decoded flow, when a fingerprint matches. On a fee-wallet match the
+/// venue's fee is backed out of `flow` (added to the gross output) unless a venue decoder already
 /// accounted a fee.
 pub(crate) fn attribute(
     registry: &Registry,
@@ -36,39 +35,36 @@ pub(crate) fn attribute(
     integrator: Option<&str>,
     app_data: Option<B256>,
 ) -> Option<String> {
-    if let Some(client) = registry.client_for_owner(flow.tracked) {
-        return Some(client.to_string());
+    if let Some(venue) = registry.venue_for_owner(flow.tracked) {
+        return Some(venue.to_string());
     }
-    if let Some(client) = app_data.and_then(|hash| registry.client_for_appdata(hash)) {
-        return Some(client.to_string());
+    if let Some(venue) = app_data.and_then(|hash| registry.venue_for_appdata(hash)) {
+        return Some(venue.to_string());
     }
-    if let Some((client, fee)) = fee_client(registry, ledger, flow.swap.token_out) {
-        if flow.venue_fee_out.is_none() {
-            flow.venue_fee_out = Some(fee);
-            flow.swap.amount_out = flow.swap.amount_out.saturating_add(fee);
-        }
-        return Some(client);
+    if let Some((venue, fee)) = fee_venue(registry, ledger, flow.swap.token_out) {
+        flow.gross_output_fee(fee);
+        return Some(venue);
     }
     integrator
-        .and_then(|tag| registry.client_for_integrator(tag))
+        .and_then(|tag| registry.venue_for_integrator(tag))
         .map(str::to_string)
 }
 
-/// The client whose fee wallet received the output token in this trade, with the fee amount.
-/// `None` when no client fee wallet took a non-zero cut of the output token.
-fn fee_client(
+/// The venue whose fee wallet received the output token in this trade, with the fee amount.
+/// `None` when no venue fee wallet took a non-zero cut of the output token.
+fn fee_venue(
     registry: &Registry,
     ledger: &TransferLedger,
     token_out: Address,
 ) -> Option<(String, U256)> {
-    for (wallet, client) in registry.client_fees() {
+    for (wallet, venue) in registry.venue_fees() {
         let fee = ledger
             .received_by(&HashSet::from([*wallet]))
             .get(&token_out)
             .copied()
             .filter(|amount| !amount.is_zero());
         if let Some(fee) = fee {
-            return Some((client.clone(), fee));
+            return Some((venue.clone(), fee));
         }
     }
     None
@@ -82,8 +78,8 @@ mod tests {
     use crate::decoder::test_utils::{addr, make_transfer_log, swap};
 
     #[test]
-    fn test_attributes_owner_to_client() {
-        // A CoW-settled kpk trade nets to the Safe that owns the order; the client is that Safe.
+    fn test_attributes_owner_to_venue() {
+        // A CoW-settled kpk trade nets to the Safe that owns the order; the venue is that Safe.
         let registry = Registry::ethereum();
         let kpk_safe = address!("0x4f2083f5fbede34c2714affb3105539775f7fe64");
         let ledger = TransferLedger::from_transaction(&[], &[]);
@@ -92,7 +88,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unknown_owner_is_not_a_client() {
+    fn test_unknown_owner_is_not_a_venue() {
         let registry = Registry::ethereum();
         let ledger = TransferLedger::from_transaction(&[], &[]);
         let mut flow = TraderFlow::without_fees(addr(9), swap(addr(10), 1, addr(11), 2));
@@ -100,7 +96,7 @@ mod tests {
     }
 
     #[test]
-    fn test_appdata_tag_attributes_client() {
+    fn test_appdata_tag_attributes_venue() {
         // A CoW order carrying DefiLlama's appData hash is attributed to LlamaSwap; an unregistered
         // hash is not.
         let registry = Registry::ethereum();
@@ -141,8 +137,8 @@ mod tests {
     }
 
     #[test]
-    fn test_integrator_tag_attributes_client() {
-        // A provider integrator tag maps to its client, case-insensitively; an unknown tag does
+    fn test_integrator_tag_attributes_venue() {
+        // A provider integrator tag maps to its venue, case-insensitively; an unknown tag does
         // not.
         let registry = Registry::ethereum();
         let ledger = TransferLedger::from_transaction(&[], &[]);
@@ -155,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn test_no_fee_transfer_is_not_a_client() {
+    fn test_no_fee_transfer_is_not_a_venue() {
         // Dust to the fee wallet in a token other than the output is not this trade's fee.
         let registry = Registry::ethereum();
         let user = addr(1);

--- a/tools/hindsight/src/decoder/venues/rabby.rs
+++ b/tools/hindsight/src/decoder/venues/rabby.rs
@@ -41,7 +41,7 @@ impl<P: Provider> TradeDecoder<P> for RabbyNetting {
             &addresses.fee_collectors,
         )?;
 
-        if flow.swap.token_out == Address::ZERO && flow.venue_fee_out.is_none() {
+        if flow.swap.token_out == Address::ZERO {
             let wrapped_fee = ctx
                 .transfer_ledger
                 .received_by(&addresses.fee_collectors)
@@ -49,8 +49,7 @@ impl<P: Provider> TradeDecoder<P> for RabbyNetting {
                 .copied()
                 .filter(|fee| !fee.is_zero());
             if let Some(fee) = wrapped_fee {
-                flow.venue_fee_out = Some(fee);
-                flow.swap.amount_out = flow.swap.amount_out.saturating_add(fee);
+                flow.gross_output_fee(fee);
             }
         }
         Some(flow)

--- a/tools/hindsight/src/decoder/venues/rainbow.rs
+++ b/tools/hindsight/src/decoder/venues/rainbow.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashSet;
 
-use alloy::{primitives::U256, providers::Provider};
+use alloy::{primitives::U256, providers::Provider, sol, sol_types::SolCall};
 use async_trait::async_trait;
 
 use crate::decoder::{
@@ -20,8 +20,10 @@ use crate::decoder::{
     netting_decoders::venue_flow,
 };
 
-/// Selector of Rainbow's ETH→token call, whose 4th argument is the input-side fee.
-const FILL_QUOTE_ETH_TO_TOKEN: [u8; 4] = [0x3c, 0x2b, 0x9a, 0x7d];
+sol! {
+    /// Rainbow's ETH→token entry; `feeAmount` is the input-side fee the router keeps.
+    function fillQuoteEthToToken(address buyToken, address to, bytes data, uint256 feeAmount);
+}
 
 /// Rainbow's calldata decoder.
 pub(crate) struct RainbowCalldata;
@@ -46,16 +48,12 @@ impl<P: Provider> TradeDecoder<P> for RainbowCalldata {
     }
 }
 
-/// The input-side fee of a `fillQuoteEthToToken` call — its 4th (static `uint256`) argument — or
-/// `None` for any other selector or a too-short input.
+/// The input-side fee of a `fillQuoteEthToToken` call, or `None` for any other selector or a
+/// malformed input.
 fn eth_to_token_fee(input: &[u8]) -> Option<U256> {
-    let (selector, args) = input.split_at_checked(4)?;
-    if selector != FILL_QUOTE_ETH_TO_TOKEN {
-        return None;
-    }
-    // Args are `buyToken, to, data (offset), feeAmount`; `feeAmount` is the 4th 32-byte word.
-    let word = args.get(3 * 32..4 * 32)?;
-    Some(U256::from_be_slice(word))
+    fillQuoteEthToTokenCall::abi_decode(input)
+        .ok()
+        .map(|call| call.feeAmount)
 }
 
 #[cfg(test)]
@@ -76,14 +74,15 @@ mod tests {
         transfer_ledger::TransferLedger,
     };
 
-    /// `fillQuoteEthToToken` calldata carrying `fee` as its 4th word.
+    /// `fillQuoteEthToToken` calldata carrying `fee` as its `feeAmount` argument.
     fn eth_to_token_calldata(fee: u64) -> Vec<u8> {
-        let mut input = FILL_QUOTE_ETH_TO_TOKEN.to_vec();
-        input.extend_from_slice(&[0u8; 32]); // buyToken
-        input.extend_from_slice(&[0u8; 32]); // to
-        input.extend_from_slice(&[0u8; 32]); // data offset
-        input.extend_from_slice(&U256::from(fee).to_be_bytes::<32>()); // feeAmount
-        input
+        fillQuoteEthToTokenCall {
+            buyToken: Address::ZERO,
+            to: Address::ZERO,
+            data: alloy::primitives::Bytes::default(),
+            feeAmount: U256::from(fee),
+        }
+        .abi_encode()
     }
 
     async fn decode(

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -56,6 +56,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const DECODE_RPC_LAG_RETRIES: usize = 5;
 const DECODE_RPC_LAG_BACKOFF: Duration = Duration::from_millis(1500);
 
+/// Wall-clock budget behind chain head that `default_lag_blocks` converts into a block count.
+const LAG_BUDGET_SECS: u64 = 20 * 60;
+
 /// Inputs for the live monitor — the `monitor` subcommand's CLI arguments, used directly as its
 /// configuration.
 #[derive(clap::Args)]
@@ -319,14 +322,14 @@ async fn build_solver(
 
 /// The default `--max-lag-blocks`: a ~20-minute wall-clock budget for how far behind chain head the
 /// monitor may fall before rebuilding, expressed as a block count at the chain's block time so the
-/// budget stays about the same wall-clock length on every chain. `Chain` carries no block time, so
-/// the per-chain seconds live here; an unlisted chain uses the 12-second-block default.
+/// budget stays about the same wall-clock length on every chain. A custom chain with no registered
+/// block time falls back to 12-second blocks.
 fn default_lag_blocks(chain: Chain) -> u64 {
-    let block_secs = match chain {
-        Chain::Base => 2,
-        _ => 12,
-    };
-    (20 * 60 / block_secs).max(1)
+    let block_secs = chain
+        .try_block_time_secs()
+        .unwrap_or(12)
+        .max(1);
+    (LAG_BUDGET_SECS / block_secs).max(1)
 }
 
 /// Resolves when the process receives Ctrl-C (SIGINT), the signal the monitor treats as "stop".
@@ -645,7 +648,7 @@ mod tests {
     fn test_default_lag_blocks_scales_with_block_time() {
         assert_eq!(default_lag_blocks(Chain::Ethereum), 100); // 12s blocks
         assert_eq!(default_lag_blocks(Chain::Base), 600); // 2s blocks
-        assert_eq!(default_lag_blocks(Chain::Unichain), 100); // unlisted → 12s default
+        assert_eq!(default_lag_blocks(Chain::Unichain), 1200); // 1s blocks
     }
 
     /// End-to-end smoke test of the live two-state monitor against a real solver.

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -317,12 +317,13 @@ async fn build_solver(
         .map_err(|e| anyhow::anyhow!("failed to build solver: {e}"))
 }
 
-/// Default chain-head lag threshold in blocks — about 20 minutes at the chain's block time, so the
-/// wall-clock tolerance stays roughly the same across chains. Used when `--max-lag-blocks` is not
-/// given; an unrecognised chain falls back to the 12-second-block assumption.
-fn default_lag_blocks(chain: &str) -> u64 {
-    let block_secs = match chain.to_lowercase().as_str() {
-        "base" => 2,
+/// The default `--max-lag-blocks`: a ~20-minute wall-clock budget for how far behind chain head the
+/// monitor may fall before rebuilding, expressed as a block count at the chain's block time so the
+/// budget stays about the same wall-clock length on every chain. `Chain` carries no block time, so
+/// the per-chain seconds live here; an unlisted chain uses the 12-second-block default.
+fn default_lag_blocks(chain: Chain) -> u64 {
+    let block_secs = match chain {
+        Chain::Base => 2,
         _ => 12,
     };
     (20 * 60 / block_secs).max(1)
@@ -425,7 +426,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
     let mut totals = Totals::default();
     let max_lag_blocks = cfg
         .max_lag_blocks
-        .unwrap_or_else(|| default_lag_blocks(&cfg.chain.name));
+        .unwrap_or_else(|| default_lag_blocks(chain));
     info!(max_lag_blocks, "chain-head lag threshold");
 
     // Resolves on Ctrl-C, so a long run stops cleanly at any await below — including the
@@ -642,10 +643,9 @@ mod tests {
 
     #[test]
     fn test_default_lag_blocks_scales_with_block_time() {
-        assert_eq!(default_lag_blocks("ethereum"), 100); // 12s blocks
-        assert_eq!(default_lag_blocks("base"), 600); // 2s blocks
-        assert_eq!(default_lag_blocks("BASE"), 600);
-        assert_eq!(default_lag_blocks("unknown"), 100);
+        assert_eq!(default_lag_blocks(Chain::Ethereum), 100); // 12s blocks
+        assert_eq!(default_lag_blocks(Chain::Base), 600); // 2s blocks
+        assert_eq!(default_lag_blocks(Chain::Unichain), 100); // unlisted → 12s default
     }
 
     /// End-to-end smoke test of the live two-state monitor against a real solver.

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -28,6 +28,14 @@ const FEED_REBUILDS: &str = "hindsight_feed_rebuilds_total";
 /// from the gas-token-anchored valuation).
 const USD_OUTLIER_THRESHOLD: f64 = 1_000.0;
 
+/// Settled USD notional below which a trade is excluded from the win-rate (`TRADES_TOTAL`) and bps
+/// (`SAVINGS_BPS`) metrics. On a dust trade a few wei of rounding is tens to thousands of bps, so
+/// dust dominates those unweighted quantiles and win counts while contributing nothing real. The
+/// USD-weighted histograms (`VOLUME_USD`/`SAVINGS_USD`/`IMPROVEMENT_USD`) keep every trade — a $5
+/// win adds $5 — so total savings and volume stay complete. A trade whose notional cannot be
+/// priced is kept: we do not drop what we cannot measure.
+const MIN_NOTIONAL_USD: f64 = 100.0;
+
 /// Whether a USD savings value is large enough to log for inspection.
 fn is_usd_outlier(usd: f64) -> bool {
     usd.abs() >= USD_OUTLIER_THRESHOLD
@@ -80,15 +88,18 @@ pub(crate) fn outcome_label(verdict: Verdict) -> &'static str {
 pub(crate) fn describe() {
     describe_counter!(
         TRADES_TOTAL,
-        "Re-solved trades, labeled by venue / solver / chain / outcome / state (top|back). \
-         Per-pair detail lives in the JSONL comparison output; a token-pair label here is unbounded \
-         on mainnet and would explode Prometheus series cardinality over a long run."
+        "Re-solved trades above the dust floor, labeled by venue / solver / chain / outcome / \
+         state (top|back). Sub-$100-notional trades are excluded so the win-rate reflects trades \
+         that matter; total volume stays complete in VOLUME_USD. Per-pair detail lives in the \
+         JSONL comparison output; a token-pair label here is unbounded on mainnet and would \
+         explode Prometheus series cardinality over a long run."
     );
     describe_histogram!(
         SAVINGS_BPS,
         Unit::Count,
         "Gross bps delta of Fynd vs settled (positive = Fynd better), labeled by venue / solver / \
-         chain / outcome / state (top|back)"
+         chain / outcome / state (top|back). Sub-$100-notional trades are excluded — a few wei of \
+         rounding is thousands of bps on dust and would swamp the quantiles."
     );
     describe_histogram!(
         SAVINGS_USD,
@@ -155,8 +166,13 @@ pub(crate) fn record_range(
         .record(volume);
     }
 
-    let savings_top = record_state(range, &range.top, "top", &labels, prices_top);
-    record_state(range, &range.back, "back", &labels, prices_back);
+    // Dust guard: sub-`MIN_NOTIONAL_USD` trades distort the unweighted win-rate and bps quantiles,
+    // so they are kept out of `TRADES_TOTAL` and `SAVINGS_BPS`. An unpriced trade has no known
+    // notional and is kept. The notional is a per-trade quantity, so both states share this gate.
+    let above_floor = volume.is_none_or(|usd| usd >= MIN_NOTIONAL_USD);
+
+    let savings_top = record_state(range, &range.top, "top", &labels, prices_top, above_floor);
+    record_state(range, &range.back, "back", &labels, prices_back, above_floor);
 
     // One structured line per priced comparison, on the headline basis (top-of-block, gross).
     // Loki ingests pod stdout, so this line feeds the dashboard's top-trades table; keep the
@@ -204,20 +220,23 @@ fn record_state(
     state_label: &'static str,
     labels: &MetricLabels<'_>,
     prices: &Prices,
+    above_floor: bool,
 ) -> Option<f64> {
-    counter!(
-        TRADES_TOTAL,
-        "venue" => labels.venue.to_string(),
-        "solver" => labels.solver.to_string(),
-        "chain" => labels.chain.to_string(),
-        "outcome" => outcome_label(state.verdict).to_string(),
-        "state" => state_label,
-    )
-    .increment(1);
+    if above_floor {
+        counter!(
+            TRADES_TOTAL,
+            "venue" => labels.venue.to_string(),
+            "solver" => labels.solver.to_string(),
+            "chain" => labels.chain.to_string(),
+            "outcome" => outcome_label(state.verdict).to_string(),
+            "state" => state_label,
+        )
+        .increment(1);
+    }
 
     let sandwiched = state.verdict == Verdict::Sandwiched;
 
-    if !sandwiched {
+    if above_floor && !sandwiched {
         if let Some(bps) = state.deltas.raw_bps {
             histogram!(
                 SAVINGS_BPS,
@@ -645,5 +664,64 @@ mod tests {
         assert!(!rendered.contains("hindsight_savings_bps"), "rendered: {rendered}");
         assert!(!rendered.contains("hindsight_savings_usd"), "rendered: {rendered}");
         assert!(!rendered.contains("hindsight_improvement_usd"), "rendered: {rendered}");
+    }
+
+    #[test]
+    fn test_below_notional_floor_excluded_from_quality_metrics() {
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        // A $1 trade (1e6 native units at the anchor below) that Fynd would win by ~50 bps: dust,
+        // whose bps and win count would swamp the unweighted metrics if it were recorded.
+        let range = build_range(
+            &trade(usdc, 1_000_000),
+            &empty_prices(),
+            solved(1_005_000, 1_005_000),
+            solved(1_005_000, 1_005_000),
+        );
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
+
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(&range, "ethereum", &prices, &prices, &Registry::ethereum());
+        });
+        let rendered = handle.render();
+
+        // Kept out of the unweighted win-rate and bps quantiles...
+        assert!(!rendered.contains("hindsight_trades_total"), "rendered: {rendered}");
+        assert!(!rendered.contains("hindsight_savings_bps"), "rendered: {rendered}");
+        // ...but its USD contribution is still counted in the weighted histograms.
+        assert!(rendered.contains("hindsight_volume_usd"), "rendered: {rendered}");
+        assert!(rendered.contains("hindsight_savings_usd"), "rendered: {rendered}");
+    }
+
+    #[test]
+    fn test_unpriced_trade_passes_the_floor() {
+        // No prices → the notional is unknown, so the trade is kept rather than silently dropped;
+        // its count and (solved) bps still land in the metrics.
+        let range = build_range(
+            &trade(Address::repeat_byte(0x42), 1_000),
+            &empty_prices(),
+            solved(1_100, 1_050),
+            solved(1_100, 1_050),
+        );
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(
+                &range,
+                "ethereum",
+                &empty_prices(),
+                &empty_prices(),
+                &Registry::ethereum(),
+            );
+        });
+        let rendered = handle.render();
+        assert!(rendered.contains("hindsight_trades_total"), "rendered: {rendered}");
+        assert!(rendered.contains("hindsight_savings_bps"), "rendered: {rendered}");
     }
 }


### PR DESCRIPTION
Two things: a min-notional floor on the Grafana metrics, and the review comments left on #324.

## Metrics floor

Sub-$100-notional trades were swamping the unweighted win-rate and bps quantiles — a few wei of rounding on a dust trade is tens to thousands of bps, so the win median and win-rate reflected noise, not real trades. A `MIN_NOTIONAL_USD = 100.0` floor now gates `hindsight_trades_total` and `hindsight_savings_bps`. The USD-weighted histograms (`volume_usd`/`savings_usd`/`improvement_usd`) still count every trade, so total savings and volume stay complete. A trade whose notional cannot be priced is kept — we do not drop what we cannot measure.

Applies uniformly to ethereum and base; no config, no helm change.

## PR #324 review comments

- **rainbow.rs** — decode the fee with a `sol!` function definition + `abi_decode` instead of a hand-rolled selector constant and word slicing.
- **rabby.rs / venue attribution** — fold the duplicated "record an output-token fee and gross it back into `amount_out`" into `TraderFlow::gross_output_fee`, so the double-count guard lives in one place.
- **monitor.rs** — `default_lag_blocks` now takes the `Chain` enum instead of a chain-name string, and reads the block time from `Chain::try_block_time_secs` instead of a local per-chain table; the doc comment states the threshold is a ~20-minute wall-clock budget expressed as a block count. Chains other than ethereum and base now get their real block time, so their default threshold changes (unichain: 100 → 1200 blocks).
- **clients → venue** — order-flow front-ends are the "venue" tier in the decoder's terminology, not a separate "client" concept. Renamed the module (`clients.rs` → `venue_attribution.rs`), its registry maps/methods/address-book sections (`client_*` → `venue_*`), and `intents::client_tag` → `venue_tag`.
