### PR TITLE
fix(hindsight): cut Base block lag and keep partially-traced blocks

### DIFF
--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -40,7 +40,7 @@ use alloy::{
     rpc::types::trace::geth::CallFrame,
 };
 use anyhow::Context;
-use futures::stream::{StreamExt, TryStreamExt};
+use futures::stream::StreamExt;
 use tracing::{debug, warn};
 
 use crate::decoder::{
@@ -188,21 +188,38 @@ impl<P: Provider> Decoder<P> {
         // collected in block order for deterministic output. Wall-clock cost is
         // one receipts call plus the slowest trace wave — not the sum of every
         // request — so a block stays well inside its block time.
+        //
+        // Failures are collected per transaction rather than aborting the wave: one transaction the
+        // RPC cannot trace costs that trade, not the whole block. Failing the block instead drops
+        // its every trade from the aggregates, and the surviving sample is selected by which
+        // transactions the RPC happened to serve.
         let traces = futures::stream::iter(
             matched
                 .iter()
                 .map(|(_, m)| fetch_trace(&self.provider, m.receipt.transaction_hash)),
         )
         .buffered(TRACE_CONCURRENCY)
-        .try_collect::<Vec<_>>()
-        .await?;
+        .collect::<Vec<_>>()
+        .await;
 
         let mut trades = Vec::with_capacity(matched.len());
-        for ((index, matched), root) in matched.into_iter().zip(traces) {
+        for ((index, matched), trace) in matched.into_iter().zip(traces) {
             let tx_index = matched
                 .receipt
                 .transaction_index
                 .unwrap_or(index as u64);
+            let root = match trace {
+                Ok(root) => root,
+                Err(e) => {
+                    warn!(
+                        block = block_number,
+                        tx = %matched.receipt.transaction_hash,
+                        "skipping untraceable transaction: {e}"
+                    );
+                    crate::telemetry::record_untraced_transaction();
+                    continue;
+                }
+            };
             if let Some(mut trade) = self
                 .decode_transaction(matched, &root, block_number, tx_index)
                 .await
@@ -321,5 +338,58 @@ impl<P: Provider> Decoder<P> {
             // transaction); the caller (`decode_block`) fills this in once decoding succeeds.
             sandwich: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::{
+        primitives::{address, U256},
+        providers::{mock::Asserter, ProviderBuilder},
+    };
+
+    use super::*;
+    use crate::decoder::test_utils::{addr, frame, make_transfer_log, receipt, tx_hash};
+
+    /// 1inch v6 — a `[solvers]` entry in the ethereum address book, so a transaction into it
+    /// matches on its entry point alone.
+    const ONEINCH: Address = address!("0x111111125421ca6dc452d289314280a0f8842a65");
+
+    /// A sender-netting swap through `ONEINCH`: `sender` pays one token and is paid another.
+    fn swap_receipt(hash: TxHash, sender: Address) -> AnyTransactionReceipt {
+        let pool = addr(0x50);
+        receipt(
+            hash,
+            sender,
+            Some(ONEINCH),
+            vec![
+                make_transfer_log(addr(0xaa), sender, pool, U256::from(1_000)),
+                make_transfer_log(addr(0xbb), pool, sender, U256::from(2_000)),
+            ],
+        )
+    }
+
+    #[tokio::test]
+    async fn test_untraceable_transaction_does_not_drop_the_block() {
+        let asserter = Asserter::new();
+        asserter.push_success(&vec![
+            swap_receipt(tx_hash(1), addr(1)),
+            swap_receipt(tx_hash(2), addr(2)),
+        ]);
+        asserter.push_failure_msg("debug_traceTransaction unavailable");
+        asserter.push_success(&frame("CALL", addr(2), ONEINCH, 0));
+
+        let mut decoder = Decoder::new(
+            ProviderBuilder::default().connect_mocked_client(asserter),
+            Registry::ethereum(),
+        );
+        let trades = decoder
+            .decode_block(21_000_000)
+            .await
+            .expect("an untraceable transaction must not fail the block");
+
+        // Only the untraceable transaction is lost; before, it took the whole block with it.
+        assert_eq!(trades.len(), 1);
+        assert_eq!(trades[0].tx_hash, tx_hash(2));
     }
 }

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -286,6 +286,7 @@ async fn decode_block_when_available<P: Provider>(
         }
         tokio::time::sleep(DECODE_RPC_LAG_POLL).await;
     }
+    telemetry::record_rpc_index_wait(started.elapsed());
     decoder.decode_block(block).await
 }
 
@@ -566,6 +567,7 @@ async fn run_session<P: Provider>(
             .get_block_number()
             .await
         {
+            telemetry::record_head_lag_blocks(head.saturating_sub(target));
             if head.saturating_sub(target) > pacing.max_lag_blocks {
                 return SessionEnd::Unhealthy(format!(
                     "monitor is {} blocks behind head {head}; presuming an unhealthy session",

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -26,7 +26,7 @@ use fynd_core::{
     BlockStepController, FyndBuilder, Solver,
 };
 use num_bigint::BigUint;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use tycho_simulation::tycho_common::models::{Address as CoreAddress, Chain};
 
 use crate::{
@@ -50,11 +50,12 @@ const FEED_DEAD_TIMEOUT: Duration = Duration::from_mins(15);
 const REBUILD_BACKOFF: Duration = Duration::from_secs(30);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
-/// The HTTP RPC used to decode receipts can trail the Tycho stream by a few seconds, so `target`
-/// (which tracks the stream's tip) may not be indexed yet on the first look. Wait for the RPC head
-/// to reach it, retrying a bounded number of times before treating it as a genuine failure.
-const DECODE_RPC_LAG_RETRIES: usize = 5;
-const DECODE_RPC_LAG_BACKOFF: Duration = Duration::from_millis(1500);
+/// How far the receipts RPC may trail the Tycho stream before the monitor decodes the target block
+/// anyway. In blocks, not seconds, because an RPC node trails by blocks.
+const DECODE_RPC_LAG_BUDGET_BLOCKS: u32 = 3;
+/// How often to re-check the RPC head while waiting out that lag. Well under a block time: the
+/// monitor only idles until the block lands, and `eth_blockNumber` is cheap.
+const DECODE_RPC_LAG_POLL: Duration = Duration::from_millis(250);
 
 /// Wall-clock budget behind chain head that `default_lag_blocks` converts into a block count.
 const LAG_BUDGET_SECS: u64 = 20 * 60;
@@ -244,14 +245,17 @@ fn biguint_to_u256(value: &BigUint) -> U256 {
 }
 
 /// Decode `block`, first waiting out any RPC lag. The HTTP RPC used for receipts can trail the
-/// Tycho stream that drives `block`, so poll the RPC head until it reaches `block` (bounded retries
-/// with backoff) — that distinguishes a transient race from a real failure. A block still
-/// undecodable once the RPC has indexed it is a genuine error and surfaces to the caller.
+/// Tycho stream that drives `block`, so poll the RPC head until it reaches `block` or `budget`
+/// expires — that distinguishes a transient race from a real failure. A block still undecodable
+/// once the RPC has indexed it is a genuine error and surfaces to the caller.
 async fn decode_block_when_available<P: Provider>(
     decoder: &mut Decoder<P>,
     block: u64,
+    budget: Duration,
 ) -> anyhow::Result<Vec<DecodedTrade>> {
-    for attempt in 0..DECODE_RPC_LAG_RETRIES {
+    let started = Instant::now();
+    let mut logged_wait = false;
+    loop {
         let head = match decoder
             .provider()
             .get_block_number()
@@ -259,15 +263,28 @@ async fn decode_block_when_available<P: Provider>(
         {
             Ok(h) => h,
             Err(e) => {
-                warn!(block, attempt, "failed to fetch RPC block number: {e}");
+                warn!(block, "failed to fetch RPC block number: {e}");
                 0
             }
         };
         if head >= block {
             break;
         }
-        warn!(block, head, attempt, "RPC lags the tycho stream; waiting for it to index the block");
-        tokio::time::sleep(DECODE_RPC_LAG_BACKOFF).await;
+        // Once per block, not once per poll: at this cadence a per-poll line would bury the log.
+        if !logged_wait {
+            logged_wait = true;
+            debug!(block, head, "RPC lags the tycho stream; waiting for it to index the block");
+        }
+        if started.elapsed() >= budget {
+            warn!(
+                block,
+                head,
+                waited_ms = started.elapsed().as_millis(),
+                "RPC never indexed the block within its lag budget; decoding anyway"
+            );
+            break;
+        }
+        tokio::time::sleep(DECODE_RPC_LAG_POLL).await;
     }
     decoder.decode_block(block).await
 }
@@ -320,16 +337,38 @@ async fn build_solver(
         .map_err(|e| anyhow::anyhow!("failed to build solver: {e}"))
 }
 
-/// The default `--max-lag-blocks`: a ~20-minute wall-clock budget for how far behind chain head the
-/// monitor may fall before rebuilding, expressed as a block count at the chain's block time so the
-/// budget stays about the same wall-clock length on every chain. A custom chain with no registered
-/// block time falls back to 12-second blocks.
-fn default_lag_blocks(chain: Chain) -> u64 {
-    let block_secs = chain
+/// The chain's block time, which every pacing budget in the monitor is expressed against. A custom
+/// chain with no registered block time falls back to 12-second blocks.
+fn block_time(chain: Chain) -> Duration {
+    let secs = chain
         .try_block_time_secs()
         .unwrap_or(12)
         .max(1);
-    (LAG_BUDGET_SECS / block_secs).max(1)
+    Duration::from_secs(secs)
+}
+
+/// The default `--max-lag-blocks`: a ~20-minute wall-clock budget for how far behind chain head the
+/// monitor may fall before rebuilding, expressed as a block count at the chain's block time so the
+/// budget stays about the same wall-clock length on every chain.
+fn default_lag_blocks(chain: Chain) -> u64 {
+    (LAG_BUDGET_SECS / block_time(chain).as_secs()).max(1)
+}
+
+/// The pacing budgets one session runs against, both scaled to the chain's block time.
+struct Pacing {
+    /// Chain-head lag beyond which the session is unhealthy and the solver is rebuilt.
+    max_lag_blocks: u64,
+    /// How long to wait for the receipts RPC to index the target block before decoding regardless.
+    rpc_lag_budget: Duration,
+}
+
+impl Pacing {
+    fn for_chain(chain: Chain, max_lag_blocks: Option<u64>) -> Self {
+        Self {
+            max_lag_blocks: max_lag_blocks.unwrap_or_else(|| default_lag_blocks(chain)),
+            rpc_lag_budget: block_time(chain) * DECODE_RPC_LAG_BUDGET_BLOCKS,
+        }
+    }
 }
 
 /// Resolves when the process receives Ctrl-C (SIGINT), the signal the monitor treats as "stop".
@@ -427,10 +466,12 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
     };
 
     let mut totals = Totals::default();
-    let max_lag_blocks = cfg
-        .max_lag_blocks
-        .unwrap_or_else(|| default_lag_blocks(chain));
-    info!(max_lag_blocks, "chain-head lag threshold");
+    let pacing = Pacing::for_chain(chain, cfg.max_lag_blocks);
+    info!(
+        max_lag_blocks = pacing.max_lag_blocks,
+        rpc_lag_budget_ms = pacing.rpc_lag_budget.as_millis(),
+        "chain pacing budgets"
+    );
 
     // Resolves on Ctrl-C, so a long run stops cleanly at any await below — including the
     // multi-minute solver builds. On shutdown the in-flight block is abandoned, the solver's
@@ -456,7 +497,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
             }
             end = run_session(
                 &cfg,
-                max_lag_blocks,
+                &pacing,
                 &adapter,
                 &mut decoder,
                 &mut comparisons,
@@ -486,7 +527,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
 /// completes or the feed dies.
 async fn run_session<P: Provider>(
     cfg: &MonitorArgs,
-    max_lag_blocks: u64,
+    pacing: &Pacing,
     adapter: &StepAdapter<'_>,
     decoder: &mut Decoder<P>,
     comparisons: &mut Option<super::jsonl::RotatingWriter>,
@@ -525,7 +566,7 @@ async fn run_session<P: Provider>(
             .get_block_number()
             .await
         {
-            if head.saturating_sub(target) > max_lag_blocks {
+            if head.saturating_sub(target) > pacing.max_lag_blocks {
                 return SessionEnd::Unhealthy(format!(
                     "monitor is {} blocks behind head {head}; presuming an unhealthy session",
                     head - target
@@ -533,7 +574,8 @@ async fn run_session<P: Provider>(
             }
         }
 
-        let trades = match decode_block_when_available(decoder, target).await {
+        let trades = match decode_block_when_available(decoder, target, pacing.rpc_lag_budget).await
+        {
             Ok(trades) => trades,
             Err(e) => {
                 totals.skipped_blocks += 1;
@@ -649,6 +691,63 @@ mod tests {
         assert_eq!(default_lag_blocks(Chain::Ethereum), 100); // 12s blocks
         assert_eq!(default_lag_blocks(Chain::Base), 600); // 2s blocks
         assert_eq!(default_lag_blocks(Chain::Unichain), 1200); // 1s blocks
+    }
+
+    #[test]
+    fn test_pacing_scales_both_budgets_with_block_time() {
+        // The RPC-lag budget is a block count, so it must shrink on a fast chain: a fixed
+        // seconds budget spends several Base blocks waiting for a block that already landed.
+        let base = Pacing::for_chain(Chain::Base, None);
+        assert_eq!(base.max_lag_blocks, 600);
+        assert_eq!(base.rpc_lag_budget, Duration::from_secs(6));
+
+        let ethereum = Pacing::for_chain(Chain::Ethereum, None);
+        assert_eq!(ethereum.max_lag_blocks, 100);
+        assert_eq!(ethereum.rpc_lag_budget, Duration::from_secs(36));
+
+        // An explicit --max-lag-blocks overrides only the lag threshold.
+        let overridden = Pacing::for_chain(Chain::Base, Some(7));
+        assert_eq!(overridden.max_lag_blocks, 7);
+        assert_eq!(overridden.rpc_lag_budget, Duration::from_secs(6));
+    }
+
+    /// A mocked provider whose `eth_blockNumber` answers come from `heads`, in order.
+    fn decoder_with_heads(heads: &[u64]) -> Decoder<impl Provider> {
+        use alloy::providers::{mock::Asserter, ProviderBuilder};
+
+        let asserter = Asserter::new();
+        for head in heads {
+            asserter.push_success(&format!("0x{head:x}"));
+        }
+        Decoder::new(
+            ProviderBuilder::default().connect_mocked_client(asserter),
+            Registry::ethereum(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_decode_waits_only_while_the_rpc_lags() {
+        // Head already covers the target: no wait, straight to decoding (which then fails on the
+        // receipts call the mock has no answer for — proof it got that far).
+        let mut ready = decoder_with_heads(&[100]);
+        let started = Instant::now();
+        assert!(decode_block_when_available(&mut ready, 100, Duration::from_secs(6))
+            .await
+            .is_err());
+        assert!(started.elapsed() < DECODE_RPC_LAG_POLL, "waited despite an indexed block");
+    }
+
+    #[tokio::test]
+    async fn test_decode_gives_up_after_the_lag_budget() {
+        // Head never reaches the target. A zero budget proves the wait is bounded by the budget
+        // alone — the old fixed backoff slept before ever re-checking, so it could not express
+        // "don't wait".
+        let mut lagging = decoder_with_heads(&[99]);
+        let started = Instant::now();
+        assert!(decode_block_when_available(&mut lagging, 100, Duration::ZERO)
+            .await
+            .is_err());
+        assert!(started.elapsed() < DECODE_RPC_LAG_POLL, "slept despite a spent budget");
     }
 
     /// End-to-end smoke test of the live two-state monitor against a real solver.

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -22,6 +22,7 @@ const VOLUME_USD: &str = "hindsight_volume_usd";
 const BLOCK_SECONDS: &str = "hindsight_block_processing_seconds";
 const SKIPPED_BLOCKS: &str = "hindsight_skipped_blocks_total";
 const FEED_REBUILDS: &str = "hindsight_feed_rebuilds_total";
+const UNTRACED_TRANSACTIONS: &str = "hindsight_untraced_transactions_total";
 
 /// Absolute USD savings beyond which a comparison is logged with full per-trade context, so large
 /// outliers can be traced and classified (a genuinely large trade vs a token-mispricing artifact
@@ -127,6 +128,12 @@ pub(crate) fn describe() {
         FEED_REBUILDS,
         "Times the monitor declared its session unhealthy (feed died, or the monitor fell too \
          far behind chain head) and rebuilt the solver to resubscribe"
+    );
+    describe_counter!(
+        UNTRACED_TRANSACTIONS,
+        "Matched solver transactions dropped because the RPC could not trace them. Their block \
+         still contributes its other trades, so this counts trades missing from the aggregates \
+         rather than blocks"
     );
 }
 
@@ -303,6 +310,10 @@ pub(crate) fn record_block_seconds(seconds: f64) {
 
 pub(crate) fn record_skipped_block() {
     counter!(SKIPPED_BLOCKS).increment(1);
+}
+
+pub(crate) fn record_untraced_transaction() {
+    counter!(UNTRACED_TRANSACTIONS).increment(1);
 }
 
 pub(crate) fn record_feed_rebuild() {

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -3,6 +3,8 @@
 //! Mirrors the exporter pattern used by the `fynd` binary: install a global Prometheus recorder
 //! and serve its rendered output on a dedicated port via Actix.
 
+use std::time::Duration;
+
 use actix_web::{web, App, HttpResponse, HttpServer, Responder};
 use metrics::{counter, describe_counter, describe_histogram, histogram, Unit};
 use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
@@ -20,6 +22,8 @@ const SAVINGS_USD: &str = "hindsight_savings_usd";
 const IMPROVEMENT_USD: &str = "hindsight_improvement_usd";
 const VOLUME_USD: &str = "hindsight_volume_usd";
 const BLOCK_SECONDS: &str = "hindsight_block_processing_seconds";
+const HEAD_LAG_BLOCKS: &str = "hindsight_chain_head_lag_blocks";
+const RPC_INDEX_WAIT: &str = "hindsight_rpc_index_wait_seconds";
 const SKIPPED_BLOCKS: &str = "hindsight_skipped_blocks_total";
 const FEED_REBUILDS: &str = "hindsight_feed_rebuilds_total";
 const UNTRACED_TRANSACTIONS: &str = "hindsight_untraced_transactions_total";
@@ -118,11 +122,32 @@ pub(crate) fn describe() {
          verdict). Valued from the output leg, falling back to the input leg when the output \
          token is unpriced"
     );
-    describe_histogram!(BLOCK_SECONDS, Unit::Seconds, "Wall-clock time to process one block");
+    describe_histogram!(
+        BLOCK_SECONDS,
+        Unit::Seconds,
+        "Wall-clock time to re-solve one block, measured from the decoded trades. Excludes fetching \
+         and decoding the block itself, so it does not measure how far behind chain head the \
+         monitor is — HEAD_LAG_BLOCKS does"
+    );
+    describe_histogram!(
+        HEAD_LAG_BLOCKS,
+        Unit::Count,
+        "How far the block being re-solved trails chain head, in blocks. The monitor is one block \
+         behind by construction (it solves block N against state N-1); beyond that this is the \
+         cost of fetching and decoding the block. Sampled once per block from the head check that \
+         guards --max-lag-blocks"
+    );
+    describe_histogram!(
+        RPC_INDEX_WAIT,
+        Unit::Seconds,
+        "Time spent waiting for the receipts RPC to index the target block before decoding it, \
+         including the head check itself. The receipts RPC trails the tycho stream that picks the \
+         target, so this is a floor on the lag that no amount of solving speed removes"
+    );
     describe_counter!(
         SKIPPED_BLOCKS,
         "Blocks skipped because the RPC could not provide receipts (e.g. it lagged the tycho \
-         stream past the retry budget, or the block genuinely failed to decode)"
+         stream past its lag budget, or the block genuinely failed to decode)"
     );
     describe_counter!(
         FEED_REBUILDS,
@@ -308,6 +333,17 @@ pub(crate) fn record_block_seconds(seconds: f64) {
     histogram!(BLOCK_SECONDS).record(seconds);
 }
 
+pub(crate) fn record_head_lag_blocks(blocks: u64) {
+    // Via u32 to keep the conversion lossless. The clamp cannot bind in practice: a lag past
+    // `--max-lag-blocks` (hundreds) ends the session long before it could approach u32.
+    let blocks = u32::try_from(blocks).unwrap_or(u32::MAX);
+    histogram!(HEAD_LAG_BLOCKS).record(f64::from(blocks));
+}
+
+pub(crate) fn record_rpc_index_wait(wait: Duration) {
+    histogram!(RPC_INDEX_WAIT).record(wait.as_secs_f64());
+}
+
 pub(crate) fn record_skipped_block() {
     counter!(SKIPPED_BLOCKS).increment(1);
 }
@@ -339,6 +375,12 @@ const SAVINGS_BPS_BUCKETS: &[f64] =
 const SAVINGS_USD_BUCKETS: &[f64] = &[-3000.0, -300.0, -30.0, -3.0, 0.0, 3.0, 30.0, 300.0, 3000.0];
 const VOLUME_USD_BUCKETS: &[f64] = &[10.0, 100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0];
 const BLOCK_SECONDS_BUCKETS: &[f64] = &[0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 16.0];
+/// One block is the floor (the monitor solves block N against state N-1), so the low edges are
+/// spaced tightly enough to tell "at the floor" from "a block or two of fetch cost".
+const HEAD_LAG_BLOCKS_BUCKETS: &[f64] = &[1.0, 2.0, 3.0, 5.0, 10.0, 30.0, 100.0, 600.0];
+/// Sub-block edges: on a 2-second chain the interesting question is what fraction of a block time
+/// goes on waiting for the RPC.
+const RPC_INDEX_WAIT_BUCKETS: &[f64] = &[0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0];
 
 /// Install the global Prometheus recorder and serve `/metrics` on `port`.
 ///
@@ -387,7 +429,9 @@ fn configure_buckets(
         .set_buckets_for_metric(Matcher::Full(SAVINGS_USD.into()), SAVINGS_USD_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(IMPROVEMENT_USD.into()), SAVINGS_USD_BUCKETS)?
         .set_buckets_for_metric(Matcher::Full(VOLUME_USD.into()), VOLUME_USD_BUCKETS)?
-        .set_buckets_for_metric(Matcher::Full(BLOCK_SECONDS.into()), BLOCK_SECONDS_BUCKETS)
+        .set_buckets_for_metric(Matcher::Full(BLOCK_SECONDS.into()), BLOCK_SECONDS_BUCKETS)?
+        .set_buckets_for_metric(Matcher::Full(HEAD_LAG_BLOCKS.into()), HEAD_LAG_BLOCKS_BUCKETS)?
+        .set_buckets_for_metric(Matcher::Full(RPC_INDEX_WAIT.into()), RPC_INDEX_WAIT_BUCKETS)
 }
 
 #[cfg(test)]
@@ -452,6 +496,27 @@ mod tests {
         assert!(!is_usd_outlier(-(USD_OUTLIER_THRESHOLD - 1.0)));
         assert!(is_usd_outlier(USD_OUTLIER_THRESHOLD));
         assert!(is_usd_outlier(-(USD_OUTLIER_THRESHOLD * 100.0)));
+    }
+
+    #[test]
+    fn test_lag_metrics_render_as_histograms() {
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_head_lag_blocks(3);
+            record_rpc_index_wait(Duration::from_millis(1_500));
+        });
+        let rendered = handle.render();
+
+        // True histograms (le-labeled _bucket series), not summaries: the lag panels read them
+        // with histogram_quantile(..., *_bucket), which cannot see summary quantiles.
+        assert!(rendered.contains("hindsight_chain_head_lag_blocks_bucket"), "{rendered}");
+        assert!(rendered.contains("hindsight_rpc_index_wait_seconds_bucket"), "{rendered}");
+        // A 1.5s wait falls above the 1s edge and within the 2s one.
+        assert!(rendered.contains("hindsight_rpc_index_wait_seconds_bucket{le=\"1\"} 0"));
+        assert!(rendered.contains("hindsight_rpc_index_wait_seconds_bucket{le=\"2\"} 1"));
     }
 
     #[test]


### PR DESCRIPTION
The staging Base monitor runs 4-6s behind chain head. Not solve cost — block
processing is 0.49s p95 and the pod uses 323m CPU with no limit. The lag is in
fetch-and-decode, which the existing metric starts after.

- The receipts-RPC wait backed off in fixed 1500ms steps, sized for Ethereum's
  12s blocks; on Base it fired on 71% of blocks. It now polls every 250ms against
  a budget in blocks, shared with `--max-lag-blocks` via one `block_time` helper.

- A single transaction the RPC could not trace failed its entire block, skipping
  every trade in it — 254 blocks on staging, ~5% of the run, which biases the
  win-rate and savings aggregates. Now only that transaction is dropped, counted
  by `hindsight_untraced_transactions_total`.

  To be clear about what did **not** change: Blocks are still dropped when the 
  monitor is behind — `--max-lag-blocks` still ends the session and rebuilds, and a
  block whose receipts never arrive still fails into `hindsight_skipped_blocks_total`. 
  The surviving trades in a partly-traced block are unaffected by the missing one:
  they have their own receipts and traces, sandwich detection reads the receipts
  slice rather than traces, and the solver is stepped so block N is still solved
  against state N-1.

- Adds `hindsight_chain_head_lag_blocks` and `hindsight_rpc_index_wait_seconds`,
  bucketed so they render as histograms.

The Ethereum lag budget grows from 7.5s to 36s: waiting beats skipping, since a
skipped block is a permanent hole in the aggregates. Set
`DECODE_RPC_LAG_BUDGET_BLOCKS` to 1 to keep Ethereum near its old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)