### PR TITLE
ci: grant validate-pr read permissions, drop deprecated app secrets

### DIFF
--- a/.github/workflows/v2-validate-pr.yaml
+++ b/.github/workflows/v2-validate-pr.yaml
@@ -13,6 +13,6 @@ on:
 jobs:
   validate-pr:
     uses: propeller-heads/ci-cd-templates/.github/workflows/validate-pr.yaml@main
-    secrets:
-      app_id: ${{ secrets.APP_ID }}
-      app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+    permissions:
+      contents: read
+      pull-requests: read


### PR DESCRIPTION
Every run of `v2-validate-pr.yaml`, which **Validates PR Title**, has ended in `startup_failure` since 2026-07-15 (291 runs, no jobs scheduled, no logs).

ci-cd-templates#89 (`security: use GITHUB_TOKEN for PR title validation`) made the reusable workflow declare `permissions: {contents: read, pull-requests: read}` and use the default token. A called workflow's permissions must be a subset of the calling job's; this caller granted none, so GitHub rejects the run at parse time.

This grants the two read scopes on the calling job and removes the `app_id` / `app_private_key` secrets, which the template deprecated in the same change. Matches the fix already applied in tycho-indexer (`dd22d4d3`).

Note: this workflow runs on `pull_request_target`, so this PR's own validate-pr run still uses the workflow file from `main` — the fix takes effect for runs after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)