### PR TITLE
feat(hindsight): attribute each route to its algorithm and protocols

### DIFF
--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -115,6 +115,23 @@ savings aggregates; unsolved states keep their coverage verdicts).
   like-for-like. Carries `sandwich` evidence when a bracket pair was found.
 - `RangeComparison` — a trade re-solved at both block states, including gas-netted settled output.
 - `Outcome` — `Solved`, `Partial`, or `Unsolvable`.
+- `RouteSummary` — which algorithm won a solved state and which protocols its route traded
+  through. Carried on `SolvedAmount` as typed fields (not dug out of the serialized quote) so the
+  metrics and the per-trade log line read it directly.
+
+### Route attribution
+
+A solved state records the algorithm whose route won the quote — the worker pool that beat the
+others on that order — and the route's protocol mix. It surfaces three ways:
+
+- **Prometheus**: an `algorithm` label on `hindsight_trades_total`, `hindsight_savings_bps`,
+  `hindsight_savings_usd`, and `hindsight_improvement_usd`. Split any of them by venue to see
+  which algorithm serves that venue's flow best. Unsolved states carry `algorithm="none"`.
+  Protocols are deliberately *not* a label: a route's protocol set is combinatorial and would
+  blow up series cardinality.
+- **Loki**: `algorithm`, `protocols` (comma-joined), and `swaps` on the `trade comparison` line,
+  for the dashboard's top-routes table.
+- **JSONL**: flat `algorithm` / `protocols` / `swaps` per state, next to the nested per-hop route.
 
 ## Adding a venue / solver / decoder / chain
 

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -115,23 +115,44 @@ savings aggregates; unsolved states keep their coverage verdicts).
   like-for-like. Carries `sandwich` evidence when a bracket pair was found.
 - `RangeComparison` — a trade re-solved at both block states, including gas-netted settled output.
 - `Outcome` — `Solved`, `Partial`, or `Unsolvable`.
-- `RouteSummary` — which algorithm won a solved state and which protocols its route traded
-  through. Carried on `SolvedAmount` as typed fields (not dug out of the serialized quote) so the
-  metrics and the per-trade log line read it directly.
+- `RouteSummary` — which algorithm won a solved state and the path its route took. Carried on
+  `SolvedAmount` as typed fields (not dug out of the serialized quote) so the metrics and the
+  per-trade log line read it directly.
 
 ### Route attribution
 
 A solved state records the algorithm whose route won the quote — the worker pool that beat the
-others on that order — and the route's protocol mix. It surfaces three ways:
+others on that order — and that route rendered as a readable path:
+
+```
+USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH
+```
+
+Protocol ids are Tycho's own, so a newly integrated DEX reads correctly with no lookup table here.
+A token the solver has no entry for falls back to a shortened address (`0xababab…`).
+
+A **split** fans several legs out of one token, so its legs cannot share a single arrow chain. Each
+becomes its own path, joined by ` + `, and every leg carries its share of the input. `Route`'s split
+convention declares an explicit fraction on each leg but the last, which declares `0.0` meaning
+"all the remaining balance"; `split_shares` reconstructs that remainder so both legs read as a
+percentage. A split that reconverges still chains its continuation onto the leg it belongs to:
+
+```
+USDC -[uniswap_v3 60%]-> WETH + USDC -[vm:curve 40%]-> WETH
+USDT -[uniswap_v3 25%]-> WETH + USDT -[vm:curve 75%]-> DAI -[uniswap_v2]-> USDC
+```
+
+It surfaces three ways:
 
 - **Prometheus**: an `algorithm` label on `hindsight_trades_total`, `hindsight_savings_bps`,
   `hindsight_savings_usd`, and `hindsight_improvement_usd`. Split any of them by venue to see
-  which algorithm serves that venue's flow best. Unsolved states carry `algorithm="none"`.
-  Protocols are deliberately *not* a label: a route's protocol set is combinatorial and would
-  blow up series cardinality.
-- **Loki**: `algorithm`, `protocols` (comma-joined), and `swaps` on the `trade comparison` line,
-  for the dashboard's top-routes table.
-- **JSONL**: flat `algorithm` / `protocols` / `swaps` per state, next to the nested per-hop route.
+  which algorithm serves that venue's flow best. Unsolved states carry `algorithm="none"`. The
+  path is deliberately *not* a label — it is per-trade and would explode series cardinality.
+- **Loki**: `algorithm` and `route` on the `trade comparison` line. `route` is the **last** field
+  on purpose: its value contains spaces, so a LogQL regexp can only bound it by end-of-line. Move
+  it and the dashboard's route column silently swallows every field after it.
+- **JSONL**: flat `algorithm` and `route` per state, next to the nested per-hop route (which keeps
+  the pools and amounts the string leaves out).
 
 ## Adding a venue / solver / decoder / chain
 

--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -243,6 +243,10 @@ top-of-block: `Win`, `Loss`, `CoverageMiss` (Fynd filled under half the settled 
 aggregates). Watchdogs rebuild the solver when the tycho feed dies or the monitor falls too
 far behind chain head (`--max-lag-blocks`).
 
+Each solved state also records which algorithm won the quote and which protocols its route traded
+through. Run `monitor` with a `--worker-pools-config` that defines a pool per algorithm to turn
+that into a comparison: with one pool configured, every trade is attributed to the same algorithm.
+
 ### The address book (`src/decoder/registry/<chain>.toml`)
 
 All chain- and protocol-specific data — solver routers, venue entry points and fee collectors,

--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -243,9 +243,11 @@ top-of-block: `Win`, `Loss`, `CoverageMiss` (Fynd filled under half the settled 
 aggregates). Watchdogs rebuild the solver when the tycho feed dies or the monitor falls too
 far behind chain head (`--max-lag-blocks`).
 
-Each solved state also records which algorithm won the quote and which protocols its route traded
-through. Run `monitor` with a `--worker-pools-config` that defines a pool per algorithm to turn
-that into a comparison: with one pool configured, every trade is attributed to the same algorithm.
+Each solved state also records which algorithm won the quote and the route it took, rendered as
+`USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH` (a split fans into ` + `-joined legs, each with its
+share). Run `monitor` with a `--worker-pools-config` that defines a pool per algorithm to turn the
+algorithm field into a comparison: with one pool configured, every trade is attributed to the same
+algorithm.
 
 ### The address book (`src/decoder/registry/<chain>.toml`)
 

--- a/tools/hindsight/src/report/record.rs
+++ b/tools/hindsight/src/report/record.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use crate::{
         decoder::{AttributionSource, DecodedTrade, Registry},
-        resolve::{build_range, jsonl::write_comparisons, Outcome, SolvedAmount},
+        resolve::{build_range, jsonl::write_comparisons, Outcome, RouteSummary, SolvedAmount},
         usd::Prices,
     };
 
@@ -101,6 +101,7 @@ mod tests {
             amount_out: U256::from(1_010_000_000u64),
             amount_out_net_gas: U256::from(1_010_000_000u64),
             gas_estimate: U256::from(21_000u64),
+            route: RouteSummary::default(),
             quote_json: None,
         });
         let range = build_range(&trade, &prices, top, Outcome::Unsolvable("x".into()));

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -116,13 +116,14 @@ pub(crate) fn verdict(outcome: &Outcome, deltas: &Deltas) -> Verdict {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::resolve::SolvedAmount;
+    use crate::resolve::{RouteSummary, SolvedAmount};
 
     fn solved(amount_out: u64, net: u64) -> Outcome {
         Outcome::Solved(SolvedAmount {
             amount_out: U256::from(amount_out),
             amount_out_net_gas: U256::from(net),
             gas_estimate: U256::from(21_000),
+            route: RouteSummary::default(),
             quote_json: None,
         })
     }

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -172,7 +172,7 @@ fn comparison_record(
 
 /// JSON for one block-state of an improvement: verdict, bps, Fynd amounts, the USD improvement
 /// (gross Fynd output minus the gross settled output, valued at `prices` — the same basis as the
-/// headline verdict), the winning route's algorithm and protocols, and the slim quote.
+/// headline verdict), the winning route's algorithm and rendered path, and the slim quote.
 /// `settled_value_usd` stays gross — it is the trade's notional, not a comparison.
 fn state_record(
     state: &StateResult,
@@ -200,11 +200,10 @@ fn state_record(
         "fynd_amount_out": solved.map(|s| s.amount_out.to_string()),
         "fynd_amount_out_net_gas": solved.map(|s| s.amount_out_net_gas.to_string()),
         "gas_estimate": solved.map(|s| s.gas_estimate.to_string()),
-        // Flat route attribution, so a jq pass can group by algorithm or protocol without walking
-        // the nested per-hop route below.
+        // Flat route attribution, so a jq pass can group by algorithm or read the path at a glance
+        // without walking the nested per-hop route below.
         "algorithm": solved.map(|s| s.route.algorithm.as_str()),
-        "protocols": solved.map(|s| s.route.protocols.as_slice()),
-        "swaps": solved.map(|s| s.route.swaps),
+        "route": solved.map(|s| s.route.path.as_str()),
         "improvement_usd": improvement_usd,
         "fynd_value_usd": fynd_value_usd,
         "settled_value_usd": prices.value_usd(token_out, range.settled_amount_out),
@@ -420,8 +419,7 @@ mod tests {
         );
         let route = RouteSummary {
             algorithm: "bellman_ford".to_string(),
-            protocols: vec!["uniswap_v3".to_string(), "vm:curve".to_string()],
-            swaps: 3,
+            path: "WETH -[uniswap_v3]-> DAI -[vm:curve]-> USDC".to_string(),
         };
         // Top: gross 1010 USDC → +$10. Back: gross 1002 USDC → +$2. Both win.
         let top = Outcome::Solved(SolvedAmount {
@@ -480,10 +478,9 @@ mod tests {
         // have to walk the nested per-hop route.
         assert_eq!(rec.pointer("/top/algorithm").unwrap(), "bellman_ford");
         assert_eq!(
-            rec.pointer("/top/protocols").unwrap(),
-            &serde_json::json!(["uniswap_v3", "vm:curve"])
+            rec.pointer("/top/route").unwrap(),
+            "WETH -[uniswap_v3]-> DAI -[vm:curve]-> USDC"
         );
-        assert_eq!(rec.pointer("/top/swaps").unwrap(), 3);
     }
 
     #[test]
@@ -525,9 +522,9 @@ mod tests {
             .pointer("/top/quote")
             .unwrap()
             .is_null());
-        // No route means nothing to attribute: the fields are null, not an empty algorithm or a
-        // zero swap count that would read as a real one-hop route.
-        for field in ["algorithm", "protocols", "swaps"] {
+        // No route means nothing to attribute: the fields are null, not an empty algorithm or an
+        // empty path string that would read as a real but unrendered route.
+        for field in ["algorithm", "route"] {
             assert!(
                 rec.pointer(&format!("/top/{field}"))
                     .unwrap()

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -172,8 +172,8 @@ fn comparison_record(
 
 /// JSON for one block-state of an improvement: verdict, bps, Fynd amounts, the USD improvement
 /// (gross Fynd output minus the gross settled output, valued at `prices` — the same basis as the
-/// headline verdict), and the slim quote. `settled_value_usd` stays gross — it is the trade's
-/// notional, not a comparison.
+/// headline verdict), the winning route's algorithm and protocols, and the slim quote.
+/// `settled_value_usd` stays gross — it is the trade's notional, not a comparison.
 fn state_record(
     state: &StateResult,
     range: &RangeComparison,
@@ -200,6 +200,11 @@ fn state_record(
         "fynd_amount_out": solved.map(|s| s.amount_out.to_string()),
         "fynd_amount_out_net_gas": solved.map(|s| s.amount_out_net_gas.to_string()),
         "gas_estimate": solved.map(|s| s.gas_estimate.to_string()),
+        // Flat route attribution, so a jq pass can group by algorithm or protocol without walking
+        // the nested per-hop route below.
+        "algorithm": solved.map(|s| s.route.algorithm.as_str()),
+        "protocols": solved.map(|s| s.route.protocols.as_slice()),
+        "swaps": solved.map(|s| s.route.swaps),
         "improvement_usd": improvement_usd,
         "fynd_value_usd": fynd_value_usd,
         "settled_value_usd": prices.value_usd(token_out, range.settled_amount_out),
@@ -264,7 +269,7 @@ mod tests {
     use super::*;
     use crate::{
         decoder::{AttributionSource, DecodedTrade, Registry, SandwichEvidence, SolverQuote},
-        resolve::{build_range, SolvedAmount},
+        resolve::{build_range, RouteSummary, SolvedAmount},
     };
 
     fn empty_prices() -> Prices {
@@ -413,17 +418,24 @@ mod tests {
                 "gas_estimate":"0","split":1.0}]}"#
                 .to_string(),
         );
+        let route = RouteSummary {
+            algorithm: "bellman_ford".to_string(),
+            protocols: vec!["uniswap_v3".to_string(), "vm:curve".to_string()],
+            swaps: 3,
+        };
         // Top: gross 1010 USDC → +$10. Back: gross 1002 USDC → +$2. Both win.
         let top = Outcome::Solved(SolvedAmount {
             amount_out: U256::from(1_010_000_000u64),
             amount_out_net_gas: U256::from(1_005_000_000u64),
             gas_estimate: U256::from(21_000u64),
+            route: route.clone(),
             quote_json: quote.clone(),
         });
         let back = Outcome::Solved(SolvedAmount {
             amount_out: U256::from(1_002_000_000u64),
             amount_out_net_gas: U256::from(1_001_000_000u64),
             gas_estimate: U256::from(21_000u64),
+            route,
             quote_json: quote,
         });
         let range = build_range(&trade, &prices, top, back);
@@ -464,6 +476,14 @@ mod tests {
                 .unwrap(),
             "uniswap_v3"
         );
+        // Route attribution is flat on the state, so grouping by algorithm or protocol does not
+        // have to walk the nested per-hop route.
+        assert_eq!(rec.pointer("/top/algorithm").unwrap(), "bellman_ford");
+        assert_eq!(
+            rec.pointer("/top/protocols").unwrap(),
+            &serde_json::json!(["uniswap_v3", "vm:curve"])
+        );
+        assert_eq!(rec.pointer("/top/swaps").unwrap(), 3);
     }
 
     #[test]
@@ -505,6 +525,16 @@ mod tests {
             .pointer("/top/quote")
             .unwrap()
             .is_null());
+        // No route means nothing to attribute: the fields are null, not an empty algorithm or a
+        // zero swap count that would read as a real one-hop route.
+        for field in ["algorithm", "protocols", "swaps"] {
+            assert!(
+                rec.pointer(&format!("/top/{field}"))
+                    .unwrap()
+                    .is_null(),
+                "{field} should be null on an unsolvable state"
+            );
+        }
     }
 
     #[test]
@@ -541,6 +571,7 @@ mod tests {
                 amount_out: U256::from(amount),
                 amount_out_net_gas: U256::from(amount),
                 gas_estimate: U256::from(21_000u64),
+                route: RouteSummary::default(),
                 quote_json: None,
             })
         };

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -20,6 +20,24 @@ use crate::{
     usd::Prices,
 };
 
+/// What Fynd's winning route was made of: the worker-pool algorithm that produced it and the
+/// protocols its swaps traded through. Kept as typed fields (not dug back out of `quote_json`) so
+/// the metrics and the per-trade log line can read them without parsing JSON.
+///
+/// `Default` means "no route detail" — every field empty.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct RouteSummary {
+    /// Name of the algorithm whose route won the quote: `bellman_ford`, `most_liquid`,
+    /// `path_frank_wolfe`, `water_fill`. Empty when the quote declared none.
+    pub algorithm: String,
+    /// Protocols across the route's swaps, deduplicated and in first-swap order (`uniswap_v3`,
+    /// `vm:balancer`, …).
+    pub protocols: Vec<String>,
+    /// Number of swaps on the route. A split route counts each leg, so this is the route's width
+    /// plus depth, not its hop count.
+    pub swaps: usize,
+}
+
 /// A Fynd quote for the re-solved order.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub(crate) struct SolvedAmount {
@@ -27,6 +45,8 @@ pub(crate) struct SolvedAmount {
     /// Output after Fynd's own estimated gas cost.
     pub amount_out_net_gas: U256,
     pub gas_estimate: U256,
+    /// Which algorithm won and which protocols the route traded through.
+    pub route: RouteSummary,
     /// The complete serialized Fynd quote (route, per-hop pools/amounts, encoded transaction) for
     /// dumping improvements. `None` when not captured (e.g. the HTTP resolve path).
     #[serde(default)]
@@ -232,6 +252,7 @@ mod tests {
             amount_out: U256::from(amount_out),
             amount_out_net_gas: U256::from(net),
             gas_estimate: U256::from(21_000),
+            route: RouteSummary::default(),
             quote_json: None,
         })
     }

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -20,22 +20,21 @@ use crate::{
     usd::Prices,
 };
 
-/// What Fynd's winning route was made of: the worker-pool algorithm that produced it and the
-/// protocols its swaps traded through. Kept as typed fields (not dug back out of `quote_json`) so
-/// the metrics and the per-trade log line can read them without parsing JSON.
+/// What Fynd's winning route was: the worker-pool algorithm that produced it and the path it took.
+/// Kept as typed fields (not dug back out of `quote_json`) so the metrics and the per-trade log
+/// line can read them without parsing JSON.
 ///
-/// `Default` means "no route detail" — every field empty.
+/// `Default` means "no route detail" — both fields empty.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub(crate) struct RouteSummary {
     /// Name of the algorithm whose route won the quote: `bellman_ford`, `most_liquid`,
     /// `path_frank_wolfe`, `water_fill`. Empty when the quote declared none.
     pub algorithm: String,
-    /// Protocols across the route's swaps, deduplicated and in first-swap order (`uniswap_v3`,
-    /// `vm:balancer`, …).
-    pub protocols: Vec<String>,
-    /// Number of swaps on the route. A split route counts each leg, so this is the route's width
-    /// plus depth, not its hop count.
-    pub swaps: usize,
+    /// The route as a readable path, tokens and protocols interleaved:
+    /// `USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH`. Split legs carry their share and are
+    /// joined with ` + `. Empty when the quote carried no route. Logged and serialized under the
+    /// name `route`.
+    pub path: String,
 }
 
 /// A Fynd quote for the re-solved order.
@@ -45,7 +44,7 @@ pub(crate) struct SolvedAmount {
     /// Output after Fynd's own estimated gas cost.
     pub amount_out_net_gas: U256,
     pub gas_estimate: U256,
-    /// Which algorithm won and which protocols the route traded through.
+    /// Which algorithm won and the path its route took.
     pub route: RouteSummary,
     /// The complete serialized Fynd quote (route, per-hop pools/amounts, encoded transaction) for
     /// dumping improvements. `None` when not captured (e.g. the HTTP resolve path).

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -21,7 +21,7 @@ use async_trait::async_trait;
 use fynd_core::{
     types::{
         parse_chain, EncodingOptions, Order, OrderQuote, OrderSide, QuoteOptions, QuoteRequest,
-        QuoteStatus,
+        QuoteStatus, Route, Swap,
     },
     BlockStepController, FyndBuilder, Solver,
 };
@@ -32,7 +32,7 @@ use tycho_simulation::tycho_common::models::{Address as CoreAddress, Chain};
 use crate::{
     decoder::{DecodedTrade, Decoder, Registry},
     provider_from,
-    resolve::{resolve_block_range, Outcome, SolvedAmount, SteppingSolver},
+    resolve::{resolve_block_range, Outcome, RouteSummary, SolvedAmount, SteppingSolver},
     telemetry,
     usd::Prices,
 };
@@ -227,8 +227,40 @@ fn order_quote_to_outcome(quote: &OrderQuote) -> Outcome {
         amount_out: biguint_to_u256(quote.amount_out()),
         amount_out_net_gas: biguint_to_u256(quote.amount_out_net_gas()),
         gas_estimate: biguint_to_u256(quote.gas_estimate()),
+        route: route_summary(quote),
         quote_json,
     })
+}
+
+/// Which algorithm won the quote and which protocols its route traded through. The winning quote is
+/// the one the `WorkerPoolRouter` ranked first across every configured pool, so its algorithm is
+/// the pool that beat the others on this order.
+fn route_summary(quote: &OrderQuote) -> RouteSummary {
+    let swaps = quote
+        .route()
+        .map(Route::swaps)
+        .unwrap_or_default();
+    RouteSummary {
+        algorithm: quote.algorithm().to_string(),
+        protocols: distinct_protocols(swaps.iter().map(Swap::protocol)),
+        swaps: swaps.len(),
+    }
+}
+
+/// Protocols across a route's swaps, deduplicated and kept in first-swap order. A split or
+/// multi-hop route hits the same protocol on several legs, and what the dashboard shows is the
+/// route's protocol mix, not one entry per leg.
+fn distinct_protocols<'a>(protocols: impl Iterator<Item = &'a str>) -> Vec<String> {
+    let mut distinct: Vec<String> = Vec::new();
+    for protocol in protocols {
+        if !distinct
+            .iter()
+            .any(|seen| seen == protocol)
+        {
+            distinct.push(protocol.to_string());
+        }
+    }
+    distinct
 }
 
 fn biguint_to_u256(value: &BigUint) -> U256 {
@@ -687,6 +719,21 @@ fn core_to_alloy(address: &CoreAddress) -> Option<Address> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_distinct_protocols() {
+        // A split route hits the same protocol on several legs; the dashboard wants the mix.
+        assert_eq!(
+            distinct_protocols(["uniswap_v3", "vm:curve", "uniswap_v3"].into_iter()),
+            vec!["uniswap_v3".to_string(), "vm:curve".to_string()]
+        );
+        // First-swap order, so the list reads along the route rather than alphabetically.
+        assert_eq!(
+            distinct_protocols(["vm:curve", "uniswap_v3"].into_iter()),
+            vec!["vm:curve".to_string(), "uniswap_v3".to_string()]
+        );
+        assert!(distinct_protocols(std::iter::empty()).is_empty());
+    }
 
     #[test]
     fn test_default_lag_blocks_scales_with_block_time() {

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -8,6 +8,7 @@
 //! integration test in `tests/` (requires `TYCHO_URL` + `RPC_URL`).
 
 use std::{
+    collections::HashMap,
     future::Future,
     pin::Pin,
     time::{Duration, Instant},
@@ -135,6 +136,25 @@ impl StepAdapter<'_> {
             .last_updated()
             .map(fynd_core::BlockInfo::number)
     }
+
+    /// Symbols for every token on `quote`'s route, read under one market-data lock. A `Swap`
+    /// carries only addresses, so without this the rendered route would be a chain of hex.
+    async fn route_symbols(&self, quote: &OrderQuote) -> HashMap<CoreAddress, String> {
+        let mut symbols = HashMap::new();
+        let Some(route) = quote.route() else {
+            return symbols;
+        };
+        let market_data = self.solver.market_data();
+        let market = market_data.read().await;
+        for swap in Route::swaps(route) {
+            for token in [swap.token_in(), swap.token_out()] {
+                if let Some(found) = market.get_token(token) {
+                    symbols.insert(token.clone(), found.symbol.clone());
+                }
+            }
+        }
+        symbols
+    }
 }
 
 #[async_trait]
@@ -161,13 +181,15 @@ impl SteppingSolver for StepAdapter<'_> {
                 .with_encoding_options(EncodingOptions::new(0.005)),
         );
 
-        match self.solver.quote(request).await {
-            Ok(quote) => quote.orders().first().map_or_else(
-                || Outcome::Unsolvable("solver returned no order quote".to_string()),
-                order_quote_to_outcome,
-            ),
-            Err(e) => Outcome::Unsolvable(format!("solve error: {e}")),
-        }
+        let quote = match self.solver.quote(request).await {
+            Ok(quote) => quote,
+            Err(e) => return Outcome::Unsolvable(format!("solve error: {e}")),
+        };
+        let Some(order) = quote.orders().first() else {
+            return Outcome::Unsolvable("solver returned no order quote".to_string());
+        };
+        let symbols = self.route_symbols(order).await;
+        order_quote_to_outcome(order, &symbols)
     }
 
     async fn advance(&self) -> anyhow::Result<()> {
@@ -214,7 +236,7 @@ impl SteppingSolver for StepAdapter<'_> {
     }
 }
 
-fn order_quote_to_outcome(quote: &OrderQuote) -> Outcome {
+fn order_quote_to_outcome(quote: &OrderQuote, symbols: &HashMap<CoreAddress, String>) -> Outcome {
     if quote.status() != QuoteStatus::Success {
         return Outcome::Unsolvable(format!("{:?}", quote.status()));
     }
@@ -227,40 +249,125 @@ fn order_quote_to_outcome(quote: &OrderQuote) -> Outcome {
         amount_out: biguint_to_u256(quote.amount_out()),
         amount_out_net_gas: biguint_to_u256(quote.amount_out_net_gas()),
         gas_estimate: biguint_to_u256(quote.gas_estimate()),
-        route: route_summary(quote),
+        route: route_summary(quote, symbols),
         quote_json,
     })
 }
 
-/// Which algorithm won the quote and which protocols its route traded through. The winning quote is
-/// the one the `WorkerPoolRouter` ranked first across every configured pool, so its algorithm is
-/// the pool that beat the others on this order.
-fn route_summary(quote: &OrderQuote) -> RouteSummary {
-    let swaps = quote
+/// Which algorithm won the quote and the path its route took. The winning quote is the one the
+/// `WorkerPoolRouter` ranked first across every configured pool, so its algorithm is the pool that
+/// beat the others on this order.
+fn route_summary(quote: &OrderQuote, symbols: &HashMap<CoreAddress, String>) -> RouteSummary {
+    let legs: Vec<Leg<'_>> = quote
         .route()
-        .map(Route::swaps)
+        .map(|route| {
+            Route::swaps(route)
+                .iter()
+                .map(Leg::from_swap)
+                .collect()
+        })
         .unwrap_or_default();
-    RouteSummary {
-        algorithm: quote.algorithm().to_string(),
-        protocols: distinct_protocols(swaps.iter().map(Swap::protocol)),
-        swaps: swaps.len(),
+    RouteSummary { algorithm: quote.algorithm().to_string(), path: render_route(&legs, symbols) }
+}
+
+/// One route leg, reduced to what rendering needs. A `Swap` also carries a `ProtocolComponent` and
+/// a boxed `ProtocolSim` that a route string has no use for and that cannot be built outside
+/// `fynd-core`, so the rendering below works on this instead and stays unit-testable.
+struct Leg<'a> {
+    token_in: &'a CoreAddress,
+    token_out: &'a CoreAddress,
+    protocol: &'a str,
+    /// The leg's declared share of `token_in`. `0.0` means "all the remaining balance".
+    split: f64,
+}
+
+impl<'a> Leg<'a> {
+    fn from_swap(swap: &'a Swap) -> Self {
+        Self {
+            token_in: swap.token_in(),
+            token_out: swap.token_out(),
+            protocol: swap.protocol(),
+            split: *swap.split(),
+        }
     }
 }
 
-/// Protocols across a route's swaps, deduplicated and kept in first-swap order. A split or
-/// multi-hop route hits the same protocol on several legs, and what the dashboard shows is the
-/// route's protocol mix, not one entry per leg.
-fn distinct_protocols<'a>(protocols: impl Iterator<Item = &'a str>) -> Vec<String> {
-    let mut distinct: Vec<String> = Vec::new();
-    for protocol in protocols {
-        if !distinct
-            .iter()
-            .any(|seen| seen == protocol)
-        {
-            distinct.push(protocol.to_string());
+/// Render a route as a readable path: `USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH`.
+///
+/// Swaps that connect — one's output token is the next's input — chain into a single arrow path.
+/// A split fans several legs out of the same token, so its legs cannot share one chain: each
+/// becomes its own path carrying its share of the input, and the paths are joined with ` + `.
+/// Protocol ids are Tycho's own, so a newly integrated DEX reads correctly without a lookup table
+/// here.
+fn render_route(legs: &[Leg<'_>], symbols: &HashMap<CoreAddress, String>) -> String {
+    let mut paths: Vec<String> = Vec::new();
+    let mut open = String::new();
+    let mut tip: Option<&CoreAddress> = None;
+    for (leg, share) in legs.iter().zip(split_shares(legs)) {
+        if tip != Some(leg.token_in) {
+            if !open.is_empty() {
+                paths.push(std::mem::take(&mut open));
+            }
+            open = token_label(leg.token_in, symbols);
         }
+        open.push_str(&arrow(leg.protocol, share));
+        open.push_str(&token_label(leg.token_out, symbols));
+        tip = Some(leg.token_out);
     }
-    distinct
+    if !open.is_empty() {
+        paths.push(open);
+    }
+    paths.join(" + ")
+}
+
+/// The arrow between two tokens: ` -[uniswap_v2]-> `, or ` -[vm:curve 40%]-> ` for one leg of a
+/// split, where the share tells you how much of the input took this leg.
+fn arrow(protocol: &str, share: Option<f64>) -> String {
+    match share {
+        Some(share) => format!(" -[{protocol} {:.0}%]-> ", share * 100.0),
+        None => format!(" -[{protocol}]-> "),
+    }
+}
+
+/// Each leg's share of its input token, or `None` when it is the only leg consuming that token.
+///
+/// A split's legs all consume the same token, and by `Route`'s split convention every leg but one
+/// declares an explicit fraction while the last declares `0.0`, meaning "all the remaining
+/// balance". Reconstruct that remainder so every leg of a split reads as a percentage.
+fn split_shares(legs: &[Leg<'_>]) -> Vec<Option<f64>> {
+    let mut consumers: HashMap<&CoreAddress, (usize, f64)> = HashMap::new();
+    for leg in legs {
+        let entry = consumers
+            .entry(leg.token_in)
+            .or_insert((0, 0.0));
+        entry.0 += 1;
+        entry.1 += leg.split;
+    }
+    legs.iter()
+        .map(|leg| {
+            let (count, declared) = consumers
+                .get(leg.token_in)
+                .copied()
+                .unwrap_or((1, 0.0));
+            if count < 2 {
+                return None;
+            }
+            Some(if leg.split == 0.0 { 1.0 - declared } else { leg.split })
+        })
+        .collect()
+}
+
+/// A token's symbol, or a shortened address when the solver has no token entry for it — an
+/// unknown token still has to read as a distinct hop rather than vanish from the path.
+fn token_label(token: &CoreAddress, symbols: &HashMap<CoreAddress, String>) -> String {
+    if let Some(symbol) = symbols.get(token) {
+        return symbol.clone();
+    }
+    let hex = token.to_string();
+    match hex.get(..8) {
+        Some(prefix) => format!("{prefix}…"),
+        None => hex,
+    }
 }
 
 fn biguint_to_u256(value: &BigUint) -> U256 {
@@ -720,19 +827,93 @@ fn core_to_alloy(address: &CoreAddress) -> Option<Address> {
 mod tests {
     use super::*;
 
+    /// A token address keyed by its symbol's last byte — distinct across the symbols used below,
+    /// where the first byte is not (USDT and USDC share it) — so `symbols()` can name it back.
+    fn token(symbol: &str) -> CoreAddress {
+        let tag = symbol
+            .as_bytes()
+            .last()
+            .copied()
+            .unwrap_or(0);
+        CoreAddress::from(vec![tag; 20])
+    }
+
+    /// The solver's token table for the symbols used below.
+    fn symbols() -> HashMap<CoreAddress, String> {
+        ["USDT", "DAI", "WETH", "USDC"]
+            .into_iter()
+            .map(|symbol| (token(symbol), symbol.to_string()))
+            .collect()
+    }
+
+    /// One route leg. `split` follows `Route`'s convention: an explicit fraction, or 0.0 for the
+    /// leg that takes whatever is left.
+    fn leg<'a>(
+        token_in: &'a CoreAddress,
+        token_out: &'a CoreAddress,
+        protocol: &'a str,
+        split: f64,
+    ) -> Leg<'a> {
+        Leg { token_in, token_out, protocol, split }
+    }
+
     #[test]
-    fn test_distinct_protocols() {
-        // A split route hits the same protocol on several legs; the dashboard wants the mix.
-        assert_eq!(
-            distinct_protocols(["uniswap_v3", "vm:curve", "uniswap_v3"].into_iter()),
-            vec!["uniswap_v3".to_string(), "vm:curve".to_string()]
+    fn test_render_route_multi_hop() {
+        // Connecting legs chain into one arrow path; no percentages, since nothing is split.
+        let (usdt, dai, weth) = (token("USDT"), token("DAI"), token("WETH"));
+        let route = render_route(
+            &[leg(&usdt, &dai, "uniswap_v2", 0.0), leg(&dai, &weth, "vm:balancer", 0.0)],
+            &symbols(),
         );
-        // First-swap order, so the list reads along the route rather than alphabetically.
-        assert_eq!(
-            distinct_protocols(["vm:curve", "uniswap_v3"].into_iter()),
-            vec!["vm:curve".to_string(), "uniswap_v3".to_string()]
+        assert_eq!(route, "USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH");
+    }
+
+    #[test]
+    fn test_render_route_split() {
+        // Two legs out of USDC: the 0.6 leg is explicit, the 0.0 leg takes the remainder. They fan
+        // out of the same token so they cannot share one chain — each becomes its own path, joined
+        // by " + ", and both carry their share.
+        let (usdc, weth) = (token("USDC"), token("WETH"));
+        let route = render_route(
+            &[leg(&usdc, &weth, "uniswap_v3", 0.6), leg(&usdc, &weth, "vm:curve", 0.0)],
+            &symbols(),
         );
-        assert!(distinct_protocols(std::iter::empty()).is_empty());
+        assert_eq!(route, "USDC -[uniswap_v3 60%]-> WETH + USDC -[vm:curve 40%]-> WETH");
+    }
+
+    #[test]
+    fn test_render_route_split_then_common_hop() {
+        // A split that reconverges: both legs land on WETH, then one leg carries on to USDC. The
+        // continuation chains onto the path that ended at WETH rather than starting a third path.
+        let (usdt, dai, weth, usdc) = (token("USDT"), token("DAI"), token("WETH"), token("USDC"));
+        let route = render_route(
+            &[
+                leg(&usdt, &weth, "uniswap_v3", 0.25),
+                leg(&usdt, &dai, "vm:curve", 0.0),
+                leg(&dai, &usdc, "uniswap_v2", 0.0),
+            ],
+            &symbols(),
+        );
+        assert_eq!(
+            route,
+            "USDT -[uniswap_v3 25%]-> WETH + USDT -[vm:curve 75%]-> DAI -[uniswap_v2]-> USDC"
+        );
+    }
+
+    #[test]
+    fn test_render_route_unknown_token() {
+        // A long-tail token with no entry in the solver's token table still has to read as a
+        // distinct hop, so it falls back to a shortened address rather than an empty string.
+        let (usdt, unknown) = (token("USDT"), CoreAddress::from(vec![0xab; 20]));
+        assert_eq!(
+            render_route(&[leg(&usdt, &unknown, "uniswap_v2", 0.0)], &symbols()),
+            "USDT -[uniswap_v2]-> 0xababab…"
+        );
+    }
+
+    #[test]
+    fn test_render_route_empty() {
+        assert_eq!(render_route(&[], &symbols()), "");
     }
 
     #[test]

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -71,11 +71,26 @@ fn solver_label<'a>(solver: &'a str, registry: &Registry) -> &'a str {
     }
 }
 
+/// Label value for a state with no winning route to attribute — Fynd did not solve it, so no
+/// algorithm competed for it. Every series of a metric must carry the same label set, so an
+/// unsolved state cannot simply omit the label.
+const ALGORITHM_NONE: &str = "none";
+
 /// The bounded label set shared by every per-trade metric, computed once per range.
 struct MetricLabels<'a> {
     venue: &'a str,
     solver: &'a str,
     chain: &'a str,
+}
+
+/// Metric label for the algorithm whose route won a state's quote. Unlike venue and solver, this
+/// needs no bounding against the registry: the value comes from Fynd's own worker pools, whose
+/// `algorithm` names must resolve in the algorithm registry for the pool to spawn at all.
+fn algorithm_label(outcome: &Outcome) -> &str {
+    match outcome {
+        Outcome::Solved(solved) if !solved.route.algorithm.is_empty() => &solved.route.algorithm,
+        Outcome::Solved(_) | Outcome::Partial(_) | Outcome::Unsolvable(_) => ALGORITHM_NONE,
+    }
 }
 
 /// Metric label for a trade's headline verdict.
@@ -94,27 +109,30 @@ pub(crate) fn describe() {
     describe_counter!(
         TRADES_TOTAL,
         "Re-solved trades above the dust floor, labeled by venue / solver / chain / outcome / \
-         state (top|back). Sub-$100-notional trades are excluded so the win-rate reflects trades \
-         that matter; total volume stays complete in VOLUME_USD. Per-pair detail lives in the \
-         JSONL comparison output; a token-pair label here is unbounded on mainnet and would \
-         explode Prometheus series cardinality over a long run."
+         algorithm / state (top|back). `algorithm` is the worker pool whose route won the quote, \
+         so a per-venue split answers which algorithm serves that venue's flow best; it is \
+         \"none\" when Fynd did not solve. Sub-$100-notional trades are excluded so the win-rate \
+         reflects trades that matter; total volume stays complete in VOLUME_USD. Per-pair detail \
+         lives in the JSONL comparison output; a token-pair label here is unbounded on mainnet and \
+         would explode Prometheus series cardinality over a long run."
     );
     describe_histogram!(
         SAVINGS_BPS,
         Unit::Count,
         "Gross bps delta of Fynd vs settled (positive = Fynd better), labeled by venue / solver / \
-         chain / outcome / state (top|back). Sub-$100-notional trades are excluded — a few wei of \
-         rounding is thousands of bps on dust and would swamp the quantiles."
+         chain / outcome / algorithm / state (top|back). Sub-$100-notional trades are excluded — a \
+         few wei of rounding is thousands of bps on dust and would swamp the quantiles."
     );
     describe_histogram!(
         SAVINGS_USD,
         "Signed gross USD savings of Fynd vs settled (positive = Fynd better), for Fynd-priced \
-         trades"
+         trades, labeled by the algorithm whose route won"
     );
     describe_histogram!(
         IMPROVEMENT_USD,
         "Gross USD uplift on trades Fynd would improve (losses excluded — a venue routes \
-         elsewhere when Fynd is worse). Sum = value of adding Fynd; count = improving trades"
+         elsewhere when Fynd is worse), labeled by the algorithm whose route won. Sum = value of \
+         adding Fynd; count = improving trades"
     );
     describe_histogram!(
         VOLUME_USD,
@@ -209,7 +227,9 @@ pub(crate) fn record_range(
     // One structured line per priced comparison, on the headline basis (top-of-block, gross).
     // Loki ingests pod stdout, so this line feeds the dashboard's top-trades table; keep the
     // message and field names stable — the LogQL query extracts them by regexp. Zero means
-    // "unpriced" (or, for quoted_usd, "the solver declared no quote").
+    // "unpriced" (or, for quoted_usd, "the solver declared no quote"). `protocols` is the winning
+    // route's protocol mix, comma-joined; `swaps` counts its legs, so a split route reads higher
+    // than its hop depth. Per-hop pools and amounts stay in the JSONL records.
     if let (Some(savings_usd), Outcome::Solved(solved)) = (savings_top, &range.top.outcome) {
         let priced = |amount| {
             prices_top
@@ -224,6 +244,9 @@ pub(crate) fn record_range(
             token_in = %range.token_in,
             token_out = %range.token_out,
             verdict = %outcome_label(range.verdict),
+            algorithm = %algorithm_label(&range.top.outcome),
+            protocols = %solved.route.protocols.join(","),
+            swaps = solved.route.swaps,
             volume_usd = volume.unwrap_or(0.0),
             settled_usd = priced(range.settled_amount_out),
             fynd_usd = priced(solved.amount_out),
@@ -254,6 +277,8 @@ fn record_state(
     prices: &Prices,
     above_floor: bool,
 ) -> Option<f64> {
+    let algorithm = algorithm_label(&state.outcome);
+
     if above_floor {
         counter!(
             TRADES_TOTAL,
@@ -261,6 +286,7 @@ fn record_state(
             "solver" => labels.solver.to_string(),
             "chain" => labels.chain.to_string(),
             "outcome" => outcome_label(state.verdict).to_string(),
+            "algorithm" => algorithm.to_string(),
             "state" => state_label,
         )
         .increment(1);
@@ -276,6 +302,7 @@ fn record_state(
                 "solver" => labels.solver.to_string(),
                 "chain" => labels.chain.to_string(),
                 "outcome" => outcome_label(state.verdict).to_string(),
+                "algorithm" => algorithm.to_string(),
                 "state" => state_label,
             )
             .record(bps);
@@ -312,6 +339,7 @@ fn record_state(
         "venue" => labels.venue.to_string(),
         "solver" => labels.solver.to_string(),
         "chain" => labels.chain.to_string(),
+        "algorithm" => algorithm.to_string(),
         "state" => state_label,
     )
     .record(usd);
@@ -322,6 +350,7 @@ fn record_state(
             "venue" => labels.venue.to_string(),
             "solver" => labels.solver.to_string(),
             "chain" => labels.chain.to_string(),
+            "algorithm" => algorithm.to_string(),
             "state" => state_label,
         )
         .record(usd);
@@ -442,7 +471,7 @@ mod tests {
     use super::*;
     use crate::{
         decoder::{AttributionSource, DecodedTrade, SandwichEvidence},
-        resolve::{build_range, SolvedAmount},
+        resolve::{build_range, RouteSummary, SolvedAmount},
     };
 
     fn empty_prices() -> Prices {
@@ -472,10 +501,20 @@ mod tests {
     }
 
     fn solved(amount_out: u64, net: u64) -> Outcome {
+        solved_by("bellman_ford", amount_out, net)
+    }
+
+    /// A solved outcome attributed to `algorithm`, for the cases that assert on the label.
+    fn solved_by(algorithm: &str, amount_out: u64, net: u64) -> Outcome {
         Outcome::Solved(SolvedAmount {
             amount_out: U256::from(amount_out),
             amount_out_net_gas: U256::from(net),
             gas_estimate: U256::from(21_000),
+            route: RouteSummary {
+                algorithm: algorithm.to_string(),
+                protocols: vec!["uniswap_v3".to_string()],
+                swaps: 1,
+            },
             quote_json: None,
         })
     }
@@ -487,6 +526,83 @@ mod tests {
         assert_eq!(outcome_label(Verdict::CoverageMiss), "coverage_miss");
         assert_eq!(outcome_label(Verdict::Unsolvable), "unsolvable");
         assert_eq!(outcome_label(Verdict::Sandwiched), "sandwiched");
+    }
+
+    #[test]
+    fn test_algorithm_label() {
+        assert_eq!(algorithm_label(&solved_by("water_fill", 1_000, 1_000)), "water_fill");
+        // Nothing solved, nothing to attribute — and a quote that declared no algorithm must not
+        // mint an empty label value.
+        assert_eq!(algorithm_label(&solved_by("", 1_000, 1_000)), ALGORITHM_NONE);
+        assert_eq!(algorithm_label(&Outcome::Unsolvable("x".into())), ALGORITHM_NONE);
+        assert_eq!(algorithm_label(&Outcome::Partial("x".into())), ALGORITHM_NONE);
+    }
+
+    #[test]
+    fn test_algorithm_label_on_the_quality_metrics() {
+        // The competition question — which algorithm serves a venue's flow best — is answered by
+        // splitting the win-rate, bps, and USD-uplift metrics on `algorithm`, so all four carry it.
+        let usdc = address!("0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48");
+        let range = build_range(
+            &trade(usdc, 1_000_000_000),
+            &empty_prices(),
+            solved_by("path_frank_wolfe", 1_010_000_000, 1_005_000_000),
+            solved_by("path_frank_wolfe", 1_010_000_000, 1_005_000_000),
+        );
+        let mut prices = empty_prices();
+        prices.insert(usdc, 2e-9);
+
+        let recorder = configure_buckets(PrometheusBuilder::new())
+            .unwrap()
+            .build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(&range, "ethereum", &prices, &prices, &Registry::ethereum());
+        });
+        let rendered = handle.render();
+
+        for metric in [TRADES_TOTAL, SAVINGS_BPS, SAVINGS_USD, IMPROVEMENT_USD] {
+            assert!(
+                rendered
+                    .lines()
+                    .any(|line| line.starts_with(metric) &&
+                        line.contains("algorithm=\"path_frank_wolfe\"")),
+                "{metric} is missing the algorithm label: {rendered}"
+            );
+        }
+        // Volume is the settled trade's notional, not a Fynd routing property, so it stays
+        // unlabeled — attributing a competitor's trade size to one of our algorithms is wrong.
+        let volume_line = rendered
+            .lines()
+            .find(|line| line.starts_with(VOLUME_USD))
+            .expect("volume histogram rendered");
+        assert!(!volume_line.contains("algorithm="), "volume line: {volume_line}");
+    }
+
+    #[test]
+    fn test_unsolved_state_is_labeled_none() {
+        // An unsolvable state still increments the win-rate counter (it is a coverage miss, not a
+        // missing sample), so it needs a label value — and it must not be blank.
+        let range = build_range(
+            &trade(Address::repeat_byte(0x22), 1_000),
+            &empty_prices(),
+            Outcome::Unsolvable("missing token in Tycho".into()),
+            Outcome::Unsolvable("missing token in Tycho".into()),
+        );
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            record_range(
+                &range,
+                "ethereum",
+                &empty_prices(),
+                &empty_prices(),
+                &Registry::ethereum(),
+            );
+        });
+        let rendered = handle.render();
+        assert!(rendered.contains("algorithm=\"none\""), "rendered: {rendered}");
+        assert!(!rendered.contains("algorithm=\"\""), "rendered: {rendered}");
     }
 
     #[test]

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -227,9 +227,12 @@ pub(crate) fn record_range(
     // One structured line per priced comparison, on the headline basis (top-of-block, gross).
     // Loki ingests pod stdout, so this line feeds the dashboard's top-trades table; keep the
     // message and field names stable — the LogQL query extracts them by regexp. Zero means
-    // "unpriced" (or, for quoted_usd, "the solver declared no quote"). `protocols` is the winning
-    // route's protocol mix, comma-joined; `swaps` counts its legs, so a split route reads higher
-    // than its hop depth. Per-hop pools and amounts stay in the JSONL records.
+    // "unpriced" (or, for quoted_usd, "the solver declared no quote"). Per-hop pools and amounts
+    // stay in the JSONL records.
+    //
+    // `route` is last on purpose: it is the only field whose value contains spaces, so a LogQL
+    // regexp can only bound it by end-of-line. Keep it last, or the dashboard's route column
+    // silently swallows every field after it.
     if let (Some(savings_usd), Outcome::Solved(solved)) = (savings_top, &range.top.outcome) {
         let priced = |amount| {
             prices_top
@@ -245,13 +248,12 @@ pub(crate) fn record_range(
             token_out = %range.token_out,
             verdict = %outcome_label(range.verdict),
             algorithm = %algorithm_label(&range.top.outcome),
-            protocols = %solved.route.protocols.join(","),
-            swaps = solved.route.swaps,
             volume_usd = volume.unwrap_or(0.0),
             settled_usd = priced(range.settled_amount_out),
             fynd_usd = priced(solved.amount_out),
             quoted_usd = range.quote.as_ref().map_or(0.0, |quote| priced(quote.amount_out)),
             savings_usd,
+            route = %solved.route.path,
             "trade comparison"
         );
     }
@@ -512,8 +514,7 @@ mod tests {
             gas_estimate: U256::from(21_000),
             route: RouteSummary {
                 algorithm: algorithm.to_string(),
-                protocols: vec!["uniswap_v3".to_string()],
-                swaps: 1,
+                path: "USDC -[uniswap_v3]-> WETH".to_string(),
             },
             quote_json: None,
         })


### PR DESCRIPTION
Adds the two things the dashboard was missing: the route Fynd took, and which algorithm won it.

A solved re-solve state now carries the winning algorithm plus the route rendered as a readable path:

```
USDT -[uniswap_v2]-> DAI -[vm:balancer]-> WETH
```

Token symbols come from the solver's token table; a token with no entry falls back to a shortened address (`0xababab…`). Protocol ids are Tycho's own, so a new DEX integration reads correctly with no lookup table.

A **split** fans legs out of one token and so cannot share a single chain — each leg becomes its own path joined by ` + `, carrying its share of the input:

```
USDC -[uniswap_v3 60%]-> WETH + USDC -[vm:curve 40%]-> WETH
USDT -[uniswap_v3 25%]-> WETH + USDT -[vm:curve 75%]-> DAI -[uniswap_v2]-> USDC
```

Surfaced three ways:

- **Prometheus**: `algorithm` label on `hindsight_trades_total`, `savings_bps`, `savings_usd`, `improvement_usd` (`"none"` when unsolved). Split by venue for the per-client comparison. The path is not a label — it is per-trade and would explode cardinality.
- **Loki**: `algorithm` and `route` on the existing `trade comparison` line. `route` is **last** on purpose: its value contains spaces, so a LogQL regexp can only bound it by end-of-line.
- **JSONL**: `algorithm` and `route` as top-level fields on both the `top` and `back` state objects, alongside the nested per-hop route that keeps the pools and amounts.

Dashboard panels: propeller-heads/terraform-infrastructure#218 (merge this first).

`monitor` attributes the winning pool, so the algorithm comparison needs a `--worker-pools-config` with more than one pool. The default `worker_pools.toml` has one, so every trade would read `algorithm=bellman_ford`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
