### PR TITLE
refactor!: rename liquidity pools to components

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -65,7 +65,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
    `WaterFillAlgorithm`
 5. **MarketState** (`fynd-core/src/feed/market_data.rs`) — `Arc<RwLock<>>` of all component/token/gas state; accessed via `MarketData` handle
 6. **TychoFeed** (`fynd-core/src/feed/tycho_feed.rs`) — Background task: Tycho WebSocket → MarketState → broadcast events
-7. **Derived Data** (`fynd-core/src/derived/`) — Pre-computed spot prices, component depths, token gas prices
+7. **Derived Data** (`fynd-core/src/derived/`) — Pre-computed spot prices, component (pool) depths, token gas prices
 8. **Encoding** (`fynd-core/src/encoding/`) — Encodes solved routes into on-chain transactions via `TychoEncoder`
 9. **Graph** (`fynd-core/src/graph/`) — `GraphManager` trait + `PetgraphStableDiGraphManager` implementation
 
@@ -76,7 +76,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 2. Writes new component/token/state data into `MarketState` (write lock)
 3. Broadcasts `MarketEvent` → each `SolverWorker` updates its local graph via `GraphManager`
 4. `GasPriceFetcher` runs independently on a timer → fetches gas price from RPC node → writes to `MarketState`
-5. Triggers `ComputationManager` → runs spot prices → component depths → token gas prices (in dependency order) → broadcasts `DerivedDataEvent` → workers update edge weights
+5. Triggers `ComputationManager` → runs spot prices → component (pool) depths → token gas prices (in dependency order) → broadcasts `DerivedDataEvent` → workers update edge weights
 
 **Quote request path** (`POST /v1/quote`):
 1. `RouterApi` validates the request

--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -7,13 +7,13 @@ multiple DeFi protocols in real-time.
 ## What is Fynd
 
 Fynd is a solver that indexes live DEX liquidity via Tycho's streaming API, maintains an in-memory
-graph of token pairs and pools, and runs pluggable routing algorithms on dedicated OS threads to
+graph of token pairs and components (liquidity pools), and runs pluggable routing algorithms on dedicated OS threads to
 find optimal swap paths. It exposes an HTTP RPC for quote requests and returns the best
 gas-aware solution with optional on-chain transaction encoding.
 
 Key properties:
 - **Multi-protocol**: Routes through any on-chain protocol supported by Tycho, plus RFQ protocols
-- **Real-time**: Tycho Stream keeps all pool states synchronized every block
+- **Real-time**: Tycho Stream keeps all component states synchronized every block
 - **Multi-algorithm competition**: Multiple worker pools compete in parallel; best result wins
 - **Gas-aware**: Best solution selected by net output after gas costs
 - **Extensible**: Implement the `Algorithm` trait to add new routing strategies
@@ -63,9 +63,9 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 4. **Algorithm trait** (`fynd-core/src/algorithm/`) — Pluggable route-finding; built-in:
    `MostLiquidAlgorithm`, `BellmanFordAlgorithm`, `PathFrankWolfeAlgorithm`, and
    `WaterFillAlgorithm`
-5. **MarketState** (`fynd-core/src/feed/market_data.rs`) — `Arc<RwLock<>>` of all pool/token/gas state; accessed via `MarketData` handle
+5. **MarketState** (`fynd-core/src/feed/market_data.rs`) — `Arc<RwLock<>>` of all component/token/gas state; accessed via `MarketData` handle
 6. **TychoFeed** (`fynd-core/src/feed/tycho_feed.rs`) — Background task: Tycho WebSocket → MarketState → broadcast events
-7. **Derived Data** (`fynd-core/src/derived/`) — Pre-computed spot prices, pool depths, token gas prices
+7. **Derived Data** (`fynd-core/src/derived/`) — Pre-computed spot prices, component depths, token gas prices
 8. **Encoding** (`fynd-core/src/encoding/`) — Encodes solved routes into on-chain transactions via `TychoEncoder`
 9. **Graph** (`fynd-core/src/graph/`) — `GraphManager` trait + `PetgraphStableDiGraphManager` implementation
 
@@ -76,7 +76,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 2. Writes new component/token/state data into `MarketState` (write lock)
 3. Broadcasts `MarketEvent` → each `SolverWorker` updates its local graph via `GraphManager`
 4. `GasPriceFetcher` runs independently on a timer → fetches gas price from RPC node → writes to `MarketState`
-5. Triggers `ComputationManager` → runs spot prices → pool depths → token gas prices (in dependency order) → broadcasts `DerivedDataEvent` → workers update edge weights
+5. Triggers `ComputationManager` → runs spot prices → component depths → token gas prices (in dependency order) → broadcasts `DerivedDataEvent` → workers update edge weights
 
 **Quote request path** (`POST /v1/quote`):
 1. `RouterApi` validates the request
@@ -91,7 +91,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 
 - **Actix/Tokio runtime** (async I/O): HTTP server, TychoFeed, WorkerPoolRouter, gas fetcher, ComputationManager
 - **Worker pools** (dedicated OS threads): Each `SolverWorker` has a local graph and single-thread tokio runtime
-- **Communication**: `async_channel` (pool queues), `oneshot` (responses), `broadcast` (events), `Arc<RwLock<>>` (shared data)
+- **Communication**: `async_channel` (worker pool queues), `oneshot` (responses), `broadcast` (events), `Arc<RwLock<>>` (shared data)
 
 ## Configuration
 

--- a/clients/openapi.json
+++ b/clients/openapi.json
@@ -7,7 +7,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.93.0"
+    "version": "0.97.7"
   },
   "paths": {
     "/v1/health": {
@@ -757,7 +757,7 @@
       },
       "Route": {
         "type": "object",
-        "description": "A route consisting of one or more sequential swaps.\n\nA route describes the path through liquidity pools to execute a swap.\nFor multi-hop swaps, the output of each swap becomes the input of the next.",
+        "description": "A route consisting of one or more sequential swaps.\n\nA route describes the path through components (liquidity pools) to execute a swap.\nFor multi-hop swaps, the output of each swap becomes the input of the next.",
         "required": [
           "swaps"
         ],
@@ -773,7 +773,7 @@
       },
       "Swap": {
         "type": "object",
-        "description": "A single swap within a route.\n\nRepresents an atomic swap on a specific liquidity pool (component).",
+        "description": "A single swap within a route.\n\nRepresents an atomic swap on a specific component (liquidity pool).",
         "required": [
           "component_id",
           "protocol",
@@ -797,7 +797,7 @@
           },
           "component_id": {
             "type": "string",
-            "description": "Identifier of the liquidity pool component.",
+            "description": "Identifier of the component (liquidity pool).",
             "example": "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc"
           },
           "gas_estimate": {

--- a/clients/rust/src/error.rs
+++ b/clients/rust/src/error.rs
@@ -17,7 +17,8 @@ pub enum ErrorCode {
     /// Server code: `NO_ROUTE_FOUND`.
     NoRouteFound,
 
-    /// A route exists but available pool liquidity is too shallow for the requested amount.
+    /// A route exists but available component liquidity is too shallow for the
+    /// requested amount.
     ///
     /// Server code: `INSUFFICIENT_LIQUIDITY`.
     InsufficientLiquidity,

--- a/clients/rust/src/mapping.rs
+++ b/clients/rust/src/mapping.rs
@@ -413,7 +413,7 @@ mod tests {
     fn sample_dto_swap() -> dto::Swap {
         serde_json::from_str(
             r#"{
-            "component_id": "pool-1",
+            "component_id": "component-1",
             "protocol": "uniswap-v3",
             "token_in": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "token_out": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
@@ -533,7 +533,7 @@ mod tests {
     #[test]
     fn swap_try_from_dto_happy_path() {
         let client_swap = Swap::try_from(sample_dto_swap()).unwrap();
-        assert_eq!(client_swap.component_id(), "pool-1");
+        assert_eq!(client_swap.component_id(), "component-1");
         assert_eq!(client_swap.protocol(), "uniswap-v3");
         assert_eq!(client_swap.token_in(), &Bytes::copy_from_slice(&[0xaa; 20]));
         assert_eq!(client_swap.token_out(), &Bytes::copy_from_slice(&[0xbb; 20]));

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -613,7 +613,7 @@ pub enum BackendKind {
 pub enum QuoteStatus {
     /// A valid route was found and `route`, `amount_out`, and `gas_estimate` are populated.
     Success,
-    /// No swap path exists between the requested token pair on any available component.
+    /// No swap path exists between the requested token pair on available swap components (pools).
     NoRouteFound,
     /// A path exists but available liquidity is too low for the requested amount.
     InsufficientLiquidity,

--- a/clients/rust/src/types.rs
+++ b/clients/rust/src/types.rs
@@ -613,7 +613,7 @@ pub enum BackendKind {
 pub enum QuoteStatus {
     /// A valid route was found and `route`, `amount_out`, and `gas_estimate` are populated.
     Success,
-    /// No swap path exists between the requested token pair on any available pool.
+    /// No swap path exists between the requested token pair on any available component.
     NoRouteFound,
     /// A path exists but available liquidity is too low for the requested amount.
     InsufficientLiquidity,
@@ -658,7 +658,7 @@ impl BlockInfo {
     }
 }
 
-/// A single atomic swap on one liquidity pool within a [`Route`].
+/// A single atomic swap on one component (liquidity pool) within a [`Route`].
 #[derive(Debug, Clone)]
 pub struct Swap {
     component_id: String,
@@ -673,7 +673,7 @@ pub struct Swap {
 }
 
 impl Swap {
-    /// The identifier of the liquidity pool component (e.g. a pool address).
+    /// The identifier of the component (e.g. a liquidity pool address).
     pub fn component_id(&self) -> &str {
         &self.component_id
     }

--- a/clients/typescript/client/src/mapping.test.ts
+++ b/clients/typescript/client/src/mapping.test.ts
@@ -261,14 +261,14 @@ describe('fromWireQuote', () => {
     expect(quote.route).toBeDefined();
     expect(quote.route?.swaps).toHaveLength(1);
     const swap = quote.route?.swaps[0];
-    expect(swap?.poolId).toBe('0xpool');
+    expect(swap?.componentId).toBe('0xpool');
     expect(swap?.protocol).toBe('uniswap_v2');
     expect(swap?.amountIn).toBe(1000n);
     expect(swap?.amountOut).toBe(3500n);
     expect(swap?.gasEstimate).toBe(80000n);
   });
 
-  it('maps component_id to poolId', () => {
+  it('maps component_id to componentId', () => {
     const wire: WireSolution = {
       ...baseWireSolution,
       orders: [
@@ -291,7 +291,7 @@ describe('fromWireQuote', () => {
       ],
     };
     const quote = fromWireQuote(wire, TOKEN_OUT, SENDER);
-    expect(quote.route?.swaps[0]?.poolId).toBe('0xpool123');
+    expect(quote.route?.swaps[0]?.componentId).toBe('0xpool123');
   });
 
   it('priceImpactBps is undefined when wire value is null', () => {

--- a/clients/typescript/client/src/mapping.ts
+++ b/clients/typescript/client/src/mapping.ts
@@ -111,7 +111,7 @@ function fromWireRoute(wire: WireRoute): Route {
 
 function fromWireSwap(wire: WireSwap): Swap {
     return {
-        poolId: wire.component_id,
+        componentId: wire.component_id,
         protocol: wire.protocol,
         tokenIn: wire.token_in as Address,
         tokenOut: wire.token_out as Address,

--- a/clients/typescript/client/src/schema.d.ts
+++ b/clients/typescript/client/src/schema.d.ts
@@ -474,7 +474,7 @@ export interface components {
         /**
          * @description A route consisting of one or more sequential swaps.
          *
-         *     A route describes the path through liquidity pools to execute a swap.
+         *     A route describes the path through components (liquidity pools) to execute a swap.
          *     For multi-hop swaps, the output of each swap becomes the input of the next.
          */
         Route: {
@@ -484,7 +484,7 @@ export interface components {
         /**
          * @description A single swap within a route.
          *
-         *     Represents an atomic swap on a specific liquidity pool (component).
+         *     Represents an atomic swap on a specific component (liquidity pool).
          */
         Swap: {
             /**
@@ -498,7 +498,7 @@ export interface components {
              */
             amount_out: string;
             /**
-             * @description Identifier of the liquidity pool component.
+             * @description Identifier of the component (liquidity pool).
              * @example 0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc
              */
             component_id: string;

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -179,7 +179,7 @@ export interface HealthStatus {
   healthy: boolean;
   /** Milliseconds since the last state update. */
   lastUpdateMs: number;
-  /** Number of liquidity pools tracked by the solver. */
+  /** Number of active solver worker pools. */
   numSolverPools: number;
   gasPriceAgeMs?: number;
 }

--- a/clients/typescript/client/src/types.ts
+++ b/clients/typescript/client/src/types.ts
@@ -122,10 +122,10 @@ export interface BlockInfo {
   timestamp: number;
 }
 
-/** A single pool-level swap within a route. */
+/** A single component-level (liquidity pool) swap within a route. */
 export interface Swap {
-  /** Unique pool identifier (wire name: `component_id`). */
-  poolId: string;
+  /** Unique component identifier (wire name: `component_id`). */
+  componentId: string;
   /** Protocol name (e.g. "uniswap_v3", "balancer_v2"). */
   protocol: string;
   tokenIn: Address;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ This modular architecture allows users to:
 * **Graph Management**: `GraphManager` trait with incremental updates from market events; built-in implementation uses `petgraph::StableDiGraph`
 * **Multi-Solver Competition**: Multiple worker pools with different configurations compete per request; WorkerPoolRouter selects the best result
 * **Output Format**: Structured `Quote` objects (routes, amounts, gas estimates) with optional encoded transaction
-* **Derived Data Pipeline**: Pre-computed spot prices, pool depths, and token gas prices fed to algorithms via a separate computation framework
+* **Derived Data Pipeline**: Pre-computed spot prices, component depths, and token gas prices fed to algorithms via a separate computation framework
 * **Observability**: Prometheus metrics on port 9898, structured tracing, health endpoint
 
 ***
@@ -109,23 +109,23 @@ This modular architecture allows users to:
               │ on event │   │ on event │   │ on event │
               └──────────┘   └──────────┘   └──────────┘
 
-┌──────────────────────────────────────────────────────────────────┐
-│                     Derived Data Pipeline                        │
-│                                                                  │
-│  TychoFeed events ──► ComputationManager                         │
-│                          │                                       │
-│                          ├─ SpotPriceComputation                 │
-│                          ├─ PoolDepthComputation (needs spots)   │
-│                          ├─ TokenGasPriceComputation(needs spots)│
-│                          │                                       │
-│                          ▼                                       │
-│                     DerivedData Store ──► broadcast events       │
-│                                              │                   │
-│                                    ┌─────────┼──────────┐        │
-│                                    ▼         ▼          ▼        │
-│                              Worker 1  Worker 2  Worker N        │
-│                              (update edge weights on graph)      │
-└──────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────────────┐
+│                     Derived Data Pipeline                             │
+│                                                                       │
+│  TychoFeed events ──► ComputationManager                              │
+│                          │                                            │
+│                          ├─ SpotPriceComputation                      │
+│                          ├─ ComponentDepthComputation (needs spots)   │
+│                          ├─ TokenGasPriceComputation (needs spots)    │
+│                          │                                            │
+│                          ▼                                            │
+│                     DerivedData Store ──► broadcast events            │
+│                                              │                        │
+│                                    ┌─────────┼──────────┐             │
+│                                    ▼         ▼          ▼             │
+│                              Worker 1  Worker 2  Worker N             │
+│                              (update edge weights on graph)           │
+└───────────────────────────────────────────────────────────────────────┘
 ```
 
 ***
@@ -141,7 +141,7 @@ Actix Web HTTP handlers. Validates requests, delegates to WorkerPoolRouter, retu
 **Endpoints:**
 
 * `POST /v1/quote` -- Submit quote requests
-* `GET /v1/health` -- Health check (data freshness, derived data readiness, gas-price staleness, pool count)
+* `GET /v1/health` -- Health check (data freshness, derived data readiness, gas-price staleness, solver pool count)
 * `GET /v1/info` -- Instance info (chain ID, router address, Permit2 address)
 * `GET /metrics` -- Prometheus metrics (separate server, port 9898 by default)
 
@@ -204,7 +204,7 @@ Pluggable interface for route-finding algorithms:
 * `MostLiquidAlgorithm` -- BFS path enumeration, depth-weighted scoring, ProtocolSim simulation, gas-adjusted ranking.
 * `BellmanFordAlgorithm` -- Bellman-Ford relaxation with gas-aware edge weights, configurable via `AlgorithmConfig.gas_aware`.
 * `PathFrankWolfeAlgorithm` -- Frank-Wolfe path-based optimization for multi-hop routing.
-* `WaterFillAlgorithm` -- portfolio split router: exhaustive plus bounded amount-aware candidate discovery, then the best net of a single path, a coarse disjoint floor, a refined 256-chunk disjoint split, and a shared-pool fill-and-spill; gas-aware net ranking when derived token gas prices are available.
+* `WaterFillAlgorithm` -- portfolio split router: exhaustive plus bounded amount-aware candidate discovery, then the best net of a single path, a coarse disjoint floor, a refined 256-chunk disjoint split, and a shared-component fill-and-spill; gas-aware net ranking when derived token gas prices are available.
 
 ***
 
@@ -224,7 +224,7 @@ Graph management infrastructure:
 
 * `GraphManager` trait: initialize + incremental updates from events
 * `PetgraphStableDiGraphManager`: Implementation using `petgraph::StableDiGraph`
-* `EdgeWeightUpdaterWithDerived`: Updates edge weights from derived data (pool depths)
+* `EdgeWeightUpdaterWithDerived`: Updates edge weights from derived data (component depths)
 * `Path` type: Sequence of edges for route representation
 
 ***
@@ -253,8 +253,8 @@ Background task that connects to Tycho's WebSocket API, processes component/stat
 
 Pre-computes analytics from raw market data:
 
-* `SpotPriceComputation`: Spot prices for all pool pairs
-* `PoolDepthComputation`: Liquidity depth at configured slippage
+* `SpotPriceComputation`: Spot prices for all component pairs
+* `ComponentDepthComputation`: Liquidity depth at configured slippage
 * `TokenGasPriceComputation`: Token prices relative to gas token
 
 Computations run in dependency order. Workers use `ReadinessTracker` to wait for required data before solving.
@@ -327,7 +327,7 @@ TychoFeed
     └──► Trigger Gas Price Fetcher
     └──► ComputationManager
             ├──► SpotPriceComputation
-            ├──► PoolDepthComputation
+            ├──► ComponentDepthComputation
             ├──► TokenGasPriceComputation
             └──► Broadcast DerivedDataEvent
                     └──► Workers (update edge weights + readiness)

--- a/docs/guides/custom-algorithm.md
+++ b/docs/guides/custom-algorithm.md
@@ -22,22 +22,22 @@ Your algorithm receives a read-only reference to the routing graph and shared ma
 From [`fynd-core/examples/custom_algorithm.rs`](../../fynd-core/examples/custom_algorithm.rs):
 
 ```rust
-/// A naive algorithm that finds a direct pool between two tokens.
+/// A naive algorithm that finds a direct component (liquidity pool) between two tokens.
 ///
 /// This iterates through all edges in the routing graph, finds one that
 /// connects `token_in` to `token_out`, simulates the swap, and returns
 /// the first successful result. It only supports single-hop (direct) routes.
-struct DirectPoolAlgorithm {
+struct DirectComponentAlgorithm {
     timeout: Duration,
 }
 
-impl DirectPoolAlgorithm {
+impl DirectComponentAlgorithm {
     fn new(_config: fynd_core::AlgorithmConfig) -> Self {
         Self { timeout: Duration::from_millis(100) }
     }
 }
 
-impl Algorithm for DirectPoolAlgorithm {
+impl Algorithm for DirectComponentAlgorithm {
     // Reuse the built-in petgraph manager — it handles graph initialization and
     // market event updates automatically. We just need a simple graph with no
     // edge weights (unit `()` type).
@@ -123,9 +123,10 @@ impl Algorithm for DirectPoolAlgorithm {
             // Validate every candidate route before returning it. The solver worker rejects
             // invalid routes (disconnected swaps, repeated tokens, malformed splits) and that
             // failure drops the whole solution for this worker pool. Skipping invalid candidates
-            // here lets a later pool be chosen instead. Any custom algorithm should validate the
-            // routes it might return, and — when it ranks multiple candidates — fall through to
-            // the next-best valid one rather than returning the invalid route.
+            // here lets a later component be chosen instead. Any custom algorithm should validate
+            // the routes it might return, and — when it ranks multiple candidates —
+            // fall through to the next-best valid one rather than returning the invalid
+            // route.
             if let Err(e) = route.validate() {
                 eprintln!("skipping invalid route: {e}");
                 continue;
@@ -137,7 +138,7 @@ impl Algorithm for DirectPoolAlgorithm {
         }
 
         Err(AlgorithmError::Other(format!(
-            "no direct pool from {:?} to {:?}",
+            "no direct component from {:?} to {:?}",
             order.token_in(),
             order.token_out()
         )))
@@ -168,7 +169,7 @@ Pass your algorithm factory to `FyndBuilder::with_algorithm()` instead of the st
         10.0,
     )
     .tycho_api_key(tycho_api_key)
-    .with_algorithm("direct_pool", DirectPoolAlgorithm::new)
+    .with_algorithm("direct_pool", DirectComponentAlgorithm::new)
     .build()?;
 ```
 

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -12,7 +12,7 @@ applications.
 | `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based |
 | `worker_pool_router/` | `WorkerPoolRouter` fans out orders to all pools, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes          |
 | `feed/`               | `TychoFeed` (WebSocket → MarketState), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`                                                                           |
-| `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `PoolDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
+| `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `ComponentDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
 | `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
 | `price_guard/`        | Price guard: external price validation for quotes. Sub-modules: `guard` (validation logic), `binance_ws` (Binance WebSocket price provider), `hyperliquid` (Hyperliquid oracle provider), `provider_registry`, `config`, `utils` |
 | `replay.rs`           | `replay_route(&Route, &MarketState)` — re-execute an already-built route against a (possibly newer) market state, honoring split fractions and shared-pool depletion. Used by `hindsight` to measure quote-to-execution slippage |

--- a/fynd-core/examples/custom_algorithm.rs
+++ b/fynd-core/examples/custom_algorithm.rs
@@ -4,8 +4,8 @@
 //! into [`FyndBuilder`] via [`FyndBuilder::with_algorithm`], without modifying
 //! fynd-core itself.
 //!
-//! [`DirectPoolAlgorithm`] is a naive algorithm that finds a single pool containing
-//! both the input and output tokens, simulates the swap, and returns the result.
+//! [`DirectComponentAlgorithm`] is a naive algorithm that finds a single component (liquidity pool)
+//! containing both the input and output tokens, simulates the swap, and returns the result.
 //! It only finds direct (1-hop) routes — no multi-hop routing.
 //!
 //! # Prerequisites
@@ -36,22 +36,22 @@ use tycho_simulation::{evm::tycho_models::Chain, tycho_core::Bytes};
 // =============================================================================
 
 // [doc:start custom-algo-impl]
-/// A naive algorithm that finds a direct pool between two tokens.
+/// A naive algorithm that finds a direct component (liquidity pool) between two tokens.
 ///
 /// This iterates through all edges in the routing graph, finds one that
 /// connects `token_in` to `token_out`, simulates the swap, and returns
 /// the first successful result. It only supports single-hop (direct) routes.
-struct DirectPoolAlgorithm {
+struct DirectComponentAlgorithm {
     timeout: Duration,
 }
 
-impl DirectPoolAlgorithm {
+impl DirectComponentAlgorithm {
     fn new(_config: fynd_core::AlgorithmConfig) -> Self {
         Self { timeout: Duration::from_millis(100) }
     }
 }
 
-impl Algorithm for DirectPoolAlgorithm {
+impl Algorithm for DirectComponentAlgorithm {
     // Reuse the built-in petgraph manager — it handles graph initialization and
     // market event updates automatically. We just need a simple graph with no
     // edge weights (unit `()` type).
@@ -137,9 +137,10 @@ impl Algorithm for DirectPoolAlgorithm {
             // Validate every candidate route before returning it. The solver worker rejects
             // invalid routes (disconnected swaps, repeated tokens, malformed splits) and that
             // failure drops the whole solution for this worker pool. Skipping invalid candidates
-            // here lets a later pool be chosen instead. Any custom algorithm should validate the
-            // routes it might return, and — when it ranks multiple candidates — fall through to
-            // the next-best valid one rather than returning the invalid route.
+            // here lets a later component be chosen instead. Any custom algorithm should validate
+            // the routes it might return, and — when it ranks multiple candidates —
+            // fall through to the next-best valid one rather than returning the invalid
+            // route.
             if let Err(e) = route.validate() {
                 eprintln!("skipping invalid route: {e}");
                 continue;
@@ -151,7 +152,7 @@ impl Algorithm for DirectPoolAlgorithm {
         }
 
         Err(AlgorithmError::Other(format!(
-            "no direct pool from {:?} to {:?}",
+            "no direct component from {:?} to {:?}",
             order.token_in(),
             order.token_out()
         )))
@@ -192,7 +193,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         10.0,
     )
     .tycho_api_key(tycho_api_key)
-    .with_algorithm("direct_pool", DirectPoolAlgorithm::new)
+    .with_algorithm("direct_pool", DirectComponentAlgorithm::new)
     .build()?;
     // [doc:end custom-algo-wire]
 

--- a/fynd-core/src/algorithm/bellman_ford.rs
+++ b/fynd-core/src/algorithm/bellman_ford.rs
@@ -1,7 +1,7 @@
 //! Bellman-Ford algorithm with SPFA optimization for simulation-driven routing.
 //!
-//! Runs actual pool simulations (`get_amount_out()`) during edge relaxation to find
-//! optimal A-to-B routes that account for slippage, fees, and pool mechanics at the
+//! Runs actual component simulations (`get_amount_out()`) during edge relaxation to find
+//! optimal A-to-B routes that account for slippage, fees, and component mechanics at the
 //! given trade size.
 //!
 //! Key features:
@@ -11,7 +11,7 @@
 //! - **Subgraph extraction**: BFS prunes the graph to nodes reachable within `max_hops`
 //! - **SPFA (Shortest Path Faster Algorithm) queuing**: Only re-relaxes edges from nodes whose
 //!   amount improved
-//! - **Forbid revisits**: Skips edges that would revisit a token or pool already in the path
+//! - **Forbid revisits**: Skips edges that would revisit a token or component already in the path
 //!
 //! # Known limitation: SPFA order-dependence
 //!
@@ -60,7 +60,8 @@ type Subgraph =
 ///
 /// Built once by `build_context`, which acquires the market and derived locks and snapshots all
 /// relevant states. `find_single_route` uses this snapshot directly — no lock re-acquisition — so
-/// all route evaluations within one order see a consistent view of the same block's pool states.
+/// all route evaluations within one order see a consistent view of the same block's component
+/// states.
 pub(crate) struct BellmanFordContext {
     pub(crate) token_in_node: NodeIndex,
     pub(crate) token_out_node: NodeIndex,
@@ -86,7 +87,8 @@ pub(crate) enum RouteScoringMode {
 /// Per-call overrides for `find_single_route`.
 #[derive(Default)]
 pub(crate) struct FindRouteOptions {
-    /// Pool state overrides: degrade or zero-gas specific pools without modifying market data.
+    /// Component state overrides: degrade or zero-gas specific components without modifying market
+    /// data.
     pub(crate) overrides: MarketOverrides,
 }
 
@@ -94,7 +96,7 @@ pub(crate) struct FindRouteOptions {
 struct SPFAResult {
     /// Best gross output amount reachable at each node index.
     amount: Vec<BigUint>,
-    /// The (predecessor node, pool) that last improved each node's amount.
+    /// The (predecessor node, component) that last improved each node's amount.
     predecessor: Vec<Option<(NodeIndex, ComponentId)>>,
     /// Gas consumed by the edge that last improved each node's amount.
     edge_gas: Vec<BigUint>,
@@ -107,8 +109,8 @@ struct SPFAResult {
 
 /// Bellman-Ford algorithm with SPFA optimisation for simulation-driven DEX routing.
 ///
-/// Finds optimal A→B routes by running actual pool simulations during edge relaxation,
-/// accounting for slippage, fees, and pool mechanics at the requested trade size.
+/// Finds optimal A→B routes by running actual component simulations during edge relaxation,
+/// accounting for slippage, fees, and component mechanics at the requested trade size.
 /// Gas costs are subtracted when price data is available.
 pub struct BellmanFordAlgorithm {
     max_hops: usize,
@@ -138,7 +140,7 @@ impl BellmanFordAlgorithm {
     /// Validates the order, extracts the subgraph, acquires the market and derived data
     /// locks exactly once, and snapshots all state into a [`BellmanFordContext`]. All
     /// subsequent `find_single_route` calls on the returned context use the same block's
-    /// pool states.
+    /// component states.
     pub(crate) async fn build_context(
         &self,
         graph: &StableDiGraph<()>,
@@ -254,9 +256,9 @@ impl BellmanFordAlgorithm {
     /// Runs the SPFA relaxation loop and reconstructs the best route from a pre-built context.
     ///
     /// This is the repeatable, synchronous solve phase. Call it multiple times with different
-    /// `opts.overrides` to evaluate alternative pool states without redoing the setup in `ctx`.
-    /// Overrides shadow the corresponding pool in `ctx.market_data` for both relaxation and route
-    /// construction.
+    /// `opts.overrides` to evaluate alternative component states without redoing the setup in
+    /// `ctx`. Overrides shadow the corresponding component in `ctx.market_data` for both
+    /// relaxation and route construction.
     pub(crate) fn find_single_route(
         &self,
         ctx: &BellmanFordContext,
@@ -388,7 +390,7 @@ impl BellmanFordAlgorithm {
                 for (v, component_id) in edges {
                     let v_idx = v.index();
 
-                    // Single predecessor walk: skip if target token or pool already in path
+                    // Single predecessor walk: skip if target token or component already in path
                     if Self::path_has_conflict(u, *v, component_id, &predecessor) {
                         continue;
                     }
@@ -550,7 +552,8 @@ impl BellmanFordAlgorithm {
                     kind: "component",
                     id: Some(component_id.clone()),
                 })?;
-            // Use the override's sim state if available so the route reflects overridden pools.
+            // Use the override's sim state if available so the route reflects overridden
+            // components.
             let sim_state = overrides
                 .get(component_id)
                 .or_else(|| {
@@ -666,12 +669,12 @@ impl BellmanFordAlgorithm {
         None
     }
 
-    /// Checks whether the target node or pool conflicts with the existing path to `from`.
+    /// Checks whether the target node or component conflicts with the existing path to `from`.
     /// Walks the predecessor chain once, checking both conditions simultaneously.
     pub(crate) fn path_has_conflict(
         from: NodeIndex,
         target_node: NodeIndex,
-        target_pool: &ComponentId,
+        target_component: &ComponentId,
         predecessor: &[Option<(NodeIndex, ComponentId)>],
     ) -> bool {
         let mut current = from;
@@ -681,7 +684,7 @@ impl BellmanFordAlgorithm {
             }
             match &predecessor[current.index()] {
                 Some((prev, cid)) => {
-                    if cid == target_pool {
+                    if cid == target_component {
                         return true;
                     }
                     current = *prev;
@@ -898,7 +901,7 @@ mod tests {
 
     /// Sets up market and graph with `()` edge weights for BellmanFord tests.
     fn setup_market_bf(
-        pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
+        components: Vec<(&str, &Token, &Token, MockProtocolSim)>,
     ) -> (MarketData, PetgraphStableDiGraphManager<()>) {
         let mut market = MarketState::new();
 
@@ -910,11 +913,14 @@ mod tests {
         });
         market.update_last_updated(crate::types::BlockInfo::new(1, "0x00".into(), 0));
 
-        for (pool_id, token_in, token_out, state) in pools {
+        for (component_id, token_in, token_out, state) in components {
             let tokens = vec![token_in.clone(), token_out.clone()];
-            let comp = component(pool_id, &tokens);
+            let comp = component(component_id, &tokens);
             market.upsert_components(std::iter::once(comp));
-            market.update_states([(pool_id.to_string(), Box::new(state) as Box<dyn ProtocolSim>)]);
+            market.update_states([(
+                component_id.to_string(),
+                Box::new(state) as Box<dyn ProtocolSim>,
+            )]);
             market.upsert_tokens(tokens);
         }
 
@@ -958,9 +964,9 @@ mod tests {
         let token_d = token(0x04, "D");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
-            ("pool_cd", &token_c, &token_d, MockProtocolSim::new(4.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_cd", &token_c, &token_d, MockProtocolSim::new(4.0)),
         ]);
 
         let algo = bf_algorithm(4, 1000);
@@ -987,10 +993,10 @@ mod tests {
         let token_d = token(0x04, "D");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bd", &token_b, &token_d, MockProtocolSim::new(3.0)),
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(4.0)),
-            ("pool_cd", &token_c, &token_d, MockProtocolSim::new(1.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bd", &token_b, &token_d, MockProtocolSim::new(3.0)),
+            ("component_ac", &token_a, &token_c, MockProtocolSim::new(4.0)),
+            ("component_cd", &token_c, &token_d, MockProtocolSim::new(1.0)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1003,20 +1009,20 @@ mod tests {
 
         // A->B->D: 100*2*3=600 is better than A->C->D: 100*4*1=400
         assert_eq!(result.route().swaps().len(), 2);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ab");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_bd");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ab");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_bd");
         assert_eq!(result.route().swaps()[1].amount_out(), &BigUint::from(600u64));
     }
 
     #[tokio::test]
-    async fn test_parallel_pools() {
-        // Two pools between A and B with different multipliers
+    async fn test_parallel_components() {
+        // Two components between A and B with different multipliers
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool2", &token_a, &token_b, MockProtocolSim::new(5.0)),
+            ("component1", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component2", &token_a, &token_b, MockProtocolSim::new(5.0)),
         ]);
 
         let algo = bf_algorithm(2, 1000);
@@ -1028,7 +1034,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.route().swaps().len(), 1);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool2");
+        assert_eq!(result.route().swaps()[0].component_id(), "component2");
         assert_eq!(result.route().swaps()[0].amount_out(), &BigUint::from(500u64));
     }
 
@@ -1040,7 +1046,7 @@ mod tests {
 
         // A-B connected, C disconnected
         let (market, manager) =
-            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+            setup_market_bf(vec![("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         // Add token_c to market without connecting it
         {
@@ -1064,7 +1070,7 @@ mod tests {
         let token_x = token(0x99, "X");
 
         let (market, manager) =
-            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+            setup_market_bf(vec![("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let algo = bf_algorithm(3, 1000);
         let ord = order(&token_x, &token_b, 100, OrderSide::Sell);
@@ -1082,9 +1088,9 @@ mod tests {
     async fn test_amount_too_small_when_reachable_but_zero_output() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
-        // Reachable pool, but rate 0.5 on a 1-unit input floors to 0 output.
+        // Reachable component, but rate 0.5 on a 1-unit input floors to 0 output.
         let (market, manager) =
-            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(0.5))]);
+            setup_market_bf(vec![("component_ab", &token_a, &token_b, MockProtocolSim::new(0.5))]);
         let algo = bf_algorithm(3, 1000);
         let ord = order(&token_a, &token_b, 1, OrderSide::Sell);
 
@@ -1105,8 +1111,8 @@ mod tests {
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(0.5)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(0.5)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
         ]);
         let algo = bf_algorithm(3, 1000);
         let ord = order(&token_a, &token_c, 1, OrderSide::Sell);
@@ -1127,7 +1133,7 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let (market, manager) = setup_market_bf(vec![(
-            "pool_ab",
+            "component_ab",
             &token_a,
             &token_b,
             MockProtocolSim::new(2.0).with_liquidity(500),
@@ -1151,8 +1157,8 @@ mod tests {
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
         ]);
         let algo = bf_algorithm(1, 1000);
         let ord = order(&token_a, &token_c, 100, OrderSide::Sell);
@@ -1175,8 +1181,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(2.0)),
         ]);
 
         let algo = BellmanFordAlgorithm::with_config(
@@ -1202,7 +1208,7 @@ mod tests {
         let token_x = token(0x99, "X");
 
         let (market, manager) =
-            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+            setup_market_bf(vec![("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let algo = bf_algorithm(3, 1000);
         let ord = order(&token_a, &token_x, 100, OrderSide::Sell);
@@ -1225,9 +1231,9 @@ mod tests {
         let token_d = token(0x04, "D");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
-            ("pool_cd", &token_c, &token_d, MockProtocolSim::new(4.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_cd", &token_c, &token_d, MockProtocolSim::new(4.0)),
         ]);
 
         let algo = bf_algorithm(2, 1000);
@@ -1251,8 +1257,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         let algo = bf_algorithm(4, 1000);
@@ -1265,8 +1271,8 @@ mod tests {
 
         // Should find exactly the 2-hop path A->B->C = 100*2*3 = 600
         assert_eq!(result.route().swaps().len(), 2);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ab");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_bc");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ab");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_bc");
         assert_eq!(result.route().swaps()[1].amount_out(), &BigUint::from(600u64));
     }
 
@@ -1280,10 +1286,10 @@ mod tests {
         let token_d = token(0x04, "D");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
-            ("pool_cb", &token_c, &token_b, MockProtocolSim::new(100.0)),
-            ("pool_bd", &token_b, &token_d, MockProtocolSim::new(2.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_cb", &token_c, &token_b, MockProtocolSim::new(100.0)),
+            ("component_bd", &token_b, &token_d, MockProtocolSim::new(2.0)),
         ]);
 
         let algo = bf_algorithm(4, 1000);
@@ -1297,8 +1303,8 @@ mod tests {
         // Should find A->B->D = 100*2*2 = 400 (the direct 2-hop path)
         // The 4-hop revisit path A->B->C->B->D is blocked
         assert_eq!(result.route().swaps().len(), 2, "should use direct 2-hop path");
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ab");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_bd");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ab");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_bd");
         assert_eq!(result.route().swaps()[1].amount_out(), &BigUint::from(400u64));
     }
 
@@ -1310,8 +1316,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1333,7 +1339,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market_bf(vec![(
-            "pool1",
+            "component1",
             &token_a,
             &token_b,
             MockProtocolSim::new(2.0).with_gas(10),
@@ -1363,8 +1369,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         // 0ms timeout
@@ -1397,9 +1403,9 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        // Pool with 10% fee
+        // Component with 10% fee
         let (market, manager) = setup_market_bf(vec![(
-            "pool1",
+            "component1",
             &token_a,
             &token_b,
             MockProtocolSim::new(2.0).with_fee(0.1),
@@ -1422,9 +1428,9 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        // Pool with limited liquidity (500 tokens)
+        // Component with limited liquidity (500 tokens)
         let (market, manager) = setup_market_bf(vec![(
-            "pool1",
+            "component1",
             &token_a,
             &token_b,
             MockProtocolSim::new(2.0).with_liquidity(500),
@@ -1439,7 +1445,7 @@ mod tests {
             .await;
         assert!(
             matches!(result, Err(AlgorithmError::NoPath { .. })),
-            "Should fail when trade exceeds pool liquidity"
+            "Should fail when trade exceeds component liquidity"
         );
     }
 
@@ -1452,8 +1458,8 @@ mod tests {
         let token_e = token(0x05, "E");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_de", &token_d, &token_e, MockProtocolSim::new(4.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_de", &token_d, &token_e, MockProtocolSim::new(4.0)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1470,17 +1476,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_spfa_skips_failed_simulations() {
-        // Pool that will fail simulation (liquidity=0 would cause error for any amount)
+        // Component that will fail simulation (liquidity=0 would cause error for any amount)
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_bf(vec![
-            // Direct path with failing pool
-            ("pool_ab_bad", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(0)),
+            // Direct path with failing component
+            ("component_ab_bad", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(0)),
             // Alternative path that works
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(2.0)),
-            ("pool_cb", &token_c, &token_b, MockProtocolSim::new(3.0)),
+            ("component_ac", &token_a, &token_c, MockProtocolSim::new(2.0)),
+            ("component_cb", &token_c, &token_b, MockProtocolSim::new(3.0)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1500,7 +1506,7 @@ mod tests {
             }
             Err(AlgorithmError::NoPath { .. }) => {
                 // Also acceptable if liquidity=0 blocks all paths through B
-                // (since the failing pool might also block the reverse B->A edge)
+                // (since the failing component might also block the reverse B->A edge)
             }
             Err(e) => panic!("Unexpected error: {:?}", e),
         }
@@ -1514,8 +1520,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1575,10 +1581,10 @@ mod tests {
         let low_gas: u64 = 100;
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(3.0).with_gas(high_gas)),
-            ("pool_bd", &token_b, &token_d, MockProtocolSim::new(2.0).with_gas(high_gas)),
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(2.0).with_gas(low_gas)),
-            ("pool_cd", &token_c, &token_d, MockProtocolSim::new(2.0).with_gas(low_gas)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(3.0).with_gas(high_gas)),
+            ("component_bd", &token_b, &token_d, MockProtocolSim::new(2.0).with_gas(high_gas)),
+            ("component_ac", &token_a, &token_c, MockProtocolSim::new(2.0).with_gas(low_gas)),
+            ("component_cd", &token_c, &token_d, MockProtocolSim::new(2.0).with_gas(low_gas)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1599,8 +1605,8 @@ mod tests {
 
         // Gas-aware relaxation should pick the cheaper path A -> C -> D
         assert_eq!(result.route().swaps().len(), 2);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ac");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_cd");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ac");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_cd");
     }
 
     #[tokio::test]
@@ -1616,10 +1622,10 @@ mod tests {
         let low_gas: u64 = 100;
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(3.0).with_gas(high_gas)),
-            ("pool_bd", &token_b, &token_d, MockProtocolSim::new(2.0).with_gas(high_gas)),
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(2.0).with_gas(low_gas)),
-            ("pool_cd", &token_c, &token_d, MockProtocolSim::new(2.0).with_gas(low_gas)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(3.0).with_gas(high_gas)),
+            ("component_bd", &token_b, &token_d, MockProtocolSim::new(2.0).with_gas(high_gas)),
+            ("component_ac", &token_a, &token_c, MockProtocolSim::new(2.0).with_gas(low_gas)),
+            ("component_cd", &token_c, &token_d, MockProtocolSim::new(2.0).with_gas(low_gas)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1633,8 +1639,8 @@ mod tests {
 
         // Without gas awareness, picks the higher-gross path A -> B -> D
         assert_eq!(result.route().swaps().len(), 2);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ab");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_bd");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ab");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_bd");
     }
 
     #[tokio::test]
@@ -1645,7 +1651,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market_bf(vec![(
-            "pool_ab",
+            "component_ab",
             &token_a,
             &token_b,
             MockProtocolSim::new(2.0).with_gas(10),
@@ -1668,13 +1674,13 @@ mod tests {
     #[tokio::test]
     async fn test_no_graph_path_when_output_uneconomic_but_input_economic() {
         // Output value (500) is below the hop's gas (1000) so the solve fails, but the
-        // input (10_000) covers it: a healthy-sized order on a low-rate pool must read
+        // input (10_000) covers it: a healthy-sized order on a low-rate component must read
         // NoGraphPath, not AmountTooSmall.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market_bf(vec![(
-            "pool_ab",
+            "component_ab",
             &token_a,
             &token_b,
             MockProtocolSim::new(0.05).with_gas(10),
@@ -1723,10 +1729,10 @@ mod tests {
         let token_d = token(0x04, "D");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bd", &token_b, &token_d, MockProtocolSim::new(2.0)),
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(3.0)),
-            ("pool_cd", &token_c, &token_d, MockProtocolSim::new(3.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bd", &token_b, &token_d, MockProtocolSim::new(2.0)),
+            ("component_ac", &token_a, &token_c, MockProtocolSim::new(3.0)),
+            ("component_cd", &token_c, &token_d, MockProtocolSim::new(3.0)),
         ]);
 
         let connectors: HashSet<Address> = [token_c.address.clone()].into();
@@ -1740,8 +1746,8 @@ mod tests {
 
         // Only A->C->D is reachable; B was pruned.
         assert_eq!(result.route().swaps().len(), 2);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ac");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_cd");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ac");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_cd");
     }
 
     #[tokio::test]
@@ -1751,7 +1757,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) =
-            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+            setup_market_bf(vec![("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         // Empty allowlist — no intermediate tokens allowed, but direct hop A->B should work.
         let algo = bf_algorithm_with_connectors(1, 1000, HashSet::new());
@@ -1775,10 +1781,10 @@ mod tests {
         let token_d = token(0x04, "D");
 
         let (market, manager) = setup_market_bf(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bd", &token_b, &token_d, MockProtocolSim::new(3.0)),
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(1.0)),
-            ("pool_cd", &token_c, &token_d, MockProtocolSim::new(1.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bd", &token_b, &token_d, MockProtocolSim::new(3.0)),
+            ("component_ac", &token_a, &token_c, MockProtocolSim::new(1.0)),
+            ("component_cd", &token_c, &token_d, MockProtocolSim::new(1.0)),
         ]);
 
         let algo = bf_algorithm(3, 1000);
@@ -1790,17 +1796,17 @@ mod tests {
             .unwrap();
 
         // Best path is A->B->D = 100*2*3 = 600
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ab");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_bd");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ab");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_bd");
         assert_eq!(result.route().swaps()[1].amount_out(), &BigUint::from(600u64));
     }
 
     #[test]
-    fn test_path_has_conflict_detects_node_and_pool() {
-        // Path: 0 -[pool_a]-> 1 -[pool_b]-> 2
+    fn test_path_has_conflict_detects_node_and_component() {
+        // Path: 0 -[component_a]-> 1 -[component_b]-> 2
         let mut pred: Vec<Option<(NodeIndex, ComponentId)>> = vec![None; 4];
-        pred[1] = Some((NodeIndex::new(0), "pool_a".into()));
-        pred[2] = Some((NodeIndex::new(1), "pool_b".into()));
+        pred[1] = Some((NodeIndex::new(0), "component_a".into()));
+        pred[2] = Some((NodeIndex::new(1), "component_b".into()));
 
         // Node conflicts: node 0 is in path, node 3 is not
         assert!(BellmanFordAlgorithm::path_has_conflict(
@@ -1823,23 +1829,23 @@ mod tests {
             &pred
         ));
 
-        // Pool conflicts: pool_a and pool_b are used, pool_c is not
+        // Component conflicts: component_a and component_b are used, component_c is not
         assert!(BellmanFordAlgorithm::path_has_conflict(
             NodeIndex::new(2),
             NodeIndex::new(3),
-            &"pool_a".into(),
+            &"component_a".into(),
             &pred
         ));
         assert!(BellmanFordAlgorithm::path_has_conflict(
             NodeIndex::new(2),
             NodeIndex::new(3),
-            &"pool_b".into(),
+            &"component_b".into(),
             &pred
         ));
         assert!(!BellmanFordAlgorithm::path_has_conflict(
             NodeIndex::new(2),
             NodeIndex::new(3),
-            &"pool_c".into(),
+            &"component_c".into(),
             &pred
         ));
     }
@@ -1850,7 +1856,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) =
-            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+            setup_market_bf(vec![("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let algo = bf_algorithm(2, 1000);
         let ord = order(&token_a, &token_b, 1000, OrderSide::Sell);
@@ -1866,10 +1872,10 @@ mod tests {
             .unwrap();
         assert_eq!(normal.route().swaps()[0].amount_out(), &BigUint::from(2000u64));
 
-        // Override pool_ab with a degraded sim (multiplier 1.0): 1000 * 1.0 = 1000
+        // Override component_ab with a degraded sim (multiplier 1.0): 1000 * 1.0 = 1000
         let opts = FindRouteOptions {
             overrides: MarketOverrides::empty()
-                .with_override("pool_ab".to_string(), Box::new(MockProtocolSim::new(1.0))),
+                .with_override("component_ab".to_string(), Box::new(MockProtocolSim::new(1.0))),
         };
         let overridden = algo
             .find_single_route(&ctx, &ord, opts)
@@ -1889,7 +1895,7 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let (market, manager) =
-            setup_market_bf(vec![("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+            setup_market_bf(vec![("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0))]);
 
         let algo = bf_algorithm(2, 1000);
         let ord = order(&token_a, &token_b, 1000, OrderSide::Sell);

--- a/fynd-core/src/algorithm/mod.rs
+++ b/fynd-core/src/algorithm/mod.rs
@@ -192,7 +192,7 @@ pub trait Algorithm: Send + Sync {
     /// * `market` - Shared reference to market data for state lookups (algorithms acquire their own
     ///   locks)
     /// * `label` - Optional overlay label; when `Some`, the algorithm reads market state through
-    ///   the named overlay so per-request pool overrides are applied during solving
+    ///   the named overlay so per-request component overrides are applied during solving
     /// * `derived` - Optional shared reference to derived data (token prices, etc.)
     /// * `order` - The order to solve
     ///
@@ -272,7 +272,7 @@ pub enum AlgorithmError {
     #[non_exhaustive]
     #[error("simulation failed for {component_id}: {error}")]
     SimulationFailed {
-        /// ID of the pool component that failed.
+        /// ID of the component (liquidity pool) that failed.
         component_id: String,
         /// Underlying simulation error message.
         error: String,

--- a/fynd-core/src/algorithm/most_liquid.rs
+++ b/fynd-core/src/algorithm/most_liquid.rs
@@ -111,12 +111,12 @@ impl crate::graph::EdgeWeightFromSimAndDerived for DepthAndPrice {
 
         // Look up pre-computed depth; skip edge if unavailable.
         let raw_depth = match derived
-            .pool_depths()
+            .component_depths()
             .and_then(|d| d.get(&key))
         {
             Some(d) => d.to_f64().unwrap_or(0.0),
             None => {
-                trace!(component_id = %component_id, "pool depth not found, skipping edge");
+                trace!(component_id = %component_id, "component depth not found, skipping edge");
                 return None;
             }
         };
@@ -312,7 +312,7 @@ impl MostLiquidAlgorithm {
     /// Returns `None` if the path cannot be scored (empty path or missing edge weights).
     /// Paths that return `None` are filtered out of simulation.
     ///
-    /// Higher score = better path candidate. Paths through deeper pools rank higher.
+    /// Higher score = better path candidate. Paths through deeper components rank higher.
     pub(crate) fn try_score_path(path: &Path<DepthAndPrice>) -> Option<f64> {
         if path.is_empty() {
             trace!("cannot score empty path");
@@ -335,8 +335,8 @@ impl MostLiquidAlgorithm {
         Some(price * min_depth)
     }
 
-    /// Simulates swaps along a path using each pool's `ProtocolSim::get_amount_out`.
-    /// Tracks intermediate state changes to handle routes that revisit the same pool.
+    /// Simulates swaps along a path using each component's `ProtocolSim::get_amount_out`.
+    /// Tracks intermediate state changes to handle routes that revisit the same component.
     ///
     /// Calculates `net_amount_out` by subtracting gas cost from the output amount.
     /// The result can be negative if gas cost exceeds output (e.g., inaccurate gas estimation).
@@ -357,7 +357,7 @@ impl MostLiquidAlgorithm {
         let mut current_amount = amount_in.clone();
         let mut swaps = Vec::with_capacity(path.len());
 
-        // Track state overrides for pools we've already swapped through.
+        // Track state overrides for components we've already swapped through.
         let mut state_overrides: HashMap<&ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
         let mut tokens: HashMap<Address, Token> = HashMap::new();
 
@@ -724,7 +724,7 @@ impl Algorithm for MostLiquidAlgorithm {
     fn computation_requirements(&self) -> ComputationRequirements {
         // MostLiquidAlgorithm uses token prices for two purposes:
         // 1. Converting gas costs from wei to output token terms (net_amount_out)
-        // 2. Normalizing pool depth to gas token units for path scoring (from_sim_and_derived)
+        // 2. Normalizing component depth to gas token units for path scoring (from_sim_and_derived)
         //
         // Token prices are marked as `allow_stale` since they don't change much
         // block-to-block. Stale prices affect scoring order (not correctness)
@@ -834,7 +834,7 @@ mod tests {
         let (a, b, _, _) = addrs();
         let mut m = linear_graph();
 
-        // Set weights for both directions of the ab pool
+        // Set weights for both directions of the ab component
         // A->B: spot=2.0, depth=1000, fee=0.3%
         // B->A: spot=0.6, depth=800, fee=0.3%
         m.set_edge_weight(&"ab".to_string(), &a, &b, DepthAndPrice::new(2.0, 1000.0), false)
@@ -884,13 +884,13 @@ mod tests {
 
     #[test]
     fn test_from_sim_and_derived_failed_spot_price_returns_none() {
-        let key = pair_key("pool1", 0x01, 0x02);
-        let key_str = pair_key_str("pool1", 0x01, 0x02);
+        let key = pair_key("component1", 0x01, 0x02);
+        let key_str = pair_key_str("component1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
         let tok_out = token(0x02, "B");
 
         let mut derived = DerivedData::new();
-        // spot price fails, pool depth not computed
+        // spot price fails, component depth not computed
         derived.set_spot_prices(
             Default::default(),
             vec![FailedItem {
@@ -900,7 +900,7 @@ mod tests {
             10,
             true,
         );
-        derived.set_pool_depths(Default::default(), vec![], 10, true);
+        derived.set_component_depths(Default::default(), vec![], 10, true);
         derived.set_token_prices(
             make_token_prices(&[tok_in.address.clone(), tok_out.address.clone()]),
             vec![],
@@ -918,9 +918,9 @@ mod tests {
     }
 
     #[test]
-    fn test_from_sim_and_derived_failed_pool_depth_returns_none() {
-        let key = pair_key("pool1", 0x01, 0x02);
-        let key_str = pair_key_str("pool1", 0x01, 0x02);
+    fn test_from_sim_and_derived_failed_component_depth_returns_none() {
+        let key = pair_key("component1", 0x01, 0x02);
+        let key_str = pair_key_str("component1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
         let tok_out = token(0x02, "B");
 
@@ -929,8 +929,8 @@ mod tests {
         let mut prices = crate::derived::types::SpotPrices::default();
         prices.insert(key.clone(), 1.5);
         derived.set_spot_prices(prices, vec![], 10, true);
-        // pool depth fails
-        derived.set_pool_depths(
+        // component depth fails
+        derived.set_component_depths(
             Default::default(),
             vec![FailedItem {
                 key: key_str,
@@ -957,8 +957,8 @@ mod tests {
 
     #[test]
     fn test_from_sim_and_derived_both_failed_returns_none() {
-        let key = pair_key("pool1", 0x01, 0x02);
-        let key_str = pair_key_str("pool1", 0x01, 0x02);
+        let key = pair_key("component1", 0x01, 0x02);
+        let key_str = pair_key_str("component1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
         let tok_out = token(0x02, "B");
 
@@ -972,7 +972,7 @@ mod tests {
             10,
             true,
         );
-        derived.set_pool_depths(
+        derived.set_component_depths(
             Default::default(),
             vec![FailedItem {
                 key: key_str,
@@ -999,19 +999,19 @@ mod tests {
 
     #[test]
     fn test_from_sim_and_derived_missing_token_price_returns_none() {
-        let key = pair_key("pool1", 0x01, 0x02);
+        let key = pair_key("component1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
         let tok_out = token(0x02, "B");
 
         let mut derived = DerivedData::new();
-        // Spot price and pool depth both present
+        // Spot price and component depth both present
         let mut prices = crate::derived::types::SpotPrices::default();
         prices.insert(key.clone(), 1.5);
         derived.set_spot_prices(prices, vec![], 10, true);
 
-        let mut depths = crate::derived::types::PoolDepths::default();
+        let mut depths = crate::derived::types::ComponentDepths::default();
         depths.insert(key.clone(), BigUint::from(1000u64));
-        derived.set_pool_depths(depths, vec![], 10, true);
+        derived.set_component_depths(depths, vec![], 10, true);
 
         // No token prices set — normalization should return None
 
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[test]
     fn test_from_sim_and_derived_normalizes_depth_to_eth() {
-        let key = pair_key("pool1", 0x01, 0x02);
+        let key = pair_key("component1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
         let tok_out = token(0x02, "B");
 
@@ -1041,9 +1041,9 @@ mod tests {
         derived.set_spot_prices(spot, vec![], 10, true);
 
         // Raw depth: 2_000_000 token_in units
-        let mut depths = crate::derived::types::PoolDepths::default();
+        let mut depths = crate::derived::types::ComponentDepths::default();
         depths.insert(key.clone(), BigUint::from(2_000_000u64));
-        derived.set_pool_depths(depths, vec![], 10, true);
+        derived.set_component_depths(depths, vec![], 10, true);
 
         // Token price: 2000 token_in per 1 ETH (numerator=2000, denominator=1)
         // So 2_000_000 raw units / 2000 = 1000 ETH
@@ -1072,7 +1072,7 @@ mod tests {
 
     #[test]
     fn test_from_sim_and_derived_normalizes_depth_fractional_price() {
-        let key = pair_key("pool1", 0x01, 0x02);
+        let key = pair_key("component1", 0x01, 0x02);
         let tok_in = token(0x01, "A");
         let tok_out = token(0x02, "B");
 
@@ -1083,9 +1083,9 @@ mod tests {
         derived.set_spot_prices(spot, vec![], 10, true);
 
         // Raw depth: 500 token_in units
-        let mut depths = crate::derived::types::PoolDepths::default();
+        let mut depths = crate::derived::types::ComponentDepths::default();
         depths.insert(key.clone(), BigUint::from(500u64));
-        derived.set_pool_depths(depths, vec![], 10, true);
+        derived.set_component_depths(depths, vec![], 10, true);
 
         // Token price: numerator=3, denominator=2 -> 1.5 tokens per ETH
         // depth_in_eth = 500 * 2 / 3 = 333.333...
@@ -1140,7 +1140,7 @@ mod tests {
         let p = MostLiquidAlgorithm::find_paths(g, &a, &d, 1, 3, None).unwrap();
         assert_eq!(all_ids(p), HashSet::from([vec!["ab", "bc", "cd"]]));
 
-        // Reverse: D->A (bidirectional pools)
+        // Reverse: D->A (bidirectional components)
         let p = MostLiquidAlgorithm::find_paths(g, &d, &a, 1, 3, None).unwrap();
         assert_eq!(all_ids(p), HashSet::from([vec!["cd", "bc", "ab"]]));
     }
@@ -1163,16 +1163,16 @@ mod tests {
     }
 
     #[test]
-    fn test_find_paths_parallel_pools() {
+    fn test_find_paths_parallel_components() {
         let (a, b, c, _) = addrs();
         let m = parallel_graph();
         let g = m.graph();
 
-        // A->B: 3 parallel pools = 3 paths
+        // A->B: 3 parallel components = 3 paths
         let p = MostLiquidAlgorithm::find_paths(g, &a, &b, 1, 1, None).unwrap();
         assert_eq!(all_ids(p), HashSet::from([vec!["ab1"], vec!["ab2"], vec!["ab3"]]));
 
-        // A->C: 3 A->B pools × 2 B->C pools = 6 paths
+        // A->C: 3 A->B components × 2 B->C components = 6 paths
         let p = MostLiquidAlgorithm::find_paths(g, &a, &c, 1, 2, None).unwrap();
         assert_eq!(
             all_ids(p),
@@ -1215,12 +1215,12 @@ mod tests {
     #[test]
     fn test_find_paths_cyclic_same_source_dest() {
         let (a, _, _, _) = addrs();
-        // Use parallel_graph with 3 A<->B pools to verify all combinations
+        // Use parallel_graph with 3 A<->B components to verify all combinations
         let m = parallel_graph();
         let g = m.graph();
 
-        // A->A (cyclic path) with 2 hops: should find all 9 combinations (3 pools × 3 pools)
-        // Note: min_hops=2 because cyclic paths require at least 2 hops
+        // A->A (cyclic path) with 2 hops: should find all 9 combinations (3 components × 3
+        // components) Note: min_hops=2 because cyclic paths require at least 2 hops
         let p = MostLiquidAlgorithm::find_paths(g, &a, &a, 2, 2, None).unwrap();
         assert_eq!(
             all_ids(p),
@@ -1302,18 +1302,22 @@ mod tests {
 
     // ==================== simulate_path Tests ====================
     //
-    // Note: These tests use MockProtocolSim which is detected as a "native" pool.
-    // Ideally we should also test VM pool state override behavior (vm_state_override),
+    // Note: These tests use MockProtocolSim which is detected as a "native" component.
+    // Ideally we should also test VM component state override behavior (vm_state_override),
     // which shares state across all VM components. This would require a mock that
-    // downcasts to EVMPoolState<PreCachedDB>, or integration tests with real VM pools.
+    // downcasts to EVMPoolState<PreCachedDB>, or integration tests with real VM components.
 
     #[test]
     fn test_simulate_path_single_hop() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        let (market, manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
 
         let paths = MostLiquidAlgorithm::find_paths(
             manager.graph(),
@@ -1337,7 +1341,7 @@ mod tests {
         assert_eq!(result.route().swaps().len(), 1);
         assert_eq!(*result.route().swaps()[0].amount_in(), BigUint::from(100u64));
         assert_eq!(*result.route().swaps()[0].amount_out(), BigUint::from(200u64)); // 100 * 2
-        assert_eq!(result.route().swaps()[0].component_id(), "pool1");
+        assert_eq!(result.route().swaps()[0].component_id(), "component1");
     }
 
     #[test]
@@ -1347,8 +1351,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_weighted(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool2", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component1", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component2", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         let paths = MostLiquidAlgorithm::find_paths(
@@ -1379,14 +1383,18 @@ mod tests {
     }
 
     #[test]
-    fn test_simulate_path_same_pool_twice_uses_updated_state() {
-        // Route: A -> B -> A through the same pool
+    fn test_simulate_path_same_component_twice_uses_updated_state() {
+        // Route: A -> B -> A through the same component
         // First swap uses multiplier=2, second should use multiplier=3 (updated state)
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        let (market, manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
 
         // A->B->A path requires min_hops=2, max_hops=2
         // Since the graph is bidirectional, we should get A->B->A path
@@ -1425,14 +1433,20 @@ mod tests {
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
 
-        let (market, _) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, _) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
         let market = market_read(&market);
 
         // Add token C to graph but not to market (A->B->C)
         let mut topology = market.component_topology();
-        topology
-            .insert("pool2".to_string(), vec![token_b.address.clone(), token_c.address.clone()]);
+        topology.insert(
+            "component2".to_string(),
+            vec![token_b.address.clone(), token_c.address.clone()],
+        );
         let mut manager = PetgraphStableDiGraphManager::default();
         manager.initialize_graph(&topology);
 
@@ -1455,12 +1469,16 @@ mod tests {
     fn test_simulate_path_missing_component_returns_data_not_found() {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
-        let (market, manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
 
         // Remove the component but keep tokens and graph
         let mut market_write = market.try_write().unwrap();
-        market_write.remove_components([&"pool1".to_string()]);
+        market_write.remove_components([&"component1".to_string()]);
         drop(market_write);
 
         let graph = manager.graph();
@@ -1533,8 +1551,12 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        let (market, manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
             AlgorithmConfig::new(1, 1, Duration::from_millis(100), None).unwrap(),
@@ -1554,11 +1576,11 @@ mod tests {
     #[tokio::test]
     async fn test_find_best_route_ranks_by_net_amount_out() {
         // Tests that route selection is based on net_amount_out (output - gas cost),
-        // not just gross output. Three parallel pools with different spot_price/gas combos:
+        // not just gross output. Three parallel components with different spot_price/gas combos:
         //
         // Gas price = 100 wei/gas (set by setup_market_weighted)
         //
-        // | Pool      | spot_price | gas | Output (1000 in) | Gas Cost (gas*100) | Net   |
+        // | Component      | spot_price | gas | Output (1000 in) | Gas Cost (gas*100) | Net   |
         // |-----------|------------|-----|------------------|-------------------|-------|
         // | best      | 3          | 10  | 3000             | 1000              | 2000  |
         // | low_out   | 2          | 5   | 2000             | 500               | 1500  |
@@ -1586,7 +1608,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Should select "best" pool for highest net_amount_out (2000)
+        // Should select "best" component for highest net_amount_out (2000)
         assert_eq!(result.route().swaps().len(), 1);
         assert_eq!(result.route().swaps()[0].component_id(), "best");
         assert_eq!(*result.route().swaps()[0].amount_out(), BigUint::from(3000u64));
@@ -1599,8 +1621,12 @@ mod tests {
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C"); // Disconnected
 
-        let (market, manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
 
         let algorithm = MostLiquidAlgorithm::new();
         let order = order(&token_a, &token_c, ONE_ETH, OrderSide::Sell);
@@ -1618,8 +1644,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_weighted(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool2", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component1", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component2", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
@@ -1636,24 +1662,24 @@ mod tests {
         // A->B: ONE_ETH*2, B->C: (ONE_ETH*2)*3
         assert_eq!(result.route().swaps().len(), 2);
         assert_eq!(*result.route().swaps()[0].amount_out(), BigUint::from(ONE_ETH * 2));
-        assert_eq!(result.route().swaps()[0].component_id(), "pool1".to_string());
+        assert_eq!(result.route().swaps()[0].component_id(), "component1".to_string());
         assert_eq!(*result.route().swaps()[1].amount_out(), BigUint::from(ONE_ETH * 2 * 3));
-        assert_eq!(result.route().swaps()[1].component_id(), "pool2".to_string());
+        assert_eq!(result.route().swaps()[1].component_id(), "component2".to_string());
     }
 
     #[tokio::test]
     async fn test_find_best_route_skips_paths_without_edge_weights() {
-        // Pool1 has edge weights (scoreable), Pool2 doesn't (filtered out during scoring)
+        // Component1 has edge weights (scoreable), Component2 doesn't (filtered out during scoring)
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        // Set up market with both pools using new API
+        // Set up market with both components using new API
         let mut market = MarketState::new();
-        let pool1_state = MockProtocolSim::new(2.0);
-        let pool2_state = MockProtocolSim::new(3.0); // Higher multiplier but no edge weight
+        let component1_state = MockProtocolSim::new(2.0);
+        let component2_state = MockProtocolSim::new(3.0); // Higher multiplier but no edge weight
 
-        let pool1_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
-        let pool2_comp = component("pool2", &[token_a.clone(), token_b.clone()]);
+        let component1_comp = component("component1", &[token_a.clone(), token_b.clone()]);
+        let component2_comp = component("component2", &[token_a.clone(), token_b.clone()]);
 
         // Set gas price (required for simulation)
         market.update_gas_price(BlockGasPrice {
@@ -1664,26 +1690,27 @@ mod tests {
         });
 
         // Insert components
-        market.upsert_components(vec![pool1_comp, pool2_comp]);
+        market.upsert_components(vec![component1_comp, component2_comp]);
 
         // Insert states
         market.update_states(vec![
-            ("pool1".to_string(), Box::new(pool1_state.clone()) as Box<dyn ProtocolSim>),
-            ("pool2".to_string(), Box::new(pool2_state) as Box<dyn ProtocolSim>),
+            ("component1".to_string(), Box::new(component1_state.clone()) as Box<dyn ProtocolSim>),
+            ("component2".to_string(), Box::new(component2_state) as Box<dyn ProtocolSim>),
         ]);
 
         // Insert tokens
         market.upsert_tokens(vec![token_a.clone(), token_b.clone()]);
 
-        // Initialize graph with both pools
+        // Initialize graph with both components
         let mut manager = PetgraphStableDiGraphManager::default();
         manager.initialize_graph(&market.component_topology());
 
-        // Only set edge weights for pool1, NOT pool2
-        let weight = DepthAndPrice::from_protocol_sim(&pool1_state, &token_a, &token_b).unwrap();
+        // Only set edge weights for component1, NOT component2
+        let weight =
+            DepthAndPrice::from_protocol_sim(&component1_state, &token_a, &token_b).unwrap();
         manager
             .set_edge_weight(
-                &"pool1".to_string(),
+                &"component1".to_string(),
                 &token_a.address,
                 &token_b.address,
                 weight,
@@ -1703,9 +1730,9 @@ mod tests {
             .await
             .unwrap();
 
-        // Should use pool1 (only scoreable path), despite pool2 having better multiplier
+        // Should use component1 (only scoreable path), despite component2 having better multiplier
         assert_eq!(result.route().swaps().len(), 1);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool1");
+        assert_eq!(result.route().swaps()[0].component_id(), "component1");
         assert_eq!(*result.route().swaps()[0].amount_out(), BigUint::from(ONE_ETH * 2));
     }
 
@@ -1716,8 +1743,8 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let mut market = MarketState::new();
-        let pool_state = MockProtocolSim::new(2.0);
-        let pool_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
+        let component_state = MockProtocolSim::new(2.0);
+        let comp = component("component1", &[token_a.clone(), token_b.clone()]);
 
         // Set gas price (required for simulation)
         market.update_gas_price(BlockGasPrice {
@@ -1730,10 +1757,10 @@ mod tests {
             },
         });
 
-        market.upsert_components(vec![pool_comp]);
+        market.upsert_components(vec![comp]);
         market.update_states(vec![(
-            "pool1".to_string(),
-            Box::new(pool_state) as Box<dyn ProtocolSim>,
+            "component1".to_string(),
+            Box::new(component_state) as Box<dyn ProtocolSim>,
         )]);
         market.upsert_tokens(vec![token_a.clone(), token_b.clone()]);
 
@@ -1759,8 +1786,12 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        let (market, manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
         let mut market_write = market.try_write().unwrap();
 
         // Set a non-zero gas price so gas cost exceeds tiny output
@@ -1799,12 +1830,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_best_route_insufficient_liquidity() {
-        // Pool has limited liquidity (1000 wei) but we try to swap ONE_ETH
+        // Component has limited liquidity (1000 wei) but we try to swap ONE_ETH
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market_weighted(vec![(
-            "pool1",
+            "component1",
             &token_a,
             &token_b,
             MockProtocolSim::new(2.0).with_liquidity(1000),
@@ -1826,24 +1857,25 @@ mod tests {
         let token_b = token(0x02, "B");
 
         let mut market = MarketState::new();
-        let pool_state = MockProtocolSim::new(2.0);
-        let pool_comp = component("pool1", &[token_a.clone(), token_b.clone()]);
+        let component_state = MockProtocolSim::new(2.0);
+        let comp = component("component1", &[token_a.clone(), token_b.clone()]);
 
         // DO NOT set gas price - this is what we're testing
-        market.upsert_components(vec![pool_comp]);
+        market.upsert_components(vec![comp]);
         market.update_states(vec![(
-            "pool1".to_string(),
-            Box::new(pool_state.clone()) as Box<dyn ProtocolSim>,
+            "component1".to_string(),
+            Box::new(component_state.clone()) as Box<dyn ProtocolSim>,
         )]);
         market.upsert_tokens(vec![token_a.clone(), token_b.clone()]);
 
         // Initialize graph and set edge weights
         let mut manager = PetgraphStableDiGraphManager::default();
         manager.initialize_graph(&market.component_topology());
-        let weight = DepthAndPrice::from_protocol_sim(&pool_state, &token_a, &token_b).unwrap();
+        let weight =
+            DepthAndPrice::from_protocol_sim(&component_state, &token_a, &token_b).unwrap();
         manager
             .set_edge_weight(
-                &"pool1".to_string(),
+                &"component1".to_string(),
                 &token_a.address,
                 &token_b.address,
                 weight,
@@ -1870,8 +1902,12 @@ mod tests {
 
         // MockProtocolSim::get_amount_out multiplies by spot_price when token_in < token_out.
         // After the first swap, spot_price increments to 3.
-        let (market, manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
 
         // Use min_hops=2 to require at least 2 hops (circular)
         let algorithm = MostLiquidAlgorithm::with_config(
@@ -1913,10 +1949,11 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_weighted(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(10.0)), /* Direct: 1-hop, high
-                                                                          * output */
-            ("pool_ac", &token_a, &token_c, MockProtocolSim::new(2.0)), // 2-hop path
-            ("pool_cb", &token_c, &token_b, MockProtocolSim::new(3.0)), // 2-hop path
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(10.0)), /* Direct: 1-hop,
+                                                                               * high
+                                                                               * output */
+            ("component_ac", &token_a, &token_c, MockProtocolSim::new(2.0)), // 2-hop path
+            ("component_cb", &token_c, &token_b, MockProtocolSim::new(3.0)), // 2-hop path
         ]);
 
         // min_hops=2 should skip the 1-hop direct path
@@ -1937,8 +1974,8 @@ mod tests {
 
         // Should use 2-hop path (A->C->B), not the direct 1-hop path
         assert_eq!(result.route().swaps().len(), 2, "Should use 2-hop path due to min_hops=2");
-        assert_eq!(result.route().swaps()[0].component_id(), "pool_ac");
-        assert_eq!(result.route().swaps()[1].component_id(), "pool_cb");
+        assert_eq!(result.route().swaps()[0].component_id(), "component_ac");
+        assert_eq!(result.route().swaps()[1].component_id(), "component_cb");
     }
 
     #[tokio::test]
@@ -1950,8 +1987,8 @@ mod tests {
         let token_c = token(0x03, "C");
 
         let (market, manager) = setup_market_weighted(vec![
-            ("pool_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
+            ("component_ab", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component_bc", &token_b, &token_c, MockProtocolSim::new(3.0)),
         ]);
 
         // max_hops=1 cannot reach C from A (needs 2 hops)
@@ -1978,13 +2015,13 @@ mod tests {
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
-        // Create many parallel pools to ensure multiple paths need processing
+        // Create many parallel components to ensure multiple paths need processing
         let (market, manager) = setup_market_weighted(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(1.0)),
-            ("pool2", &token_a, &token_b, MockProtocolSim::new(2.0)),
-            ("pool3", &token_a, &token_b, MockProtocolSim::new(3.0)),
-            ("pool4", &token_a, &token_b, MockProtocolSim::new(4.0)),
-            ("pool5", &token_a, &token_b, MockProtocolSim::new(5.0)),
+            ("component1", &token_a, &token_b, MockProtocolSim::new(1.0)),
+            ("component2", &token_a, &token_b, MockProtocolSim::new(2.0)),
+            ("component3", &token_a, &token_b, MockProtocolSim::new(3.0)),
+            ("component4", &token_a, &token_b, MockProtocolSim::new(4.0)),
+            ("component5", &token_a, &token_b, MockProtocolSim::new(5.0)),
         ]);
 
         // timeout=0ms should timeout after processing some paths
@@ -2055,26 +2092,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_best_route_respects_max_routes_cap() {
-        // 4 parallel pools. Score = spot_price * min_depth.
+        // 4 parallel components. Score = spot_price * min_depth.
         // In tests, depth comes from get_limits().0 (sell_limit), which is
         // liquidity / (spot_price * (1 - fee)). With fee=0: depth = liquidity / spot_price.
         // We vary liquidity to create a clear score ranking:
-        //   pool4 (score = 1.0 * 4M/1.0 = 4M)
-        //   pool3 (score = 2.0 * 3M/2.0 = 3M)
-        //   pool2 (score = 3.0 * 2M/3.0 = 2M)
-        //   pool1 (score = 4.0 * 1M/4.0 = 1M)
+        //   component4 (score = 1.0 * 4M/1.0 = 4M)
+        //   component3 (score = 2.0 * 3M/2.0 = 3M)
+        //   component2 (score = 3.0 * 2M/3.0 = 2M)
+        //   component1 (score = 4.0 * 1M/4.0 = 1M)
         //
-        // With max_routes=2, only pool4 and pool3 are simulated.
-        // pool1 has the best simulation output (4x) but the lowest score,
+        // With max_routes=2, only component4 and component3 are simulated.
+        // component1 has the best simulation output (4x) but the lowest score,
         // so it's excluded by the cap.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market_weighted(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(4.0).with_liquidity(1_000_000)),
-            ("pool2", &token_a, &token_b, MockProtocolSim::new(3.0).with_liquidity(2_000_000)),
-            ("pool3", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(3_000_000)),
-            ("pool4", &token_a, &token_b, MockProtocolSim::new(1.0).with_liquidity(4_000_000)),
+            ("component1", &token_a, &token_b, MockProtocolSim::new(4.0).with_liquidity(1_000_000)),
+            ("component2", &token_a, &token_b, MockProtocolSim::new(3.0).with_liquidity(2_000_000)),
+            ("component3", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(3_000_000)),
+            ("component4", &token_a, &token_b, MockProtocolSim::new(1.0).with_liquidity(4_000_000)),
         ]);
 
         // Cap at 2: only the two highest-scored paths are simulated
@@ -2088,25 +2125,25 @@ mod tests {
             .await
             .unwrap();
 
-        // pool1 has the best simulation output (4x) but lowest score, so it's
-        // excluded by the cap. Among the top-2 scored (pool4=4M, pool3=3M),
-        // pool3 gives the best simulation output (2x vs 1x).
+        // component1 has the best simulation output (4x) but lowest score, so it's
+        // excluded by the cap. Among the top-2 scored (component4=4M, component3=3M),
+        // component3 gives the best simulation output (2x vs 1x).
         assert_eq!(result.route().swaps().len(), 1);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool3");
+        assert_eq!(result.route().swaps()[0].component_id(), "component3");
         assert_eq!(*result.route().swaps()[0].amount_out(), BigUint::from(2000u64));
     }
 
     #[tokio::test]
     async fn test_find_best_route_no_cap_when_max_routes_is_none() {
-        // Same setup but no cap — pool1 (best output) should win.
+        // Same setup but no cap — component1 (best output) should win.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
         let (market, manager) = setup_market_weighted(vec![
-            ("pool1", &token_a, &token_b, MockProtocolSim::new(4.0).with_liquidity(1_000_000)),
-            ("pool2", &token_a, &token_b, MockProtocolSim::new(3.0).with_liquidity(2_000_000)),
-            ("pool3", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(3_000_000)),
-            ("pool4", &token_a, &token_b, MockProtocolSim::new(1.0).with_liquidity(4_000_000)),
+            ("component1", &token_a, &token_b, MockProtocolSim::new(4.0).with_liquidity(1_000_000)),
+            ("component2", &token_a, &token_b, MockProtocolSim::new(3.0).with_liquidity(2_000_000)),
+            ("component3", &token_a, &token_b, MockProtocolSim::new(2.0).with_liquidity(3_000_000)),
+            ("component4", &token_a, &token_b, MockProtocolSim::new(1.0).with_liquidity(4_000_000)),
         ]);
 
         let algorithm = MostLiquidAlgorithm::with_config(
@@ -2119,9 +2156,9 @@ mod tests {
             .await
             .unwrap();
 
-        // All 4 paths simulated, pool1 wins with best output (4x)
+        // All 4 paths simulated, component1 wins with best output (4x)
         assert_eq!(result.route().swaps().len(), 1);
-        assert_eq!(result.route().swaps()[0].component_id(), "pool1");
+        assert_eq!(result.route().swaps()[0].component_id(), "component1");
         assert_eq!(*result.route().swaps()[0].amount_out(), BigUint::from(4000u64));
     }
 

--- a/fynd-core/src/algorithm/path_frank_wolfe.rs
+++ b/fynd-core/src/algorithm/path_frank_wolfe.rs
@@ -7,7 +7,7 @@
 //!
 //! The optimisation objective is output net of gas, evaluated by simulating
 //! paths sequentially against a shared post-swap state map — paths that share
-//! a pool see its depleted reserves instead of double-counting liquidity. The
+//! a component see its depleted reserves instead of double-counting liquidity. The
 //! single-path route is a floor: any failure while optimising the split falls
 //! back to it rather than failing the solve.
 
@@ -155,10 +155,10 @@ impl PathFrankWolfeAlgorithm {
     /// Finds the next candidate routing path for the Frank-Wolfe algorithm.
     ///
     /// Builds a post-swap market state that reflects `current_allocations` (applying each
-    /// allocation's simulated pool outputs as overrides), then runs Bellman-Ford at
+    /// allocation's simulated component outputs as overrides), then runs Bellman-Ford at
     /// `probe_amount` to discover the best remaining route.
     ///
-    /// Pools already present in `current_allocations` are promoted to zero-gas so their
+    /// Components already present in `current_allocations` are promoted to zero-gas so their
     /// committed gas cost is not counted again as marginal cost for the new path.
     ///
     /// Returns an ordered sequence of [`SimulatedHop`]s representing the discovered path,
@@ -171,10 +171,10 @@ impl PathFrankWolfeAlgorithm {
     ) -> Result<Vec<SimulatedHop>, AlgorithmError> {
         let mut overrides = build_post_swap_overrides(current_allocations, &ctx.market_data)?;
 
-        // Pools committed in the current solution are executed once on-chain — their gas is
+        // Components committed in the current solution are executed once on-chain — their gas is
         // already priced into the combined transaction. Zero out protocol gas so BF doesn't
         // double-charge them when evaluating extensions. We track by (component_id, token_in,
-        // token_out) because different token pairs through the same pool are separate on-chain
+        // token_out) because different token pairs through the same component are separate on-chain
         // swaps with independent gas costs.
         for alloc in current_allocations {
             for hop in &alloc.hops {
@@ -430,7 +430,7 @@ impl PathFrankWolfeAlgorithm {
 
     /// Applies a Frank-Wolfe step: shifts `step_size` fraction of flow to the
     /// candidate path, re-simulates all paths sequentially against a shared
-    /// post-swap state map (so shared pools see depleted reserves), and drops
+    /// post-swap state map (so shared components see depleted reserves), and drops
     /// any path whose fraction falls below `config.min_split` (renormalizing
     /// the remainder).
     fn apply_step(
@@ -636,8 +636,8 @@ impl PathFrankWolfeAlgorithm {
     /// Returns `true` if `candidate` has the same ordered sequence of
     /// `(component_id, token_in, token_out)` as any existing allocation.
     ///
-    /// Both the pool and the token pair must match at every hop — the same pool used with
-    /// different tokens (e.g. in a multi-token pool) is a distinct path.
+    /// Both the component and the token pair must match at every hop — the same component used with
+    /// different tokens (e.g. in a multi-token component) is a distinct path.
     ///
     /// Paths that share only a prefix but diverge at a later hop are **not** duplicates — the
     /// shared hops are handled by `build_split_route`, which emits a single combined swap for
@@ -768,7 +768,7 @@ mod tests {
     /// Builds a `SharedDerivedDataRef` with token prices for the given tokens.
     ///
     /// Price is set so gas costs are small but non-zero relative to test trade
-    /// amounts. With `setup_market_unweighted` (gas_price=100 wei) and pool
+    /// amounts. With `setup_market_unweighted` (gas_price=100 wei) and component
     /// gas=50,000, each hop costs ~5 output tokens.
     fn derived_with_token_prices(tokens: &[&Token]) -> SharedDerivedDataRef {
         let mut prices = TokenGasPrices::new();
@@ -877,7 +877,7 @@ mod tests {
     #[test]
     fn test_average_price_impact_redistribution() {
         // Splitting flow across more paths should reduce average price impact.
-        // Uses constant-product pool outputs (reserve_in=1M, reserve_out=2M) to construct
+        // Uses constant-product component outputs (reserve_in=1M, reserve_out=2M) to construct
         // allocations at 1, 2, and 3 paths.
         let hops = dummy_hops(18, 18);
         let iter_0 = [PathAllocation {
@@ -995,7 +995,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_pi_exit_criterion_with_high_gas() {
-        // Three parallel pools, each A→B:
+        // Three parallel components, each A→B:
         //
         //        ┌──[P1]──┐
         //   A ───┼──[P2]──┼─── B
@@ -1003,11 +1003,11 @@ mod tests {
         //
         // High gas costs relative to trade size mean that after the first split
         // lowers PI, `compute_probe_amount` returns None before iteration 2 can
-        // discover the third pool → the loop exits via PI criterion at 2 swaps
+        // discover the third component → the loop exits via PI criterion at 2 swaps
         // instead of the 3 it would produce with lower gas.
         //
         // Math (constant-product, reserves R=5000, trade=2000):
-        //   Initial PI (full amount, one pool): 2000/7000 ≈ 0.286
+        //   Initial PI (full amount, one component): 2000/7000 ≈ 0.286
         //   After ~50/50 split (1000 each):     1000/6000 ≈ 0.167
         //   gas_cost = 1_000_000 × 100 / 1_000_000 = 100 output tokens
         //   PI threshold = gas_cost / (total × max_probe) = 100 / 500 = 0.2
@@ -1051,9 +1051,9 @@ mod tests {
             "PI exit should stop the loop after the first split"
         );
 
-        // Lower-gas control: same pools but gas_cost=50 output tokens.
+        // Lower-gas control: same components but gas_cost=50 output tokens.
         // PI threshold = 50 / 500 = 0.1, below post-split PI (~0.167),
-        // so PI exit never fires and the algorithm discovers all three pools.
+        // so PI exit never fires and the algorithm discovers all three components.
         let (market_lo, gm_lo) = setup_market_unweighted(vec![
             ("P1", &token_a, &token_b, cp(500_000)),
             ("P2", &token_a, &token_b, cp(500_000)),
@@ -1069,13 +1069,13 @@ mod tests {
         assert_eq!(
             result_lo.route().swaps().len(),
             3,
-            "without PI exit, all three pools should be used"
+            "without PI exit, all three components should be used"
         );
     }
 
     #[tokio::test]
     async fn test_step_size_rejects_gas_losing_candidate() {
-        // Two identical parallel pools; the candidate's gas is so large that
+        // Two identical parallel components; the candidate's gas is so large that
         // splitting improves gross output but loses net of gas. The net-aware
         // line search must return a step below min_split, while a normal-gas
         // candidate on the same market is worth a real step.
@@ -1108,8 +1108,8 @@ mod tests {
             .await
             .unwrap();
 
-        let hop = |pool: &str| {
-            HopDescriptor::new(pool.to_string(), token_a.clone(), token_b.clone())
+        let hop = |component: &str| {
+            HopDescriptor::new(component.to_string(), token_a.clone(), token_b.clone())
                 .with_amounts(BigUint::ZERO, BigUint::ZERO)
         };
         let allocations = [PathAllocation {
@@ -1131,7 +1131,7 @@ mod tests {
             algo.optimize_step_size(&allocations, &[hop("P3_cheap")], ord.amount(), &ctx);
         assert!(
             cheap_step >= algo.config.min_split,
-            "identical cheap pool should get a real allocation, got step {cheap_step}"
+            "identical cheap component should get a real allocation, got step {cheap_step}"
         );
     }
 
@@ -1197,11 +1197,11 @@ mod tests {
     }
 
     #[test]
-    fn test_is_duplicate_path_same_pool_different_tokens() {
+    fn test_is_duplicate_path_same_component_different_tokens() {
         // Existing:  A──[P1]──B
         // Candidate: A──[P1]──C
         //
-        // Same pool but different output tokens → not a duplicate.
+        // Same component but different output tokens → not a duplicate.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
         let token_c = token(0x03, "C");
@@ -1220,8 +1220,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_shared_first_pool_two_outputs() {
-        // Diamond topology — two paths share the entry pool:
+    async fn test_shared_first_component_two_outputs() {
+        // Diamond topology — two paths share the entry component:
         //
         //                ┌──[P2]──┐
         //   A ──[P1]── B ┤        ├ C
@@ -1376,7 +1376,7 @@ mod tests {
             marginal_price_product: 2.0,
         };
 
-        // P1 is the only pool — BF returns it again.
+        // P1 is the only component — BF returns it again.
         let second_path = algo
             .find_candidate_path(&ctx, std::slice::from_ref(&first_alloc), &probe_amount)
             .unwrap();
@@ -1420,14 +1420,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_amount_too_small_surfaces_from_inner_bf() {
-        // Reachable pool, but rate 0.5 on a 1-unit input floors to 0 output.
+        // Reachable component, but rate 0.5 on a 1-unit input floors to 0 output.
         // find_best_route propagates the inner BF error with `?`, so
         // AmountTooSmall reaches the caller unchanged.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
         let (market, graph_manager) = setup_market_unweighted(vec![(
-            "pool_ab",
+            "component_ab",
             &token_a,
             &token_b,
             Box::new(MockProtocolSim::new(0.5)) as Box<dyn ProtocolSim>,
@@ -1448,7 +1448,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_path_no_split() {
-        // Only one pool exists → the loop terminates via duplicate detection and
+        // Only one component exists → the loop terminates via duplicate detection and
         // returns the single-path result unchanged.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1479,12 +1479,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_two_parallel_pools_symmetric() {
+    async fn test_two_parallel_components_symmetric() {
         //        ┌──[P1]──┐
         //   A ───┤        ├─── B
         //        └──[P2]──┘
         //
-        // Two identical pools → should split ~50/50.
+        // Two identical components → should split ~50/50.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
@@ -1519,7 +1519,7 @@ mod tests {
             .unwrap();
 
         let swaps = result.route().swaps();
-        assert_eq!(swaps.len(), 2, "should use both pools");
+        assert_eq!(swaps.len(), 2, "should use both components");
         let ids: Vec<&str> = swaps
             .iter()
             .map(|s| s.component_id())
@@ -1527,7 +1527,7 @@ mod tests {
         assert!(ids.contains(&"P1"));
         assert!(ids.contains(&"P2"));
 
-        // Both pools are identical → amounts should be roughly equal (within 10%).
+        // Both components are identical → amounts should be roughly equal (within 10%).
         let amounts: Vec<f64> = swaps
             .iter()
             .map(|s| s.amount_in().to_f64().unwrap())
@@ -1541,7 +1541,7 @@ mod tests {
 
     #[tokio::test]
     async fn find_best_route_reports_price_impact_for_split() {
-        // Two identical pools force a split route; path_frank_wolfe must report the price
+        // Two identical components force a split route; path_frank_wolfe must report the price
         // impact it computes for it. (Single-path routes are linear and get their price
         // impact from the worker's spot-price fallback instead.)
         let token_a = token(0x01, "A");
@@ -1582,12 +1582,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_two_parallel_pools_asymmetric() {
+    async fn test_two_parallel_components_asymmetric() {
         //        ┌──[deep: 200k]───┐
         //   A ───┤                  ├─── B
         //        └──[shallow: 50k]──┘
         //
-        // Large trade should favor the deep pool but still use the shallow one.
+        // Large trade should favor the deep component but still use the shallow one.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
 
@@ -1622,7 +1622,7 @@ mod tests {
             .unwrap();
 
         let swaps = result.route().swaps();
-        assert_eq!(swaps.len(), 2, "should use both pools");
+        assert_eq!(swaps.len(), 2, "should use both components");
 
         let deep_swap = swaps
             .iter()
@@ -1635,7 +1635,7 @@ mod tests {
 
         assert!(
             deep_swap.amount_in() > shallow_swap.amount_in(),
-            "deep pool should get more flow: deep={}, shallow={}",
+            "deep component should get more flow: deep={}, shallow={}",
             deep_swap.amount_in(),
             shallow_swap.amount_in()
         );
@@ -1647,7 +1647,7 @@ mod tests {
         //   A ───┤              ├─── B
         //        └──[P2: 100k]──┘
         //
-        // Large trade (50k) through two parallel pools should produce more
+        // Large trade (50k) through two parallel components should produce more
         // output than routing everything through just one.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1674,7 +1674,7 @@ mod tests {
                 ..Default::default()
             },
         );
-        // Large trade: 50% of each pool's reserves → significant price impact.
+        // Large trade: 50% of each component's reserves → significant price impact.
         let derived = derived_with_token_prices(&[&token_a, &token_b]);
         let ord = order(&token_a, &token_b, 50_000, OrderSide::Sell);
 
@@ -1689,7 +1689,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Single-path: route everything through one pool.
+        // Single-path: route everything through one component.
         let single_algo =
             pfw_algo_with_config(2, PathFrankWolfeConfig { max_paths: 1, ..Default::default() });
         let single_result = single_algo
@@ -1759,7 +1759,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_shared_pool_degradation() {
+    async fn test_shared_component_degradation() {
         //        ┌──[P1]──┐
         //   A ───┤        ├─── B ──[P_shared]── C
         //        └──[P2]──┘
@@ -1767,7 +1767,7 @@ mod tests {
         // Path 1: A─[P1]─B─[P_shared]─C
         // Path 2: A─[P2]─B─[P_shared]─C
         //
-        // Both routes share the interior pool P_shared. Sequential simulation
+        // Both routes share the interior component P_shared. Sequential simulation
         // through P_shared must degrade state correctly.
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
@@ -1835,12 +1835,12 @@ mod tests {
             .map(|s| s.component_id())
             .collect();
 
-        // Should use both entry pools plus the shared pool.
-        assert!(ids.contains(&"P1") && ids.contains(&"P2"), "should use both entry pools");
-        assert!(ids.contains(&"P_shared"), "must use shared B→C pool");
+        // Should use both entry components plus the shared component.
+        assert!(ids.contains(&"P1") && ids.contains(&"P2"), "should use both entry components");
+        assert!(ids.contains(&"P_shared"), "must use shared B→C component");
 
         // Output should be better than single-path (which goes through one entry
-        // pool and hits P_shared with the full amount).
+        // component and hits P_shared with the full amount).
         let single_algo =
             pfw_algo_with_config(3, PathFrankWolfeConfig { max_paths: 1, ..Default::default() });
         let single_result = single_algo
@@ -1860,11 +1860,11 @@ mod tests {
     async fn test_timeout_mid_iteration() {
         //        ┌──[P0]──┐
         //        ├──[P1]──┤
-        //   A ───┼──[P2]──┼─── B     (8 identical parallel pools)
+        //   A ───┼──[P2]──┼─── B     (8 identical parallel components)
         //        ├── ⋯  ──┤
         //        └──[P7]──┘
         //
-        // With a generous timeout the algo splits across all pools.
+        // With a generous timeout the algo splits across all components.
         // With a near-zero timeout it returns fewer paths, proving the FW loop
         // was cut short while still producing a valid result.
         let token_a = token(0x01, "A");
@@ -1878,18 +1878,18 @@ mod tests {
             })
         };
 
-        let pool_names: [&str; 8] = ["P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7"];
+        let component_names: [&str; 8] = ["P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7"];
 
         let pfw_config =
             PathFrankWolfeConfig { max_paths: 8, min_split: 0.001, ..Default::default() };
         let ord = order(&token_a, &token_b, 80_000, OrderSide::Sell);
 
-        // Generous timeout — should split across many pools.
-        let pools: Vec<_> = pool_names
+        // Generous timeout — should split across many components.
+        let components: Vec<_> = component_names
             .iter()
             .map(|id| (*id, &token_a, &token_b, cp(100_000)))
             .collect();
-        let (market, graph_manager) = setup_market_unweighted(pools);
+        let (market, graph_manager) = setup_market_unweighted(components);
         let generous_algo = pfw_algo_with_config(2, pfw_config.clone());
         let derived = derived_with_token_prices(&[&token_a, &token_b]);
         let generous_result = generous_algo
@@ -1899,11 +1899,11 @@ mod tests {
         let generous_swaps = generous_result.route().swaps().len();
 
         // Near-zero timeout — should produce a valid result with fewer paths.
-        let pools: Vec<_> = pool_names
+        let components: Vec<_> = component_names
             .iter()
             .map(|id| (*id, &token_a, &token_b, cp(100_000)))
             .collect();
-        let (market, graph_manager) = setup_market_unweighted(pools);
+        let (market, graph_manager) = setup_market_unweighted(components);
         let timeout_algo = PathFrankWolfeAlgorithm::new(
             AlgorithmConfig::new(1, 2, StdDuration::from_millis(1), None).unwrap(),
             pfw_config,

--- a/fynd-core/src/algorithm/sim_guard.rs
+++ b/fynd-core/src/algorithm/sim_guard.rs
@@ -1,10 +1,10 @@
-//! Panic containment for pool simulation calls.
+//! Panic containment for component simulation calls.
 //!
-//! `ProtocolSim` implementations run third-party pool math that can panic on degenerate
+//! `ProtocolSim` implementations run third-party component math that can panic on degenerate
 //! inputs (e.g. a U256 division by zero when quoting an absurdly large amount). Left
 //! uncaught, such a panic unwinds through the solver worker thread and permanently kills
 //! it. Simulation calls made while solving therefore go through this guard, which turns
-//! a panic into a `SimulationError` so the algorithm skips the pool and keeps solving.
+//! a panic into a `SimulationError` so the algorithm skips the component and keeps solving.
 
 use std::panic::{catch_unwind, AssertUnwindSafe};
 
@@ -26,7 +26,7 @@ pub(crate) trait GuardedProtocolSim {
     /// Calls `get_amount_out`, converting a panic into a `SimulationError::FatalError`.
     ///
     /// On a contained panic, logs the input that triggered it (amount and token pair) so
-    /// the offending pool/quote can be tracked down from the logs.
+    /// the offending component/quote can be tracked down from the logs.
     fn get_amount_out_guarded(
         &self,
         amount_in: BigUint,
@@ -64,7 +64,7 @@ impl<T: ProtocolSim + ?Sized> GuardedProtocolSim for T {
                 token_in_symbol = %token_in.symbol,
                 token_out_symbol = %token_out.symbol,
                 panic = message,
-                "pool simulation panicked; skipping pool"
+                "component simulation panicked; skipping component"
             );
             Err(SimulationError::FatalError(format!("get_amount_out panicked: {message}")))
         })

--- a/fynd-core/src/algorithm/split_primitives.rs
+++ b/fynd-core/src/algorithm/split_primitives.rs
@@ -98,12 +98,12 @@ pub(crate) struct SimResult {
     pub(crate) marginal_price_product: f64,
     /// Per-hop `(amount_out, gas)` in path order.
     pub(crate) hop_results: Vec<(BigUint, BigUint)>,
-    /// Per-hop post-swap pool states in path order. Apply these as overrides
-    /// before simulating another path so shared pools see depleted reserves.
+    /// Per-hop post-swap component states in path order. Apply these as overrides
+    /// before simulating another path so shared components see depleted reserves.
     pub(crate) post_swap_states: Vec<(ComponentId, Box<dyn ProtocolSim>)>,
 }
 
-/// Pool state overrides for passing degraded states to `find_single_route`.
+/// Component state overrides for passing degraded states to `find_single_route`.
 #[derive(Default)]
 pub(crate) struct MarketOverrides(HashMap<ComponentId, Box<dyn ProtocolSim>>);
 
@@ -112,7 +112,7 @@ impl MarketOverrides {
         Self::default()
     }
 
-    /// Insert a degraded pool state as an override.
+    /// Insert a degraded component state as an override.
     pub(crate) fn with_override(mut self, id: ComponentId, sim: Box<dyn ProtocolSim>) -> Self {
         self.0.insert(id, sim);
         self
@@ -120,9 +120,9 @@ impl MarketOverrides {
 
     /// Wraps an existing override entry so that `get_amount_out().gas` is zero for
     /// the specified `(token_in, token_out)` pair, but unchanged for other pairs
-    /// through the same pool.
+    /// through the same component.
     ///
-    /// Different token pairs through the same pool are separate on-chain swaps with
+    /// Different token pairs through the same component are separate on-chain swaps with
     /// independent gas costs, so only committed pairs should be zeroed. Call this
     /// once per committed `(component_id, token_in, token_out)` triple.
     ///
@@ -398,7 +398,7 @@ pub(crate) fn compute_marginal_price_product(
 /// For each hop, the path's own post-swap states are checked first, then
 /// `overrides`, then the live market state. Returns the final output amount,
 /// marginal price product (spot prices at the state each hop executed
-/// against), per-hop results, and the post-swap pool states.
+/// against), per-hop results, and the post-swap component states.
 pub(crate) fn simulate_path(
     hops: &[HopDescriptor],
     amount_in: &BigUint,
@@ -412,7 +412,7 @@ pub(crate) fn simulate_path(
     let mut marginal_price_product = 1.0;
 
     for hop in hops {
-        // Prefer this path's own post-swap state so a pool reused by an
+        // Prefer this path's own post-swap state so a component reused by an
         // earlier hop is simulated on depleted reserves, not fresh ones.
         let sim = post_swap_states
             .iter()
@@ -454,7 +454,7 @@ pub(crate) fn simulate_path(
     })
 }
 
-/// Builds post-swap pool states after all paths in a split-route solution
+/// Builds post-swap component states after all paths in a split-route solution
 /// have been executed.
 ///
 /// For example, if the current solution splits 1000 USDC→ETH across:
@@ -497,7 +497,7 @@ struct SplitSwap {
     amount_in: BigUint,
 }
 
-/// One pool swap in a split route, after it has been simulated.
+/// One component swap in a split route, after it has been simulated.
 struct SimulatedSplitSwap {
     hop: HopDescriptor,
     split: f64,
@@ -627,13 +627,13 @@ fn build_in_degree(hops_by_token: &HashMap<Bytes, Vec<SplitSwap>>) -> HashMap<By
 /// Simulates a split route from start token to outputs and returns the outcome.
 ///
 /// Swaps run in dependency order, so each token is fully pooled from all its
-/// inflows before being re-split downstream, and every swap sees the pool state
-/// left by the swaps before it — so paths sharing a pool no longer each assume
+/// inflows before being re-split downstream, and every swap sees the component state
+/// left by the swaps before it — so paths sharing a component no longer each assume
 /// fresh liquidity. This one pass backs scoring, candidate discovery, and route
 /// assembly, so all three agree on the same executable route. Round-trips that
 /// end on the input token are supported.
 ///
-/// Errors if a path revisits an intermediate token, a pool cannot be simulated,
+/// Errors if a path revisits an intermediate token, a component cannot be simulated,
 /// or the merged swaps cannot be ordered (a genuine dependency cycle).
 fn execute_split_plan(
     paths: &[PathAllocation],
@@ -824,7 +824,7 @@ pub(crate) fn evaluate_total_output(
 /// Assembles a [`Route`] from split-route path allocations with shared-hop
 /// deduplication.
 ///
-/// Paths may share pool hops (same `component_id`, `token_in`, `token_out`).
+/// Paths may share component hops (same `component_id`, `token_in`, `token_out`).
 /// When they do, this function emits one combined swap rather than duplicates.
 /// Within each branch collection of swaps sharing a `token_in`, the tycho-execution
 /// remainder convention is applied: sorted by fraction descending, all but the
@@ -838,8 +838,8 @@ pub(crate) fn evaluate_total_output(
 /// has been emitted.
 ///
 /// Why this matters:
-/// - `merge_shared_hops` collapses a shared pool hop into one swap (not one per path), saving gas
-///   by calling the pool once with combined input.
+/// - `merge_shared_hops` collapses a shared component hop into one swap (not one per path), saving
+///   gas by calling the component once with combined input.
 /// - That single swap's split fraction is computed against the full token balance, so all inflows
 ///   must be complete before it is emitted.
 /// - The in-degree of each token tracks how many upstream swaps produce it; the token is processed
@@ -847,29 +847,29 @@ pub(crate) fn evaluate_total_output(
 ///
 /// Note: the TychoRouter contract *could* support interleaved splits
 /// (partial consume, more inflows, consume rest), but that would require
-/// an extra swap on the same pool, spending more gas.
+/// an extra swap on the same component, spending more gas.
 ///
 /// For example, given paths of different lengths that converge on the same
 /// intermediate token:
 ///
 /// ```text
-/// Path 1 (2 hops): WETH -> USDC -(pool A)-> DAI
-/// Path 2 (3 hops): WETH -> USDT -> USDC -(pool A)-> DAI
+/// Path 1 (2 hops): WETH -> USDC -(component A)-> DAI
+/// Path 2 (3 hops): WETH -> USDT -> USDC -(component A)-> DAI
 /// ```
 ///
-/// Pool A (USDC→DAI) is merged into one swap. If USDC were visited before
-/// the USDT→USDC hop completes, Pool A would see only Path 1's USDC. The
+/// Component A (USDC→DAI) is merged into one swap. If USDC were visited before
+/// the USDT→USDC hop completes, Component A would see only Path 1's USDC. The
 /// topological sort prevents this by waiting for all inflows to USDC
-/// before emitting Pool A's swap. This extends to downstream splits too:
+/// before emitting Component A's swap. This extends to downstream splits too:
 ///
 /// ```text
-/// Path 1: WETH -> USDC -> DAI (Pool A) -> PEPE (Pool B)  (0.5)
-/// Path 2: WETH -> USDC -> DAI (Pool A) -> PEPE (Pool C)  (0.5)
-/// Path 3: WETH -> USDT -> USDC -> DAI (Pool A) -> PEPE (Pool B or C)
+/// Path 1: WETH -> USDC -> DAI (Component A) -> PEPE (Component B)  (0.5)
+/// Path 2: WETH -> USDC -> DAI (Component A) -> PEPE (Component C)  (0.5)
+/// Path 3: WETH -> USDT -> USDC -> DAI (Component A) -> PEPE (Component B or C)
 /// ```
 ///
-/// The DAI→PEPE split between Pool B and Pool C must wait until all DAI
-/// has been produced (from both paths through the merged Pool A swap).
+/// The DAI→PEPE split between Component B and Component C must wait until all DAI
+/// has been produced (from both paths through the merged Component A swap).
 pub(crate) fn build_split_route(
     paths: &[PathAllocation],
     market: &MarketState,
@@ -933,11 +933,11 @@ mod tests {
         types::OrderSide,
     };
 
-    fn make_market(pools: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketState {
+    fn make_market(components: Vec<(&str, Vec<Token>, Box<dyn ProtocolSim>)>) -> MarketState {
         let mut market = MarketState::new();
-        for (pool_id, tokens, sim) in pools {
-            market.upsert_components(std::iter::once(component(pool_id, &tokens)));
-            market.update_states([(pool_id.to_string(), sim)]);
+        for (component_id, tokens, sim) in components {
+            market.upsert_components(std::iter::once(component(component_id, &tokens)));
+            market.update_states([(component_id.to_string(), sim)]);
             market.upsert_tokens(tokens);
         }
         market
@@ -1130,12 +1130,12 @@ mod tests {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let market = make_market(vec![(
-            "pool_ab",
+            "component_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(MockProtocolSim::new(3.0)),
         )]);
 
-        let hops = [HopDescriptor::new("pool_ab".to_string(), token_a, token_b)];
+        let hops = [HopDescriptor::new("component_ab".to_string(), token_a, token_b)];
 
         let product =
             compute_marginal_price_product(&hops, &market, &MarketOverrides::empty()).unwrap();
@@ -1149,20 +1149,20 @@ mod tests {
         let token_c = token(0x0C, "C");
         let market = make_market(vec![
             (
-                "pool_ab",
+                "component_ab",
                 vec![token_a.clone(), token_b.clone()],
                 Box::new(MockProtocolSim::new(2.0)),
             ),
             (
-                "pool_bc",
+                "component_bc",
                 vec![token_b.clone(), token_c.clone()],
                 Box::new(MockProtocolSim::new(4.0)),
             ),
         ]);
 
         let hops = [
-            HopDescriptor::new("pool_ab".to_string(), token_a, token_b.clone()),
-            HopDescriptor::new("pool_bc".to_string(), token_b, token_c),
+            HopDescriptor::new("component_ab".to_string(), token_a, token_b.clone()),
+            HopDescriptor::new("component_bc".to_string(), token_b, token_c),
         ];
 
         let product =
@@ -1176,16 +1176,16 @@ mod tests {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let market = make_market(vec![(
-            "pool_ab",
+            "component_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(MockProtocolSim::new(3.0)),
         )]);
 
-        let hops = [HopDescriptor::new("pool_ab".to_string(), token_a, token_b)];
+        let hops = [HopDescriptor::new("component_ab".to_string(), token_a, token_b)];
 
-        // Override pool_ab with a different spot price.
+        // Override component_ab with a different spot price.
         let overrides = MarketOverrides::empty()
-            .with_override("pool_ab".to_string(), Box::new(MockProtocolSim::new(7.0)));
+            .with_override("component_ab".to_string(), Box::new(MockProtocolSim::new(7.0)));
 
         let product = compute_marginal_price_product(&hops, &market, &overrides).unwrap();
         assert!((product - 7.0).abs() < f64::EPSILON, "expected 7.0, got {product}");
@@ -1200,20 +1200,20 @@ mod tests {
         let token_c = token(0x0C, "C");
         let market = make_market(vec![
             (
-                "pool_ab",
+                "component_ab",
                 vec![token_a.clone(), token_b.clone()],
                 Box::new(MockProtocolSim::new(2.0)),
             ),
             (
-                "pool_bc",
+                "component_bc",
                 vec![token_b.clone(), token_c.clone()],
                 Box::new(MockProtocolSim::new(3.0)),
             ),
         ]);
 
         let hops = [
-            HopDescriptor::new("pool_ab".to_string(), token_a, token_b.clone()),
-            HopDescriptor::new("pool_bc".to_string(), token_b, token_c),
+            HopDescriptor::new("component_ab".to_string(), token_a, token_b.clone()),
+            HopDescriptor::new("component_bc".to_string(), token_b, token_c),
         ];
 
         let amount_in = BigUint::from(1000u64);
@@ -1232,23 +1232,23 @@ mod tests {
 
     #[test]
     fn test_simulate_path_contains_simulation_panic() {
-        // Pool math that panics (e.g. U256 division by zero on degenerate amounts) must
+        // Component math that panics (e.g. U256 division by zero on degenerate amounts) must
         // surface as a SimulationFailed error, not unwind through the solver thread.
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let market = make_market(vec![(
-            "pool_ab",
+            "component_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(DivByZeroSim::default()),
         )]);
 
-        let hops = [HopDescriptor::new("pool_ab".to_string(), token_a, token_b)];
+        let hops = [HopDescriptor::new("component_ab".to_string(), token_a, token_b)];
         let result =
             simulate_path(&hops, &BigUint::from(1000u64), &market, &MarketOverrides::empty());
 
         match result {
             Err(AlgorithmError::SimulationFailed { component_id, error }) => {
-                assert_eq!(component_id, "pool_ab");
+                assert_eq!(component_id, "component_ab");
                 assert!(error.contains("panic"), "error should mention the panic: {error}");
             }
             Err(other) => panic!("expected SimulationFailed, got {other:?}"),
@@ -1264,18 +1264,23 @@ mod tests {
         let sim_ab = MockProtocolSim::new(2.0).with_gas(100_000);
         let sim_bc = MockProtocolSim::new(3.0).with_gas(70_000);
         let market = make_market(vec![
-            ("pool_ab", vec![token_a.clone(), token_b.clone()], Box::new(sim_ab.clone())),
-            ("pool_bc", vec![token_b.clone(), token_c.clone()], Box::new(sim_bc.clone())),
+            ("component_ab", vec![token_a.clone(), token_b.clone()], Box::new(sim_ab.clone())),
+            ("component_bc", vec![token_b.clone(), token_c.clone()], Box::new(sim_bc.clone())),
         ]);
 
-        // Zero gas on pool_ab, leave pool_bc as a normal override.
+        // Zero gas on component_ab, leave component_bc as a normal override.
         let overrides = MarketOverrides::empty()
-            .with_override("pool_ab".to_string(), Box::new(sim_ab))
-            .with_zero_gas("pool_ab".to_string(), token_a.address.clone(), token_b.address.clone())
-            .with_override("pool_bc".to_string(), Box::new(sim_bc));
+            .with_override("component_ab".to_string(), Box::new(sim_ab))
+            .with_zero_gas(
+                "component_ab".to_string(),
+                token_a.address.clone(),
+                token_b.address.clone(),
+            )
+            .with_override("component_bc".to_string(), Box::new(sim_bc));
 
-        let hops_ab = [HopDescriptor::new("pool_ab".to_string(), token_a.clone(), token_b.clone())];
-        let hops_bc = [HopDescriptor::new("pool_bc".to_string(), token_b, token_c)];
+        let hops_ab =
+            [HopDescriptor::new("component_ab".to_string(), token_a.clone(), token_b.clone())];
+        let hops_bc = [HopDescriptor::new("component_bc".to_string(), token_b, token_c)];
         let amount_in = BigUint::from(1000u64);
 
         let hop_gas_sum = |sim: &SimResult| -> BigUint {
@@ -1297,7 +1302,7 @@ mod tests {
             "zero-gas override should report gas=0"
         );
 
-        // pool_bc is a normal override — its gas should be unaffected.
+        // component_bc is a normal override — its gas should be unaffected.
         let result_bc = simulate_path(&hops_bc, &amount_in, &market, &overrides).unwrap();
         assert_eq!(
             hop_gas_sum(&result_bc),
@@ -1310,30 +1315,31 @@ mod tests {
     fn test_evaluate_total_output_two_paths() {
         // 50/50 split of 1000 across two parallel 1-hop paths:
         //
-        //       500 -- pool_1 (price=2.0) --> 1000
+        //       500 -- component_1 (price=2.0) --> 1000
         //      /                                   \
         //  1000                                     2500
         //      \                                   /
-        //       500 -- pool_2 (price=3.0) --> 1500
+        //       500 -- component_2 (price=3.0) --> 1500
         //
         // total_gas = 50k + 60k = 110k
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let market = make_market(vec![
             (
-                "pool_1",
+                "component_1",
                 vec![token_a.clone(), token_b.clone()],
                 Box::new(MockProtocolSim::new(2.0).with_gas(50_000)),
             ),
             (
-                "pool_2",
+                "component_2",
                 vec![token_a.clone(), token_b.clone()],
                 Box::new(MockProtocolSim::new(3.0).with_gas(60_000)),
             ),
         ]);
 
-        let hops_1 = [HopDescriptor::new("pool_1".to_string(), token_a.clone(), token_b.clone())];
-        let hops_2 = [HopDescriptor::new("pool_2".to_string(), token_a, token_b)];
+        let hops_1 =
+            [HopDescriptor::new("component_1".to_string(), token_a.clone(), token_b.clone())];
+        let hops_2 = [HopDescriptor::new("component_2".to_string(), token_a, token_b)];
 
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
@@ -1348,8 +1354,8 @@ mod tests {
     }
 
     #[test]
-    fn test_evaluate_total_output_shared_pool_depletes() {
-        // Two "paths" through the SAME constant-product pool. Sequential
+    fn test_evaluate_total_output_shared_component_depletes() {
+        // Two "paths" through the SAME constant-product component. Sequential
         // simulation must thread the post-swap state, so the combined output
         // matches one full-amount swap instead of double-counting the fresh
         // reserves for each half.
@@ -1361,13 +1367,15 @@ mod tests {
             gas: 50_000,
         };
         let market = make_market(vec![(
-            "pool",
+            "component",
             vec![token_a.clone(), token_b.clone()],
             Box::new(cp.clone()),
         )]);
 
-        let hops_1 = [HopDescriptor::new("pool".to_string(), token_a.clone(), token_b.clone())];
-        let hops_2 = [HopDescriptor::new("pool".to_string(), token_a.clone(), token_b.clone())];
+        let hops_1 =
+            [HopDescriptor::new("component".to_string(), token_a.clone(), token_b.clone())];
+        let hops_2 =
+            [HopDescriptor::new("component".to_string(), token_a.clone(), token_b.clone())];
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let total_amount = BigUint::from(1000u64);
 
@@ -1393,7 +1401,7 @@ mod tests {
         // equals the full-amount swap up to per-chunk rounding.
         assert!(
             total_out < &half_fresh_out * 2u32,
-            "shared pool must deplete between paths: {total_out} >= {}",
+            "shared component must deplete between paths: {total_out} >= {}",
             &half_fresh_out * 2u32
         );
         let diff = BigInt::from(total_out) - BigInt::from(full_swap_out);
@@ -1405,7 +1413,7 @@ mod tests {
 
     #[test]
     fn test_evaluate_total_output_gas_deduplication() {
-        // Two paths share pool P1 (pre-split hop). P1's gas should be
+        // Two paths share component P1 (pre-split hop). P1's gas should be
         // counted once, not twice.
         //
         //              P2 (50k gas) --> C
@@ -1472,29 +1480,29 @@ mod tests {
         let token_d = token(0x0D, "D");
         let market = make_market(vec![
             (
-                "tripool",
+                "tricomponent",
                 vec![token_a.clone(), token_b.clone(), token_c.clone()],
                 Box::new(MockProtocolSim::new(2.0).with_gas(80_000)),
             ),
             (
-                "pool_bd",
+                "component_bd",
                 vec![token_b.clone(), token_d.clone()],
                 Box::new(MockProtocolSim::new(1.0)),
             ),
             (
-                "pool_cd",
+                "component_cd",
                 vec![token_c.clone(), token_d.clone()],
                 Box::new(MockProtocolSim::new(1.0)),
             ),
         ]);
 
         let hops_b = [
-            HopDescriptor::new("tripool".to_string(), token_a.clone(), token_b.clone()),
-            HopDescriptor::new("pool_bd".to_string(), token_b, token_d.clone()),
+            HopDescriptor::new("tricomponent".to_string(), token_a.clone(), token_b.clone()),
+            HopDescriptor::new("component_bd".to_string(), token_b, token_d.clone()),
         ];
         let hops_c = [
-            HopDescriptor::new("tripool".to_string(), token_a.clone(), token_c.clone()),
-            HopDescriptor::new("pool_cd".to_string(), token_c.clone(), token_d.clone()),
+            HopDescriptor::new("tricomponent".to_string(), token_a.clone(), token_c.clone()),
+            HopDescriptor::new("component_cd".to_string(), token_c.clone(), token_d.clone()),
         ];
 
         let total_amount = BigUint::from(1000u64);
@@ -1555,23 +1563,23 @@ mod tests {
 
     #[test]
     fn test_gas_dedup_different_tokens() {
-        // A single 3-token pool used for two different token pairs is two
+        // A single 3-token component used for two different token pairs is two
         // distinct hops — gas must be counted for each.
         //
-        //  A -- TRIPOOL (A→B) --> B    (path 1)
-        //  B -- TRIPOOL (B→C) --> C    (path 2)
+        //  A -- TRICOMPONENT (A→B) --> B    (path 1)
+        //  B -- TRICOMPONENT (B→C) --> C    (path 2)
         //
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
         let market = make_market(vec![(
-            "tripool",
+            "tricomponent",
             vec![token_a.clone(), token_b.clone(), token_c.clone()],
             Box::new(MockProtocolSim::new(1.0).with_gas(80_000)),
         )]);
 
-        let hops_1 = [HopDescriptor::new("tripool".to_string(), token_a, token_b.clone())];
-        let hops_2 = [HopDescriptor::new("tripool".to_string(), token_b, token_c)];
+        let hops_1 = [HopDescriptor::new("tricomponent".to_string(), token_a, token_b.clone())];
+        let hops_2 = [HopDescriptor::new("tricomponent".to_string(), token_b, token_c)];
 
         let paths: Vec<&[HopDescriptor]> = vec![&hops_1, &hops_2];
         let fractions = [0.5, 0.5];
@@ -1581,16 +1589,16 @@ mod tests {
         let (_, total_gas) =
             evaluate_total_output(&paths, &fractions, &total_amount, &market, &overrides).unwrap();
 
-        // Different token pairs on the same pool: 80k + 80k = 160k
+        // Different token pairs on the same component: 80k + 80k = 160k
         assert_eq!(total_gas, 160_000);
     }
 
     #[test]
-    fn test_build_post_swap_overrides_degrades_used_pools() {
+    fn test_build_post_swap_overrides_degrades_used_components() {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let market = make_market(vec![(
-            "pool_ab",
+            "component_ab",
             vec![token_a.clone(), token_b.clone()],
             Box::new(ConstantProductSim {
                 reserve_0: BigUint::from(10_000u64),
@@ -1602,7 +1610,7 @@ mod tests {
         let allocation = PathAllocation {
             hops: vec![SimulatedHop {
                 descriptor: HopDescriptor::new(
-                    "pool_ab".to_string(),
+                    "component_ab".to_string(),
                     token_a.clone(),
                     token_b.clone(),
                 ),
@@ -1618,10 +1626,10 @@ mod tests {
         let degraded = build_post_swap_overrides(&[allocation], &market).unwrap();
 
         // xy=k: amount_out = amount_in * reserve_out / (reserve_in + amount_in)
-        // Fresh pool (10000/20000): 100 * 20000 / (10000 + 100) = 198
+        // Fresh component (10000/20000): 100 * 20000 / (10000 + 100) = 198
         let probe = BigUint::from(100u64);
         let fresh_out = market
-            .get_simulation_state("pool_ab")
+            .get_simulation_state("component_ab")
             .unwrap()
             .get_amount_out(probe.clone(), &token_a, &token_b)
             .unwrap()
@@ -1630,9 +1638,9 @@ mod tests {
 
         // The 1000-in allocation produces 1000*20000/(10000+1000) = 1818 out,
         // shifting reserves to (10000+1000, 20000-1818) = (11000, 18182).
-        // Degraded pool: 100 * 18182 / (11000 + 100) = 163
+        // Degraded component: 100 * 18182 / (11000 + 100) = 163
         let degraded_out = degraded
-            .get(&"pool_ab".to_string())
+            .get(&"component_ab".to_string())
             .unwrap()
             .get_amount_out(probe, &token_a, &token_b)
             .unwrap()
@@ -1735,12 +1743,12 @@ mod tests {
 
         let branch_collection = vec![
             SplitSwap {
-                hop: HopDescriptor::new("pool1".to_string(), token_a.clone(), token_b.clone()),
+                hop: HopDescriptor::new("component1".to_string(), token_a.clone(), token_b.clone()),
                 split: 0.7,
                 amount_in: BigUint::ZERO,
             },
             SplitSwap {
-                hop: HopDescriptor::new("pool2".to_string(), token_a.clone(), token_b.clone()),
+                hop: HopDescriptor::new("component2".to_string(), token_a.clone(), token_b.clone()),
                 split: 0.3,
                 amount_in: BigUint::ZERO,
             },
@@ -1759,12 +1767,12 @@ mod tests {
     fn test_assign_splits_and_amounts_single_hop() {
         // A single hop receives the entire amount with split = 0.0.
         //
-        //  1000 -- pool1 (split=0.0) --> B
+        //  1000 -- component1 (split=0.0) --> B
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
 
         let branch_collection = vec![SplitSwap {
-            hop: HopDescriptor::new("pool1".to_string(), token_a, token_b),
+            hop: HopDescriptor::new("component1".to_string(), token_a, token_b),
             split: 1.0,
             amount_in: BigUint::ZERO,
         }];
@@ -1784,17 +1792,29 @@ mod tests {
         // 3 paths splitting at source: last swap at the split point must
         // have split=0.0.
         //
-        //       500 -- pool1 (price=2) --> 1000
+        //       500 -- component1 (price=2) --> 1000
         //      /
-        //  1000---- 300 -- pool2 (price=3) -->  900
+        //  1000---- 300 -- component2 (price=3) -->  900
         //      \
-        //       200 -- pool3 (price=4) -->  800
+        //       200 -- component3 (price=4) -->  800
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let market = make_market(vec![
-            ("pool1", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(2.0))),
-            ("pool2", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(3.0))),
-            ("pool3", vec![token_a.clone(), token_b.clone()], Box::new(MockProtocolSim::new(4.0))),
+            (
+                "component1",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(2.0)),
+            ),
+            (
+                "component2",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(3.0)),
+            ),
+            (
+                "component3",
+                vec![token_a.clone(), token_b.clone()],
+                Box::new(MockProtocolSim::new(4.0)),
+            ),
         ]);
         let ord = order(&token_a, &token_b, 1000, OrderSide::Sell);
 
@@ -1803,7 +1823,7 @@ mod tests {
             PathAllocation {
                 hops: vec![SimulatedHop {
                     descriptor: HopDescriptor::new(
-                        "pool1".to_string(),
+                        "component1".to_string(),
                         token_a.clone(),
                         token_b.clone(),
                     ),
@@ -1818,7 +1838,7 @@ mod tests {
             PathAllocation {
                 hops: vec![SimulatedHop {
                     descriptor: HopDescriptor::new(
-                        "pool2".to_string(),
+                        "component2".to_string(),
                         token_a.clone(),
                         token_b.clone(),
                     ),
@@ -1833,7 +1853,7 @@ mod tests {
             PathAllocation {
                 hops: vec![SimulatedHop {
                     descriptor: HopDescriptor::new(
-                        "pool3".to_string(),
+                        "component3".to_string(),
                         token_a.clone(),
                         token_b.clone(),
                     ),
@@ -1852,12 +1872,12 @@ mod tests {
 
         assert_eq!(swaps.len(), 3);
 
-        // Sorted descending: pool1 (0.5), pool2 (0.3), pool3 (0.2).
-        assert_eq!(swaps[0].component_id(), "pool1");
+        // Sorted descending: component1 (0.5), component2 (0.3), component3 (0.2).
+        assert_eq!(swaps[0].component_id(), "component1");
         assert_eq!(*swaps[0].split(), 0.5);
-        assert_eq!(swaps[1].component_id(), "pool2");
+        assert_eq!(swaps[1].component_id(), "component2");
         assert_eq!(*swaps[1].split(), 0.3);
-        assert_eq!(swaps[2].component_id(), "pool3");
+        assert_eq!(swaps[2].component_id(), "component3");
         assert_eq!(*swaps[2].split(), 0.0);
     }
 
@@ -1869,12 +1889,12 @@ mod tests {
         let token_c = token(0x0C, "C");
         let market = make_market(vec![
             (
-                "pool_ab",
+                "component_ab",
                 vec![token_a.clone(), token_b.clone()],
                 Box::new(MockProtocolSim::new(2.0)),
             ),
             (
-                "pool_bc",
+                "component_bc",
                 vec![token_b.clone(), token_c.clone()],
                 Box::new(MockProtocolSim::new(3.0)),
             ),
@@ -1886,7 +1906,7 @@ mod tests {
             hops: vec![
                 SimulatedHop {
                     descriptor: HopDescriptor::new(
-                        "pool_ab".to_string(),
+                        "component_ab".to_string(),
                         token_a.clone(),
                         token_b.clone(),
                     ),
@@ -1894,7 +1914,7 @@ mod tests {
                     gas: gas.clone(),
                 },
                 SimulatedHop {
-                    descriptor: HopDescriptor::new("pool_bc".to_string(), token_b, token_c),
+                    descriptor: HopDescriptor::new("component_bc".to_string(), token_b, token_c),
                     amount_out: BigUint::from(6000u64),
                     gas,
                 },
@@ -1915,8 +1935,8 @@ mod tests {
     }
 
     #[test]
-    fn test_build_split_route_shared_first_pool() {
-        // Two paths sharing pool P1 at A→B, diverging at B→C (P2 vs P3).
+    fn test_build_split_route_shared_first_component() {
+        // Two paths sharing component P1 at A→B, diverging at B→C (P2 vs P3).
         //
         //                  P2 (price=3) --> C
         //                 /
@@ -2026,33 +2046,33 @@ mod tests {
         // Paths A→B→Z and A→C→Z: source-level split with different
         // intermediate tokens.
         //
-        //       pool_ab --> B -- pool_bz
+        //       component_ab --> B -- component_bz
         //      /                         \
         //  A --                           Z
         //      \                         /
-        //       pool_ac --> C -- pool_cz
+        //       component_ac --> C -- component_cz
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
         let token_c = token(0x0C, "C");
         let token_z = token(0x1A, "Z");
         let market = make_market(vec![
             (
-                "pool_ab",
+                "component_ab",
                 vec![token_a.clone(), token_b.clone()],
                 Box::new(MockProtocolSim::new(2.0)),
             ),
             (
-                "pool_ac",
+                "component_ac",
                 vec![token_a.clone(), token_c.clone()],
                 Box::new(MockProtocolSim::new(3.0)),
             ),
             (
-                "pool_bz",
+                "component_bz",
                 vec![token_b.clone(), token_z.clone()],
                 Box::new(MockProtocolSim::new(4.0)),
             ),
             (
-                "pool_cz",
+                "component_cz",
                 vec![token_c.clone(), token_z.clone()],
                 Box::new(MockProtocolSim::new(5.0)),
             ),
@@ -2065,7 +2085,7 @@ mod tests {
                 hops: vec![
                     SimulatedHop {
                         descriptor: HopDescriptor::new(
-                            "pool_ab".to_string(),
+                            "component_ab".to_string(),
                             token_a.clone(),
                             token_b.clone(),
                         ),
@@ -2074,7 +2094,7 @@ mod tests {
                     },
                     SimulatedHop {
                         descriptor: HopDescriptor::new(
-                            "pool_bz".to_string(),
+                            "component_bz".to_string(),
                             token_b,
                             token_z.clone(),
                         ),
@@ -2091,7 +2111,7 @@ mod tests {
                 hops: vec![
                     SimulatedHop {
                         descriptor: HopDescriptor::new(
-                            "pool_ac".to_string(),
+                            "component_ac".to_string(),
                             token_a.clone(),
                             token_c.clone(),
                         ),
@@ -2099,7 +2119,11 @@ mod tests {
                         gas: gas.clone(),
                     },
                     SimulatedHop {
-                        descriptor: HopDescriptor::new("pool_cz".to_string(), token_c, token_z),
+                        descriptor: HopDescriptor::new(
+                            "component_cz".to_string(),
+                            token_c,
+                            token_z,
+                        ),
                         amount_out: BigUint::from(6000u64),
                         gas,
                     },
@@ -2116,77 +2140,77 @@ mod tests {
 
         assert_eq!(swaps.len(), 4, "expected 4 swaps (2 source + 2 intermediate)");
 
-        // Source-level split: pool_ab (0.6) first, pool_ac (0.4) last.
-        assert_eq!(swaps[0].component_id(), "pool_ab");
+        // Source-level split: component_ab (0.6) first, component_ac (0.4) last.
+        assert_eq!(swaps[0].component_id(), "component_ab");
         assert_eq!(*swaps[0].split(), 0.6);
         assert_eq!(*swaps[0].amount_in(), BigUint::from(600u64));
         assert_eq!(*swaps[0].amount_out(), BigUint::from(1200u64));
 
-        assert_eq!(swaps[1].component_id(), "pool_ac");
+        assert_eq!(swaps[1].component_id(), "component_ac");
         assert_eq!(*swaps[1].split(), 0.0);
         assert_eq!(*swaps[1].amount_in(), BigUint::from(400u64));
         assert_eq!(*swaps[1].amount_out(), BigUint::from(1200u64));
 
         // Intermediate swaps: single hops from B and C, all split=0.0.
-        assert_eq!(swaps[2].component_id(), "pool_bz");
+        assert_eq!(swaps[2].component_id(), "component_bz");
         assert_eq!(*swaps[2].split(), 0.0);
         assert_eq!(*swaps[2].amount_in(), BigUint::from(1200u64));
         assert_eq!(*swaps[2].amount_out(), BigUint::from(4800u64));
 
-        assert_eq!(swaps[3].component_id(), "pool_cz");
+        assert_eq!(swaps[3].component_id(), "component_cz");
         assert_eq!(*swaps[3].split(), 0.0);
         assert_eq!(*swaps[3].amount_in(), BigUint::from(1200u64));
         assert_eq!(*swaps[3].amount_out(), BigUint::from(6000u64));
     }
 
     #[test]
-    fn test_build_split_route_cross_depth_shared_pool() {
-        // Two paths of different lengths share Pool A (USDC→DAI).
+    fn test_build_split_route_cross_depth_shared_component() {
+        // Two paths of different lengths share Component A (USDC→DAI).
         // The BFS must process all USDC inflows before visiting USDC's
         // outgoing swaps.
         //
-        //  WETH ──┬────────────────────▶ USDC ─── pool_a ──▶ DAI
+        //  WETH ──┬────────────────────▶ USDC ─── component_a ──▶ DAI
         //         │                      ▲
         //         └──────────▶ USDT ─────┘
         //
         // Path 1 (2 hops): WETH → USDC → DAI      (0.6 fraction)
         // Path 2 (3 hops): WETH → USDT → USDC → DAI (0.4 fraction)
         //
-        // Pool A appears in both paths with (USDC, DAI). After merging,
-        // Pool A's amount_in must reflect USDC from *both* paths.
+        // Component A appears in both paths with (USDC, DAI). After merging,
+        // Component A's amount_in must reflect USDC from *both* paths.
         let weth = token(0x01, "WETH");
         let usdc = token(0x02, "USDC");
         let usdt = token(0x03, "USDT");
         let dai = token(0x04, "DAI");
         let market = make_market(vec![
             (
-                "pool_weth_usdc",
+                "component_weth_usdc",
                 vec![weth.clone(), usdc.clone()],
                 Box::new(MockProtocolSim::new(2.0)),
             ),
             (
-                "pool_weth_usdt",
+                "component_weth_usdt",
                 vec![weth.clone(), usdt.clone()],
                 Box::new(MockProtocolSim::new(3.0)),
             ),
             (
-                "pool_usdt_usdc",
+                "component_usdt_usdc",
                 vec![usdt.clone(), usdc.clone()],
                 Box::new(MockProtocolSim::new(1.0)),
             ),
-            ("pool_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("component_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
         ]);
         let ord = order(&weth, &dai, 1000, OrderSide::Sell);
 
         let gas = BigUint::from(50_000u64);
 
-        // Path 1: WETH --(pool_weth_usdc)--> USDC --(pool_a)--> DAI
-        // 600 WETH in, 1200 USDC out from first hop, 1200 DAI out from pool_a
+        // Path 1: WETH --(component_weth_usdc)--> USDC --(component_a)--> DAI
+        // 600 WETH in, 1200 USDC out from first hop, 1200 DAI out from component_a
         let path1 = PathAllocation {
             hops: vec![
-                HopDescriptor::new("pool_weth_usdc".to_string(), weth.clone(), usdc.clone())
+                HopDescriptor::new("component_weth_usdc".to_string(), weth.clone(), usdc.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                HopDescriptor::new("component_a".to_string(), usdc.clone(), dai.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
             ],
             flow_fraction: 0.6,
@@ -2195,16 +2219,16 @@ mod tests {
             marginal_price_product: 2.0,
         };
 
-        // Path 2: WETH --(pool_weth_usdt)--> USDT --(pool_usdt_usdc)--> USDC
-        //         --(pool_a)--> DAI
-        // 400 WETH in, 1200 USDT out, 1200 USDC out, 1200 DAI out from pool_a
+        // Path 2: WETH --(component_weth_usdt)--> USDT --(component_usdt_usdc)--> USDC
+        //         --(component_a)--> DAI
+        // 400 WETH in, 1200 USDT out, 1200 USDC out, 1200 DAI out from component_a
         let path2 = PathAllocation {
             hops: vec![
-                HopDescriptor::new("pool_weth_usdt".to_string(), weth.clone(), usdt.clone())
+                HopDescriptor::new("component_weth_usdt".to_string(), weth.clone(), usdt.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_usdt_usdc".to_string(), usdt.clone(), usdc.clone())
+                HopDescriptor::new("component_usdt_usdc".to_string(), usdt.clone(), usdc.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                HopDescriptor::new("component_a".to_string(), usdc.clone(), dai.clone())
                     .with_amounts(BigUint::from(1200u64), gas),
             ],
             flow_fraction: 0.4,
@@ -2216,73 +2240,73 @@ mod tests {
         let route = build_split_route(&[path1, path2], &market, &ord).unwrap();
         let swaps = route.swaps();
 
-        // Pool A is shared and merged: it should receive the total USDC
+        // Component A is shared and merged: it should receive the total USDC
         // from both paths (1200 + 1200 = 2400).
-        let pool_a_swap = swaps
+        let component_a_swap = swaps
             .iter()
-            .find(|s| s.component_id() == "pool_a")
-            .expect("pool_a swap must exist");
+            .find(|s| s.component_id() == "component_a")
+            .expect("component_a swap must exist");
         assert_eq!(
-            *pool_a_swap.amount_in(),
+            *component_a_swap.amount_in(),
             BigUint::from(2400u64),
-            "pool_a must receive USDC from both paths (1200 + 1200)"
+            "component_a must receive USDC from both paths (1200 + 1200)"
         );
         assert_eq!(
-            *pool_a_swap.amount_out(),
+            *component_a_swap.amount_out(),
             BigUint::from(2400u64),
-            "pool_a amount_out should be the merged total"
+            "component_a amount_out should be the merged total"
         );
 
-        // Pool A is merged into one swap, so its gas is counted once.
-        // Total = 4 distinct pools × 50k gas = 200k (not 5 × 50k).
-        assert_eq!(swaps.len(), 4, "pool_a must appear once, not once per path");
+        // Component A is merged into one swap, so its gas is counted once.
+        // Total = 4 distinct components × 50k gas = 200k (not 5 × 50k).
+        assert_eq!(swaps.len(), 4, "component_a must appear once, not once per path");
         assert_eq!(
             route.total_gas(),
             BigUint::from(200_000u64),
-            "gas must be counted once per pool, not once per path"
+            "gas must be counted once per component, not once per path"
         );
     }
 
     #[test]
     fn test_build_split_route_cross_depth_convergence_with_downstream_split() {
-        // Cross-depth convergence on Pool A (USDC→DAI) followed by a
-        // downstream split at DAI (Pool B and Pool C → PEPE).
+        // Cross-depth convergence on Component A (USDC→DAI) followed by a
+        // downstream split at DAI (Component B and Component C → PEPE).
         //
-        //  WETH ──┬──────────────▶ USDC ── pool_a ──▶ DAI ──┬── pool_b ──▶ PEPE
+        //  WETH ──┬──────────────▶ USDC ── component_a ──▶ DAI ──┬── component_b ──▶ PEPE
         //         │                  ▲                      │
-        //         └──────▶ USDT ─────┘                      └── pool_c ──▶ PEPE
+        //         └──────▶ USDT ─────┘                      └── component_c ──▶ PEPE
         //
-        // Path 1: WETH → USDC → DAI → PEPE (Pool B)    fraction 0.3
-        // Path 2: WETH → USDC → DAI → PEPE (Pool C)    fraction 0.3
-        // Path 3: WETH → USDT → USDC → DAI → PEPE (Pool B) fraction 0.4
+        // Path 1: WETH → USDC → DAI → PEPE (Component B)    fraction 0.3
+        // Path 2: WETH → USDC → DAI → PEPE (Component C)    fraction 0.3
+        // Path 3: WETH → USDT → USDC → DAI → PEPE (Component B) fraction 0.4
         //
-        // Pool A is shared across all 3 paths. The DAI split between Pool B
-        // and Pool C must wait until all DAI has been produced (from both
-        // the direct and USDT-detour paths through the merged Pool A swap).
+        // Component A is shared across all 3 paths. The DAI split between Component B
+        // and Component C must wait until all DAI has been produced (from both
+        // the direct and USDT-detour paths through the merged Component A swap).
         let weth = token(0x01, "WETH");
         let usdc = token(0x02, "USDC");
         let usdt = token(0x03, "USDT");
         let dai = token(0x04, "DAI");
         let pepe = token(0x05, "PEPE");
         let market = make_market(vec![
-            ("pool_wu", vec![weth.clone(), usdc.clone()], Box::new(MockProtocolSim::new(2.0))),
-            ("pool_wt", vec![weth.clone(), usdt.clone()], Box::new(MockProtocolSim::new(3.0))),
-            ("pool_tu", vec![usdt.clone(), usdc.clone()], Box::new(MockProtocolSim::new(1.0))),
-            ("pool_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
-            ("pool_b", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(5.0))),
-            ("pool_c", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(4.0))),
+            ("component_wu", vec![weth.clone(), usdc.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("component_wt", vec![weth.clone(), usdt.clone()], Box::new(MockProtocolSim::new(3.0))),
+            ("component_tu", vec![usdt.clone(), usdc.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("component_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("component_b", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(5.0))),
+            ("component_c", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(4.0))),
         ]);
         let ord = order(&weth, &pepe, 1000, OrderSide::Sell);
         let gas = BigUint::from(50_000u64);
 
-        // Path 1: WETH → USDC → DAI → PEPE (Pool B)
+        // Path 1: WETH → USDC → DAI → PEPE (Component B)
         let path1 = PathAllocation {
             hops: vec![
-                HopDescriptor::new("pool_wu".to_string(), weth.clone(), usdc.clone())
+                HopDescriptor::new("component_wu".to_string(), weth.clone(), usdc.clone())
                     .with_amounts(BigUint::from(600u64), gas.clone()),
-                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                HopDescriptor::new("component_a".to_string(), usdc.clone(), dai.clone())
                     .with_amounts(BigUint::from(600u64), gas.clone()),
-                HopDescriptor::new("pool_b".to_string(), dai.clone(), pepe.clone())
+                HopDescriptor::new("component_b".to_string(), dai.clone(), pepe.clone())
                     .with_amounts(BigUint::from(3000u64), gas.clone()),
             ],
             flow_fraction: 0.3,
@@ -2291,14 +2315,14 @@ mod tests {
             marginal_price_product: 10.0,
         };
 
-        // Path 2: WETH → USDC → DAI → PEPE (Pool C)
+        // Path 2: WETH → USDC → DAI → PEPE (Component C)
         let path2 = PathAllocation {
             hops: vec![
-                HopDescriptor::new("pool_wu".to_string(), weth.clone(), usdc.clone())
+                HopDescriptor::new("component_wu".to_string(), weth.clone(), usdc.clone())
                     .with_amounts(BigUint::from(600u64), gas.clone()),
-                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                HopDescriptor::new("component_a".to_string(), usdc.clone(), dai.clone())
                     .with_amounts(BigUint::from(600u64), gas.clone()),
-                HopDescriptor::new("pool_c".to_string(), dai.clone(), pepe.clone())
+                HopDescriptor::new("component_c".to_string(), dai.clone(), pepe.clone())
                     .with_amounts(BigUint::from(2400u64), gas.clone()),
             ],
             flow_fraction: 0.3,
@@ -2307,16 +2331,16 @@ mod tests {
             marginal_price_product: 8.0,
         };
 
-        // Path 3: WETH → USDT → USDC → DAI → PEPE (Pool B)
+        // Path 3: WETH → USDT → USDC → DAI → PEPE (Component B)
         let path3 = PathAllocation {
             hops: vec![
-                HopDescriptor::new("pool_wt".to_string(), weth.clone(), usdt.clone())
+                HopDescriptor::new("component_wt".to_string(), weth.clone(), usdt.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_tu".to_string(), usdt.clone(), usdc.clone())
+                HopDescriptor::new("component_tu".to_string(), usdt.clone(), usdc.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                HopDescriptor::new("component_a".to_string(), usdc.clone(), dai.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_b".to_string(), dai.clone(), pepe.clone())
+                HopDescriptor::new("component_b".to_string(), dai.clone(), pepe.clone())
                     .with_amounts(BigUint::from(6000u64), gas),
             ],
             flow_fraction: 0.4,
@@ -2328,92 +2352,92 @@ mod tests {
         let route = build_split_route(&[path1, path2, path3], &market, &ord).unwrap();
         let swaps = route.swaps();
 
-        // Pool A is merged: total USDC in = 600+600+1200 = 2400,
+        // Component A is merged: total USDC in = 600+600+1200 = 2400,
         // total DAI out = 600+600+1200 = 2400.
-        let pool_a_swap = swaps
+        let component_a_swap = swaps
             .iter()
-            .find(|s| s.component_id() == "pool_a")
-            .expect("pool_a swap must exist");
+            .find(|s| s.component_id() == "component_a")
+            .expect("component_a swap must exist");
         assert_eq!(
-            *pool_a_swap.amount_in(),
+            *component_a_swap.amount_in(),
             BigUint::from(2400u64),
-            "pool_a must receive all USDC from both direct and USDT-detour paths"
+            "component_a must receive all USDC from both direct and USDT-detour paths"
         );
 
-        // Pool B is merged (paths 1+3): DAI in from both = fraction 0.7
-        // Pool C has only path 2: DAI in = fraction 0.3
-        let pool_b_swap = swaps
+        // Component B is merged (paths 1+3): DAI in from both = fraction 0.7
+        // Component C has only path 2: DAI in = fraction 0.3
+        let component_b_swap = swaps
             .iter()
-            .find(|s| s.component_id() == "pool_b")
-            .expect("pool_b swap must exist");
-        let pool_c_swap = swaps
+            .find(|s| s.component_id() == "component_b")
+            .expect("component_b swap must exist");
+        let component_c_swap = swaps
             .iter()
-            .find(|s| s.component_id() == "pool_c")
-            .expect("pool_c swap must exist");
+            .find(|s| s.component_id() == "component_c")
+            .expect("component_c swap must exist");
 
-        // Total DAI = 2400. Pool B gets 0.7 fraction, Pool C gets the
+        // Total DAI = 2400. Component B gets 0.7 fraction, Component C gets the
         // remainder. Amounts are simulated from the emitted route, not summed
         // from path-local fixtures.
         assert_eq!(
-            *pool_b_swap.amount_out(),
+            *component_b_swap.amount_out(),
             BigUint::from(8400u64),
-            "pool_b amount_out should be simulated from emitted amount_in"
+            "component_b amount_out should be simulated from emitted amount_in"
         );
         assert_eq!(
-            *pool_c_swap.amount_out(),
+            *component_c_swap.amount_out(),
             BigUint::from(2880u64),
-            "pool_c amount_out should be simulated from remainder amount_in"
+            "component_c amount_out should be simulated from remainder amount_in"
         );
 
-        // Verify ordering: pool_a must appear before pool_b and pool_c
+        // Verify ordering: component_a must appear before component_b and component_c
         // (DAI must be fully produced before splitting).
-        let pool_a_idx = swaps
+        let component_a_idx = swaps
             .iter()
-            .position(|s| s.component_id() == "pool_a")
+            .position(|s| s.component_id() == "component_a")
             .unwrap();
-        let pool_b_idx = swaps
+        let component_b_idx = swaps
             .iter()
-            .position(|s| s.component_id() == "pool_b")
+            .position(|s| s.component_id() == "component_b")
             .unwrap();
-        let pool_c_idx = swaps
+        let component_c_idx = swaps
             .iter()
-            .position(|s| s.component_id() == "pool_c")
-            .unwrap();
-        assert!(
-            pool_a_idx < pool_b_idx && pool_a_idx < pool_c_idx,
-            "pool_a (idx {pool_a_idx}) must appear before pool_b (idx {pool_b_idx}) \
-             and pool_c (idx {pool_c_idx})"
-        );
-
-        // Also verify USDT→USDC appears before pool_a (USDC→DAI).
-        let pool_tu_idx = swaps
-            .iter()
-            .position(|s| s.component_id() == "pool_tu")
+            .position(|s| s.component_id() == "component_c")
             .unwrap();
         assert!(
-            pool_tu_idx < pool_a_idx,
-            "pool_tu (idx {pool_tu_idx}) must appear before pool_a (idx {pool_a_idx})"
+            component_a_idx < component_b_idx && component_a_idx < component_c_idx,
+            "component_a (idx {component_a_idx}) must appear before component_b (idx {component_b_idx}) \
+             and component_c (idx {component_c_idx})"
         );
 
-        // Pool A is merged into one swap, so its gas is counted once.
-        // Total = 6 distinct pools × 50k gas = 300k (not 8 × 50k).
-        assert_eq!(swaps.len(), 6, "pool_a must appear once, not once per path");
+        // Also verify USDT→USDC appears before component_a (USDC→DAI).
+        let component_tu_idx = swaps
+            .iter()
+            .position(|s| s.component_id() == "component_tu")
+            .unwrap();
+        assert!(
+            component_tu_idx < component_a_idx,
+            "component_tu (idx {component_tu_idx}) must appear before component_a (idx {component_a_idx})"
+        );
+
+        // Component A is merged into one swap, so its gas is counted once.
+        // Total = 6 distinct components × 50k gas = 300k (not 8 × 50k).
+        assert_eq!(swaps.len(), 6, "component_a must appear once, not once per path");
         assert_eq!(
             route.total_gas(),
             BigUint::from(300_000u64),
-            "gas must be counted once per pool, not once per path"
+            "gas must be counted once per component, not once per path"
         );
     }
 
     #[test]
-    fn test_build_split_route_rejects_reverse_order_shared_pools() {
-        // Two paths use Pool A and Pool B in opposite order:
+    fn test_build_split_route_rejects_reverse_order_shared_components() {
+        // Two paths use Component A and Component B in opposite order:
         //
-        //         ┌── USDC ── pool_a ──▶ DAI ── PEPE ── pool_b ──▶ UNI ── WBTC
+        //         ┌── USDC ── component_a ──▶ DAI ── PEPE ── component_b ──▶ UNI ── WBTC
         //  WETH ──┤
-        //         └── PEPE ── pool_b ──▶ UNI ── USDC ── pool_a ──▶ DAI ── WBTC
+        //         └── PEPE ── component_b ──▶ UNI ── USDC ── component_a ──▶ DAI ── WBTC
         //
-        // merge_shared_hops collapses Pool A and Pool B into single swaps,
+        // merge_shared_hops collapses Component A and Component B into single swaps,
         // creating the cycle: USDC → DAI → PEPE → UNI → USDC.
         let weth = token(0x01, "WETH");
         let usdc = token(0x02, "USDC");
@@ -2422,29 +2446,29 @@ mod tests {
         let uni = token(0x05, "UNI");
         let wbtc = token(0x06, "WBTC");
         let market = make_market(vec![
-            ("pool_wu", vec![weth.clone(), usdc.clone()], Box::new(MockProtocolSim::new(2.0))),
-            ("pool_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
-            ("pool_dp", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(5.0))),
-            ("pool_b", vec![pepe.clone(), uni.clone()], Box::new(MockProtocolSim::new(1.0))),
-            ("pool_uw", vec![uni.clone(), wbtc.clone()], Box::new(MockProtocolSim::new(3.0))),
-            ("pool_wp", vec![weth.clone(), pepe.clone()], Box::new(MockProtocolSim::new(4.0))),
-            ("pool_us", vec![uni.clone(), usdc.clone()], Box::new(MockProtocolSim::new(1.0))),
-            ("pool_dw", vec![dai.clone(), wbtc.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("component_wu", vec![weth.clone(), usdc.clone()], Box::new(MockProtocolSim::new(2.0))),
+            ("component_a", vec![usdc.clone(), dai.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("component_dp", vec![dai.clone(), pepe.clone()], Box::new(MockProtocolSim::new(5.0))),
+            ("component_b", vec![pepe.clone(), uni.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("component_uw", vec![uni.clone(), wbtc.clone()], Box::new(MockProtocolSim::new(3.0))),
+            ("component_wp", vec![weth.clone(), pepe.clone()], Box::new(MockProtocolSim::new(4.0))),
+            ("component_us", vec![uni.clone(), usdc.clone()], Box::new(MockProtocolSim::new(1.0))),
+            ("component_dw", vec![dai.clone(), wbtc.clone()], Box::new(MockProtocolSim::new(2.0))),
         ]);
         let ord = order(&weth, &wbtc, 1000, OrderSide::Sell);
         let gas = BigUint::from(50_000u64);
 
         let path1 = PathAllocation {
             hops: vec![
-                HopDescriptor::new("pool_wu".to_string(), weth.clone(), usdc.clone())
+                HopDescriptor::new("component_wu".to_string(), weth.clone(), usdc.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                HopDescriptor::new("component_a".to_string(), usdc.clone(), dai.clone())
                     .with_amounts(BigUint::from(1200u64), gas.clone()),
-                HopDescriptor::new("pool_dp".to_string(), dai.clone(), pepe.clone())
+                HopDescriptor::new("component_dp".to_string(), dai.clone(), pepe.clone())
                     .with_amounts(BigUint::from(6000u64), gas.clone()),
-                HopDescriptor::new("pool_b".to_string(), pepe.clone(), uni.clone())
+                HopDescriptor::new("component_b".to_string(), pepe.clone(), uni.clone())
                     .with_amounts(BigUint::from(6000u64), gas.clone()),
-                HopDescriptor::new("pool_uw".to_string(), uni.clone(), wbtc.clone())
+                HopDescriptor::new("component_uw".to_string(), uni.clone(), wbtc.clone())
                     .with_amounts(BigUint::from(18000u64), gas.clone()),
             ],
             flow_fraction: 0.6,
@@ -2455,15 +2479,15 @@ mod tests {
 
         let path2 = PathAllocation {
             hops: vec![
-                HopDescriptor::new("pool_wp".to_string(), weth.clone(), pepe.clone())
+                HopDescriptor::new("component_wp".to_string(), weth.clone(), pepe.clone())
                     .with_amounts(BigUint::from(1600u64), gas.clone()),
-                HopDescriptor::new("pool_b".to_string(), pepe.clone(), uni.clone())
+                HopDescriptor::new("component_b".to_string(), pepe.clone(), uni.clone())
                     .with_amounts(BigUint::from(1600u64), gas.clone()),
-                HopDescriptor::new("pool_us".to_string(), uni.clone(), usdc.clone())
+                HopDescriptor::new("component_us".to_string(), uni.clone(), usdc.clone())
                     .with_amounts(BigUint::from(1600u64), gas.clone()),
-                HopDescriptor::new("pool_a".to_string(), usdc.clone(), dai.clone())
+                HopDescriptor::new("component_a".to_string(), usdc.clone(), dai.clone())
                     .with_amounts(BigUint::from(1600u64), gas.clone()),
-                HopDescriptor::new("pool_dw".to_string(), dai.clone(), wbtc.clone())
+                HopDescriptor::new("component_dw".to_string(), dai.clone(), wbtc.clone())
                     .with_amounts(BigUint::from(3200u64), gas),
             ],
             flow_fraction: 0.4,
@@ -2472,23 +2496,23 @@ mod tests {
             marginal_price_product: 8.0,
         };
 
-        // merge_shared_hops collapses Pool A and Pool B into single entries.
+        // merge_shared_hops collapses Component A and Component B into single entries.
         let merged = merge_shared_hops(&[path1.clone(), path2.clone()]).unwrap();
         assert_eq!(
             merged[&usdc.address]
                 .iter()
-                .filter(|s| s.hop.component_id == "pool_a")
+                .filter(|s| s.hop.component_id == "component_a")
                 .count(),
             1,
-            "merge_shared_hops merges pool_a into one"
+            "merge_shared_hops merges component_a into one"
         );
         assert_eq!(
             merged[&pepe.address]
                 .iter()
-                .filter(|s| s.hop.component_id == "pool_b")
+                .filter(|s| s.hop.component_id == "component_b")
                 .count(),
             1,
-            "merge_shared_hops merges pool_b into one"
+            "merge_shared_hops merges component_b into one"
         );
 
         // build_split_route rejects the combination.

--- a/fynd-core/src/algorithm/split_test_harness.rs
+++ b/fynd-core/src/algorithm/split_test_harness.rs
@@ -28,13 +28,13 @@ use crate::{
     },
 };
 
-/// Returns `(fraction_for_pool_1, total_output)` — the theoretically optimal output when
-/// splitting `trade_amount` between two constant-product pools with no fees.
+/// Returns `(fraction_for_component_1, total_output)` — the theoretically optimal output when
+/// splitting `trade_amount` between two constant-product components with no fees.
 ///
-/// Finds the split where both pools offer the same marginal rate on the last unit traded.
+/// Finds the split where both components offer the same marginal rate on the last unit traded.
 /// Negative allocations are clamped to `0` — a clamped value means the full trade routes through
-/// the other pool.
-pub(crate) fn optimal_two_pool_output(
+/// the other component.
+pub(crate) fn optimal_two_component_output(
     reserve_in_1: f64,
     reserve_out_1: f64,
     reserve_in_2: f64,
@@ -53,11 +53,11 @@ pub(crate) fn optimal_two_pool_output(
     (fraction_1, out_1 + out_2)
 }
 
-// ==================== Weighted two-pool market for split-algorithm tests ====================
+// ==================== Weighted two-component market for split-algorithm tests ====================
 
 /// A WETH/USDC market for the `DepthAndPrice` split algorithm (`split`). The two
-/// pools are fee-free constant-product pools, so their optimal split matches
-/// [`optimal_two_pool_output`]. One `MarketState` backs the whole market.
+/// components are fee-free constant-product components, so their optimal split matches
+/// [`optimal_two_component_output`]. One `MarketState` backs the whole market.
 pub(crate) struct WeightedSplitMarket {
     pub market: MarketData,
     pub weighted: PetgraphStableDiGraphManager<DepthAndPrice>,
@@ -66,11 +66,12 @@ pub(crate) struct WeightedSplitMarket {
     pub usdc: Address,
 }
 
-/// Per-pool reserves for [`two_equal_weth_usdc`], in whole tokens (WETH has 18 decimals, USDC 6).
+/// Per-component reserves for [`two_equal_weth_usdc`], in whole tokens (WETH has 18 decimals, USDC
+/// 6).
 pub(crate) const TWO_EQUAL_WETH_RESERVE: u128 = 1000;
 pub(crate) const TWO_EQUAL_USDC_RESERVE: u128 = 3_000_000;
 
-fn weth_usdc_pool() -> ConstantProductSim {
+fn weth_usdc_component() -> ConstantProductSim {
     ConstantProductSim {
         // reserve_0 is the lower-address token (WETH, 0x01); reserve_1 is USDC (0x02).
         reserve_0: BigUint::from(TWO_EQUAL_WETH_RESERVE) * BigUint::from(10u64).pow(18),
@@ -79,9 +80,9 @@ fn weth_usdc_pool() -> ConstantProductSim {
     }
 }
 
-/// Builds two equally-deep, fee-free WETH/USDC constant-product pools (1000 WETH / 3,000,000 USDC
-/// each) at `gas_price` wei/gas. Derived data carries unit token gas prices so the split algorithms
-/// deduct gas in output-token terms.
+/// Builds two equally-deep, fee-free WETH/USDC constant-product components (1000 WETH / 3,000,000
+/// USDC each) at `gas_price` wei/gas. Derived data carries unit token gas prices so the split
+/// algorithms deduct gas in output-token terms.
 pub(crate) fn two_equal_weth_usdc(gas_price: u64) -> WeightedSplitMarket {
     let weth = token_with_decimals(0x01, "WETH", 18);
     let usdc = token_with_decimals(0x02, "USDC", 6);
@@ -97,24 +98,36 @@ pub(crate) fn two_equal_weth_usdc(gas_price: u64) -> WeightedSplitMarket {
 
     let tokens = [weth.clone(), usdc.clone()];
     let mut edge_weights = Vec::new();
-    for pool_id in ["pool_a", "pool_b"] {
-        let sim = weth_usdc_pool();
+    for component_id in ["component_a", "component_b"] {
+        let sim = weth_usdc_component();
         let weight_to = DepthAndPrice::from_protocol_sim(&sim, &weth, &usdc).unwrap();
         let weight_from = DepthAndPrice::from_protocol_sim(&sim, &usdc, &weth).unwrap();
-        market.upsert_components(std::iter::once(component(pool_id, &tokens)));
-        market.update_states([(pool_id.to_string(), Box::new(sim) as Box<dyn ProtocolSim>)]);
+        market.upsert_components(std::iter::once(component(component_id, &tokens)));
+        market.update_states([(component_id.to_string(), Box::new(sim) as Box<dyn ProtocolSim>)]);
         market.upsert_tokens(tokens.clone());
-        edge_weights.push((pool_id, weight_to, weight_from));
+        edge_weights.push((component_id, weight_to, weight_from));
     }
 
     let mut weighted = PetgraphStableDiGraphManager::<DepthAndPrice>::default();
     weighted.initialize_graph(&market.component_topology());
-    for (pool_id, weight_to, weight_from) in edge_weights {
+    for (component_id, weight_to, weight_from) in edge_weights {
         weighted
-            .set_edge_weight(&pool_id.to_string(), &weth.address, &usdc.address, weight_to, false)
+            .set_edge_weight(
+                &component_id.to_string(),
+                &weth.address,
+                &usdc.address,
+                weight_to,
+                false,
+            )
             .unwrap();
         weighted
-            .set_edge_weight(&pool_id.to_string(), &usdc.address, &weth.address, weight_from, false)
+            .set_edge_weight(
+                &component_id.to_string(),
+                &usdc.address,
+                &weth.address,
+                weight_from,
+                false,
+            )
             .unwrap();
     }
 
@@ -155,8 +168,8 @@ pub(crate) fn split_metrics(
 
 // ==================== Scenario harness ====================
 
-/// A pool entry in a `TestScenario`.
-pub(crate) struct ScenarioPool {
+/// A component entry in a `TestScenario`.
+pub(crate) struct ScenarioComponent {
     pub id: &'static str,
     pub token_1: Token,
     pub token_2: Token,
@@ -171,31 +184,33 @@ pub(crate) struct ScenarioPool {
 pub(crate) struct TestScenario {
     pub name: &'static str,
     pub description: &'static str,
-    pub pools: Vec<ScenarioPool>,
+    pub components: Vec<ScenarioComponent>,
     pub token_in: Token,
     pub token_out: Token,
     pub trade_amount: BigUint,
     /// Floor: the algorithm must produce at least this much net output.
     pub lower_bound: BigInt,
-    /// Target: the best net output achievable under the scenario's simplified pool model. A
+    /// Target: the best net output achievable under the scenario's simplified component model. A
     /// quality ceiling to measure against, not a hard constraint.
     pub analytical_optimum: BigInt,
 }
 
 impl TestScenario {
-    /// Builds an unweighted `MarketData` + graph manager from this scenario's pool definitions.
+    /// Builds an unweighted `MarketData` + graph manager from this scenario's component
+    /// definitions.
     pub(crate) fn build_market(&self) -> (MarketData, PetgraphStableDiGraphManager<()>) {
-        let pools = self
-            .pools
+        let components = self
+            .components
             .iter()
             .map(|p| (p.id, &p.token_1, &p.token_2, p.sim.clone_box()))
             .collect();
-        setup_market_unweighted(pools)
+        setup_market_unweighted(components)
     }
 
-    /// Builds a `DepthAndPrice`-weighted `MarketData` + graph manager from this scenario's pool
-    /// definitions, for algorithms that route on the weighted graph (`water_fill`, Most Liquid).
-    /// Uses the same fixed gas assumptions as [`build_market`](Self::build_market) (100 wei/gas).
+    /// Builds a `DepthAndPrice`-weighted `MarketData` + graph manager from this scenario's
+    /// component definitions, for algorithms that route on the weighted graph (`water_fill`,
+    /// Most Liquid). Uses the same fixed gas assumptions as
+    /// [`build_market`](Self::build_market) (100 wei/gas).
     pub(crate) fn build_market_weighted(
         &self,
     ) -> (MarketData, PetgraphStableDiGraphManager<DepthAndPrice>) {
@@ -209,21 +224,27 @@ impl TestScenario {
         market.update_last_updated(BlockInfo::new(1, "0x00".to_string(), 0));
 
         let mut edge_weights = Vec::new();
-        for pool in &self.pools {
-            let tokens = [pool.token_1.clone(), pool.token_2.clone()];
-            let weight_to =
-                DepthAndPrice::from_protocol_sim(pool.sim.as_ref(), &pool.token_1, &pool.token_2)
-                    .unwrap();
-            let weight_from =
-                DepthAndPrice::from_protocol_sim(pool.sim.as_ref(), &pool.token_2, &pool.token_1)
-                    .unwrap();
-            market.upsert_components(std::iter::once(component(pool.id, &tokens)));
-            market.update_states([(pool.id.to_string(), pool.sim.clone_box())]);
+        for scenario in &self.components {
+            let tokens = [scenario.token_1.clone(), scenario.token_2.clone()];
+            let weight_to = DepthAndPrice::from_protocol_sim(
+                scenario.sim.as_ref(),
+                &scenario.token_1,
+                &scenario.token_2,
+            )
+            .unwrap();
+            let weight_from = DepthAndPrice::from_protocol_sim(
+                scenario.sim.as_ref(),
+                &scenario.token_2,
+                &scenario.token_1,
+            )
+            .unwrap();
+            market.upsert_components(std::iter::once(component(scenario.id, &tokens)));
+            market.update_states([(scenario.id.to_string(), scenario.sim.clone_box())]);
             market.upsert_tokens(tokens.to_vec());
             edge_weights.push((
-                pool.id,
-                pool.token_1.address.clone(),
-                pool.token_2.address.clone(),
+                scenario.id,
+                scenario.token_1.address.clone(),
+                scenario.token_2.address.clone(),
                 weight_to,
                 weight_from,
             ));
@@ -231,12 +252,12 @@ impl TestScenario {
 
         let mut weighted = PetgraphStableDiGraphManager::<DepthAndPrice>::default();
         weighted.initialize_graph(&market.component_topology());
-        for (pool_id, addr_1, addr_2, weight_to, weight_from) in edge_weights {
+        for (component_id, addr_1, addr_2, weight_to, weight_from) in edge_weights {
             weighted
-                .set_edge_weight(&pool_id.to_string(), &addr_1, &addr_2, weight_to, false)
+                .set_edge_weight(&component_id.to_string(), &addr_1, &addr_2, weight_to, false)
                 .unwrap();
             weighted
-                .set_edge_weight(&pool_id.to_string(), &addr_2, &addr_1, weight_from, false)
+                .set_edge_weight(&component_id.to_string(), &addr_2, &addr_1, weight_from, false)
                 .unwrap();
         }
 
@@ -252,12 +273,12 @@ impl TestScenario {
 
         token_prices.insert(self.token_in.address.clone(), unit_price.clone());
         token_prices.insert(self.token_out.address.clone(), unit_price.clone());
-        for pool in &self.pools {
+        for component in &self.components {
             token_prices
-                .entry(pool.token_1.address.clone())
+                .entry(component.token_1.address.clone())
                 .or_insert_with(|| unit_price.clone());
             token_prices
-                .entry(pool.token_2.address.clone())
+                .entry(component.token_2.address.clone())
                 .or_insert_with(|| unit_price.clone());
         }
 
@@ -279,7 +300,7 @@ pub(crate) struct ScenarioResult {
     pub net_output: BigInt,
     /// Best single-route net output. `net_output` must be >= this.
     pub lower_bound: BigInt,
-    /// Net analytical optimum for the scenario's simplified pool model. A reference value for
+    /// Net analytical optimum for the scenario's simplified component model. A reference value for
     /// measuring quality — the algorithm is not required to reach it.
     pub analytical_optimum: BigInt,
     /// Number of swaps consuming `token_in`. 1 for single-route, N for a split.
@@ -397,19 +418,19 @@ where
 pub(crate) mod split_scenarios {
     use num_bigint::{BigInt, BigUint};
 
-    use super::{ScenarioPool, TestScenario};
+    use super::{ScenarioComponent, TestScenario};
     use crate::algorithm::test_utils::{token, ConstantProductSim, ONE_ETH};
 
     /// Valid Ethereum addresses the swap encoder registry recognizes
-    const POOL_ADDR_1: &str = "0xaB00000000000000000000000000000000000001";
-    const POOL_ADDR_2: &str = "0xaB00000000000000000000000000000000000002";
-    const POOL_ADDR_3: &str = "0xaB00000000000000000000000000000000000003";
-    const POOL_ADDR_4: &str = "0xaB00000000000000000000000000000000000004";
+    const COMPONENT_ADDR_1: &str = "0xaB00000000000000000000000000000000000001";
+    const COMPONENT_ADDR_2: &str = "0xaB00000000000000000000000000000000000002";
+    const COMPONENT_ADDR_3: &str = "0xaB00000000000000000000000000000000000003";
+    const COMPONENT_ADDR_4: &str = "0xaB00000000000000000000000000000000000004";
 
-    /// S1: two identical A→B pools; 50/50 split is optimal.
+    /// S1: two identical A→B components; 50/50 split is optimal.
     ///
-    /// `analytical_optimum`: `optimal_two_pool_output` with equal reserves — exact mathematical
-    /// optimum (50/50).
+    /// `analytical_optimum`: `optimal_two_component_output` with equal reserves — exact
+    /// mathematical optimum (50/50).
     pub(crate) fn symmetric_split() -> TestScenario {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
@@ -417,10 +438,10 @@ pub(crate) mod split_scenarios {
 
         TestScenario {
             name: "SYMMETRIC_SPLIT",
-            description: "Two identical A→B pools. 50/50 split is optimal.",
-            pools: vec![
-                ScenarioPool {
-                    id: POOL_ADDR_1,
+            description: "Two identical A→B components. 50/50 split is optimal.",
+            components: vec![
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_1,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -429,8 +450,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_2,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_2,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -443,17 +464,17 @@ pub(crate) mod split_scenarios {
             token_in: token_a,
             token_out: token_b,
             trade_amount: BigUint::from(100_000u64) * BigUint::from(ONE_ETH),
-            // gross 90_909_090_909_090_909_090_909 − 1 pool × 50_000 gas × 100 wei/gas
+            // gross 90_909_090_909_090_909_090_909 − 1 component × 50_000 gas × 100 wei/gas
             lower_bound: BigInt::from(90_909_090_909_090_904_090_909u128),
-            // gross 95_238_095_238_095_236_709_344 − 2 pools × 50_000 gas × 100 wei/gas
+            // gross 95_238_095_238_095_236_709_344 − 2 components × 50_000 gas × 100 wei/gas
             analytical_optimum: BigInt::from(95_238_095_238_095_226_709_344u128),
         }
     }
 
-    /// S2: two A→B pools with reserves 1_000_000 and 500_000; optimal split favours the larger
-    /// pool.
+    /// S2: two A→B components with reserves 1_000_000 and 500_000; optimal split favours the larger
+    /// component.
     ///
-    /// `analytical_optimum`: `optimal_two_pool_output` with the asymmetric reserves — exact
+    /// `analytical_optimum`: `optimal_two_component_output` with the asymmetric reserves — exact
     /// mathematical optimum.
     pub(crate) fn asymmetric_split() -> TestScenario {
         let token_a = token(0x0A, "A");
@@ -464,10 +485,11 @@ pub(crate) mod split_scenarios {
 
         TestScenario {
             name: "ASYMMETRIC_SPLIT",
-            description: "Two A→B pools of unequal size. Optimal split favours the larger pool.",
-            pools: vec![
-                ScenarioPool {
-                    id: POOL_ADDR_1,
+            description:
+                "Two A→B components of unequal size. Optimal split favours the larger component.",
+            components: vec![
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_1,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -476,8 +498,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_2,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_2,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -490,9 +512,9 @@ pub(crate) mod split_scenarios {
             token_in: token_a,
             token_out: token_b,
             trade_amount: BigUint::from(200_000u64) * &one_eth,
-            // gross 166_666_666_666_666_666_666_666 − 1 pool × 50_000 gas × 100 wei/gas
+            // gross 166_666_666_666_666_666_666_666 − 1 component × 50_000 gas × 100 wei/gas
             lower_bound: BigInt::from(166_666_666_666_666_661_666_666u128),
-            // gross 176_470_588_235_294_097_103_232 − 2 pools × 50_000 gas × 100 wei/gas
+            // gross 176_470_588_235_294_097_103_232 − 2 components × 50_000 gas × 100 wei/gas
             analytical_optimum: BigInt::from(176_470_588_235_294_087_103_232u128),
         }
     }
@@ -509,9 +531,9 @@ pub(crate) mod split_scenarios {
         TestScenario {
             name: "GAS_KILLS_SPLIT",
             description: "Split has a real gross benefit but the extra-hop gas exceeds it, making the split net-negative.",
-            pools: vec![
-                ScenarioPool {
-                    id: POOL_ADDR_1,
+            components: vec![
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_1,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -520,8 +542,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_2,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_2,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -534,17 +556,17 @@ pub(crate) mod split_scenarios {
             token_in: token_a,
             token_out: token_b,
             trade_amount: BigUint::from(10_000_000u64),
-            // gross 6_666_666 − 1 pool × 50_000 gas × 100 wei/gas
+            // gross 6_666_666 − 1 component × 50_000 gas × 100 wei/gas
             lower_bound: BigInt::from(1_666_666i64),
             // optimal net strategy is single route; gross split output (8M) loses on net
             analytical_optimum: BigInt::from(1_666_666i64),
         }
     }
 
-    /// S4: single A→B pool only; no alternative path to split into.
+    /// S4: single A→B component only; no alternative path to split into.
     ///
-    /// `analytical_optimum`: equals `lower_bound`. With only one pool there is nothing to split
-    /// across; the analytical optimum is simply the single-route output.
+    /// `analytical_optimum`: equals `lower_bound`. With only one component there is nothing to
+    /// split across; the analytical optimum is simply the single-route output.
     pub(crate) fn no_alternative_path() -> TestScenario {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
@@ -553,9 +575,9 @@ pub(crate) mod split_scenarios {
         TestScenario {
             name: "NO_ALTERNATIVE_PATH",
             description:
-                "Single A→B pool. No pool to split into; algorithm must return single-route result.",
-            pools: vec![ScenarioPool {
-                id: POOL_ADDR_1,
+                "Single A→B component. No component to split into; algorithm must return single-route result.",
+            components: vec![ScenarioComponent {
+                id: COMPONENT_ADDR_1,
                 token_1: token_a.clone(),
                 token_2: token_b.clone(),
                 sim: Box::new(ConstantProductSim {
@@ -567,23 +589,23 @@ pub(crate) mod split_scenarios {
             token_in: token_a,
             token_out: token_b,
             trade_amount: BigUint::from(100_000u64) * BigUint::from(ONE_ETH),
-            // gross 90_909_090_909_090_909_090_909 − 1 pool × 50_000 gas × 100 wei/gas
+            // gross 90_909_090_909_090_909_090_909 − 1 component × 50_000 gas × 100 wei/gas
             lower_bound: BigInt::from(90_909_090_909_090_904_090_909u128),
-            // single pool only — no split possible; net optimum equals lower_bound
+            // single component only — no split possible; net optimum equals lower_bound
             analytical_optimum: BigInt::from(90_909_090_909_090_904_090_909u128),
         }
     }
 
-    /// S5: A→B (one pool) → C (two parallel pools); bottleneck is at the B→C hop.
+    /// S5: A→B (one component) → C (two parallel components); bottleneck is at the B→C hop.
     ///
     /// PathFrankWolfe discovers two complete paths [P_AB, P_BC1] and [P_AB, P_BC2]. Because both
     /// share P_AB, `build_split_route` emits one combined A→B swap followed by split B→C swaps,
     /// with P_AB's gas counted once.
     ///
-    /// `lower_bound`: best single 2-hop route A→B→C through the larger B→C pool.
-    /// `analytical_optimum`: only one A→B pool (P_AB) exists so the B amount is fixed;
-    /// `optimal_two_pool_output` gives the exact optimum for splitting that B across the two B→C
-    /// pools.
+    /// `lower_bound`: best single 2-hop route A→B→C through the larger B→C component.
+    /// `analytical_optimum`: only one A→B component (P_AB) exists so the B amount is fixed;
+    /// `optimal_two_component_output` gives the exact optimum for splitting that B across the two
+    /// B→C components.
     pub(crate) fn multi_hop_bottleneck() -> TestScenario {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
@@ -595,10 +617,10 @@ pub(crate) mod split_scenarios {
 
         TestScenario {
             name: "MULTI_HOP_BOTTLENECK",
-            description: "A→B→C with two parallel B→C pools. PathFrankWolfe discovers both paths sharing P_AB.",
-            pools: vec![
-                ScenarioPool {
-                    id: POOL_ADDR_1,
+            description: "A→B→C with two parallel B→C components. PathFrankWolfe discovers both paths sharing P_AB.",
+            components: vec![
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_1,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -607,8 +629,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_2,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_2,
                     token_1: token_b.clone(),
                     token_2: token_c.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -617,8 +639,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_3,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_3,
                     token_1: token_b.clone(),
                     token_2: token_c.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -631,19 +653,19 @@ pub(crate) mod split_scenarios {
             token_in: token_a,
             token_out: token_c,
             trade_amount: BigUint::from(200_000u64) * &one_eth,
-            // gross 163_934_426_229_508_196_721_311 − 2 pools × 50_000 gas × 100 wei/gas
+            // gross 163_934_426_229_508_196_721_311 − 2 components × 50_000 gas × 100 wei/gas
             lower_bound: BigInt::from(163_934_426_229_508_186_721_311u128),
-            // gross 173_410_404_624_277_463_881_280 − 3 pools × 50_000 gas × 100 wei/gas
+            // gross 173_410_404_624_277_463_881_280 − 3 components × 50_000 gas × 100 wei/gas
             analytical_optimum: BigInt::from(173_410_404_624_277_448_881_280u128),
         }
     }
 
-    /// S6: two A→B pools then two B→C pools; pool sizes mismatched between hops so the optimal
-    /// A→B and B→C splits differ. An algorithm that routes independent per-path hops without
-    /// pooling B first will use the wrong cross-allocations and miss the optimum.
+    /// S6: two A→B components then two B→C components; component sizes mismatched between hops so
+    /// the optimal A→B and B→C splits differ. An algorithm that routes independent per-path
+    /// hops without pooling B first will use the wrong cross-allocations and miss the optimum.
     ///
-    /// `lower_bound`: best single 2-hop path (larger pool at each hop).
-    /// `analytical_optimum`: chained `optimal_two_pool_output` across both hops.
+    /// `lower_bound`: best single 2-hop path (larger component at each hop).
+    /// `analytical_optimum`: chained `optimal_two_component_output` across both hops.
     pub(crate) fn double_split() -> TestScenario {
         let token_a = token(0x0A, "A");
         let token_b = token(0x0B, "B");
@@ -656,12 +678,13 @@ pub(crate) mod split_scenarios {
 
         TestScenario {
             name: "DOUBLE_SPLIT",
-            description: "Two A→B pools (1M and 500k ETH) then two B→C pools (500k and 1.5M \
+            description:
+                "Two A→B components (1M and 500k ETH) then two B→C components (500k and 1.5M \
                           ETH). Optimal splits differ at each hop, forcing B to be pooled before \
                           re-splitting.",
-            pools: vec![
-                ScenarioPool {
-                    id: POOL_ADDR_1,
+            components: vec![
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_1,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -670,8 +693,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_2,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_2,
                     token_1: token_a.clone(),
                     token_2: token_b.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -680,8 +703,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_3,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_3,
                     token_1: token_b.clone(),
                     token_2: token_c.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -690,8 +713,8 @@ pub(crate) mod split_scenarios {
                         gas: 50_000,
                     }),
                 },
-                ScenarioPool {
-                    id: POOL_ADDR_4,
+                ScenarioComponent {
+                    id: COMPONENT_ADDR_4,
                     token_1: token_b.clone(),
                     token_2: token_c.clone(),
                     sim: Box::new(ConstantProductSim {
@@ -704,11 +727,11 @@ pub(crate) mod split_scenarios {
             token_in: token_a,
             token_out: token_c,
             trade_amount: BigUint::from(500_000u64) * &one_eth,
-            // gross floor(3×10²⁴/11) = 272_727_272_727_272_727_272_727 − 2 pools × 50_000 gas × 100
-            // wei/gas
+            // gross floor(3×10²⁴/11) = 272_727_272_727_272_727_272_727 − 2 components × 50_000 gas
+            // × 100 wei/gas
             lower_bound: BigInt::from(272_727_272_727_272_717_272_727u128),
-            // gross floor(6×10²⁴/19) = 315_789_473_684_210_526_315_789 − 4 pools × 50_000 gas × 100
-            // wei/gas
+            // gross floor(6×10²⁴/19) = 315_789_473_684_210_526_315_789 − 4 components × 50_000 gas
+            // × 100 wei/gas
             analytical_optimum: BigInt::from(315_789_473_684_210_526_295_789u128),
         }
     }
@@ -799,29 +822,32 @@ mod tests {
     }
 
     #[test]
-    fn test_optimal_two_pool_output_symmetric() {
-        // Identical pools → 50/50 split is always optimal
+    fn test_optimal_two_component_output_symmetric() {
+        // Identical components → 50/50 split is always optimal
         let (fraction, _) =
-            optimal_two_pool_output(10_000.0, 10_000.0, 10_000.0, 10_000.0, 1_000.0);
-        assert!(f64_eq(fraction, 0.5), "symmetric pools: expected fraction 0.5, got {fraction}");
+            optimal_two_component_output(10_000.0, 10_000.0, 10_000.0, 10_000.0, 1_000.0);
+        assert!(
+            f64_eq(fraction, 0.5),
+            "symmetric components: expected fraction 0.5, got {fraction}"
+        );
     }
 
     #[test]
-    fn test_optimal_two_pool_output_asymmetric() {
-        // Pool 1: reserve_in=100, reserve_out=400
-        // Pool 2: reserve_in=100, reserve_out=100
+    fn test_optimal_two_component_output_asymmetric() {
+        // Component 1: reserve_in=100, reserve_out=400
+        // Component 2: reserve_in=100, reserve_out=100
         // swap amount: 400
-        let (fraction, split_out) = optimal_two_pool_output(100.0, 400.0, 100.0, 100.0, 400.0);
+        let (fraction, split_out) = optimal_two_component_output(100.0, 400.0, 100.0, 100.0, 400.0);
 
         // Verify the split is correct
         assert!(f64_eq(fraction, 0.75), "expected fraction 0.75, got {fraction}");
         assert!(f64_eq(split_out, 350.0), "expected split output 350.0, got {split_out}");
 
         // Verify marginal prices are equal at the optimal split.
-        let pool_1_amount = fraction * 400.0;
-        let pool_2_amount = 400.0 - pool_1_amount;
-        let marginal_1 = (100.0 * 400.0) / (100.0 + pool_1_amount).powi(2);
-        let marginal_2 = (100.0 * 100.0) / (100.0 + pool_2_amount).powi(2);
+        let component_1_amount = fraction * 400.0;
+        let component_2_amount = 400.0 - component_1_amount;
+        let marginal_1 = (100.0 * 400.0) / (100.0 + component_1_amount).powi(2);
+        let marginal_2 = (100.0 * 100.0) / (100.0 + component_2_amount).powi(2);
         assert!(
             f64_eq(marginal_1, marginal_2),
             "marginal prices should equalise at the optimum: {marginal_1} vs {marginal_2}"
@@ -856,9 +882,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_shared_hop_split_lower_bound() {
-        // BF on double_split finds the best single 2-hop route via the largest pool at each hop
-        // (pool_ab_1 → pool_bc_2). Confirms the lower bound is set correctly before any
-        // split-routing algorithm is evaluated against it.
+        // BF on double_split finds the best single 2-hop route via the largest component at each
+        // hop (component_ab_1 → component_bc_2). Confirms the lower bound is set correctly
+        // before any split-routing algorithm is evaluated against it.
         let scenario = split_scenarios::double_split();
         let bf = BellmanFordAlgorithm::with_config(
             AlgorithmConfig::new(1, 4, Duration::from_millis(100), None).unwrap(),

--- a/fynd-core/src/algorithm/test_utils.rs
+++ b/fynd-core/src/algorithm/test_utils.rs
@@ -38,7 +38,7 @@ pub const ONE_ETH: u128 = 1_000_000_000_000_000_000;
 ///
 /// Each call to `get_amount_out` returns a new state with an incremented spot_price,
 /// simulating liquidity changes after a swap. This allows testing state override logic
-/// when the same pool is used multiple times in a path.
+/// when the same component is used multiple times in a path.
 // TODO: Consider moving MockProtocolSim to the tycho-common
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct MockProtocolSim {
@@ -255,7 +255,7 @@ impl ProtocolSim for MockProtocolSim {
 
 /// ProtocolSim whose `get_amount_out` performs a real U256 division by zero.
 ///
-/// Reproduces pool math panicking inside a simulation call instead of returning a
+/// Reproduces component math panicking inside a simulation call instead of returning a
 /// `SimulationError`, so tests can assert that callers contain the panic. All other
 /// methods delegate to a [`MockProtocolSim`].
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -518,10 +518,10 @@ pub fn order(token_in: &Token, token_out: &Token, amount: u128, side: OrderSide)
 ///
 /// Use `market_read(&market_ref)` to get a `MarketState` reference for other tests.
 pub fn setup_market_weighted(
-    pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
+    components: Vec<(&str, &Token, &Token, MockProtocolSim)>,
 ) -> (MarketData, PetgraphStableDiGraphManager<DepthAndPrice>) {
     setup_market_weighted_boxed(
-        pools
+        components
             .into_iter()
             .map(|(id, a, b, sim)| (id, a, b, Box::new(sim) as Box<dyn ProtocolSim>))
             .collect(),
@@ -529,9 +529,10 @@ pub fn setup_market_weighted(
 }
 
 /// Like [`setup_market_weighted`] but accepts any boxed [`ProtocolSim`], for tests that need a
-/// non-`MockProtocolSim` pool (e.g. a constant-product pool that reverts past its reserves).
+/// non-`MockProtocolSim` component (e.g. a constant-product component that reverts past its
+/// reserves).
 pub fn setup_market_weighted_boxed(
-    pools: Vec<(&str, &Token, &Token, Box<dyn ProtocolSim>)>,
+    components: Vec<(&str, &Token, &Token, Box<dyn ProtocolSim>)>,
 ) -> (MarketData, PetgraphStableDiGraphManager<DepthAndPrice>) {
     let mut market = MarketState::new();
     let mut component_weights = HashMap::new();
@@ -545,9 +546,9 @@ pub fn setup_market_weighted_boxed(
     });
     market.update_last_updated(BlockInfo::new(1, "0x00".into(), 0));
 
-    for (pool_id, token_in, token_out, state) in pools {
+    for (component_id, token_in, token_out, state) in components {
         let tokens = vec![token_in.clone(), token_out.clone()];
-        let comp = component(pool_id, &tokens);
+        let comp = component(component_id, &tokens);
         let weight_to =
             DepthAndPrice::from_protocol_sim(state.as_ref(), token_in, token_out).unwrap();
         let weight_from =
@@ -555,19 +556,19 @@ pub fn setup_market_weighted_boxed(
 
         // Insert component, state, and tokens separately using new API
         market.upsert_components(std::iter::once(comp));
-        market.update_states([(pool_id.to_string(), state)]);
+        market.update_states([(component_id.to_string(), state)]);
         market.upsert_tokens(tokens);
 
-        component_weights.insert(pool_id, (token_in, token_out, weight_to, weight_from));
+        component_weights.insert(component_id, (token_in, token_out, weight_to, weight_from));
     }
 
     let mut graph_manager = PetgraphStableDiGraphManager::default();
     graph_manager.initialize_graph(&market.component_topology());
 
-    for (pool_id, (token_in, token_out, weight_to, weight_from)) in component_weights {
+    for (component_id, (token_in, token_out, weight_to, weight_from)) in component_weights {
         graph_manager
             .set_edge_weight(
-                &pool_id.to_string(),
+                &component_id.to_string(),
                 &token_in.address,
                 &token_out.address,
                 weight_to,
@@ -576,7 +577,7 @@ pub fn setup_market_weighted_boxed(
             .unwrap();
         graph_manager
             .set_edge_weight(
-                &pool_id.to_string(),
+                &component_id.to_string(),
                 &token_out.address,
                 &token_in.address,
                 weight_from,
@@ -590,7 +591,7 @@ pub fn setup_market_weighted_boxed(
 
 /// Setup helper for algorithms that do not use pre-computed edge weights
 pub fn setup_market_unweighted(
-    pools: Vec<(&str, &Token, &Token, Box<dyn ProtocolSim>)>,
+    components: Vec<(&str, &Token, &Token, Box<dyn ProtocolSim>)>,
 ) -> (MarketData, PetgraphStableDiGraphManager<()>) {
     let mut market = MarketState::new();
 
@@ -602,11 +603,11 @@ pub fn setup_market_unweighted(
     });
     market.update_last_updated(BlockInfo::new(1, "0x00".into(), 0));
 
-    for (pool_id, token_in, token_out, state) in pools {
+    for (component_id, token_in, token_out, state) in components {
         let tokens = vec![token_in.clone(), token_out.clone()];
-        let comp = component(pool_id, &tokens);
+        let comp = component(component_id, &tokens);
         market.upsert_components(std::iter::once(comp));
-        market.update_states([(pool_id.to_string(), state)]);
+        market.update_states([(component_id.to_string(), state)]);
         market.upsert_tokens(tokens);
     }
 
@@ -644,7 +645,7 @@ pub mod fixtures {
         m
     }
 
-    /// 3 parallel pools A<->B, 2 pools B<->C.
+    /// 3 parallel components A<->B, 2 components B<->C.
     pub(crate) fn parallel_graph() -> PetgraphStableDiGraphManager<DepthAndPrice> {
         let (a, b, c, _) = addrs();
         let mut m = PetgraphStableDiGraphManager::<DepthAndPrice>::new();
@@ -1066,7 +1067,7 @@ mod tests {
 
     // ==================== ConstantProductSim Tests ====================
 
-    fn cp_pool(reserve_0: u64, reserve_1: u64) -> ConstantProductSim {
+    fn cp_component(reserve_0: u64, reserve_1: u64) -> ConstantProductSim {
         ConstantProductSim {
             reserve_0: BigUint::from(reserve_0),
             reserve_1: BigUint::from(reserve_1),
@@ -1078,7 +1079,7 @@ mod tests {
     fn test_constant_product_get_amount_out() {
         // reserve_in=1000, reserve_out=2000, amount_in=100
         // amount_out = 100 * 2000 / (1000 + 100) = 200_000 / 1100 = 181
-        let sim = cp_pool(1000, 2000);
+        let sim = cp_component(1000, 2000);
         let t_in = token(0x01, "T0");
         let t_out = token(0x02, "T1");
 
@@ -1098,20 +1099,20 @@ mod tests {
 
     #[test]
     fn test_constant_product_split_beats_single() {
-        // Concavity of xy=k: splitting across two identical pools yields more output.
+        // Concavity of xy=k: splitting across two identical components yields more output.
         // Single: 200 * 2000 / (1000 + 200) = 333
         // Split 100+100: (181) + (181) = 362 > 333
         let t_in = token(0x01, "T0");
         let t_out = token(0x02, "T1");
 
-        let single = cp_pool(1000, 2000)
+        let single = cp_component(1000, 2000)
             .get_amount_out(BigUint::from(200u64), &t_in, &t_out)
             .unwrap();
 
-        let half1 = cp_pool(1000, 2000)
+        let half1 = cp_component(1000, 2000)
             .get_amount_out(BigUint::from(100u64), &t_in, &t_out)
             .unwrap();
-        let half2 = cp_pool(1000, 2000)
+        let half2 = cp_component(1000, 2000)
             .get_amount_out(BigUint::from(100u64), &t_in, &t_out)
             .unwrap();
         let split_total = half1.amount + half2.amount;
@@ -1127,7 +1128,7 @@ mod tests {
     fn test_constant_product_spot_price_direction() {
         // reserve_0=1000 (token 0x01), reserve_1=2000 (token 0x02)
         // forward: 2000/1000 = 2.0; reverse: 1000/2000 = 0.5; product = 1.0
-        let sim = cp_pool(1000, 2000);
+        let sim = cp_component(1000, 2000);
         let token_low = token(0x01, "T0");
         let token_high = token(0x02, "T1");
 
@@ -1146,8 +1147,8 @@ mod tests {
     }
 
     #[test]
-    fn test_constant_product_empties_pool_error() {
-        let sim = cp_pool(1000, 2000);
+    fn test_constant_product_empties_component_error() {
+        let sim = cp_component(1000, 2000);
         let t_in = token(0x01, "T0");
         let t_out = token(0x02, "T1");
 
@@ -1175,12 +1176,12 @@ mod tests {
         };
 
         let (market, _graph) =
-            setup_market_unweighted(vec![("pool1", &t_in, &t_out, Box::new(sim))]);
+            setup_market_unweighted(vec![("component1", &t_in, &t_out, Box::new(sim))]);
 
         let view = market_read(&market);
         let state = view
-            .get_simulation_state("pool1")
-            .expect("pool1 should be in market");
+            .get_simulation_state("component1")
+            .expect("component1 should be in market");
         let result = state
             .get_amount_out(BigUint::from(100u64), &t_in, &t_out)
             .expect("swap should succeed");

--- a/fynd-core/src/algorithm/water_fill.rs
+++ b/fynd-core/src/algorithm/water_fill.rs
@@ -6,21 +6,21 @@
 //!
 //! The four candidates are the best single path plus three ways to split it:
 //!
-//! * **20-chunk disjoint split** — splits across paths that share no pool, in 20 chunks. This is
-//!   the safety net: it is cheap and always finishes, so a tight timeout cannot cut off the split
-//!   while leaving the single path. That is what makes the never-lose guarantee hold under time
-//!   pressure.
-//! * **256-chunk disjoint split** — the same pool-disjoint paths in 256 chunks, in two phases:
+//! * **20-chunk disjoint split** — splits across paths that share no component, in 20 chunks. This
+//!   is the safety net: it is cheap and always finishes, so a tight timeout cannot cut off the
+//!   split while leaving the single path. That is what makes the never-lose guarantee hold under
+//!   time pressure.
+//! * **256-chunk disjoint split** — the same component-disjoint paths in 256 chunks, in two phases:
 //!   first pick which paths to use at coarse (20-chunk) granularity, where each path's share is
 //!   large enough for its gas-activation gate to be meaningful; then allocate across the chosen
 //!   paths at fine (256-chunk) granularity with the gate off, since their gas is already covered.
-//! * **Fill-and-spill** — a split that lets paths share a pool and branch at an intermediate token
-//!   (a tree route), which the pool-disjoint splits cannot express.
+//! * **Fill-and-spill** — a split that lets paths share a component and branch at an intermediate
+//!   token (a tree route), which the component-disjoint splits cannot express.
 //!
 //! Every split fills the order in chunks: for each chunk, it checks how much each path returns for
 //! that chunk and gives the chunk to the best one. Because constant-product / tick AMMs are
 //! path-independent in cumulative input (one swap of `x` equals two back-to-back swaps summing to
-//! `x`), it simulates only the next chunk against the pool state committed so far — O(chunks)
+//! `x`), it simulates only the next chunk against the component state committed so far — O(chunks)
 //! instead of O(chunks^2). That saved work makes the 256-chunk split affordable.
 //!
 //! Candidate discovery (the "Candidate discovery" section below) combines an exhaustive path
@@ -67,7 +67,7 @@ const DEFAULT_MAX_PATHS: usize = 4;
 const COARSE_CHUNKS: usize = 20;
 /// Chunk grid for the fine allocation pass over the fixed active set.
 const FINE_CHUNKS: usize = 256;
-/// Number of top full-amount paths always considered for shared-pool fill-and-spill.
+/// Number of top full-amount paths always considered for shared-component fill-and-spill.
 const SHARED_FULL_PATHS: usize = 8;
 /// Number of full-amount-ranked paths probed with the first chunk for fill-and-spill.
 const SHARED_MARGIN_PROBE_PATHS: usize = 32;
@@ -79,9 +79,9 @@ const SHARED_MAX_CANDIDATES: usize = 12;
 const CANDIDATE_STATES_PER_NODE: usize = 4;
 /// Candidate edge expansions from one path state during discovery.
 const CANDIDATE_EDGES_PER_STATE: usize = 16;
-/// Parallel pools kept for a discovery edge directly into the target token.
+/// Parallel components kept for a discovery edge directly into the target token.
 const CANDIDATE_DIRECT_EDGES_PER_TOKEN: usize = 4;
-/// Parallel pools kept for a discovery edge into an anchor or configured connector token.
+/// Parallel components kept for a discovery edge into an anchor or configured connector token.
 const CANDIDATE_CONNECTOR_EDGES_PER_TOKEN: usize = 2;
 /// Number of highest-connectivity tokens taken as bounded-discovery anchors, derived per solve
 /// from the graph (see `derive_anchor_tokens`).
@@ -116,8 +116,8 @@ impl SplitCandidate {
     }
 }
 
-/// Splits an order across pool-disjoint (and, via fill-and-spill, pool-sharing) paths to reduce
-/// price impact, returning the best net of the single path and several split allocations.
+/// Splits an order across component-disjoint (and, via fill-and-spill, component-sharing) paths to
+/// reduce price impact, returning the best net of the single path and several split allocations.
 pub struct WaterFillAlgorithm {
     min_hops: usize,
     max_hops: usize,
@@ -138,7 +138,8 @@ struct ExchangeMove {
     gain: BigInt,
 }
 
-/// One simulated traversal of a path, with the resulting per-pool states so they can be committed.
+/// One simulated traversal of a path, with the resulting per-component states so they can be
+/// committed.
 struct StepResult {
     amount_out: BigUint,
     gas: BigUint,
@@ -184,9 +185,9 @@ impl WaterFillAlgorithm {
         })
     }
 
-    /// Simulates `amount` through `path`, reading each pool from `overlay` if present else the base
-    /// state. Returns the output, summed gas, and the resulting per-pool states so the caller can
-    /// commit them into an overlay.
+    /// Simulates `amount` through `path`, reading each component from `overlay` if present else the
+    /// base state. Returns the output, summed gas, and the resulting per-component states so
+    /// the caller can commit them into an overlay.
     fn simulate_step(
         path: &Path<DepthAndPrice>,
         market: &MarketState,
@@ -195,10 +196,11 @@ impl WaterFillAlgorithm {
     ) -> Option<StepResult> {
         let mut current = amount;
         let mut total_gas = BigUint::zero();
-        // A pool touched twice in one path must see its own first swap, which needs an intra-path
-        // overlay carried across hops. That reuse is rare, so only pay the per-hop state clone when
-        // the path actually repeats a pool; the common case skips the clone entirely.
-        let path_reuses_pool = {
+        // A component touched twice in one path must see its own first swap, which needs an
+        // intra-path overlay carried across hops. That reuse is rare, so only pay the
+        // per-hop state clone when the path actually repeats a component; the common case
+        // skips the clone entirely.
+        let path_reuses_component = {
             let mut seen: HashSet<&ComponentId> = HashSet::with_capacity(path.len());
             !path
                 .edge_iter()
@@ -226,7 +228,7 @@ impl WaterFillAlgorithm {
                 .get_amount_out_guarded(current.clone(), token_in, token_out)
                 .ok()?;
             total_gas += &result.gas;
-            if path_reuses_pool {
+            if path_reuses_component {
                 intra_path_states.insert(component_id.clone(), result.new_state.clone_box());
             }
             new_states.push((component_id.clone(), result.new_state));
@@ -258,29 +260,29 @@ impl WaterFillAlgorithm {
             .unwrap_or_else(BigInt::zero)
     }
 
-    /// Picks up to `max_paths` paths that share no pool, so their outputs can be summed without
-    /// re-simulating — two paths through the same pool compete for its liquidity, so their separate
-    /// outputs would not add up.
+    /// Picks up to `max_paths` paths that share no component, so their outputs can be summed
+    /// without re-simulating — two paths through the same component compete for its liquidity,
+    /// so their separate outputs would not add up.
     ///
-    /// Walks `ranked` best first and keeps a path only if none of its pools are already used by a
-    /// kept path, skipping it otherwise. Returns the kept paths' indices into `ranked`.
+    /// Walks `ranked` best first and keeps a path only if none of its components are already used
+    /// by a kept path, skipping it otherwise. Returns the kept paths' indices into `ranked`.
     fn select_disjoint(ranked: &[Path<DepthAndPrice>], max_paths: usize) -> Vec<usize> {
-        let mut visited_pools: HashSet<&ComponentId> = HashSet::new();
+        let mut visited_components: HashSet<&ComponentId> = HashSet::new();
         let mut selected = Vec::new();
         for (idx, path) in ranked.iter().enumerate() {
-            let path_pools: Vec<&ComponentId> = path
+            let path_components: Vec<&ComponentId> = path
                 .edge_iter()
                 .iter()
                 .map(|e| &e.component_id)
                 .collect();
-            if path_pools
+            if path_components
                 .iter()
-                .any(|c| visited_pools.contains(*c))
+                .any(|c| visited_components.contains(*c))
             {
                 continue;
             }
-            for c in path_pools {
-                visited_pools.insert(c);
+            for c in path_components {
+                visited_components.insert(c);
             }
             selected.push(idx);
             if selected.len() >= max_paths {
@@ -452,9 +454,9 @@ impl WaterFillAlgorithm {
             }
         }
 
-        // No early exit on a missing single path: a split across thin pools can fill an order that
-        // no single path can, so the caller decides — it only errors when neither a single path nor
-        // a split candidate fills the order.
+        // No early exit on a missing single path: a split across thin components can fill an order
+        // that no single path can, so the caller decides — it only errors when neither a
+        // single path nor a split candidate fills the order.
         full_outputs.sort_by(|(_, a), (_, b)| b.cmp(a));
         let ordered: Vec<Path<DepthAndPrice>> = full_outputs
             .into_iter()
@@ -507,10 +509,10 @@ impl Algorithm for WaterFillAlgorithm {
 
         // Build the split candidates; the best net of them competes with the single path.
         let mut candidates: Vec<SplitCandidate> = Vec::new();
-        // One coarse (20-chunk) water-fill over the pool-disjoint paths feeds both the floor split
-        // and the refined split, so run it once. It is cheap and always finishes, so a tight
-        // timeout cannot cut it off while leaving the single path — a winning split is never lost
-        // to the clock.
+        // One coarse (20-chunk) water-fill over the component-disjoint paths feeds both the floor
+        // split and the refined split, so run it once. It is cheap and always finishes, so
+        // a tight timeout cannot cut it off while leaving the single path — a winning split
+        // is never lost to the clock.
         let disjoint = Self::select_disjoint(ctx.ordered, self.max_paths);
         let coarse = (disjoint.len() >= 2)
             .then(|| self.disjoint_waterfill(&ctx, &disjoint, COARSE_CHUNKS, true))
@@ -526,8 +528,8 @@ impl Algorithm for WaterFillAlgorithm {
                 candidates.push(c);
             }
         }
-        // Fill-and-spill: a split that lets paths share a pool and branch at an intermediate token
-        // (a tree route), which the pool-disjoint splits cannot express.
+        // Fill-and-spill: a split that lets paths share a component and branch at an intermediate
+        // token (a tree route), which the component-disjoint splits cannot express.
         if let Some(c) = self.fillspill_alloc(&ctx, FINE_CHUNKS) {
             candidates.push(c);
         }
@@ -612,10 +614,10 @@ impl WaterFillAlgorithm {
     }
 
     /// Net output (gross output minus gas cost in output-token terms) of `path` simulated in
-    /// isolation at `amount`. Pool-disjoint paths never interfere, so an isolated re-simulation is
-    /// exact. A zero amount means the path is dropped from the route: it yields no output and,
-    /// since it is no longer swapped, no gas — so dropping a donor credits its saved gas
-    /// automatically.
+    /// isolation at `amount`. Component-disjoint paths never interfere, so an isolated
+    /// re-simulation is exact. A zero amount means the path is dropped from the route: it
+    /// yields no output and, since it is no longer swapped, no gas — so dropping a donor
+    /// credits its saved gas automatically.
     fn path_net(
         ctx: &SplitContext,
         path: &Path<DepthAndPrice>,
@@ -634,10 +636,10 @@ impl WaterFillAlgorithm {
     /// Water-fill can never un-commit a chunk, so its split is only accurate to one fine chunk and
     /// can miss the equal-marginal split. This shifts `delta` of input from an over-allocated donor
     /// to an under-allocated recipient whenever the pair's summed net output strictly improves,
-    /// then halves `delta` once no move helps, down to a sub-chunk floor. Paths are pool-disjoint,
-    /// so a trial re-simulates only the two paths it touches (unchanged paths keep their cached
-    /// net). Only strictly-improving moves are accepted, so the result never scores below the split
-    /// it started from.
+    /// then halves `delta` once no move helps, down to a sub-chunk floor. Paths are
+    /// component-disjoint, so a trial re-simulates only the two paths it touches (unchanged
+    /// paths keep their cached net). Only strictly-improving moves are accepted, so the result
+    /// never scores below the split it started from.
     fn disjoint_exchange(
         &self,
         ctx: &SplitContext,
@@ -735,8 +737,8 @@ impl WaterFillAlgorithm {
         cum
     }
 
-    /// Simulates `amount` through `path`, reading and committing pool states via `overrides`, and
-    /// returns the allocation the route assembly consumes.
+    /// Simulates `amount` through `path`, reading and committing component states via `overrides`,
+    /// and returns the allocation the route assembly consumes.
     fn allocation_commit(
         path: &Path<DepthAndPrice>,
         market: &MarketState,
@@ -803,8 +805,8 @@ impl WaterFillAlgorithm {
     }
 
     /// Builds one independent leg per path at its allocated amount. `subset` and `alloc` are
-    /// aligned by index; pool-disjoint paths never interfere, so each leg is a real independent
-    /// simulation.
+    /// aligned by index; component-disjoint paths never interfere, so each leg is a real
+    /// independent simulation.
     fn build_disjoint_legs(
         &self,
         ctx: &SplitContext,
@@ -817,8 +819,8 @@ impl WaterFillAlgorithm {
             if alloc[i].is_zero() {
                 continue;
             }
-            // Fresh overrides per leg: legs are pool-disjoint, but a pool reused within one path
-            // must still see its own first swap.
+            // Fresh overrides per leg: legs are component-disjoint, but a component reused within
+            // one path must still see its own first swap.
             let mut overrides: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
             let allocation = Self::allocation_commit(
                 &ctx.ordered[path_idx],
@@ -835,9 +837,9 @@ impl WaterFillAlgorithm {
         Self::candidate_from_allocations(ctx, &allocations)
     }
 
-    /// Incremental water-fill over a set of pool-disjoint paths. Returns the amount allocated to
-    /// each path in `subset` order. With `gate`, a path only activates when its first chunk covers
-    /// its gas; without it, every path is eligible (used once the active set is fixed).
+    /// Incremental water-fill over a set of component-disjoint paths. Returns the amount allocated
+    /// to each path in `subset` order. With `gate`, a path only activates when its first chunk
+    /// covers its gas; without it, every path is eligible (used once the active set is fixed).
     fn disjoint_waterfill(
         &self,
         ctx: &SplitContext,
@@ -951,7 +953,7 @@ impl WaterFillAlgorithm {
         candidates
     }
 
-    /// Coarse set-selection then fine allocation with shared-pool fill-and-spill.
+    /// Coarse set-selection then fine allocation with shared-component fill-and-spill.
     fn fillspill_alloc(&self, ctx: &SplitContext, fine_chunks: usize) -> Option<SplitCandidate> {
         let candidates = self.select_shared_candidates(ctx);
         if candidates.len() < 2 {
@@ -1313,11 +1315,11 @@ fn score_candidate_edges<'a, W>(
 }
 
 /// Derives bounded discovery's soft anchor set from the live graph: the `DERIVED_ANCHOR_COUNT`
-/// most-connected tokens (highest pool-edge degree) plus the native-ETH sentinel. Degree is the
-/// same connectivity signal `derive-connector-tokens` ranks by, so anchoring stays correct on any
-/// chain without a hardcoded per-chain list. The native-ETH zero address carries near-zero degree
-/// but is load-bearing for `WETH → ETH → token` routes where Tycho models native ETH as `0x0`, so
-/// it is anchored explicitly.
+/// most-connected tokens (highest component-edge degree) plus the native-ETH sentinel. Degree is
+/// the same connectivity signal `derive-connector-tokens` ranks by, so anchoring stays correct on
+/// any chain without a hardcoded per-chain list. The native-ETH zero address carries near-zero
+/// degree but is load-bearing for `WETH → ETH → token` routes where Tycho models native ETH as
+/// `0x0`, so it is anchored explicitly.
 fn derive_anchor_tokens<W>(graph: &StableDiGraph<W>) -> HashSet<Address> {
     let mut by_degree: Vec<(NodeIndex, usize)> = graph
         .node_indices()
@@ -1491,7 +1493,7 @@ mod tests {
     use crate::{
         algorithm::{
             split_test_harness::{
-                evaluate_scenario, optimal_two_pool_output, split_metrics, split_scenarios,
+                evaluate_scenario, optimal_two_component_output, split_metrics, split_scenarios,
                 two_equal_weth_usdc, TWO_EQUAL_USDC_RESERVE, TWO_EQUAL_WETH_RESERVE,
             },
             test_utils::{
@@ -1521,7 +1523,7 @@ mod tests {
         )
     }
 
-    fn v2_pool(reserve_a: u128, reserve_b: u128) -> UniswapV2State {
+    fn v2_component(reserve_a: u128, reserve_b: u128) -> UniswapV2State {
         UniswapV2State::new(
             U256::from(reserve_a) * U256::from(10u64).pow(U256::from(18u64)),
             U256::from(reserve_b) * U256::from(10u64).pow(U256::from(18u64)),
@@ -1549,7 +1551,7 @@ mod tests {
 
             result.assert_passes_lower_bound();
             // water_fill reaches the analytical optimum within 5% on single-hop and shared-prefix
-            // scenarios. DOUBLE_SPLIT re-splits at both hops with mismatched pool sizes; the
+            // scenarios. DOUBLE_SPLIT re-splits at both hops with mismatched component sizes; the
             // token-merged disjoint/fill-and-spill allocation reaches ~90% of that cross-hop
             // optimum -- still well above the single-path floor, just short of PFW's per-hop
             // line search there.
@@ -1576,17 +1578,19 @@ mod tests {
         assert_eq!(result.path_count, 1, "high gas should prevent splitting");
     }
 
-    /// A split fills an order that no single path can. Two parallel constant-product pools each
-    /// revert once the input reaches their reserve, so the full order overruns either pool alone;
-    /// split in half it fits both. The portfolio returns the split even though the single-path
-    /// baseline is absent — instead of the earlier `InsufficientLiquidity` short-circuit.
+    /// A split fills an order that no single path can. Two parallel constant-product components
+    /// each revert once the input reaches their reserve, so the full order overruns either
+    /// component alone; split in half it fits both. The portfolio returns the split even though
+    /// the single-path baseline is absent — instead of the earlier `InsufficientLiquidity`
+    /// short-circuit.
     #[tokio::test]
     async fn test_split_fills_when_no_single_path_can() {
         let a = token_with_decimals(0x01, "A", 18);
         let b = token_with_decimals(0x02, "B", 18);
         // reserve_0 (token A, the input side) = 800; a swap reverts once its input reaches it. The
-        // full order (1000 A) overruns either pool, but ~500 A per pool in a 50/50 split fits.
-        let pool = || {
+        // full order (1000 A) overruns either component, but ~500 A per component in a 50/50 split
+        // fits.
+        let component = || {
             Box::new(ConstantProductSim {
                 reserve_0: BigUint::from(800u64) * BigUint::from(10u64).pow(18),
                 reserve_1: BigUint::from(10_000u64) * BigUint::from(10u64).pow(18),
@@ -1594,8 +1598,8 @@ mod tests {
             }) as Box<dyn ProtocolSim>
         };
         let (market, gm) = setup_market_weighted_boxed(vec![
-            ("pool_x", &a, &b, pool()),
-            ("pool_y", &a, &b, pool()),
+            ("component_x", &a, &b, component()),
+            ("component_y", &a, &b, component()),
         ]);
         let order = Order::new(
             a.address.clone(),
@@ -1612,18 +1616,18 @@ mod tests {
             .await;
         assert!(single.is_err(), "premise: no single path fills the full order");
 
-        // The portfolio still returns a split across both pools.
+        // The portfolio still returns a split across both components.
         let split = WaterFillAlgorithm::with_config(config())
             .unwrap()
             .find_best_route(gm.graph(), market.clone(), None, None, &order)
             .await
             .expect("water_fill returns a split when no single path fills");
-        assert!(split.route().swaps().len() >= 2, "expected a split across both pools");
+        assert!(split.route().swaps().len() >= 2, "expected a split across both components");
     }
 
-    /// A pool whose math panics mid-simulation must be skipped like any failing pool, not
-    /// unwind through the solver worker thread. The panicking pool advertises huge depth so
-    /// discovery ranks it first and the bulk fill loops actually simulate it.
+    /// A component whose math panics mid-simulation must be skipped like any failing component,
+    /// not unwind through the solver worker thread. The panicking component advertises huge depth
+    /// so discovery ranks it first and the bulk fill loops actually simulate it.
     #[tokio::test]
     async fn test_water_fill_contains_simulation_panic() {
         let a = token_with_decimals(0x01, "A", 18);
@@ -1634,8 +1638,8 @@ mod tests {
             gas: 50_000,
         }) as Box<dyn ProtocolSim>;
         let (market, gm) = setup_market_weighted_boxed(vec![
-            ("pool_ok", &a, &b, healthy),
-            ("pool_panics", &a, &b, Box::new(DivByZeroSim::default())),
+            ("component_ok", &a, &b, healthy),
+            ("component_panics", &a, &b, Box::new(DivByZeroSim::default())),
         ]);
         let order = Order::new(
             a.address.clone(),
@@ -1649,23 +1653,23 @@ mod tests {
             .unwrap()
             .find_best_route(gm.graph(), market.clone(), None, None, &order)
             .await
-            .expect("panicking pool is skipped; the healthy pool still fills the order");
+            .expect("panicking component is skipped; the healthy component still fills the order");
 
         assert!(
             result
                 .route()
                 .swaps()
                 .iter()
-                .all(|swap| swap.component_id() == "pool_ok"),
-            "route must only use the healthy pool",
+                .all(|swap| swap.component_id() == "component_ok"),
+            "route must only use the healthy component",
         );
     }
 
-    /// On two equal fee-free pools the split's gross output must come within a tight tolerance of
-    /// the analytical two-pool optimum (a 50/50 split): the fine 256-chunk allocation finds the
-    /// optimal split, not just any splitting one.
+    /// On two equal fee-free components the split's gross output must come within a tight tolerance
+    /// of the analytical two-component optimum (a 50/50 split): the fine 256-chunk allocation
+    /// finds the optimal split, not just any splitting one.
     #[tokio::test]
-    async fn test_water_fill_output_near_two_pool_optimum() {
+    async fn test_water_fill_output_near_two_component_optimum() {
         let m = two_equal_weth_usdc(1);
         let trade = 500u64;
         let order = whole_weth_order(&m.weth, &m.usdc, trade);
@@ -1682,26 +1686,31 @@ mod tests {
             .await
             .expect("split solves");
         let (_, path_count, gross) = split_metrics(&result, &m.weth, &m.usdc);
-        assert_eq!(path_count, 2, "the optimum uses both pools");
+        assert_eq!(path_count, 2, "the optimum uses both components");
 
-        // Fee-free reserves in raw units, so the no-fee two-pool optimum applies directly.
+        // Fee-free reserves in raw units, so the no-fee two-component optimum applies directly.
         let reserve_in = TWO_EQUAL_WETH_RESERVE as f64 * 1e18;
         let reserve_out = TWO_EQUAL_USDC_RESERVE as f64 * 1e6;
         let trade_amount = trade as f64 * 1e18;
-        let (_, optimum) =
-            optimal_two_pool_output(reserve_in, reserve_out, reserve_in, reserve_out, trade_amount);
+        let (_, optimum) = optimal_two_component_output(
+            reserve_in,
+            reserve_out,
+            reserve_in,
+            reserve_out,
+            trade_amount,
+        );
 
         let gross = gross.to_f64().unwrap();
         assert!(
             gross >= optimum * 0.999 && gross <= optimum * 1.0001,
-            "split gross {gross} should be within 0.1% of the two-pool optimum {optimum}",
+            "split gross {gross} should be within 0.1% of the two-component optimum {optimum}",
         );
     }
 
     /// Under a tight timeout the split must never lose to the best single path: the 20-chunk split
     /// does the cheap coarse allocation, so cutting off later refinement cannot drop the result
     /// below the single path. A budget too tight to finish yields no route at all (the router falls
-    /// back to other pools) — a no-answer, not a loss — so the never-lose check runs only for
+    /// back to other components) — a no-answer, not a loss — so the never-lose check runs only for
     /// budgets where water-fill returns a route. The 50ms budget comfortably exceeds this
     /// scenario's few-ms solve, so the comparison is always exercised.
     #[tokio::test]
@@ -1745,11 +1754,11 @@ mod tests {
 
     // ==================== Candidate discovery ====================
 
-    /// Bounded discovery finds both parallel pools as candidate paths and ranks the deeper pool
-    /// first by simulated full-amount output, using live simulation only (no precomputed edge
-    /// weights on the weightless graph).
+    /// Bounded discovery finds both parallel components as candidate paths and ranks the deeper
+    /// component first by simulated full-amount output, using live simulation only (no
+    /// precomputed edge weights on the weightless graph).
     #[tokio::test]
-    async fn test_discovery_finds_and_ranks_parallel_pools() {
+    async fn test_discovery_finds_and_ranks_parallel_components() {
         let link = token_with_decimals(0x01, "LINK", 18);
         let weth = token_with_decimals(0x02, "WETH", 18);
         let (market, graph_manager) = setup_market_unweighted(vec![
@@ -1757,13 +1766,13 @@ mod tests {
                 "a_weak_link_weth",
                 &link,
                 &weth,
-                Box::new(v2_pool(2_000_000, 264)) as Box<dyn ProtocolSim>,
+                Box::new(v2_component(2_000_000, 264)) as Box<dyn ProtocolSim>,
             ),
             (
                 "z_strong_link_weth",
                 &link,
                 &weth,
-                Box::new(v2_pool(2_000_000, 5_700)) as Box<dyn ProtocolSim>,
+                Box::new(v2_component(2_000_000, 5_700)) as Box<dyn ProtocolSim>,
             ),
         ]);
         let order = Order::new(
@@ -1793,8 +1802,8 @@ mod tests {
         )
         .expect("discovery finds candidates");
 
-        assert_eq!(paths.len(), 2, "both parallel pools should be discovered");
-        // Scores are (path index, full-amount gross output), best first: the deeper pool wins.
+        assert_eq!(paths.len(), 2, "both parallel components should be discovered");
+        // Scores are (path index, full-amount gross output), best first: the deeper component wins.
         let best_path = &paths[scores[0].0];
         assert_eq!(
             best_path.edge_iter()[0].component_id,
@@ -1812,7 +1821,7 @@ mod tests {
             "link_weth",
             &link,
             &weth,
-            Box::new(v2_pool(2_000_000, 5_700)) as Box<dyn ProtocolSim>,
+            Box::new(v2_component(2_000_000, 5_700)) as Box<dyn ProtocolSim>,
         )]);
         let order = Order::new(
             link.address.clone(),
@@ -1845,7 +1854,7 @@ mod tests {
         );
     }
 
-    /// Anchors are the most-connected tokens (highest pool-edge degree) plus the native-ETH
+    /// Anchors are the most-connected tokens (highest component-edge degree) plus the native-ETH
     /// sentinel, derived from the graph rather than a hardcoded list.
     #[test]
     fn test_derive_anchor_tokens_ranks_hub_and_includes_native_sentinel() {
@@ -1854,9 +1863,9 @@ mod tests {
         let b = token_with_decimals(0x03, "B", 18);
         let c = token_with_decimals(0x04, "C", 18);
         let (_market, graph_manager) = setup_market_unweighted(vec![
-            ("hub_a", &hub, &a, Box::new(v2_pool(1, 1)) as Box<dyn ProtocolSim>),
-            ("hub_b", &hub, &b, Box::new(v2_pool(1, 1)) as Box<dyn ProtocolSim>),
-            ("hub_c", &hub, &c, Box::new(v2_pool(1, 1)) as Box<dyn ProtocolSim>),
+            ("hub_a", &hub, &a, Box::new(v2_component(1, 1)) as Box<dyn ProtocolSim>),
+            ("hub_b", &hub, &b, Box::new(v2_component(1, 1)) as Box<dyn ProtocolSim>),
+            ("hub_c", &hub, &c, Box::new(v2_component(1, 1)) as Box<dyn ProtocolSim>),
         ]);
 
         let anchors = derive_anchor_tokens(graph_manager.graph());

--- a/fynd-core/src/derived/computation.rs
+++ b/fynd-core/src/derived/computation.rs
@@ -128,11 +128,11 @@ impl ComputationRequirements {
 /// Typed error for a failed computation item.
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum FailedItemError {
-    /// The pool's simulation state was not available in shared market data.
+    /// The component's simulation state was not available in shared market data.
     #[error("missing simulation state")]
     MissingSimulationState,
 
-    /// Token metadata (decimals, symbol) was not found for the pool's tokens.
+    /// Token metadata (decimals, symbol) was not found for the component's tokens.
     #[error("missing token metadata")]
     MissingTokenMetadata,
 
@@ -157,7 +157,7 @@ pub enum FailedItemError {
     #[error("simulation failed: {0}")]
     SimulationFailed(String),
 
-    /// Every simulation path for this pool failed.
+    /// Every simulation path for this component failed.
     #[error("all simulation paths failed")]
     AllSimulationPathsFailed,
 }

--- a/fynd-core/src/derived/computations/component_depth.rs
+++ b/fynd-core/src/derived/computations/component_depth.rs
@@ -1,7 +1,7 @@
-//! Pool depth computation.
+//! Component depth computation.
 //!
-//! Computes liquidity depths for all pools using `query_pool_swap`, falling back to
-//! the generic Brent solver from tycho-simulation when the pool doesn't implement it natively.
+//! Computes liquidity depths for all components using `query_pool_swap`, falling back to
+//! the generic Brent solver from tycho-simulation when the component doesn't implement it natively.
 //! Depth represents the maximum input amount before reaching the configured slippage
 //! threshold from the spot price.
 //!
@@ -35,30 +35,30 @@ use crate::{
         error::ComputationError,
         manager::{ChangedComponents, SharedDerivedDataRef},
         store::DerivedData,
-        types::PoolDepths,
+        types::ComponentDepths,
     },
     feed::market_data::{MarketData, MarketState},
     types::ComponentId,
 };
 
-/// Computes pool depths for all pools in all directions.
+/// Computes component depths for all components in all directions.
 ///
-/// For each pool and token pair, uses `query_pool_swap` (with Brent solver fallback)
+/// For each component and token pair, uses `query_pool_swap` (with Brent solver fallback)
 /// to find the maximum input amount that results in at most the configured slippage
 /// from spot price.
 #[derive(Debug)]
-pub struct PoolDepthComputation {
+pub struct ComponentDepthComputation {
     slippage_threshold: f64,
 }
 
-impl Default for PoolDepthComputation {
+impl Default for ComponentDepthComputation {
     fn default() -> Self {
         Self { slippage_threshold: 0.01 }
     }
 }
 
-impl PoolDepthComputation {
-    /// Creates a new PoolDepthComputation with the given slippage threshold.
+impl ComponentDepthComputation {
+    /// Creates a new ComponentDepthComputation with the given slippage threshold.
     ///
     /// # Arguments
     /// * `slippage_threshold` - Value between 0 and 1 exclusive (e.g., 0.01 for 1%)
@@ -76,9 +76,11 @@ impl PoolDepthComputation {
 }
 
 #[async_trait]
-impl DerivedComputation for PoolDepthComputation {
-    type Output = PoolDepths;
+impl DerivedComputation for ComponentDepthComputation {
+    type Output = ComponentDepths;
 
+    // Legacy ID: this string is the `computation` label value on Prometheus metrics
+    // (derived_computation_* series), so renaming it would break existing dashboards.
     const ID: ComputationId = "pool_depths";
 
     fn requirements(&self) -> ComputationRequirements {
@@ -91,10 +93,10 @@ impl DerivedComputation for PoolDepthComputation {
         block: u64,
         is_full_recompute: bool,
     ) {
-        store.set_pool_depths(output.data, output.failed_items, block, is_full_recompute);
+        store.set_component_depths(output.data, output.failed_items, block, is_full_recompute);
     }
 
-    #[instrument(level = "debug", skip(market, store, changed), fields(computation_id = Self::ID, updated_pool_depths))]
+    #[instrument(level = "debug", skip(market, store, changed), fields(computation_id = Self::ID, updated_component_depths))]
     async fn compute(
         &self,
         market: &MarketData,
@@ -102,7 +104,7 @@ impl DerivedComputation for PoolDepthComputation {
         changed: &ChangedComponents,
     ) -> Result<ComputationOutput<Self::Output>, ComputationError> {
         // Read derived data from store
-        let (spot_prices, mut pool_depths) = {
+        let (spot_prices, mut component_depths) = {
             let store_guard = store.read().await;
             // Get precomputed spot prices (required dependency).
             let spot_prices = store_guard
@@ -110,20 +112,20 @@ impl DerivedComputation for PoolDepthComputation {
                 .ok_or(ComputationError::MissingDependency(SpotPriceComputation::ID))?
                 .clone();
             // Start with existing depths (or empty for full recompute).
-            let pool_depths = if changed.is_full_recompute {
-                PoolDepths::new()
+            let component_depths = if changed.is_full_recompute {
+                ComponentDepths::new()
             } else {
                 store_guard
-                    .pool_depths()
+                    .component_depths()
                     .cloned()
                     .unwrap_or_default()
             };
-            (spot_prices, pool_depths)
+            (spot_prices, component_depths)
         };
 
-        // Remove pool depths for removed components.
+        // Remove component depths for removed components.
         for component_id in &changed.removed {
-            pool_depths.retain(|key, _| &key.0 != component_id);
+            component_depths.retain(|key, _| &key.0 != component_id);
         }
 
         // Snapshot market data under brief lock.
@@ -170,8 +172,8 @@ impl DerivedComputation for PoolDepthComputation {
             };
 
             let Some(sim_state) = snapshot.get_simulation_state(component_id) else {
-                warn!(component_id, "missing simulation state, skipping pool");
-                pool_depths.retain(|key, _| &key.0 != component_id);
+                warn!(component_id, "missing simulation state, skipping component");
+                component_depths.retain(|key, _| &key.0 != component_id);
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
@@ -181,13 +183,13 @@ impl DerivedComputation for PoolDepthComputation {
                 continue;
             };
 
-            let pool_tokens: Result<Vec<_>, _> = token_addresses
+            let component_tokens: Result<Vec<_>, _> = token_addresses
                 .iter()
                 .map(|addr| tokens.get(addr).ok_or(addr))
                 .collect();
-            let Ok(pool_tokens) = pool_tokens else {
-                warn!(component_id, "missing token metadata, skipping pool");
-                pool_depths.retain(|key, _| &key.0 != component_id);
+            let Ok(component_tokens) = component_tokens else {
+                warn!(component_id, "missing token metadata, skipping component");
+                component_depths.retain(|key, _| &key.0 != component_id);
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, perm[0], perm[1]),
@@ -197,7 +199,7 @@ impl DerivedComputation for PoolDepthComputation {
                 continue;
             };
 
-            for perm in pool_tokens.iter().permutations(2) {
+            for perm in component_tokens.iter().permutations(2) {
                 let (token_in, token_out) = (*perm[0], *perm[1]);
                 let key =
                     (component_id.clone(), token_in.address.clone(), token_out.address.clone());
@@ -210,7 +212,7 @@ impl DerivedComputation for PoolDepthComputation {
                         token_out = %token_out.address,
                         "missing spot price, skipping pair"
                     );
-                    pool_depths.remove(&key);
+                    component_depths.remove(&key);
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
                         error: FailedItemError::MissingSpotPrice,
@@ -235,7 +237,7 @@ impl DerivedComputation for PoolDepthComputation {
                         "extreme decimal mismatch ({}→{}), skipping pair",
                         token_in.decimals, token_out.decimals
                     );
-                    pool_depths.remove(&key);
+                    component_depths.remove(&key);
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
                         error: FailedItemError::ExtremeDecimalMismatch {
@@ -257,7 +259,7 @@ impl DerivedComputation for PoolDepthComputation {
                         spot_price,
                         "spot price too small to compute depth, skipping pair"
                     );
-                    pool_depths.remove(&key);
+                    component_depths.remove(&key);
                     failed_items.push(FailedItem {
                         key: format!("{}/{}/{}", component_id, token_in.address, token_out.address),
                         error: FailedItemError::SpotPriceTooSmall(*spot_price),
@@ -302,13 +304,13 @@ impl DerivedComputation for PoolDepthComputation {
 
                 match depth_result {
                     Ok(depth) => {
-                        pool_depths.insert(key, depth);
+                        component_depths.insert(key, depth);
                         succeeded += 1;
                     }
                     Err(e) => {
                         // Diagnostic: probe with 1 unit to understand why depth search failed.
-                        // Guarded so a panicking pool degrades to a diagnostic string instead of
-                        // killing the computation worker.
+                        // Guarded so a panicking component degrades to a diagnostic string instead
+                        // of killing the computation worker.
                         let probe_info = sim_state
                             .get_amount_out_guarded(BigUint::from(1u32), token_in, token_out)
                             .map(|r| format!("amount_out={}", r.amount))
@@ -326,9 +328,9 @@ impl DerivedComputation for PoolDepthComputation {
                             probe_info,
                             limits_info,
                             error = %e,
-                            "pool depth failed, skipping pair"
+                            "component depth failed, skipping pair"
                         );
-                        pool_depths.remove(&key);
+                        component_depths.remove(&key);
                         failed_items.push(FailedItem {
                             key: format!(
                                 "{}/{}/{}",
@@ -346,12 +348,12 @@ impl DerivedComputation for PoolDepthComputation {
         debug!(
             succeeded,
             failed = failed_items.len(),
-            total = pool_depths.len(),
-            "pool depth computation complete"
+            total = component_depths.len(),
+            "component depth computation complete"
         );
-        Span::current().record("updated_pool_depths", pool_depths.len());
+        Span::current().record("updated_component_depths", component_depths.len());
 
-        Ok(ComputationOutput::with_failures(pool_depths, failed_items))
+        Ok(ComputationOutput::with_failures(component_depths, failed_items))
     }
 }
 
@@ -370,19 +372,19 @@ mod tests {
         derived::{
             computation::FailedItemError,
             store::DerivedData,
-            types::{PoolDepthKey, SpotPrices},
+            types::{ComponentDepthKey, SpotPrices},
         },
         feed::market_data::MarketData,
     };
 
     #[test]
     fn computation_id() {
-        assert_eq!(PoolDepthComputation::ID, "pool_depths");
+        assert_eq!(ComponentDepthComputation::ID, "pool_depths");
     }
 
     #[test]
     fn default_slippage_is_one_percent() {
-        let comp = PoolDepthComputation::default();
+        let comp = ComponentDepthComputation::default();
         assert!((comp.slippage_threshold - 0.01).abs() < f64::EPSILON);
     }
 
@@ -392,7 +394,7 @@ mod tests {
     #[case(0.5)]
     #[case(0.99)]
     fn new_with_valid_slippage(#[case] threshold: f64) {
-        let comp = PoolDepthComputation::new(threshold).unwrap();
+        let comp = ComponentDepthComputation::new(threshold).unwrap();
         assert!((comp.slippage_threshold - threshold).abs() < f64::EPSILON);
     }
 
@@ -404,7 +406,7 @@ mod tests {
     #[case(f64::NAN, "NaN")]
     #[case(f64::INFINITY, "infinity")]
     fn new_with_invalid_slippage(#[case] threshold: f64, #[case] _desc: &str) {
-        let result = PoolDepthComputation::new(threshold);
+        let result = ComponentDepthComputation::new(threshold);
         assert!(
             matches!(result, Err(ComputationError::InvalidConfiguration(_))),
             "expected InvalidConfiguration for {_desc}, got {result:?}"
@@ -421,7 +423,7 @@ mod tests {
             .set_spot_prices(SpotPrices::new(), vec![], 0, true);
         let changed = ChangedComponents::default();
 
-        let output = PoolDepthComputation::default()
+        let output = ComponentDepthComputation::default()
             .compute(&market, &derived, &changed)
             .await
             .unwrap();
@@ -435,11 +437,11 @@ mod tests {
         let usdc = token(1, "USDC");
 
         let (market, _) =
-            setup_market_weighted(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000.0))]);
+            setup_market_weighted(vec![("component", &eth, &usdc, MockProtocolSim::new(2000.0))]);
         let derived = DerivedData::new_shared(); // No spot prices
         let changed = ChangedComponents::default();
 
-        let result = PoolDepthComputation::default()
+        let result = ComponentDepthComputation::default()
             .compute(&market, &derived, &changed)
             .await;
 
@@ -466,7 +468,7 @@ mod tests {
         let usdc = token_with_decimals(1, "USDC", decimals_out);
 
         let (market, _) = setup_market_weighted(vec![(
-            "pool",
+            "component",
             &eth,
             &usdc,
             MockProtocolSim::new(spot_price)
@@ -477,7 +479,7 @@ mod tests {
         let spot_comp = SpotPriceComputation::new();
         let changed = ChangedComponents {
             added: std::collections::HashMap::from([(
-                "pool".to_string(),
+                "component".to_string(),
                 vec![eth.address.clone(), usdc.address.clone()],
             )]),
             removed: vec![],
@@ -493,19 +495,21 @@ mod tests {
             .unwrap()
             .set_spot_prices(spot_output.data, vec![], 0, true);
 
-        let pool_depths_output = PoolDepthComputation::default()
+        let component_depths_output = ComponentDepthComputation::default()
             .compute(&market, &derived, &changed)
             .await
             .expect("computation should succeed");
-        let pool_depths = pool_depths_output.data;
+        let component_depths = component_depths_output.data;
 
-        assert_eq!(pool_depths.len(), 2, "should have depths for both directions");
+        assert_eq!(component_depths.len(), 2, "should have depths for both directions");
 
-        let key_eth_usdc: PoolDepthKey = ("pool".into(), eth.address.clone(), usdc.address.clone());
-        let key_usdc_eth: PoolDepthKey = ("pool".into(), usdc.address.clone(), eth.address.clone());
+        let key_eth_usdc: ComponentDepthKey =
+            ("component".into(), eth.address.clone(), usdc.address.clone());
+        let key_usdc_eth: ComponentDepthKey =
+            ("component".into(), usdc.address.clone(), eth.address.clone());
 
-        assert!(pool_depths.contains_key(&key_eth_usdc), "should have depth for ETH→USDC");
-        assert!(pool_depths.contains_key(&key_usdc_eth), "should have depth for USDC→ETH");
+        assert!(component_depths.contains_key(&key_eth_usdc), "should have depth for ETH→USDC");
+        assert!(component_depths.contains_key(&key_usdc_eth), "should have depth for USDC→ETH");
 
         let expected_depth = |sell_token: &Token, buy_token: &Token| -> BigUint {
             let effective_price =
@@ -519,12 +523,16 @@ mod tests {
             }
         };
         assert_eq!(
-            pool_depths.get(&key_eth_usdc).unwrap(),
+            component_depths
+                .get(&key_eth_usdc)
+                .unwrap(),
             &expected_depth(&eth, &usdc),
             "ETH→USDC depth"
         );
         assert_eq!(
-            pool_depths.get(&key_usdc_eth).unwrap(),
+            component_depths
+                .get(&key_usdc_eth)
+                .unwrap(),
             &expected_depth(&usdc, &eth),
             "USDC→ETH depth"
         );
@@ -612,22 +620,22 @@ mod tests {
         );
     }
 
-    /// Exercises the Brent solver fallback path with realistic UniV2 pool states to verify
+    /// Exercises the Brent solver fallback path with realistic UniV2 component states to verify
     /// it produces sensible depth values. This validates that the Price construction
     /// approach in compute() is correct across a range of real-world token pairs.
     ///
-    /// Three pools covering the key decimal configurations encountered in production:
+    /// Three components covering the key decimal configurations encountered in production:
     ///   - WETH/USDC: 18/6 decimals, ~$2000 price, ~$10M liquidity
     ///   - WETH/WBTC: 18/8 decimals, ~15 price, ~$5M liquidity
     ///   - USDC/USDT: 6/6 decimals, ~1 price, ~$50M liquidity
     #[test]
-    fn test_brent_solver_with_realistic_pools() {
+    fn test_brent_solver_with_realistic_components() {
         use alloy::primitives::U256;
         use tycho_simulation::evm::{
             protocol::uniswap_v2::state::UniswapV2State, query_pool_swap::query_pool_swap,
         };
 
-        struct PoolCase {
+        struct ComponentCase {
             name: &'static str,
             token_in: tycho_simulation::tycho_core::models::token::Token,
             token_out: tycho_simulation::tycho_core::models::token::Token,
@@ -639,21 +647,21 @@ mod tests {
         // WETH reserve ~333 ETH, WBTC reserve ~5000 WBTC  → ~15 WBTC/WETH, ~$5M TVL
         // USDC reserve ~25M, USDT reserve ~25M            → ~1:1, ~$50M TVL
         let cases = vec![
-            PoolCase {
+            ComponentCase {
                 name: "WETH(18)/USDC(6)",
                 token_in: token_with_decimals(0x01, "WETH", 18),
                 token_out: token_with_decimals(0x02, "USDC", 6),
                 reserve_in_human: 5_000,
                 reserve_out_human: 10_000_000,
             },
-            PoolCase {
+            ComponentCase {
                 name: "WETH(18)/WBTC(8)",
                 token_in: token_with_decimals(0x01, "WETH", 18),
                 token_out: token_with_decimals(0x02, "WBTC", 8),
                 reserve_in_human: 5_000,
                 reserve_out_human: 333,
             },
-            PoolCase {
+            ComponentCase {
                 name: "USDC(6)/USDT(6)",
                 token_in: token_with_decimals(0x01, "USDC", 6),
                 token_out: token_with_decimals(0x02, "USDT", 6),
@@ -754,7 +762,7 @@ mod tests {
         let usdc = token(0x02, "USDC");
 
         let (market, _) = setup_market_weighted(vec![(
-            "pool",
+            "component",
             &eth,
             &usdc,
             MockProtocolSim::new(2000.0)
@@ -765,7 +773,7 @@ mod tests {
 
         // Provide spot price for only one direction so the other becomes a FailedItem
         let mut partial_spot = SpotPrices::new();
-        let key_eth_usdc = ("pool".to_string(), eth.address.clone(), usdc.address.clone());
+        let key_eth_usdc = ("component".to_string(), eth.address.clone(), usdc.address.clone());
         partial_spot.insert(key_eth_usdc, 2000.0);
         derived
             .try_write()
@@ -774,7 +782,7 @@ mod tests {
 
         let changed = ChangedComponents {
             added: std::collections::HashMap::from([(
-                "pool".to_string(),
+                "component".to_string(),
                 vec![eth.address.clone(), usdc.address.clone()],
             )]),
             removed: vec![],
@@ -782,7 +790,7 @@ mod tests {
             is_full_recompute: true,
         };
 
-        let output = PoolDepthComputation::default()
+        let output = ComponentDepthComputation::default()
             .compute(&market, &derived, &changed)
             .await
             .expect("should succeed with partial results");
@@ -790,11 +798,12 @@ mod tests {
         assert!(output.has_failures(), "missing USDC→ETH spot price should produce a failed item");
 
         // ETH→USDC direction should succeed
-        let key_eth_usdc: PoolDepthKey = ("pool".into(), eth.address.clone(), usdc.address.clone());
+        let key_eth_usdc: ComponentDepthKey =
+            ("component".into(), eth.address.clone(), usdc.address.clone());
         assert!(output.data.contains_key(&key_eth_usdc), "ETH→USDC depth should be present");
 
         // USDC→ETH direction should be in failed_items
-        let usdc_eth_key = format!("pool/{}/{}", usdc.address, eth.address);
+        let usdc_eth_key = format!("component/{}/{}", usdc.address, eth.address);
         assert!(
             output
                 .failed_items
@@ -820,7 +829,7 @@ mod tests {
 
         let changed = ChangedComponents {
             added: std::collections::HashMap::from([(
-                "phantom_pool".to_string(),
+                "phantom_component".to_string(),
                 vec![eth.address.clone(), usdc.address.clone()],
             )]),
             removed: vec![],
@@ -828,15 +837,15 @@ mod tests {
             is_full_recompute: false,
         };
 
-        let output = PoolDepthComputation::default()
+        let output = ComponentDepthComputation::default()
             .compute(&market, &derived, &changed)
             .await
             .expect("should succeed with partial results");
 
         assert!(output.has_failures());
 
-        let eth_usdc_key = format!("phantom_pool/{}/{}", eth.address, usdc.address);
-        let usdc_eth_key = format!("phantom_pool/{}/{}", usdc.address, eth.address);
+        let eth_usdc_key = format!("phantom_component/{}/{}", eth.address, usdc.address);
+        let usdc_eth_key = format!("phantom_component/{}/{}", usdc.address, eth.address);
         assert!(
             output
                 .failed_items
@@ -856,14 +865,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_compute_partial_failure_pool_depth_computation() {
+    async fn test_compute_partial_failure_component_depth_computation() {
         // Without .with_tokens(), get_limits doesn't scale by decimals,
         // but get_amount_out does — causing a liquidity overflow on swap.
         let token_in = token_with_decimals(0x01, "A", 6);
         let token_out = token_with_decimals(0x02, "B", 18);
 
         let (market, _) = setup_market_weighted(vec![(
-            "pool",
+            "component",
             &token_in,
             &token_out,
             MockProtocolSim::new(1.0).with_liquidity(100),
@@ -872,7 +881,7 @@ mod tests {
 
         let changed = ChangedComponents {
             added: std::collections::HashMap::from([(
-                "pool".to_string(),
+                "component".to_string(),
                 vec![token_in.address.clone(), token_out.address.clone()],
             )]),
             removed: vec![],
@@ -889,7 +898,7 @@ mod tests {
             .unwrap()
             .set_spot_prices(spot_output.data, vec![], 0, true);
 
-        let output = PoolDepthComputation::default()
+        let output = ComponentDepthComputation::default()
             .compute(&market, &derived, &changed)
             .await
             .expect("should succeed with partial results");
@@ -902,7 +911,7 @@ mod tests {
             output
                 .failed_items
                 .iter()
-                .any(|item| item.key.starts_with("pool/") &&
+                .any(|item| item.key.starts_with("component/") &&
                     matches!(&item.error, FailedItemError::SimulationFailed(_))),
             "should have ComputationFailed failure, got: {:?}",
             output.failed_items

--- a/fynd-core/src/derived/computations/mod.rs
+++ b/fynd-core/src/derived/computations/mod.rs
@@ -4,10 +4,10 @@
 //! to produce derived data from market data. The ComputationManager calls `compute()`
 //! when relevant market events occur.
 
-pub mod pool_depth;
+pub mod component_depth;
 pub mod spot_price;
 pub mod token_gas_price;
 
-pub use pool_depth::PoolDepthComputation;
+pub use component_depth::ComponentDepthComputation;
 pub use spot_price::SpotPriceComputation;
 pub use token_gas_price::TokenGasPriceComputation;

--- a/fynd-core/src/derived/computations/spot_price.rs
+++ b/fynd-core/src/derived/computations/spot_price.rs
@@ -1,12 +1,12 @@
 //! Spot price computation.
 //!
-//! Computes spot prices for all pools in both directions using `ProtocolSim::spot_price()`.
+//! Computes spot prices for all components in both directions using `ProtocolSim::spot_price()`.
 //! Spot prices are the instantaneous exchange rates without slippage.
 //!
-//! `ProtocolSim::spot_price()` is cheap for all pool types: VM pools return a pre-computed
-//! HashMap lookup, native pools do simple arithmetic. This means the read lock hold time is
-//! negligible (microseconds per pool), so we hold it for the full loop rather than paying the
-//! cost of cloning simulation states via `extract_subset()`.
+//! `ProtocolSim::spot_price()` is cheap for all component types: VM components return a
+//! pre-computed HashMap lookup, native components do simple arithmetic. This means the read lock
+//! hold time is negligible (microseconds per component), so we hold it for the full loop rather
+//! than paying the cost of cloning simulation states via `extract_subset()`.
 
 use async_trait::async_trait;
 use itertools::Itertools;
@@ -25,9 +25,9 @@ use crate::{
     feed::market_data::MarketData,
 };
 
-/// Computes spot prices for all pools.
+/// Computes spot prices for all components.
 ///
-/// For each pool with tokens A and B, computes:
+/// For each component with tokens A and B, computes:
 /// - Spot price A -> B
 /// - Spot price B -> A
 ///
@@ -112,7 +112,7 @@ impl DerivedComputation for SpotPriceComputation {
             };
 
             let Some(sim_state) = market_guard.get_simulation_state(component_id) else {
-                warn!(component_id, "missing simulation state, skipping pool");
+                warn!(component_id, "missing simulation state, skipping component");
                 spot_prices.retain(|key, _| &key.0 != component_id);
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
@@ -123,12 +123,12 @@ impl DerivedComputation for SpotPriceComputation {
                 continue;
             };
 
-            let pool_tokens: Result<Vec<_>, _> = token_addresses
+            let component_tokens: Result<Vec<_>, _> = token_addresses
                 .iter()
                 .map(|addr| tokens.get(addr).ok_or(addr))
                 .collect();
-            let Ok(pool_tokens) = pool_tokens else {
-                warn!(component_id, "missing token metadata, skipping pool");
+            let Ok(component_tokens) = component_tokens else {
+                warn!(component_id, "missing token metadata, skipping component");
                 spot_prices.retain(|key, _| &key.0 != component_id);
                 for perm in token_addresses.iter().permutations(2) {
                     failed_items.push(FailedItem {
@@ -139,7 +139,7 @@ impl DerivedComputation for SpotPriceComputation {
                 continue;
             };
 
-            for perm in pool_tokens.iter().permutations(2) {
+            for perm in component_tokens.iter().permutations(2) {
                 let (token_in, token_out) = (*perm[0], *perm[1]);
                 let key =
                     (component_id.clone(), token_in.address.clone(), token_out.address.clone());
@@ -226,20 +226,20 @@ mod tests {
 
     #[tokio::test]
     async fn partial_failure_yields_ok_with_failed_items() {
-        // pool1: has sim state → spot prices computed
-        // pool2: no sim state → FailedItem
+        // component1: has sim state → spot prices computed
+        // component2: no sim state → FailedItem
         let eth = token(0x01, "ETH");
         let usdc = token(0x02, "USDC");
         let dai = token(0x03, "DAI");
 
         let (market, _) =
-            setup_market_weighted(vec![("pool1", &eth, &usdc, MockProtocolSim::new(2000.0))]);
+            setup_market_weighted(vec![("component1", &eth, &usdc, MockProtocolSim::new(2000.0))]);
 
-        // Add pool2 without sim state
+        // Add component2 without sim state
         {
             let mut m = market.write().await;
-            let pool2 = component("pool2", &[eth.clone(), dai.clone()]);
-            m.upsert_components(std::iter::once(pool2));
+            let component2 = component("component2", &[eth.clone(), dai.clone()]);
+            m.upsert_components(std::iter::once(component2));
             m.upsert_tokens([dai.clone()]);
         }
 
@@ -249,24 +249,24 @@ mod tests {
         let output = SpotPriceComputation::new()
             .compute(&market, &derived, &changed)
             .await
-            .expect("should not be total failure since pool1 succeeds");
+            .expect("should not be total failure since component1 succeeds");
 
-        assert!(output.has_failures(), "pool2 missing sim state should produce a failed item");
+        assert!(output.has_failures(), "component2 missing sim state should produce a failed item");
 
-        let key_eth_usdc = ("pool1".to_string(), eth.address.clone(), usdc.address.clone());
-        let key_usdc_eth = ("pool1".to_string(), usdc.address.clone(), eth.address.clone());
+        let key_eth_usdc = ("component1".to_string(), eth.address.clone(), usdc.address.clone());
+        let key_usdc_eth = ("component1".to_string(), usdc.address.clone(), eth.address.clone());
         assert!(output.data.contains_key(&key_eth_usdc), "ETH→USDC price should be present");
         assert!(output.data.contains_key(&key_usdc_eth), "USDC→ETH price should be present");
 
         // Component-level failures are expanded to pair-level keys
-        let key_eth_dai = format!("pool2/{}/{}", eth.address, dai.address);
-        let key_dai_eth = format!("pool2/{}/{}", dai.address, eth.address);
+        let key_eth_dai = format!("component2/{}/{}", eth.address, dai.address);
+        let key_dai_eth = format!("component2/{}/{}", dai.address, eth.address);
         assert!(
             output
                 .failed_items
                 .iter()
                 .any(|item| item.key == key_eth_dai || item.key == key_dai_eth),
-            "pool2 pair keys should appear in failed_items"
+            "component2 pair keys should appear in failed_items"
         );
     }
 

--- a/fynd-core/src/derived/computations/token_gas_price.rs
+++ b/fynd-core/src/derived/computations/token_gas_price.rs
@@ -115,7 +115,7 @@ impl TokenGasPriceComputation {
     ) -> Result<HashMap<Address, Vec<CandidatePath<'a>>>, ComputationError> {
         let graph = graph_manager.graph();
 
-        // If gas token has no pools, it won't be in the graph → no paths to discover
+        // If gas token has no components, it won't be in the graph → no paths to discover
         let Ok(entry_node) = graph_manager.find_node(&self.gas_token) else {
             return Ok(HashMap::new());
         };
@@ -147,7 +147,7 @@ impl TokenGasPriceComputation {
                 // buy_price = forward_spot (target per gas when buying)
                 // sell_price = 1/reverse_spot (target per gas when selling)
                 // spread = |buy_price - sell_price|
-                // Score = spread directly (lower = better, 0 for symmetric pools)
+                // Score = spread directly (lower = better, 0 for symmetric components)
                 let buy_price = frame.forward_spot;
                 let sell_price = 1.0 / frame.reverse_spot;
                 let spot_spread = (buy_price - sell_price).abs();
@@ -179,7 +179,8 @@ impl TokenGasPriceComputation {
                 let rev_key: SpotPriceKey =
                     (component_id.clone(), next_token.clone(), token_reached.clone());
 
-                // Skip edges with missing spot prices (pool may have failed spot price computation)
+                // Skip edges with missing spot prices (component may have failed spot price
+                // computation)
                 let Some(&fwd_spot) = spot_prices.get(&fwd_key) else {
                     continue;
                 };
@@ -385,8 +386,8 @@ impl TokenGasPriceComputation {
         }
 
         // Collect all component IDs from every candidate path per token.
-        // This ensures path_components captures any pool that could flip which path is best,
-        // not just pools on the currently-selected path.
+        // This ensures path_components captures any component that could flip which path is best,
+        // not just components on the currently-selected path.
         let all_candidate_components: HashMap<Address, HashSet<ComponentId>> = paths_by_token
             .iter()
             .map(|(token, candidates)| {
@@ -404,7 +405,7 @@ impl TokenGasPriceComputation {
             .collect();
 
         // Sort each token's paths: lowest spread last (for popping). A NaN score (degenerate
-        // pool math in the spread computation) cannot rank a path and would panic a
+        // component math in the spread computation) cannot rank a path and would panic a
         // partial_cmp-based sort, so drop those candidates and sort with the float total order.
         for paths in paths_by_token.values_mut() {
             paths.retain(|path| !path.score.is_nan());
@@ -445,7 +446,7 @@ impl TokenGasPriceComputation {
         }
 
         // Extend each token's path_components with all candidate path components so
-        // incremental recomputation fires when any competing path's pool changes.
+        // incremental recomputation fires when any competing path's component changes.
         for (token, (_, _, components)) in best_prices.iter_mut() {
             if let Some(all_comps) = all_candidate_components.get(token) {
                 components.extend(all_comps.iter().cloned());
@@ -661,17 +662,17 @@ mod tests {
 
     // ==================== Test Helpers ====================
 
-    /// Sets up a complete test environment: market with pools + precomputed spot prices.
+    /// Sets up a complete test environment: market with components + precomputed spot prices.
     /// Returns (market_guard, store) ready for computation.
     async fn setup_test_env(
-        pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
+        components: Vec<(&str, &Token, &Token, MockProtocolSim)>,
     ) -> (MarketData, SharedDerivedDataRef) {
-        let (wrapped_market, _) = setup_market_weighted(pools.clone());
+        let (wrapped_market, _) = setup_market_weighted(components.clone());
 
         let wrapped_store = DerivedData::new_shared();
         let spot_comp = SpotPriceComputation::new();
         let changed = ChangedComponents {
-            added: pools
+            added: components
                 .iter()
                 .map(|(id, t1, t2, _)| {
                     (id.to_string(), vec![t1.address.clone(), t2.address.clone()])
@@ -694,9 +695,9 @@ mod tests {
     }
 
     async fn setup_graph_and_spot_prices(
-        pools: Vec<(&str, &Token, &Token, MockProtocolSim)>,
+        components: Vec<(&str, &Token, &Token, MockProtocolSim)>,
     ) -> (PetgraphStableDiGraphManager<()>, SpotPrices) {
-        let (market, derived) = setup_test_env(pools).await;
+        let (market, derived) = setup_test_env(components).await;
         let market = market_read(&market);
 
         let mut graph = PetgraphStableDiGraphManager::new();
@@ -723,24 +724,28 @@ mod tests {
         let eth = token(0, "ETH");
         let usdc = token(1, "USDC");
 
-        let (graph_manager, spot_prices) =
-            setup_graph_and_spot_prices(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000.0))])
-                .await;
+        let (graph_manager, spot_prices) = setup_graph_and_spot_prices(vec![(
+            "component",
+            &eth,
+            &usdc,
+            MockProtocolSim::new(2000.0),
+        )])
+        .await;
 
         let computation = computation_for(&eth.address);
         let paths = computation
             .discover_paths(&graph_manager, &spot_prices)
             .unwrap();
 
-        // Exactly 1 path to USDC (single hop via "pool")
+        // Exactly 1 path to USDC (single hop via "component")
         let usdc_paths = &paths[&usdc.address];
         assert_eq!(usdc_paths.len(), 1, "should have exactly 1 path to USDC");
 
         let path = &usdc_paths[0];
         assert_eq!(path.path.len(), 1, "path should be single hop");
-        assert_eq!(path.path.edge_data[0].component_id, "pool");
+        assert_eq!(path.path.edge_data[0].component_id, "component");
 
-        // For a symmetric pool, spread = 0
+        // For a symmetric component, spread = 0
         assert_eq!(path.score, 0.0);
     }
 
@@ -779,19 +784,27 @@ mod tests {
 
     #[tokio::test]
     async fn nan_scored_paths_are_dropped_not_panicked_on() {
-        // Degenerate pool math can yield a NaN spot-price spread. A NaN-scored candidate must
+        // Degenerate component math can yield a NaN spot-price spread. A NaN-scored candidate must
         // be dropped — never panicked on — and the affected token simply gets no price.
         let eth = token(0, "ETH");
         let usdc = token(1, "USDC");
 
-        let (market, _) =
-            setup_market_weighted(vec![("nan_pool", &eth, &usdc, MockProtocolSim::new(2000.0))]);
+        let (market, _) = setup_market_weighted(vec![(
+            "nan_component",
+            &eth,
+            &usdc,
+            MockProtocolSim::new(2000.0),
+        )]);
         // Inject NaN spot prices directly: the spread |forward - 1/reverse| becomes NaN.
         let mut spot_prices = SpotPrices::default();
-        spot_prices
-            .insert(("nan_pool".to_string(), eth.address.clone(), usdc.address.clone()), f64::NAN);
-        spot_prices
-            .insert(("nan_pool".to_string(), usdc.address.clone(), eth.address.clone()), f64::NAN);
+        spot_prices.insert(
+            ("nan_component".to_string(), eth.address.clone(), usdc.address.clone()),
+            f64::NAN,
+        );
+        spot_prices.insert(
+            ("nan_component".to_string(), usdc.address.clone(), eth.address.clone()),
+            f64::NAN,
+        );
 
         let computation = computation_for(&eth.address);
         let (prices, _, _) = computation
@@ -848,10 +861,10 @@ mod tests {
         let eth = token(0, "ETH");
         let usdc = token(1, "USDC");
 
-        // Two pools with different spot prices
+        // Two components with different spot prices
         let (graph, spot_prices) = setup_graph_and_spot_prices(vec![
-            ("pool_low", &eth, &usdc, MockProtocolSim::new(1000.0)),
-            ("pool_high", &eth, &usdc, MockProtocolSim::new(2000.0)),
+            ("component_low", &eth, &usdc, MockProtocolSim::new(1000.0)),
+            ("component_high", &eth, &usdc, MockProtocolSim::new(2000.0)),
         ])
         .await;
 
@@ -860,19 +873,19 @@ mod tests {
             .discover_paths(&graph, &spot_prices)
             .unwrap();
 
-        // Exactly 2 paths to USDC (one via each pool)
+        // Exactly 2 paths to USDC (one via each component)
         let usdc_paths = &paths[&usdc.address];
         assert_eq!(usdc_paths.len(), 2, "should have exactly 2 paths to USDC");
 
         // MockProtocolSim's spot_price is symmetric: forward_spot = 1/reverse_spot,
-        // so spread = |forward - 1/reverse| = 0 for all pools.
+        // so spread = |forward - 1/reverse| = 0 for all components.
         // TODO: Test with asymmetric simulation component to verify non-zero spread ranking.
         for path in usdc_paths {
             assert_eq!(path.path.len(), 1, "path should be single hop");
             assert_eq!(path.score, 0.0, "symmetric mock produces zero spread");
         }
 
-        // Verify both pools are discovered (order is arbitrary when scores are equal)
+        // Verify both components are discovered (order is arbitrary when scores are equal)
         let component_ids: Vec<_> = usdc_paths
             .iter()
             .map(|p| {
@@ -881,8 +894,8 @@ mod tests {
                     .as_str()
             })
             .collect();
-        assert!(component_ids.contains(&"pool_low"));
-        assert!(component_ids.contains(&"pool_high"));
+        assert!(component_ids.contains(&"component_low"));
+        assert!(component_ids.contains(&"component_high"));
     }
 
     // ==================== compute_spread_and_mid_price tests ====================
@@ -913,7 +926,7 @@ mod tests {
         // mid_price = (buy_price + sell_price) / 2 ≈ 2085.79
         let gas_units: u64 = 1_000_000_000_000_000; // 1e15
         let (market, _) = setup_test_env(vec![(
-            "pool",
+            "component",
             &eth,
             &usdc,
             MockProtocolSim::new(2000.0)
@@ -1002,7 +1015,7 @@ mod tests {
             "gas token numerator should equal simulation amount"
         );
 
-        // USDC mid-price should be 2000 (symmetric pool, no fee)
+        // USDC mid-price should be 2000 (symmetric component, no fee)
         // Small deviation due to gas cost adjustment in buy_price/sell_price
         let usdc_price = prices
             .get(&usdc.address)
@@ -1129,7 +1142,7 @@ mod tests {
 
         // Create market without spot prices set
         let (market, _) =
-            setup_market_weighted(vec![("pool", &eth, &usdc, MockProtocolSim::new(2000.0))]);
+            setup_market_weighted(vec![("component", &eth, &usdc, MockProtocolSim::new(2000.0))]);
         let derived = DerivedData::new_shared(); // No spot prices
         let changed = ChangedComponents::default();
 
@@ -1145,12 +1158,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_compute_gas_token_with_no_pools_returns_only_self() {
+    async fn test_compute_gas_token_with_no_components_returns_only_self() {
         let eth = token(0, "ETH");
         let usdc = token(1, "USDC");
         let dai = token(2, "DAI");
 
-        // Create a pool that doesn't include ETH (gas token)
+        // Create a component that doesn't include ETH (gas token)
         let (market, derived) =
             setup_test_env(vec![("usdc_dai", &usdc, &dai, MockProtocolSim::new(1.0))]).await;
         let changed = ChangedComponents::default();
@@ -1177,26 +1190,26 @@ mod tests {
     async fn test_path_components_includes_all_candidate_paths() {
         // Diamond topology: two paths to token_a
         //
-        //   pool_direct: ETH → token_a  (fee-free, ratio=2, lower spread → selected)
-        //   pool_indirect_1 + pool_indirect_2: ETH → token_b → token_a (higher spread)
+        //   component_direct: ETH → token_a  (fee-free, ratio=2, lower spread → selected)
+        //   component_indirect_1 + component_indirect_2: ETH → token_b → token_a (higher spread)
         //
-        // After full compute, token_a's path_components must include all three pool IDs
-        // even though only pool_direct is on the best path.
+        // After full compute, token_a's path_components must include all three component IDs
+        // even though only component_direct is on the best path.
         let eth = token(0, "ETH");
         let token_a = token(1, "A");
         let token_b = token(2, "B");
 
         let (market, derived) = setup_test_env(vec![
-            ("pool_direct", &eth, &token_a, MockProtocolSim::new(2.0).with_gas(0)),
+            ("component_direct", &eth, &token_a, MockProtocolSim::new(2.0).with_gas(0)),
             (
-                "pool_indirect_1",
+                "component_indirect_1",
                 &eth,
                 &token_b,
                 MockProtocolSim::new(3.0)
                     .with_fee(0.1)
                     .with_gas(0),
             ),
-            ("pool_indirect_2", &token_b, &token_a, MockProtocolSim::new(1.0).with_gas(0)),
+            ("component_indirect_2", &token_b, &token_a, MockProtocolSim::new(1.0).with_gas(0)),
         ])
         .await;
         let changed = ChangedComponents::default();
@@ -1219,43 +1232,43 @@ mod tests {
         assert!(
             entry
                 .path_components
-                .contains("pool_direct"),
-            "path_components should contain pool_direct (best path)"
+                .contains("component_direct"),
+            "path_components should contain component_direct (best path)"
         );
         assert!(
             entry
                 .path_components
-                .contains("pool_indirect_1"),
-            "path_components should contain pool_indirect_1 (competing path)"
+                .contains("component_indirect_1"),
+            "path_components should contain component_indirect_1 (competing path)"
         );
         assert!(
             entry
                 .path_components
-                .contains("pool_indirect_2"),
-            "path_components should contain pool_indirect_2 (competing path)"
+                .contains("component_indirect_2"),
+            "path_components should contain component_indirect_2 (competing path)"
         );
     }
 
     #[tokio::test]
-    async fn test_incremental_recompute_triggered_by_competing_path_pool() {
+    async fn test_incremental_recompute_triggered_by_competing_path_component() {
         // Same diamond topology as above.
-        // After full compute, changing pool_indirect_1 (not on best path) must
+        // After full compute, changing component_indirect_1 (not on best path) must
         // put token_a in tokens_to_recompute because it's now in path_components.
         let eth = token(0, "ETH");
         let token_a = token(1, "A");
         let token_b = token(2, "B");
 
         let (market, derived) = setup_test_env(vec![
-            ("pool_direct", &eth, &token_a, MockProtocolSim::new(2.0).with_gas(0)),
+            ("component_direct", &eth, &token_a, MockProtocolSim::new(2.0).with_gas(0)),
             (
-                "pool_indirect_1",
+                "component_indirect_1",
                 &eth,
                 &token_b,
                 MockProtocolSim::new(3.0)
                     .with_fee(0.1)
                     .with_gas(0),
             ),
-            ("pool_indirect_2", &token_b, &token_a, MockProtocolSim::new(1.0).with_gas(0)),
+            ("component_indirect_2", &token_b, &token_a, MockProtocolSim::new(1.0).with_gas(0)),
         ])
         .await;
 
@@ -1267,11 +1280,11 @@ mod tests {
             .await
             .unwrap();
 
-        // Incremental change: only pool_indirect_1 updated
+        // Incremental change: only component_indirect_1 updated
         let incremental_changed = ChangedComponents {
             added: HashMap::new(),
             removed: vec![],
-            updated: vec!["pool_indirect_1".to_string()],
+            updated: vec!["component_indirect_1".to_string()],
             is_full_recompute: false,
         };
 
@@ -1293,11 +1306,11 @@ mod tests {
 
         assert!(
             tokens_to_recompute.contains(&token_a.address),
-            "token_a should be scheduled for recomputation when pool_indirect_1 changes"
+            "token_a should be scheduled for recomputation when component_indirect_1 changes"
         );
         assert!(
             tokens_to_recompute.contains(&token_b.address),
-            "token_b should be scheduled for recomputation when pool_indirect_1 changes"
+            "token_b should be scheduled for recomputation when component_indirect_1 changes"
         );
     }
 
@@ -1308,10 +1321,12 @@ mod tests {
 
         // Create market without gas price set
         let mut market_inner = MarketState::new();
-        let comp = component("pool", &[eth.clone(), usdc.clone()]);
+        let comp = component("component", &[eth.clone(), usdc.clone()]);
         market_inner.upsert_components(std::iter::once(comp));
-        market_inner
-            .update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
+        market_inner.update_states([(
+            "component".to_string(),
+            Box::new(MockProtocolSim::new(2000.0)) as _,
+        )]);
         market_inner.upsert_tokens([eth.clone(), usdc.clone()]);
         let market = MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market_inner)));
 
@@ -1319,7 +1334,7 @@ mod tests {
         let derived = DerivedData::new_shared();
         let changed = ChangedComponents {
             added: std::collections::HashMap::from([(
-                "pool".to_string(),
+                "component".to_string(),
                 vec![eth.address.clone(), usdc.address.clone()],
             )]),
             removed: vec![],

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -2,7 +2,7 @@
 //!
 //! The ComputationManager:
 //! - Subscribes to MarketEvents from TychoFeed
-//! - Runs derived computations (token prices, spot prices, pool depths)
+//! - Runs derived computations (token prices, spot prices, component depths)
 //! - Updates DerivedDataStore (exclusive write access)
 //! - Provides read access to workers via shared store reference
 
@@ -105,7 +105,7 @@ fn coalesce_market_events(events: &[MarketEvent]) -> Option<ChangedComponents> {
 
 use super::{
     computation::{ComputationId, ComputationRequirements, DerivedComputation},
-    computations::{PoolDepthComputation, SpotPriceComputation, TokenGasPriceComputation},
+    computations::{ComponentDepthComputation, SpotPriceComputation, TokenGasPriceComputation},
     error::ComputationError,
     events::DerivedDataEvent,
     registry::ErasedComputation,
@@ -126,7 +126,7 @@ pub struct ComputationManagerConfig {
     gas_token: Address,
     /// Max hop count for token gas price computation.
     max_hop: usize,
-    /// Slippage threshold for pool depth computation (0.0 < threshold < 1.0).
+    /// Slippage threshold for component depth computation (0.0 < threshold < 1.0).
     depth_slippage_threshold: f64,
 }
 
@@ -136,7 +136,7 @@ impl ComputationManagerConfig {
         Self::default()
     }
 
-    /// Sets the slippage threshold for pool depth computation.
+    /// Sets the slippage threshold for component depth computation.
     pub fn with_depth_slippage_threshold(mut self, threshold: f64) -> Self {
         self.depth_slippage_threshold = threshold;
         self
@@ -213,7 +213,7 @@ impl ComputationManager {
                 .with_max_hops(config.max_hop)
                 .with_gas_token(config.gas_token),
         )?;
-        manager.register(PoolDepthComputation::new(config.depth_slippage_threshold)?)?;
+        manager.register(ComponentDepthComputation::new(config.depth_slippage_threshold)?)?;
         Ok((manager, event_rx))
     }
 
@@ -791,7 +791,7 @@ mod tests {
 
     #[test]
     fn schedule_diamond_places_join_after_both_parents() {
-        // a <- {b, c} <- d; mirrors fynd's spot -> {token, pool} fan-out.
+        // a <- {b, c} <- d; mirrors fynd's spot -> {token, component} fan-out.
         let schedule = build_schedule(&[
             ("a", ComputationRequirements::none()),
             ("b", ComputationRequirements::fresh(["a"])),
@@ -1325,30 +1325,30 @@ mod tests {
     fn market_with_component_no_sim_state() -> MarketData {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
-        let pool = component("pool", &[eth.clone(), usdc.clone()]);
+        let component = component("component", &[eth.clone(), usdc.clone()]);
 
         let mut market = MarketState::new();
         market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
-        market.upsert_components(std::iter::once(pool));
+        market.upsert_components(std::iter::once(component));
         // Note: no update_states() — simulation state is intentionally absent
         market.upsert_tokens([eth, usdc]);
         MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
 
-    /// Creates a market with two pools: one with sim state (pool succeeds) and one without (pool
-    /// fails). Used to trigger partial spot price failure.
+    /// Creates a market with two components: one with sim state (component succeeds) and one
+    /// without (component fails). Used to trigger partial spot price failure.
     fn market_with_mixed_sim_states() -> MarketData {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
         let dai = token(3, "DAI");
 
-        let pool1 = component("eth_usdc", &[eth.clone(), usdc.clone()]);
-        let pool2 = component("eth_dai", &[eth.clone(), dai.clone()]);
+        let component1 = component("eth_usdc", &[eth.clone(), usdc.clone()]);
+        let component2 = component("eth_dai", &[eth.clone(), dai.clone()]);
 
         let mut market = MarketState::new();
         market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
-        market.upsert_components([pool1, pool2]);
-        // Only pool1 has simulation state; pool2 intentionally has none
+        market.upsert_components([component1, component2]);
+        // Only component1 has simulation state; component2 intentionally has none
         market
             .update_states([("eth_usdc".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
         market.upsert_tokens([eth, usdc, dai]);
@@ -1362,13 +1362,16 @@ mod tests {
     fn market_with_sim_state_no_gas_price() -> MarketData {
         let eth = token(1, "ETH");
         let usdc = token(2, "USDC");
-        let pool = component("pool", &[eth.clone(), usdc.clone()]);
+        let component = component("component", &[eth.clone(), usdc.clone()]);
 
         let mut market = MarketState::new();
         // Note: no update_gas_price() — gas price is intentionally absent
         market.update_last_updated(BlockInfo::new(10, "0xhash".into(), 0));
-        market.upsert_components(std::iter::once(pool));
-        market.update_states([("pool".to_string(), Box::new(MockProtocolSim::new(2000.0)) as _)]);
+        market.upsert_components(std::iter::once(component));
+        market.update_states([(
+            "component".to_string(),
+            Box::new(MockProtocolSim::new(2000.0)) as _,
+        )]);
         market.upsert_tokens([eth, usdc]);
         MarketData::new(std::sync::Arc::new(tokio::sync::RwLock::new(market)))
     }
@@ -1405,7 +1408,7 @@ mod tests {
         // handle_event with added components — spot_price succeeds, token_price fails
         let event = MarketEvent::MarketUpdated {
             added_components: HashMap::from([(
-                "pool".to_string(),
+                "component".to_string(),
                 vec![eth.address.clone(), usdc.address.clone()],
             )]),
             removed_components: vec![],
@@ -1449,7 +1452,7 @@ mod tests {
 
     #[tokio::test]
     async fn partial_spot_price_failure_broadcasts_computation_complete() {
-        // market_with_mixed_sim_states has pool1 (with sim state) and pool2 (without)
+        // market_with_mixed_sim_states has component1 (with sim state) and component2 (without)
         // → spot price computation partially succeeds → ComputationComplete with failed_items
         let market = market_with_mixed_sim_states();
         let config = ComputationManagerConfig::new();
@@ -1460,7 +1463,7 @@ mod tests {
 
         let events = drain_events(&mut event_rx);
 
-        // Should broadcast ComputationComplete (not ComputationFailed) because pool1 succeeds
+        // Should broadcast ComputationComplete (not ComputationFailed) because component1 succeeds
         assert!(
             events.iter().any(|e| matches!(
                 e,
@@ -1476,19 +1479,19 @@ mod tests {
             "should not broadcast ComputationFailed for partial failure"
         );
 
-        // The ComputationComplete event should carry the failed item for pool2
+        // The ComputationComplete event should carry the failed item for component2
         let complete = events.iter().find(|e| {
             matches!(e, DerivedDataEvent::ComputationComplete { computation_id: "spot_prices", .. })
         });
         if let Some(DerivedDataEvent::ComputationComplete { failed_items, .. }) = complete {
             assert!(
                 !failed_items.is_empty(),
-                "ComputationComplete should carry failed_items for pool2"
+                "ComputationComplete should carry failed_items for component2"
             );
         }
 
-        // The store should persist the failure reason for the failed pool.
-        // market_with_mixed_sim_states uses token(1, "ETH") and token(3, "DAI") for pool2.
+        // The store should persist the failure reason for the failed component.
+        // market_with_mixed_sim_states uses token(1, "ETH") and token(3, "DAI") for component2.
         let eth = token(1, "ETH");
         let dai = token(3, "DAI");
         let store = manager.store();

--- a/fynd-core/src/derived/mod.rs
+++ b/fynd-core/src/derived/mod.rs
@@ -1,7 +1,7 @@
 //! Derived data computation system.
 //!
 //! This module provides a framework for computing derived market data
-//! (token prices, pool depths, spot prices, etc.) from raw market data.
+//! (token prices, component depths, spot prices, etc.) from raw market data.
 //!
 //! # Architecture
 //!
@@ -22,11 +22,11 @@
 //!                 SpotPriceComputation
 //!                    /           \
 //!                   v             v
-//!    PoolDepthComputation    TokenGasPriceComputation
+//!    ComponentDepthComputation    TokenGasPriceComputation
 //! ```
 //!
-//! - **SpotPriceComputation**: No dependencies, computes spot prices for all pools
-//! - **PoolDepthComputation**: Depends on `spot_prices`
+//! - **SpotPriceComputation**: No dependencies, computes spot prices for all components
+//! - **ComponentDepthComputation**: Depends on `spot_prices`
 //! - **TokenGasPriceComputation**: Depends on `spot_prices` and `gas_price` (from market data)
 //!
 //! # Example

--- a/fynd-core/src/derived/mod.rs
+++ b/fynd-core/src/derived/mod.rs
@@ -19,9 +19,9 @@
 //! `DerivedComputation::requirements`, and the manager runs them in dependency order:
 //!
 //! ```text
-//!                 SpotPriceComputation
-//!                    /           \
-//!                   v             v
+//!                     SpotPriceComputation
+//!                   /                       \
+//!                  v                         v
 //!    ComponentDepthComputation    TokenGasPriceComputation
 //! ```
 //!

--- a/fynd-core/src/derived/store.rs
+++ b/fynd-core/src/derived/store.rs
@@ -7,10 +7,10 @@ use tycho_simulation::tycho_common::models::Address;
 
 use super::{
     computation::{ComputationId, DerivedComputation, FailedItem, FailedItemError},
-    computations::{PoolDepthComputation, SpotPriceComputation, TokenGasPriceComputation},
+    computations::{ComponentDepthComputation, SpotPriceComputation, TokenGasPriceComputation},
     types::{
-        PoolDepthKey, PoolDepths, SpotPriceKey, SpotPrices, TokenGasPriceKey, TokenGasPrices,
-        TokenPricesWithDeps,
+        ComponentDepthKey, ComponentDepths, SpotPriceKey, SpotPrices, TokenGasPriceKey,
+        TokenGasPrices, TokenPricesWithDeps,
     },
 };
 use crate::derived::SharedDerivedDataRef;
@@ -50,7 +50,7 @@ pub struct DerivedData {
     /// Token prices with path dependency tracking for incremental computation.
     token_prices_deps: Option<ComputedValue<TokenPricesWithDeps>>,
     /// Persistent failure map: key → (block, error). Merged on incremental runs, replaced on full.
-    pool_depths_failed: HashMap<PoolDepthKey, (u64, FailedItemError)>,
+    component_depths_failed: HashMap<ComponentDepthKey, (u64, FailedItemError)>,
     /// Persistent failure map: key → (block, error). Merged on incremental runs, replaced on full.
     spot_prices_failed: HashMap<SpotPriceKey, (u64, FailedItemError)>,
 }
@@ -115,7 +115,7 @@ impl DerivedData {
     pub fn derived_data_ready(&self) -> bool {
         self.token_prices_block().is_some() &&
             self.token_prices_deps_block().is_some() &&
-            self.pool_depths_block().is_some() &&
+            self.component_depths_block().is_some() &&
             self.spot_prices_block().is_some()
     }
 
@@ -209,62 +209,65 @@ impl DerivedData {
     }
 
     // -------------------------------------------------------------------------
-    // Pool Depths
+    // Component Depths
     // -------------------------------------------------------------------------
 
-    /// Returns pool depths if computed.
-    pub fn pool_depths(&self) -> Option<&PoolDepths> {
-        self.output(PoolDepthComputation::ID)
+    /// Returns component depths if computed.
+    pub fn component_depths(&self) -> Option<&ComponentDepths> {
+        self.output(ComponentDepthComputation::ID)
     }
 
-    /// Returns the block at which pool depths were last computed.
-    pub fn pool_depths_block(&self) -> Option<u64> {
-        self.output_block(PoolDepthComputation::ID)
+    /// Returns the block at which component depths were last computed.
+    pub fn component_depths_block(&self) -> Option<u64> {
+        self.output_block(ComponentDepthComputation::ID)
     }
 
-    /// Sets pool depths, merging failures for incremental runs.
+    /// Sets component depths, merging failures for incremental runs.
     ///
     /// For full recomputes, the failure map is replaced entirely. For incremental runs,
     /// failures are merged: existing entries for keys that now succeed are removed, new
     /// failures are inserted, and entries for keys not attempted this run are preserved.
-    pub fn set_pool_depths(
+    pub fn set_component_depths(
         &mut self,
-        depths: PoolDepths,
+        depths: ComponentDepths,
         failed_items: Vec<FailedItem>,
         block: u64,
         is_full_recompute: bool,
     ) {
-        let new_failures: HashMap<PoolDepthKey, (u64, FailedItemError)> = failed_items
+        let new_failures: HashMap<ComponentDepthKey, (u64, FailedItemError)> = failed_items
             .into_iter()
             .filter_map(|f| parse_pair_key(&f.key).map(|k| (k, (block, f.error))))
             .collect();
 
         if is_full_recompute {
-            self.pool_depths_failed = new_failures;
+            self.component_depths_failed = new_failures;
         } else {
-            self.pool_depths_failed
+            self.component_depths_failed
                 .retain(|k, _| !depths.contains_key(k));
-            self.pool_depths_failed
+            self.component_depths_failed
                 .extend(new_failures);
         }
 
-        self.set_output(PoolDepthComputation::ID, depths, block);
+        self.set_output(ComponentDepthComputation::ID, depths, block);
     }
 
-    /// Returns `(block, error)` for this key if it failed in a past pool depth
+    /// Returns `(block, error)` for this key if it failed in a past component depth
     /// computation, or `None` if it succeeded or was not attempted.
     ///
     /// Key format: `(component_id, token_in, token_out)`
-    pub fn pool_depth_failure(&self, key: &PoolDepthKey) -> Option<(u64, &FailedItemError)> {
-        self.pool_depths_failed
+    pub fn component_depth_failure(
+        &self,
+        key: &ComponentDepthKey,
+    ) -> Option<(u64, &FailedItemError)> {
+        self.component_depths_failed
             .get(key)
             .map(|(block, error)| (*block, error))
     }
 
-    /// Clears pool depths and their failure map.
-    pub fn clear_pool_depths(&mut self) {
-        self.clear_output(PoolDepthComputation::ID);
-        self.pool_depths_failed.clear();
+    /// Clears component depths and their failure map.
+    pub fn clear_component_depths(&mut self) {
+        self.clear_output(ComponentDepthComputation::ID);
+        self.component_depths_failed.clear();
     }
 
     // -------------------------------------------------------------------------
@@ -335,7 +338,7 @@ impl DerivedData {
         self.slots.clear();
         self.token_prices_failed.clear();
         self.token_prices_deps = None;
-        self.pool_depths_failed.clear();
+        self.component_depths_failed.clear();
         self.spot_prices_failed.clear();
     }
 }
@@ -363,7 +366,7 @@ mod tests {
 
         // Other computations not set yet
         assert_eq!(store.spot_prices_block(), None);
-        assert_eq!(store.pool_depths_block(), None);
+        assert_eq!(store.component_depths_block(), None);
     }
 
     #[test]
@@ -375,10 +378,10 @@ mod tests {
     }
 
     #[test]
-    fn test_pool_depths_block_tracks_independently() {
+    fn test_component_depths_block_tracks_independently() {
         let mut store = DerivedData::new();
-        store.set_pool_depths(Default::default(), vec![], 7, true);
-        assert_eq!(store.pool_depths_block(), Some(7));
+        store.set_component_depths(Default::default(), vec![], 7, true);
+        assert_eq!(store.component_depths_block(), Some(7));
         assert_eq!(store.token_prices_block(), None);
     }
 
@@ -396,7 +399,7 @@ mod tests {
         store.set_token_prices_deps(Default::default(), 10);
         assert!(!store.derived_data_ready());
 
-        store.set_pool_depths(Default::default(), vec![], 9, true);
+        store.set_component_depths(Default::default(), vec![], 9, true);
         assert!(store.derived_data_ready());
     }
 
@@ -405,13 +408,13 @@ mod tests {
         let mut store = DerivedData::new();
         store.set_token_prices(Default::default(), vec![], 1, true);
         store.set_spot_prices(Default::default(), vec![], 1, true);
-        store.set_pool_depths(Default::default(), vec![], 1, true);
+        store.set_component_depths(Default::default(), vec![], 1, true);
 
         store.clear_all();
 
         assert!(store.token_prices().is_none());
         assert!(store.spot_prices().is_none());
-        assert!(store.pool_depths().is_none());
+        assert!(store.component_depths().is_none());
         assert!(!store.derived_data_ready());
     }
 
@@ -435,8 +438,8 @@ mod tests {
 
     #[test]
     fn test_spot_price_failure_stored_with_block() {
-        let key = pair_key("pool1", 0x01, 0x02);
-        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let key = pair_key("component1", 0x01, 0x02);
+        let key_str = format!("component1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
         store.set_spot_prices(
             Default::default(),
@@ -448,31 +451,31 @@ mod tests {
             store.spot_price_failure(&key),
             Some((10, &FailedItemError::SimulationFailed("sim error".into())))
         );
-        assert_eq!(store.spot_price_failure(&pair_key("pool1", 0x01, 0x03)), None);
+        assert_eq!(store.spot_price_failure(&pair_key("component1", 0x01, 0x03)), None);
     }
 
     #[test]
-    fn test_pool_depth_failure_stored_with_block() {
-        let key: PoolDepthKey = pair_key("pool1", 0x01, 0x02);
-        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+    fn test_component_depth_failure_stored_with_block() {
+        let key: ComponentDepthKey = pair_key("component1", 0x01, 0x02);
+        let key_str = format!("component1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
-        store.set_pool_depths(
+        store.set_component_depths(
             Default::default(),
             vec![failed(&key_str, FailedItemError::SimulationFailed("depth error".into()))],
             7,
             true,
         );
         assert_eq!(
-            store.pool_depth_failure(&key),
+            store.component_depth_failure(&key),
             Some((7, &FailedItemError::SimulationFailed("depth error".into())))
         );
-        assert_eq!(store.pool_depth_failure(&pair_key("pool2", 0x01, 0x02)), None);
+        assert_eq!(store.component_depth_failure(&pair_key("component2", 0x01, 0x02)), None);
     }
 
     #[test]
     fn test_rerunning_with_empty_failures_clears_old_reasons() {
-        let key = pair_key("pool1", 0x01, 0x02);
-        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let key = pair_key("component1", 0x01, 0x02);
+        let key_str = format!("component1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
         store.set_spot_prices(
             Default::default(),
@@ -504,8 +507,8 @@ mod tests {
 
     #[test]
     fn test_clear_spot_prices_clears_failure_map() {
-        let key = pair_key("pool1", 0x01, 0x02);
-        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let key = pair_key("component1", 0x01, 0x02);
+        let key_str = format!("component1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
         store.set_spot_prices(
             Default::default(),
@@ -518,26 +521,26 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_pool_depths_clears_failure_map() {
-        let key: PoolDepthKey = pair_key("pool1", 0x01, 0x02);
-        let key_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+    fn test_clear_component_depths_clears_failure_map() {
+        let key: ComponentDepthKey = pair_key("component1", 0x01, 0x02);
+        let key_str = format!("component1/{}/{}", addr(0x01), addr(0x02));
         let mut store = DerivedData::new();
-        store.set_pool_depths(
+        store.set_component_depths(
             Default::default(),
             vec![failed(&key_str, FailedItemError::MissingSpotPrice)],
             1,
             true,
         );
-        store.clear_pool_depths();
-        assert_eq!(store.pool_depth_failure(&key), None);
+        store.clear_component_depths();
+        assert_eq!(store.component_depth_failure(&key), None);
     }
 
     #[test]
     fn test_incremental_run_preserves_failures_for_unattempted_items() {
-        let key_a = pair_key("pool_a", 0x01, 0x02);
-        let key_a_str = format!("pool_a/{}/{}", addr(0x01), addr(0x02));
-        let key_b = pair_key("pool_b", 0x03, 0x04);
-        let key_b_str = format!("pool_b/{}/{}", addr(0x03), addr(0x04));
+        let key_a = pair_key("component_a", 0x01, 0x02);
+        let key_a_str = format!("component_a/{}/{}", addr(0x01), addr(0x02));
+        let key_b = pair_key("component_b", 0x03, 0x04);
+        let key_b_str = format!("component_b/{}/{}", addr(0x03), addr(0x04));
 
         let mut store = DerivedData::new();
 
@@ -560,24 +563,24 @@ mod tests {
             Some((10, &FailedItemError::MissingTokenMetadata))
         );
 
-        // Incremental run at block 11: only pool_b is attempted and succeeds
+        // Incremental run at block 11: only component_b is attempted and succeeds
         let mut prices = SpotPrices::default();
         prices.insert(key_b.clone(), 1.0);
         store.set_spot_prices(prices, vec![], 11, false);
 
-        // pool_a was not attempted — failure is preserved from block 10
+        // component_a was not attempted — failure is preserved from block 10
         assert_eq!(
             store.spot_price_failure(&key_a),
             Some((10, &FailedItemError::MissingSimulationState))
         );
-        // pool_b succeeded — failure is cleared
+        // component_b succeeded — failure is cleared
         assert_eq!(store.spot_price_failure(&key_b), None);
     }
 
     #[test]
     fn test_incremental_run_updates_block_on_repeated_failure() {
-        let key = pair_key("pool_a", 0x01, 0x02);
-        let key_str = format!("pool_a/{}/{}", addr(0x01), addr(0x02));
+        let key = pair_key("component_a", 0x01, 0x02);
+        let key_str = format!("component_a/{}/{}", addr(0x01), addr(0x02));
 
         let mut store = DerivedData::new();
 
@@ -592,7 +595,7 @@ mod tests {
             Some((10, &FailedItemError::MissingSimulationState))
         );
 
-        // Incremental run at block 11: pool_a fails again with a new error
+        // Incremental run at block 11: component_a fails again with a new error
         store.set_spot_prices(
             Default::default(),
             vec![failed(&key_str, FailedItemError::MissingTokenMetadata)],
@@ -609,8 +612,8 @@ mod tests {
     fn test_clear_all_clears_all_failure_maps() {
         let token_addr = addr(0xab);
         let token_str = format!("{token_addr}");
-        let pair = pair_key("pool1", 0x01, 0x02);
-        let pair_str = format!("pool1/{}/{}", addr(0x01), addr(0x02));
+        let pair = pair_key("component1", 0x01, 0x02);
+        let pair_str = format!("component1/{}/{}", addr(0x01), addr(0x02));
 
         let mut store = DerivedData::new();
         store.set_token_prices(
@@ -625,7 +628,7 @@ mod tests {
             1,
             true,
         );
-        store.set_pool_depths(
+        store.set_component_depths(
             Default::default(),
             vec![failed(&pair_str, FailedItemError::MissingSpotPrice)],
             1,
@@ -636,6 +639,6 @@ mod tests {
 
         assert_eq!(store.token_price_failure(&token_addr), None);
         assert_eq!(store.spot_price_failure(&pair), None);
-        assert_eq!(store.pool_depth_failure(&pair), None);
+        assert_eq!(store.component_depth_failure(&pair), None);
     }
 }

--- a/fynd-core/src/derived/types.rs
+++ b/fynd-core/src/derived/types.rs
@@ -15,7 +15,7 @@ use crate::types::ComponentId;
 
 /// Key for spot price lookups: (component_id, token_in, token_out).
 ///
-/// Uniquely identifies a directional price within a specific pool.
+/// Uniquely identifies a directional price within a specific component.
 pub type SpotPriceKey = (ComponentId, Address, Address);
 
 /// Spot prices map: key -> spot price as f64.
@@ -24,18 +24,18 @@ pub type SpotPriceKey = (ComponentId, Address, Address);
 pub type SpotPrices = HashMap<SpotPriceKey, f64>;
 
 // =============================================================================
-// Pool Depth Types
+// Component Depth Types
 // =============================================================================
 
-/// Key for pool depth lookups: (component_id, token_in, token_out).
+/// Key for component depth lookups: (component_id, token_in, token_out).
 ///
-/// Uniquely identifies a directional liquidity depth within a specific pool.
-pub type PoolDepthKey = (ComponentId, Address, Address);
+/// Uniquely identifies a directional liquidity depth within a specific component.
+pub type ComponentDepthKey = (ComponentId, Address, Address);
 
-/// Pool depths map: key -> maximum input amount at the configured slippage threshold.
+/// Component depths map: key -> maximum input amount at the configured slippage threshold.
 ///
 /// Represents how much can be traded before the specified price impact.
-pub type PoolDepths = HashMap<PoolDepthKey, BigUint>;
+pub type ComponentDepths = HashMap<ComponentDepthKey, BigUint>;
 
 // =============================================================================
 // Token Gas Price Types
@@ -49,17 +49,17 @@ pub type TokenGasPrices = HashMap<TokenGasPriceKey, Price>;
 
 /// Token price with path dependency tracking for incremental computation.
 ///
-/// Tracks which components (pools) were used in the selected path,
-/// enabling selective recomputation when only specific pools change.
+/// Tracks which components were used in the selected path,
+/// enabling selective recomputation when only specific components change.
 #[derive(Debug, Clone)]
 pub struct TokenPriceEntry {
     /// The computed mid-price relative to gas token.
     pub price: Price,
-    /// Components (pool IDs) from all candidate paths considered for this token.
+    /// Component IDs from all candidate paths considered for this token.
     ///
     /// Used for invalidation: if any of these components change,
-    /// this token's price needs recomputation. Includes pools from all discovered
-    /// paths, not just the selected best path, so a change in any competing pool
+    /// this token's price needs recomputation. Includes components from all discovered
+    /// paths, not just the selected best path, so a change in any competing component
     /// triggers recomputation.
     pub path_components: HashSet<ComponentId>,
 }

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -624,16 +624,16 @@ mod tests {
         let tin = make_token(token_in.clone());
         let tout = make_token(token_out.clone());
         // Component ID must be a valid address for the USV2 swap encoder
-        let pool_addr = "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc";
+        let component_addr = "0xB4e16d0168e52d35CaCD2c6185b44281Ec28C9Dc";
         crate::types::Swap::new(
-            pool_addr.to_string(),
+            component_addr.to_string(),
             "uniswap_v2".to_string(),
             token_in,
             token_out,
             BigUint::from(1000u64),
             BigUint::from(990u64),
             BigUint::from(50_000u64),
-            component(pool_addr, &[tin, tout]),
+            component(component_addr, &[tin, tout]),
             Box::new(MockProtocolSim::default()),
         )
     }

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -277,7 +277,8 @@ impl Encoder {
             return Ok(solution);
         }
 
-        // `route_swaps` carry `committed_amount_out` and the pool attributes; `solution.swaps()`
+        // `route_swaps` carry `committed_amount_out` and the component attributes;
+        // `solution.swaps()`
         // are built 1:1 from them by `Solution::try_from` and are what the router executes.
         // We read the committed amount from the route swap but stamp `user_data` onto the
         // matching solution swap, matched by index via the zip below.
@@ -575,8 +576,8 @@ impl From<EncodingError> for SolveError {
     }
 }
 
-/// Returns whether the quote routes through an exclusive pool, i.e. any swap in its route carries
-/// a committed amount.
+/// Returns whether the quote routes through an exclusive component, i.e. any swap in its route
+/// carries a committed amount.
 fn has_exclusive_leg(quote: &OrderQuote) -> bool {
     quote.route().is_some_and(|route| {
         route

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -1,13 +1,13 @@
 //! Exclusive-component classification and per-worker graph filtering.
 //!
 //! "Exclusive" means accessible only to Fynd: such components must never enter the route a
-//! public pool returns, while an exclusive-access pool routes through them to capture the
-//! surplus they offer above the best public-market rate. Both pool kinds serve the same
-//! request; they differ only in which liquidity their workers may route through. Isolation is
-//! achieved by filtering each worker's local graph topology/events through the pool's
-//! `ExclusivityPolicy` — the shared `MarketState` is never duplicated. Workers of public pools
-//! hold `Some(policy)` and filter; workers of exclusive-access pools hold `None` and ingest
-//! everything.
+//! public worker pool returns, while an exclusive-access worker pool routes through them to
+//! capture the surplus they offer above the best public-market rate. Both worker pool kinds
+//! serve the same request; they differ only in which liquidity their workers may route through.
+//! Isolation is achieved by filtering each worker's local graph topology/events through the
+//! worker pool's `ExclusivityPolicy` — the shared `MarketState` is never duplicated. Workers of
+//! public worker pools hold `Some(policy)` and filter; workers of exclusive-access worker pools
+//! hold `None` and ingest everything.
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -9,8 +9,8 @@
 //!
 //! # Overlay design
 //!
-//! Labeled overlay states (used by solver pools to inject per-request pool states) are stored in a
-//! separate `Arc<RwLock<...>>` on `MarketData` rather than inside the main
+//! Labeled overlay states (used by solver components to inject per-request component states) are
+//! stored in a separate `Arc<RwLock<...>>` on `MarketData` rather than inside the main
 //! `MarketState` lock. This decouples overlay writes from base-state reads: a TychoFeed block
 //! update no longer stalls overlay registrations and vice versa.
 
@@ -33,8 +33,8 @@ use crate::types::{BlockInfo, ComponentId};
 
 /// A label identifying an overlay state layer.
 ///
-/// Each labeled overlay is an independent snapshot of pool states that can be layered
-/// on top of the base market state for a specific worker pool or request context.
+/// Each labeled overlay is an independent snapshot of component states that can be layered
+/// on top of the base market state for a specific worker component or request context.
 pub type StateLabel = String;
 
 /// An immutable snapshot of per-component simulation states for one overlay layer.
@@ -42,7 +42,7 @@ pub type OverlayStates = Arc<HashMap<ComponentId, Box<dyn ProtocolSim>>>;
 
 /// A named simulation-state overlay with a block-number expiry.
 pub struct OverlayEntry {
-    /// The overlay pool states (only pools that differ from base state).
+    /// The overlay component states (only components that differ from base state).
     pub states: OverlayStates,
     /// Last block number for which this overlay is valid.
     /// The overlay is automatically evicted before block `valid_until + 1` is applied.
@@ -205,7 +205,7 @@ impl MarketData {
 /// An overlay-aware view of the market data, held for the duration of a read lock.
 ///
 /// Holds a read lock on the base `MarketState` and an optional overlay snapshot.
-/// Use `get_simulation_state` for overlay-aware pool lookups. All other accessors
+/// Use `get_simulation_state` for overlay-aware component lookups. All other accessors
 /// delegate to the base data.
 pub struct MarketDataView<'a> {
     guard: tokio::sync::RwLockReadGuard<'a, MarketState>,
@@ -320,7 +320,7 @@ pub struct MarketState {
     last_updated: Option<BlockInfo>,
     /// Number of components per protocol system, maintained incrementally on
     /// upsert/remove so readers never scan the full component map.
-    pool_counts: HashMap<String, u64>,
+    component_counts: HashMap<String, u64>,
 }
 
 impl MarketState {
@@ -334,7 +334,7 @@ impl MarketState {
             gas_price: None,
             protocol_sync_status: HashMap::new(),
             last_updated: None,
-            pool_counts: HashMap::new(),
+            component_counts: HashMap::new(),
         }
     }
 
@@ -348,7 +348,7 @@ impl MarketState {
         self.last_updated.as_ref()
     }
 
-    /// Number of protocol components (pools) currently tracked.
+    /// Number of protocol components (components) currently tracked.
     pub fn component_count(&self) -> usize {
         self.components.len()
     }
@@ -358,12 +358,12 @@ impl MarketState {
         self.tokens.len()
     }
 
-    /// Number of components (pools) per protocol system.
+    /// Number of components (components) per protocol system.
     ///
-    /// Entries stay present at zero after all of a protocol's pools are
+    /// Entries stay present at zero after all of a protocol's components are
     /// removed so exported gauges reset instead of freezing at the last value.
-    pub fn pool_counts_by_protocol(&self) -> &HashMap<String, u64> {
-        &self.pool_counts
+    pub fn component_counts_by_protocol(&self) -> &HashMap<String, u64> {
+        &self.component_counts
     }
 
     /// Returns the sync status of every protocol system.
@@ -422,7 +422,7 @@ impl MarketState {
                 .insert(component.id.clone(), component);
             if previous.is_none() {
                 *self
-                    .pool_counts
+                    .component_counts
                     .entry(protocol_system)
                     .or_default() += 1;
             }
@@ -453,7 +453,7 @@ impl MarketState {
         for id in ids {
             if let Some(component) = self.components.remove(id) {
                 if let Some(count) = self
-                    .pool_counts
+                    .component_counts
                     .get_mut(&component.protocol_system)
                 {
                     *count = count.saturating_sub(1);
@@ -530,7 +530,7 @@ impl MarketState {
             gas_price: self.gas_price.clone(),
             protocol_sync_status: HashMap::new(), // Not needed for simulation
             last_updated: self.last_updated.clone(),
-            pool_counts: HashMap::new(), // Not needed for simulation
+            component_counts: HashMap::new(), // Not needed for simulation
         }
     }
 }
@@ -546,42 +546,46 @@ mod tests {
     };
 
     #[test]
-    fn pool_counts_by_protocol_tracks_upserts_and_removals() {
+    fn component_counts_by_protocol_tracks_upserts_and_removals() {
         let mut market = MarketState::new();
-        let pool_tokens = [token(0x0A, "A"), token(0x0B, "B")];
+        let component_tokens = [token(0x0A, "A"), token(0x0B, "B")];
 
         market.upsert_components([
-            component_with_protocol("pool_1", "uniswap_v2", &pool_tokens),
-            component_with_protocol("pool_2", "uniswap_v2", &pool_tokens),
-            component_with_protocol("pool_3", "uniswap_v3", &pool_tokens),
+            component_with_protocol("component_1", "uniswap_v2", &component_tokens),
+            component_with_protocol("component_2", "uniswap_v2", &component_tokens),
+            component_with_protocol("component_3", "uniswap_v3", &component_tokens),
         ]);
-        let counts = market.pool_counts_by_protocol();
+        let counts = market.component_counts_by_protocol();
         assert_eq!(counts.get("uniswap_v2"), Some(&2));
         assert_eq!(counts.get("uniswap_v3"), Some(&1));
 
-        // Re-upserting an existing component is an update, not a new pool.
-        market.upsert_components([component_with_protocol("pool_1", "uniswap_v2", &pool_tokens)]);
+        // Re-upserting an existing component is an update, not a new component.
+        market.upsert_components([component_with_protocol(
+            "component_1",
+            "uniswap_v2",
+            &component_tokens,
+        )]);
         assert_eq!(
             market
-                .pool_counts_by_protocol()
+                .component_counts_by_protocol()
                 .get("uniswap_v2"),
             Some(&2)
         );
 
         // Removals decrement; the entry stays at zero so exported gauges reset
         // instead of freezing at the last non-zero value.
-        let removed_ids = ["pool_1".to_string(), "pool_3".to_string()];
+        let removed_ids = ["component_1".to_string(), "component_3".to_string()];
         market.remove_components(removed_ids.iter());
-        let counts = market.pool_counts_by_protocol();
+        let counts = market.component_counts_by_protocol();
         assert_eq!(counts.get("uniswap_v2"), Some(&1));
         assert_eq!(counts.get("uniswap_v3"), Some(&0));
 
         // Removing an unknown id leaves counts untouched.
-        let unknown_ids = ["unknown_pool".to_string()];
+        let unknown_ids = ["unknown_component".to_string()];
         market.remove_components(unknown_ids.iter());
         assert_eq!(
             market
-                .pool_counts_by_protocol()
+                .component_counts_by_protocol()
                 .get("uniswap_v2"),
             Some(&1)
         );
@@ -589,7 +593,7 @@ mod tests {
 
     #[test]
     fn extract_subset_filters_by_component_ids() {
-        // Setup: market with 2 pools (A-B, B-C) and 3 tokens
+        // Setup: market with 2 components (A-B, B-C) and 3 tokens
         let mut market = MarketState::new();
 
         let token_a = token(0x0A, "A");
@@ -597,13 +601,19 @@ mod tests {
         let token_c = token(0x0C, "C");
 
         market.upsert_components([
-            component("pool_ab", &[token_a.clone(), token_b.clone()]),
-            component("pool_bc", &[token_b.clone(), token_c.clone()]),
+            component("component_ab", &[token_a.clone(), token_b.clone()]),
+            component("component_bc", &[token_b.clone(), token_c.clone()]),
         ]);
         market.upsert_tokens([token_a.clone(), token_b.clone(), token_c.clone()]);
         market.update_states([
-            ("pool_ab".to_string(), Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>),
-            ("pool_bc".to_string(), Box::new(MockProtocolSim::new(3.0)) as Box<dyn ProtocolSim>),
+            (
+                "component_ab".to_string(),
+                Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+            ),
+            (
+                "component_bc".to_string(),
+                Box::new(MockProtocolSim::new(3.0)) as Box<dyn ProtocolSim>,
+            ),
         ]);
         market.update_gas_price(BlockGasPrice {
             block_number: 1,
@@ -613,19 +623,19 @@ mod tests {
         });
         market.update_last_updated(BlockInfo::new(12345, "0xabc".to_string(), 0));
 
-        // Extract only pool_ab
-        let ids: HashSet<_> = ["pool_ab".to_string()]
+        // Extract only component_ab
+        let ids: HashSet<_> = ["component_ab".to_string()]
             .into_iter()
             .collect();
         let subset = market.extract_subset(&ids);
 
-        // Components: only pool_ab
+        // Components: only component_ab
         assert_eq!(subset.components.len(), 1);
         assert!(subset
             .components
-            .contains_key("pool_ab"));
+            .contains_key("component_ab"));
 
-        // Tokens: only A and B (referenced by pool_ab), not C
+        // Tokens: only A and B (referenced by component_ab), not C
         assert_eq!(subset.tokens.len(), 2);
         assert!(subset
             .tokens
@@ -637,11 +647,11 @@ mod tests {
             .tokens
             .contains_key(&token_c.address));
 
-        // Simulation states: only pool_ab
+        // Simulation states: only component_ab
         assert_eq!(subset.simulation_states.len(), 1);
         assert!(subset
             .simulation_states
-            .contains_key("pool_ab"));
+            .contains_key("component_ab"));
 
         // Gas price and block info are copied
         assert_eq!(subset.gas_price, market.gas_price);
@@ -665,7 +675,7 @@ mod tests {
         let label = "test_label".to_string();
         let mut states: HashMap<ComponentId, Box<dyn ProtocolSim>> = HashMap::new();
         states.insert(
-            "pool_ab".to_string(),
+            "component_ab".to_string(),
             Box::new(MockProtocolSim::new(99.0)) as Box<dyn ProtocolSim>,
         );
 
@@ -678,7 +688,7 @@ mod tests {
             .await
             .expect("label was just registered");
         // Base data is empty — overlay provides the state
-        let sim = guard.get_simulation_state("pool_ab");
+        let sim = guard.get_simulation_state("component_ab");
         assert!(sim.is_some());
     }
 
@@ -690,7 +700,7 @@ mod tests {
             .register_labeled_state(
                 "my_label".to_string(),
                 HashMap::from([(
-                    "pool1".to_string(),
+                    "component1".to_string(),
                     Box::new(MockProtocolSim::new(5.0)) as Box<dyn ProtocolSim>,
                 )]),
                 u64::MAX,
@@ -700,7 +710,7 @@ mod tests {
         // A handle with no label must not see the overlay
         let guard = market_ref.read().await;
         assert!(guard
-            .get_simulation_state("pool1")
+            .get_simulation_state("component1")
             .is_none());
     }
 
@@ -713,7 +723,7 @@ mod tests {
             .register_labeled_state(
                 label.clone(),
                 HashMap::from([(
-                    "pool".to_string(),
+                    "component".to_string(),
                     Box::new(MockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
                 )]),
                 u64::MAX,
@@ -737,7 +747,7 @@ mod tests {
                 .register_labeled_state(
                     format!("label_{i}"),
                     HashMap::from([(
-                        format!("pool_{i}"),
+                        format!("component_{i}"),
                         Box::new(MockProtocolSim::new(f64::from(i))) as Box<dyn ProtocolSim>,
                     )]),
                     u64::MAX,
@@ -763,7 +773,7 @@ mod tests {
         base.register_labeled_state(
             "shared".to_string(),
             HashMap::from([(
-                "pool_x".to_string(),
+                "component_x".to_string(),
                 Box::new(MockProtocolSim::new(7.0)) as Box<dyn ProtocolSim>,
             )]),
             u64::MAX,
@@ -776,7 +786,7 @@ mod tests {
             .await
             .expect("label was just registered");
         assert!(guard_a
-            .get_simulation_state("pool_x")
+            .get_simulation_state("component_x")
             .is_some());
         drop(guard_a);
 
@@ -785,7 +795,7 @@ mod tests {
             .await
             .expect("label was just registered");
         assert!(guard_b
-            .get_simulation_state("pool_x")
+            .get_simulation_state("component_x")
             .is_some());
     }
 
@@ -800,10 +810,10 @@ mod tests {
 
         {
             let mut data = market_ref.write().await;
-            data.upsert_components([mk_component("pool_ab", &[tok_a.clone(), tok_b.clone()])]);
+            data.upsert_components([mk_component("component_ab", &[tok_a.clone(), tok_b.clone()])]);
             data.upsert_tokens([tok_a.clone(), tok_b.clone()]);
             data.update_states([(
-                "pool_ab".to_string(),
+                "component_ab".to_string(),
                 Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
             )]);
         }
@@ -813,7 +823,7 @@ mod tests {
             .register_labeled_state(
                 label.clone(),
                 HashMap::from([(
-                    "pool_ab".to_string(),
+                    "component_ab".to_string(),
                     Box::new(MockProtocolSim::new(99.0)) as Box<dyn ProtocolSim>,
                 )]),
                 u64::MAX,
@@ -824,13 +834,13 @@ mod tests {
             .read_labeled(&label)
             .await
             .expect("label was just registered");
-        let ids: HashSet<ComponentId> = ["pool_ab".to_string()]
+        let ids: HashSet<ComponentId> = ["component_ab".to_string()]
             .into_iter()
             .collect();
         let subset = guard.extract_subset_with_overlay(&ids);
 
         let sim = subset
-            .get_simulation_state("pool_ab")
+            .get_simulation_state("component_ab")
             .unwrap();
         let mock = sim
             .as_any()
@@ -848,7 +858,7 @@ mod tests {
             .register_labeled_state(
                 "stale".to_string(),
                 HashMap::from([(
-                    "pool_stale".to_string(),
+                    "component_stale".to_string(),
                     Box::new(MockProtocolSim::new(1.0)) as Box<dyn ProtocolSim>,
                 )]),
                 10,
@@ -858,7 +868,7 @@ mod tests {
             .register_labeled_state(
                 "fresh".to_string(),
                 HashMap::from([(
-                    "pool_fresh".to_string(),
+                    "component_fresh".to_string(),
                     Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
                 )]),
                 20,
@@ -903,7 +913,10 @@ mod tests {
 
         market
             .apply_block_update(1, |data| {
-                data.upsert_components([component("pool_ab", &[tok_a.clone(), tok_b.clone()])]);
+                data.upsert_components([component(
+                    "component_ab",
+                    &[tok_a.clone(), tok_b.clone()],
+                )]);
                 data.upsert_tokens([tok_a.clone(), tok_b.clone()]);
             })
             .await;
@@ -919,7 +932,7 @@ mod tests {
 
         market
             .apply_block_update(2, |data| {
-                data.remove_components(["pool_ab".to_string()].iter());
+                data.remove_components(["component_ab".to_string()].iter());
             })
             .await;
         let data = market.read().await;

--- a/fynd-core/src/feed/metrics_sampler.rs
+++ b/fynd-core/src/feed/metrics_sampler.rs
@@ -2,7 +2,7 @@
 //!
 //! Runs off the block-update path: on a fixed interval it takes a non-blocking
 //! read of [`MarketState`](crate::feed::market_data::MarketState) and exports
-//! pool counts and synchronizer status per protocol. Sampling independently of
+//! component counts and synchronizer status per protocol. Sampling independently of
 //! the Tycho feed keeps these gauges flowing even when the feed itself is
 //! stalled — which is exactly when the sync-status metrics matter.
 
@@ -17,7 +17,7 @@ use tycho_simulation::tycho_client::feed::SynchronizerState;
 
 use crate::feed::market_data::MarketData;
 
-/// Periodically exports per-protocol pool counts and sync status as gauges.
+/// Periodically exports per-protocol component counts and sync status as gauges.
 pub(crate) struct MetricsSampler {
     market_data: MarketData,
     sample_interval: Duration,
@@ -41,32 +41,36 @@ impl MetricsSampler {
             let Some(state) = self.market_data.try_read() else {
                 continue;
             };
-            let pool_counts = state.pool_counts_by_protocol().clone();
+            let component_counts = state
+                .component_counts_by_protocol()
+                .clone();
             let sync_states = state.protocol_sync_states().clone();
             drop(state);
 
-            emit_market_metrics(&pool_counts, &sync_states);
+            emit_market_metrics(&component_counts, &sync_states);
         }
     }
 }
 
-/// Sets the per-protocol gauges from a snapshot of pool counts and sync states.
+/// Sets the per-protocol gauges from a snapshot of component counts and sync states.
 ///
 /// Protocols are the union of both maps: a protocol that reported a sync
-/// status but has no pools yet exports a zero pool count rather than no series.
+/// status but has no components yet exports a zero component count rather than no series.
 fn emit_market_metrics(
-    pool_counts: &HashMap<String, u64>,
+    component_counts: &HashMap<String, u64>,
     sync_states: &HashMap<String, SynchronizerState>,
 ) {
-    let protocols: HashSet<&String> = pool_counts
+    let protocols: HashSet<&String> = component_counts
         .keys()
         .chain(sync_states.keys())
         .collect();
     for protocol in protocols {
-        let count = pool_counts
+        let count = component_counts
             .get(protocol)
             .copied()
             .unwrap_or(0);
+        // Counts components; the legacy "pools" metric name is kept so existing
+        // dashboards and alerts keep working (queried in monitoring/grafana/dashboards/fynd.json).
         gauge!("market_pools_per_protocol", "protocol" => protocol.clone()).set(count as f64);
     }
 
@@ -151,11 +155,11 @@ mod tests {
     }
 
     #[test]
-    fn emit_market_metrics_records_pool_and_sync_gauges() {
+    fn emit_market_metrics_records_component_and_sync_gauges() {
         let recorder = DebuggingRecorder::new();
         let snapshotter = recorder.snapshotter();
 
-        let pool_counts =
+        let component_counts =
             HashMap::from([("uniswap_v2".to_string(), 100u64), ("curve".to_string(), 5u64)]);
         let sync_states = HashMap::from([
             ("uniswap_v2".to_string(), SynchronizerState::Ready(header(42))),
@@ -163,7 +167,7 @@ mod tests {
         ]);
 
         metrics::with_local_recorder(&recorder, || {
-            emit_market_metrics(&pool_counts, &sync_states);
+            emit_market_metrics(&component_counts, &sync_states);
         });
 
         let recorded = snapshotter.snapshot().into_vec();
@@ -172,12 +176,12 @@ mod tests {
             find_gauge(&recorded, "market_pools_per_protocol", &[("protocol", "uniswap_v2")]),
             100.0
         );
-        // A protocol with pools but no sync status yet is still exported.
+        // A protocol with components but no sync status yet is still exported.
         assert_eq!(
             find_gauge(&recorded, "market_pools_per_protocol", &[("protocol", "curve")]),
             5.0
         );
-        // A protocol with a sync status but no pools yet must export zero, not
+        // A protocol with a sync status but no components yet must export zero, not
         // be absent, so dashboards see it immediately.
         assert_eq!(
             find_gauge(&recorded, "market_pools_per_protocol", &[("protocol", "uniswap_v3")]),

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -49,8 +49,9 @@ pub(crate) struct TychoFeedConfig {
     /// Component IDs to exclude from the Tycho stream.
     pub(crate) blocklisted_components: HashSet<String>,
     /// Enable partial block (flashblock) updates from the Tycho stream.
-    /// When enabled, pool state updates are delivered mid-block rather than only at finalization,
-    /// reducing effective latency at the cost of processing more frequent, smaller updates.
+    /// When enabled, component state updates are delivered mid-block rather than only at
+    /// finalization, reducing effective latency at the cost of processing more frequent,
+    /// smaller updates.
     pub(crate) partial_blocks: bool,
 }
 

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -203,7 +203,7 @@ pub(crate) fn register_exchanges(
             }
             "vm:curve" => {
                 // The hybrid CurveState with tycho-simulation's own curve_filter, which drops
-                // the pools CurveState cannot quote correctly (oracle/rate-bearing/rebasing
+                // the components CurveState cannot quote correctly (oracle/rate-bearing/rebasing
                 // coins) — the source of the overestimation that forced the temporary
                 // full-EVM fallback (see #318); fixed upstream in tycho-simulation 0.338.0.
                 builder = builder.exchange::<CurveState>(

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -690,7 +690,7 @@ impl TychoFeed {
         trace!("Updating market data");
         let new_block_number = msg.block_number_or_timestamp;
         let update_start = Instant::now();
-        let mut pool_count = 0;
+        let mut latest_component_count = 0;
         let mut token_count = 0;
         self.market_data
             .apply_block_update(new_block_number, |market_data| {
@@ -730,7 +730,7 @@ impl TychoFeed {
                     market_data.update_last_updated(block_info);
                 }
 
-                pool_count = market_data.component_count();
+                latest_component_count = market_data.component_count();
                 token_count = market_data.token_count();
             })
             .instrument(span!(Level::DEBUG, "data_feed_write_lock"))
@@ -738,7 +738,9 @@ impl TychoFeed {
         trace!("Market data updated");
 
         histogram!("market_update_duration_seconds").record(update_start.elapsed().as_secs_f64());
-        gauge!("market_pools").set(pool_count as f64);
+        // Counts components; the legacy "pools" metric name is kept so existing
+        // dashboards and alerts keep working.
+        gauge!("market_pools").set(latest_component_count as f64);
         gauge!("market_tokens").set(token_count as f64);
         if let Some((block_number, block_timestamp)) = latest_block_fields {
             gauge!("market_current_block").set(block_number as f64);

--- a/fynd-core/src/graph/mod.rs
+++ b/fynd-core/src/graph/mod.rs
@@ -125,7 +125,7 @@ use crate::{derived::DerivedData, feed::market_data::MarketDataView};
 /// Trait for edge weight types that can be computed from a ProtocolSim and DerivedData.
 ///
 /// Implement this trait for edge data types that should use pre-computed derived data
-/// (pool depths, spot prices, etc.) instead of computing them from scratch.
+/// (component depths, spot prices, etc.) instead of computing them from scratch.
 pub trait EdgeWeightFromSimAndDerived: Sized {
     /// Computes edge weight data using ProtocolSim and pre-computed DerivedData.
     ///
@@ -135,7 +135,7 @@ pub trait EdgeWeightFromSimAndDerived: Sized {
     /// * `component_id` - The component ID for derived data lookup
     /// * `token_in` - The input token
     /// * `token_out` - The output token
-    /// * `derived` - Pre-computed derived data (pool depths, spot prices, etc.)
+    /// * `derived` - Pre-computed derived data (component depths, spot prices, etc.)
     ///
     /// # Returns
     ///

--- a/fynd-core/src/graph/petgraph.rs
+++ b/fynd-core/src/graph/petgraph.rs
@@ -28,7 +28,7 @@ use crate::{
 
 /// Data stored on each edge of the graph.
 ///
-/// Contains the component ID (which pool this edge represents) and
+/// Contains the component ID (which component this edge represents) and
 /// optional algorithm-specific data. The type `D` is generic to allow
 /// different algorithms to store their own scoring data.
 ///
@@ -313,14 +313,14 @@ impl<D: Clone> PetgraphStableDiGraphManager<D> {
 impl<D: Clone + super::EdgeWeightFromSimAndDerived> PetgraphStableDiGraphManager<D> {
     /// Updates edge weights using simulation states and pre-computed derived data.
     ///
-    /// Uses pre-computed derived data (spot prices, pool depths, etc.) to update
+    /// Uses pre-computed derived data (spot prices, component depths, etc.) to update
     /// edge weights. This is more accurate than computing from scratch as it uses
     /// data computed with slippage thresholds via `query_pool_swap` or binary search.
     ///
     /// # Arguments
     ///
     /// * `market` - The market data containing simulation states and tokens
-    /// * `derived` - Pre-computed derived data (pool depths, spot prices, etc.)
+    /// * `derived` - Pre-computed derived data (component depths, spot prices, etc.)
     ///
     /// # Returns
     ///
@@ -496,19 +496,21 @@ mod tests {
         let token_c = addr("0x6B175474E89094C44Da98b954EedeAC495271d0F"); // DAI
         let token_d = addr("0xdAC17F958D2ee523a2206206994597C13D831ec7"); // USDT
 
-        // Pool 1: A-B-C (3-token pool, fully connected)
-        topology
-            .insert("pool1".to_string(), vec![token_a.clone(), token_b.clone(), token_c.clone()]);
-        // Pool 2: C-D (2-token pool, overlapping with pool 1)
-        topology.insert("pool2".to_string(), vec![token_c.clone(), token_d.clone()]);
+        // Component 1: A-B-C (3-token component, fully connected)
+        topology.insert(
+            "component1".to_string(),
+            vec![token_a.clone(), token_b.clone(), token_c.clone()],
+        );
+        // Component 2: C-D (2-token component, overlapping with component 1)
+        topology.insert("component2".to_string(), vec![token_c.clone(), token_d.clone()]);
 
         manager.initialize_graph(&topology);
 
         let graph = manager.graph();
         // 4 unique tokens
         assert_eq!(graph.node_count(), 4);
-        // Pool 1: 3 pairs × 2 directions = 6 edges (A-B, B-A, A-C, C-A, B-C, C-B)
-        // Pool 2: 1 pair × 2 directions = 2 edges (C-D, D-C)
+        // Component 1: 3 pairs × 2 directions = 6 edges (A-B, B-A, A-C, C-A, B-C, C-B)
+        // Component 2: 1 pair × 2 directions = 2 edges (C-D, D-C)
         // Total: 8 edges
         assert_eq!(graph.edge_count(), 8);
 
@@ -518,64 +520,64 @@ mod tests {
         let node_c = manager.find_node(&token_c).unwrap();
         let node_d = manager.find_node(&token_d).unwrap();
 
-        // Pool 1 edges: A-B, B-A, A-C, C-A, B-C, C-B (bidirectional)
+        // Component 1 edges: A-B, B-A, A-C, C-A, B-C, C-B (bidirectional)
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_a, node_b).unwrap())
                 .unwrap()
                 .component_id,
-            "pool1".to_string()
+            "component1".to_string()
         );
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_b, node_a).unwrap())
                 .unwrap()
                 .component_id,
-            "pool1".to_string()
+            "component1".to_string()
         );
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_a, node_c).unwrap())
                 .unwrap()
                 .component_id,
-            "pool1".to_string()
+            "component1".to_string()
         );
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_c, node_a).unwrap())
                 .unwrap()
                 .component_id,
-            "pool1".to_string()
+            "component1".to_string()
         );
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_b, node_c).unwrap())
                 .unwrap()
                 .component_id,
-            "pool1".to_string()
+            "component1".to_string()
         );
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_c, node_b).unwrap())
                 .unwrap()
                 .component_id,
-            "pool1".to_string()
+            "component1".to_string()
         );
 
-        // Pool 2 edges: C-D, D-C (bidirectional)
+        // Component 2 edges: C-D, D-C (bidirectional)
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_c, node_d).unwrap())
                 .unwrap()
                 .component_id,
-            "pool2".to_string()
+            "component2".to_string()
         );
         assert_eq!(
             graph
                 .edge_weight(graph.find_edge(node_d, node_c).unwrap())
                 .unwrap()
                 .component_id,
-            "pool2".to_string()
+            "component2".to_string()
         );
     }
 
@@ -587,9 +589,9 @@ mod tests {
         let token_b = addr("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
 
         // Multiple components connecting the same token pair
-        topology.insert("pool1".to_string(), vec![token_a.clone(), token_b.clone()]);
-        topology.insert("pool2".to_string(), vec![token_a.clone(), token_b.clone()]);
-        topology.insert("pool3".to_string(), vec![token_a.clone(), token_b.clone()]);
+        topology.insert("component1".to_string(), vec![token_a.clone(), token_b.clone()]);
+        topology.insert("component2".to_string(), vec![token_a.clone(), token_b.clone()]);
+        topology.insert("component3".to_string(), vec![token_a.clone(), token_b.clone()]);
 
         manager.initialize_graph(&topology);
 
@@ -614,9 +616,9 @@ mod tests {
             .collect();
 
         // Verify all three component IDs are present
-        assert!(component_ids.contains(&&"pool1".to_string()));
-        assert!(component_ids.contains(&&"pool2".to_string()));
-        assert!(component_ids.contains(&&"pool3".to_string()));
+        assert!(component_ids.contains(&&"component1".to_string()));
+        assert!(component_ids.contains(&&"component2".to_string()));
+        assert!(component_ids.contains(&&"component3".to_string()));
     }
 
     #[test]
@@ -627,7 +629,7 @@ mod tests {
         let token_b = addr("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
 
         // Add first component with token A and B
-        components.insert("pool1".to_string(), vec![token_a.clone(), token_b.clone()]);
+        components.insert("component1".to_string(), vec![token_a.clone(), token_b.clone()]);
         manager
             .add_components(&components)
             .unwrap();
@@ -637,7 +639,7 @@ mod tests {
 
         // Add second component with overlapping token A
         components.clear();
-        components.insert("pool2".to_string(), vec![token_a.clone(), token_b.clone()]);
+        components.insert("component2".to_string(), vec![token_a.clone(), token_b.clone()]);
         manager
             .add_components(&components)
             .unwrap();
@@ -654,17 +656,17 @@ mod tests {
         let token_b = addr("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
 
         // Mix valid and invalid components
-        components.insert("pool1".to_string(), vec![token_a.clone(), token_b.clone()]);
-        components.insert("pool2".to_string(), vec![]);
-        components.insert("pool3".to_string(), vec![]);
+        components.insert("component1".to_string(), vec![token_a.clone(), token_b.clone()]);
+        components.insert("component2".to_string(), vec![]);
+        components.insert("component3".to_string(), vec![]);
         let result = manager.add_components(&components);
 
         assert!(result.is_err());
         match result.unwrap_err() {
             GraphError::InvalidComponents(ids) => {
                 assert_eq!(ids.len(), 2);
-                assert!(ids.contains(&"pool2".to_string()));
-                assert!(ids.contains(&"pool3".to_string()));
+                assert!(ids.contains(&"component2".to_string()));
+                assert!(ids.contains(&"component3".to_string()));
             }
             _ => panic!("Expected InvalidComponents error"),
         }
@@ -682,30 +684,30 @@ mod tests {
         let token_b = addr("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
 
         // Add components first
-        components.insert("pool1".to_string(), vec![token_a.clone(), token_b.clone()]);
-        components.insert("pool2".to_string(), vec![token_a.clone(), token_b.clone()]);
+        components.insert("component1".to_string(), vec![token_a.clone(), token_b.clone()]);
+        components.insert("component2".to_string(), vec![token_a.clone(), token_b.clone()]);
         manager
             .add_components(&components)
             .unwrap();
 
         // Try to remove mix of existing and non-existing components
         let result = manager.remove_components(&[
-            "pool1".to_string(),
-            "pool3".to_string(),
-            "pool4".to_string(),
+            "component1".to_string(),
+            "component3".to_string(),
+            "component4".to_string(),
         ]);
 
         assert!(result.is_err());
         match result.unwrap_err() {
             GraphError::ComponentsNotFound(ids) => {
                 assert_eq!(ids.len(), 2, "Expected 2 missing components");
-                assert!(ids.contains(&"pool3".to_string()));
-                assert!(ids.contains(&"pool4".to_string()));
+                assert!(ids.contains(&"component3".to_string()));
+                assert!(ids.contains(&"component4".to_string()));
             }
             _ => panic!("Expected ComponentsNotFound error"),
         }
 
-        // Verify only pool2 edges remain
+        // Verify only component2 edges remain
         for edge in manager.graph().edge_indices() {
             assert_eq!(
                 manager
@@ -713,7 +715,7 @@ mod tests {
                     .edge_weight(edge)
                     .unwrap()
                     .component_id,
-                "pool2".to_string()
+                "component2".to_string()
             );
         }
     }
@@ -726,17 +728,18 @@ mod tests {
         let token_b = addr("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"); // USDC
         let token_c = addr("0x6B175474E89094C44Da98b954EedeAC495271d0F"); // DAI
 
-        // Initialize with pool1 connecting A-B, and pool2 connecting B-C
-        topology.insert("pool1".to_string(), vec![token_a.clone(), token_b.clone()]);
-        topology.insert("pool2".to_string(), vec![token_b.clone(), token_c.clone()]);
+        // Initialize with component1 connecting A-B, and component2 connecting B-C
+        topology.insert("component1".to_string(), vec![token_a.clone(), token_b.clone()]);
+        topology.insert("component2".to_string(), vec![token_b.clone(), token_c.clone()]);
         manager.initialize_graph(&topology);
 
         // Test 1: Component not found
-        let result = manager.set_edge_weight(&"pool3".to_string(), &token_a, &token_b, (), true);
+        let result =
+            manager.set_edge_weight(&"component3".to_string(), &token_a, &token_b, (), true);
         assert!(result.is_err());
         match result.unwrap_err() {
             GraphError::ComponentsNotFound(ids) => {
-                assert_eq!(ids, vec!["pool3".to_string()]);
+                assert_eq!(ids, vec!["component3".to_string()]);
             }
             _ => panic!("Expected ComponentsNotFound error"),
         }
@@ -744,7 +747,7 @@ mod tests {
         // Test 2: Token not found
         let non_existent_token = addr("0x0000000000000000000000000000000000000000");
         let result = manager.set_edge_weight(
-            &"pool1".to_string(),
+            &"component1".to_string(),
             &token_a,
             &non_existent_token, // Non-existent token
             (),
@@ -760,9 +763,9 @@ mod tests {
 
         // Test 3: Component doesn't connect the specified tokens
         let result = manager.set_edge_weight(
-            &"pool1".to_string(),
+            &"component1".to_string(),
             &token_a,
-            &token_c, // pool1 doesn't connect A-C, only A-B
+            &token_c, // component1 doesn't connect A-C, only A-B
             (),
             true,
         );
@@ -771,7 +774,7 @@ mod tests {
             GraphError::MissingComponentBetweenTokens(in_token, out_token, comp_id) => {
                 assert_eq!(in_token, token_a);
                 assert_eq!(out_token, token_c);
-                assert_eq!(comp_id, "pool1".to_string());
+                assert_eq!(comp_id, "component1".to_string());
             }
             _ => panic!("Expected MissingComponentBetweenTokens error"),
         }
@@ -786,8 +789,8 @@ mod tests {
 
         // Create an event with both add and remove operations that will fail
         let event = MarketEvent::MarketUpdated {
-            added_components: HashMap::from([("pool1".to_string(), vec![])]),
-            removed_components: vec!["pool2".to_string()],
+            added_components: HashMap::from([("component1".to_string(), vec![])]),
+            removed_components: vec!["component2".to_string()],
             updated_components: vec![],
         };
 
@@ -818,7 +821,7 @@ mod tests {
         let token_b = addr("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
 
         let mut components = HashMap::new();
-        components.insert("pool1".to_string(), vec![token_a.clone(), token_b.clone()]);
+        components.insert("component1".to_string(), vec![token_a.clone(), token_b.clone()]);
 
         manager
             .add_components(&components)
@@ -840,7 +843,7 @@ mod tests {
     #[test]
     fn edge_weight_cleared_on_spot_price_miss() {
         // Regression: when spot price computation fails, stale edge weights must be cleared so the
-        // pool is excluded from path scoring rather than routed with an outdated price.
+        // component is excluded from path scoring rather than routed with an outdated price.
         use num_bigint::BigUint;
         use num_traits::One;
         use tycho_simulation::tycho_core::simulation::protocol_sim::Price;
@@ -852,8 +855,12 @@ mod tests {
 
         let token_a = token(0x01, "A");
         let token_b = token(0x02, "B");
-        let (market, mut manager) =
-            setup_market_weighted(vec![("pool1", &token_a, &token_b, MockProtocolSim::new(2.0))]);
+        let (market, mut manager) = setup_market_weighted(vec![(
+            "component1",
+            &token_a,
+            &token_b,
+            MockProtocolSim::new(2.0),
+        )]);
 
         assert!(
             manager
@@ -877,7 +884,7 @@ mod tests {
         }
         let mut derived = DerivedData::new();
         derived.set_spot_prices(Default::default(), vec![], 10, true);
-        derived.set_pool_depths(Default::default(), vec![], 10, true);
+        derived.set_component_depths(Default::default(), vec![], 10, true);
         derived.set_token_prices(token_prices, vec![], 10, true);
 
         manager.update_edge_weights_with_derived(market_read(&market), &derived);

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -61,7 +61,9 @@ pub use price_guard::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
 pub use replay::{replay_route, ReplayError, RouteReplay};
-pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
+pub use solver::{
+    FyndBuilder, Solver, SolverBuildError, SolverParts, WaitReadyError, WorkerPoolConfig,
+};
 /// Processes ephemeral pending bundles against live Tycho market state. Obtained by calling
 /// [`FyndBuilder::build_with_pending`](solver::FyndBuilder::build_with_pending).
 pub use tycho_simulation::evm::pending::PendingBlockProcessor;
@@ -84,7 +86,7 @@ pub use types::{
     SolveParams, SolveResult, SurplusInfo, Swap, TaskId, Transaction, UserTransferType,
 };
 pub use worker_pool::{
-    pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig},
+    pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolSpawnConfig},
     registry::UnknownAlgorithmError,
     TaskQueueHandle,
 };

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -61,9 +61,7 @@ pub use price_guard::{
     provider::{ExternalPrice, PriceProvider, PriceProviderError},
 };
 pub use replay::{replay_route, ReplayError, RouteReplay};
-pub use solver::{
-    FyndBuilder, Solver, SolverBuildError, SolverParts, WaitReadyError, WorkerPoolConfig,
-};
+pub use solver::{FyndBuilder, PoolConfig, Solver, SolverBuildError, SolverParts, WaitReadyError};
 /// Processes ephemeral pending bundles against live Tycho market state. Obtained by calling
 /// [`FyndBuilder::build_with_pending`](solver::FyndBuilder::build_with_pending).
 pub use tycho_simulation::evm::pending::PendingBlockProcessor;
@@ -86,7 +84,7 @@ pub use types::{
     SolveParams, SolveResult, SurplusInfo, Swap, TaskId, Transaction, UserTransferType,
 };
 pub use worker_pool::{
-    pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolSpawnConfig},
+    pool::{WorkerPool, WorkerPoolBuilder, WorkerPoolConfig},
     registry::UnknownAlgorithmError,
     TaskQueueHandle,
 };

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -24,7 +24,7 @@
 /// [`algorithm::BellmanFordAlgorithm`], [`PathFrankWolfeAlgorithm`],
 /// [`algorithm::WaterFillAlgorithm`], and the pluggable [`Algorithm`] trait.
 pub mod algorithm;
-/// Derived data computations: spot prices, pool depths, and gas prices.
+/// Derived data computations: spot prices, component depths, and gas prices.
 pub mod derived;
 /// Encodes solved routes into ABI-encoded on-chain calldata via Tycho's router contracts.
 pub mod encoding;

--- a/fynd-core/src/price_guard/guard.rs
+++ b/fynd-core/src/price_guard/guard.rs
@@ -307,14 +307,14 @@ mod tests {
         let weth_token = make_token(weth_addr.clone(), "WETH");
         let usdc_token = make_token(usdc_addr.clone(), "USDC");
         Swap::new(
-            "weth-usdc-pool".to_string(),
+            "weth-usdc-component".to_string(),
             "uniswap_v2".to_string(),
             weth_addr,
             usdc_addr,
             BigUint::from(1000u64),
             BigUint::from(950u64),
             BigUint::from(100_000u64),
-            component("weth-usdc-pool", &[weth_token, usdc_token]),
+            component("weth-usdc-component", &[weth_token, usdc_token]),
             Box::new(MockProtocolSim::default()),
         )
     }

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -67,7 +67,8 @@ pub mod defaults {
     pub const MIN_TOKEN_QUALITY: i32 = 100;
     /// Maximum age (in days) of trading history required for a token to be considered liquid.
     pub const TRADED_N_DAYS_AGO: u64 = 3;
-    /// Multiplier applied to a pool's TVL when estimating available liquidity.
+    /// Multiplier applied to a component's (liquidity pool's) TVL when estimating available
+    /// liquidity.
     pub const TVL_BUFFER_RATIO: f64 = 1.1;
     /// How often the gas price is refreshed from the RPC node.
     pub const GAS_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
@@ -534,7 +535,7 @@ impl FyndBuilder {
 
     /// Enables partial block (flashblock) updates from the Tycho stream (default: `false`).
     ///
-    /// When enabled, the stream delivers pool state updates mid-block rather than only at
+    /// When enabled, the stream delivers component state updates mid-block rather than only at
     /// finalization, reducing latency. Only supported for on-chain protocols; RFQ streams are
     /// unaffected.
     pub fn partial_blocks(mut self, enabled: bool) -> Self {

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -55,7 +55,7 @@ use crate::{
     Algorithm, Quote, QuoteRequest, SolveError,
 };
 
-/// Default values for [`FyndBuilder`] configuration and [`PoolConfig`] deserialization.
+/// Default values for [`FyndBuilder`] configuration and [`WorkerPoolConfig`] deserialization.
 ///
 /// These are the single source of truth for all tunable defaults. Downstream
 /// crates (e.g. `fynd-rpc`) should re-export or reference these rather than
@@ -82,13 +82,13 @@ pub mod defaults {
     /// all).
     pub const ROUTER_MIN_RESPONSES: usize = 0;
     /// Capacity of the task queue for each worker pool.
-    pub const POOL_TASK_QUEUE_CAPACITY: usize = 1000;
+    pub const WORKER_POOL_TASK_QUEUE_CAPACITY: usize = 1000;
     /// Minimum number of hops allowed in a route.
-    pub const POOL_MIN_HOPS: usize = 1;
+    pub const WORKER_POOL_MIN_HOPS: usize = 1;
     /// Maximum number of hops allowed in a route.
-    pub const POOL_MAX_HOPS: usize = 3;
+    pub const WORKER_POOL_MAX_HOPS: usize = 3;
     /// Per-worker-pool solve timeout in milliseconds.
-    pub const POOL_TIMEOUT_MS: u64 = 100;
+    pub const WORKER_POOL_TIMEOUT_MS: u64 = 100;
 }
 
 // Internal-only defaults not shared with downstream crates.
@@ -101,19 +101,19 @@ const DEFAULT_ROUTER_TIMEOUT: Duration = Duration::from_secs(10);
 // serde requires free functions for `#[serde(default = "...")]` — these delegate to the
 // defaults module so both deserialization and the builder stay in sync.
 fn default_task_queue_capacity() -> usize {
-    defaults::POOL_TASK_QUEUE_CAPACITY
+    defaults::WORKER_POOL_TASK_QUEUE_CAPACITY
 }
 
 fn default_min_hops() -> usize {
-    defaults::POOL_MIN_HOPS
+    defaults::WORKER_POOL_MIN_HOPS
 }
 
 fn default_max_hops() -> usize {
-    defaults::POOL_MAX_HOPS
+    defaults::WORKER_POOL_MAX_HOPS
 }
 
 fn default_algo_timeout_ms() -> u64 {
-    defaults::POOL_TIMEOUT_MS
+    defaults::WORKER_POOL_TIMEOUT_MS
 }
 
 fn parse_connector_tokens(
@@ -132,10 +132,10 @@ fn parse_connector_tokens(
     Ok(Some(set))
 }
 
-/// Configuration for one worker pool, used by [`FyndBuilder::add_pool`].
+/// Configuration for one worker pool, used by [`FyndBuilder::add_worker_pool`].
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PoolConfig {
+pub struct WorkerPoolConfig {
     /// Algorithm name for this worker pool (e.g., `"most_liquid"`).
     algorithm: String,
     /// Number of worker threads for this worker pool.
@@ -167,17 +167,17 @@ pub struct PoolConfig {
     liquidity_scope: Option<LiquidityScope>,
 }
 
-impl PoolConfig {
+impl WorkerPoolConfig {
     /// Creates a new worker pool config with the given algorithm name and defaults for all other
     /// fields.
     pub fn new(algorithm: impl Into<String>) -> Self {
         Self {
             algorithm: algorithm.into(),
             num_workers: num_cpus::get(),
-            task_queue_capacity: defaults::POOL_TASK_QUEUE_CAPACITY,
-            min_hops: defaults::POOL_MIN_HOPS,
-            max_hops: defaults::POOL_MAX_HOPS,
-            timeout_ms: defaults::POOL_TIMEOUT_MS,
+            task_queue_capacity: defaults::WORKER_POOL_TASK_QUEUE_CAPACITY,
+            min_hops: defaults::WORKER_POOL_MIN_HOPS,
+            max_hops: defaults::WORKER_POOL_MAX_HOPS,
+            timeout_ms: defaults::WORKER_POOL_TIMEOUT_MS,
             max_routes: None,
             connector_tokens: None,
             liquidity_scope: None,
@@ -313,7 +313,7 @@ pub enum SolverBuildError {
     GasToken,
     /// [`FyndBuilder::build`] was called without configuring any worker pools.
     #[error("no worker pools configured")]
-    NoPools,
+    NoWorkerPools,
     /// A worker pool sets `liquidity_scope` but no exclusivity policy is configured. The
     /// policy is what public worker pools filter by and what the router identifies exclusive legs
     /// with — without it, nothing distinguishes exclusive protocol components from public ones.
@@ -344,7 +344,7 @@ pub enum SolverBuildError {
 }
 
 /// Internal worker pool entry — either a built-in algorithm (by name) or a custom one.
-enum PoolEntry {
+enum WorkerPoolEntry {
     BuiltIn {
         name: String,
         algorithm: String,
@@ -357,21 +357,21 @@ enum PoolEntry {
         connector_tokens: Option<HashSet<Address>>,
         liquidity_scope: Option<LiquidityScope>,
     },
-    Custom(CustomPoolEntry),
+    Custom(CustomWorkerPoolEntry),
 }
 
-impl PoolEntry {
+impl WorkerPoolEntry {
     /// Returns the configured liquidity scope for this worker pool.
     fn liquidity_scope(&self) -> Option<LiquidityScope> {
         match self {
-            PoolEntry::BuiltIn { liquidity_scope, .. } => *liquidity_scope,
-            PoolEntry::Custom(custom) => custom.liquidity_scope,
+            WorkerPoolEntry::BuiltIn { liquidity_scope, .. } => *liquidity_scope,
+            WorkerPoolEntry::Custom(custom) => custom.liquidity_scope,
         }
     }
 }
 
 /// Worker pool entry backed by a custom [`Algorithm`] implementation.
-struct CustomPoolEntry {
+struct CustomWorkerPoolEntry {
     name: String,
     num_workers: usize,
     task_queue_capacity: usize,
@@ -429,7 +429,7 @@ pub struct FyndBuilder {
     router_timeout: Duration,
     router_min_responses: usize,
     encoder: Option<Encoder>,
-    pools: Vec<PoolEntry>,
+    pools: Vec<WorkerPoolEntry>,
     price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
     pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
@@ -564,18 +564,19 @@ impl FyndBuilder {
 
     /// Shorthand: adds a single worker pool named `"default"` using a built-in algorithm by name.
     pub fn algorithm(mut self, algorithm: impl Into<String>) -> Self {
-        self.pools.push(PoolEntry::BuiltIn {
-            name: "default".to_string(),
-            algorithm: algorithm.into(),
-            num_workers: num_cpus::get(),
-            task_queue_capacity: defaults::POOL_TASK_QUEUE_CAPACITY,
-            min_hops: defaults::POOL_MIN_HOPS,
-            max_hops: defaults::POOL_MAX_HOPS,
-            timeout_ms: defaults::POOL_TIMEOUT_MS,
-            max_routes: None,
-            connector_tokens: None,
-            liquidity_scope: None,
-        });
+        self.pools
+            .push(WorkerPoolEntry::BuiltIn {
+                name: "default".to_string(),
+                algorithm: algorithm.into(),
+                num_workers: num_cpus::get(),
+                task_queue_capacity: defaults::WORKER_POOL_TASK_QUEUE_CAPACITY,
+                min_hops: defaults::WORKER_POOL_MIN_HOPS,
+                max_hops: defaults::WORKER_POOL_MAX_HOPS,
+                timeout_ms: defaults::WORKER_POOL_TIMEOUT_MS,
+                max_routes: None,
+                connector_tokens: None,
+                liquidity_scope: None,
+            });
         self
     }
 
@@ -593,13 +594,13 @@ impl FyndBuilder {
         let configure =
             Box::new(move |builder: WorkerPoolBuilder| builder.with_algorithm(algo_name, factory));
         self.pools
-            .push(PoolEntry::Custom(CustomPoolEntry {
+            .push(WorkerPoolEntry::Custom(CustomWorkerPoolEntry {
                 name,
                 num_workers: num_cpus::get(),
-                task_queue_capacity: defaults::POOL_TASK_QUEUE_CAPACITY,
-                min_hops: defaults::POOL_MIN_HOPS,
-                max_hops: defaults::POOL_MAX_HOPS,
-                timeout_ms: defaults::POOL_TIMEOUT_MS,
+                task_queue_capacity: defaults::WORKER_POOL_TASK_QUEUE_CAPACITY,
+                min_hops: defaults::WORKER_POOL_MIN_HOPS,
+                max_hops: defaults::WORKER_POOL_MAX_HOPS,
+                timeout_ms: defaults::WORKER_POOL_TIMEOUT_MS,
                 max_routes: None,
                 liquidity_scope: None,
                 configure,
@@ -672,30 +673,31 @@ impl FyndBuilder {
         self
     }
 
-    /// Adds a named worker pool using the given [`PoolConfig`].
+    /// Adds a named worker pool using the given [`WorkerPoolConfig`].
     ///
     /// # Errors
     ///
     /// Returns [`SolverBuildError::AlgorithmConfig`] if any address in `connector_tokens` is not
     /// valid hex.
-    pub fn add_pool(
+    pub fn add_worker_pool(
         mut self,
         name: impl Into<String>,
-        config: &PoolConfig,
+        config: &WorkerPoolConfig,
     ) -> Result<Self, SolverBuildError> {
         let connector_tokens = parse_connector_tokens(config.connector_tokens())?;
-        self.pools.push(PoolEntry::BuiltIn {
-            name: name.into(),
-            algorithm: config.algorithm().to_string(),
-            num_workers: config.num_workers(),
-            task_queue_capacity: config.task_queue_capacity(),
-            min_hops: config.min_hops(),
-            max_hops: config.max_hops(),
-            timeout_ms: config.timeout_ms(),
-            max_routes: config.max_routes(),
-            connector_tokens,
-            liquidity_scope: config.liquidity_scope(),
-        });
+        self.pools
+            .push(WorkerPoolEntry::BuiltIn {
+                name: name.into(),
+                algorithm: config.algorithm().to_string(),
+                num_workers: config.num_workers(),
+                task_queue_capacity: config.task_queue_capacity(),
+                min_hops: config.min_hops(),
+                max_hops: config.max_hops(),
+                timeout_ms: config.timeout_ms(),
+                max_routes: config.max_routes(),
+                connector_tokens,
+                liquidity_scope: config.liquidity_scope(),
+            });
         Ok(self)
     }
 
@@ -703,7 +705,7 @@ impl FyndBuilder {
     /// [`build_with_pending`](Self::build_with_pending).
     fn assemble_components(mut self) -> Result<BuiltComponents, SolverBuildError> {
         if self.pools.is_empty() {
-            return Err(SolverBuildError::NoPools);
+            return Err(SolverBuildError::NoWorkerPools);
         }
 
         // Setting `liquidity_scope` on any worker pool (either value) declares exclusive routing
@@ -793,7 +795,7 @@ impl FyndBuilder {
             };
 
             let (worker_pool, task_handle) = match pool_entry {
-                PoolEntry::BuiltIn {
+                WorkerPoolEntry::BuiltIn {
                     name,
                     algorithm,
                     num_workers,
@@ -828,7 +830,7 @@ impl FyndBuilder {
                         derived_rx,
                     )?
                 }
-                PoolEntry::Custom(custom) => {
+                WorkerPoolEntry::Custom(custom) => {
                     let algo_cfg = AlgorithmConfig::new(
                         custom.min_hops,
                         custom.max_hops,
@@ -1242,11 +1244,11 @@ impl Solver {
     pub async fn from_recording(
         chain: Chain,
         updates: Vec<tycho_simulation::protocol::models::Update>,
-        pools: std::collections::HashMap<String, PoolConfig>,
+        pools: std::collections::HashMap<String, WorkerPoolConfig>,
         gas_price_wei: Option<num_bigint::BigUint>,
     ) -> Result<Self, SolverBuildError> {
         if pools.is_empty() {
-            return Err(SolverBuildError::NoPools);
+            return Err(SolverBuildError::NoWorkerPools);
         }
 
         let market_data = MarketData::new_shared();
@@ -1442,7 +1444,7 @@ impl Solver {
 pub struct SolverParts {
     /// Routes quote requests across worker pools.
     router: WorkerPoolRouter,
-    /// One [`WorkerPool`] per entry configured via [`FyndBuilder::add_pool`].
+    /// One [`WorkerPool`] per entry configured via [`FyndBuilder::add_worker_pool`].
     worker_pools: Vec<WorkerPool>,
     /// Live market snapshot shared across all components.
     market_data: MarketData,
@@ -1544,7 +1546,7 @@ mod tests {
     #[case::all(LiquidityScope::All)]
     #[case::public_only(LiquidityScope::PublicOnly)]
     fn test_build_rejects_scoped_pool_without_policy(#[case] scope: LiquidityScope) {
-        let config = PoolConfig::new("most_liquid").with_liquidity_scope(scope);
+        let config = WorkerPoolConfig::new("most_liquid").with_liquidity_scope(scope);
         let result = FyndBuilder::new(
             Chain::Ethereum,
             "wss://example.invalid",
@@ -1552,8 +1554,8 @@ mod tests {
             vec!["uniswap_v2".to_string()],
             100.0,
         )
-        .add_pool("surplus", &config)
-        .expect("add_pool should accept the config")
+        .add_worker_pool("surplus", &config)
+        .expect("add_worker_pool should accept the config")
         .build();
 
         assert!(matches!(result, Err(SolverBuildError::LiquidityScopeWithoutPolicy)));

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -87,7 +87,7 @@ pub mod defaults {
     pub const POOL_MIN_HOPS: usize = 1;
     /// Maximum number of hops allowed in a route.
     pub const POOL_MAX_HOPS: usize = 3;
-    /// Per-pool solve timeout in milliseconds.
+    /// Per-worker-pool solve timeout in milliseconds.
     pub const POOL_TIMEOUT_MS: u64 = 100;
 }
 
@@ -132,16 +132,16 @@ fn parse_connector_tokens(
     Ok(Some(set))
 }
 
-/// Per-pool configuration for [`FyndBuilder::add_pool`].
+/// Configuration for one worker pool, used by [`FyndBuilder::add_pool`].
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PoolConfig {
-    /// Algorithm name for this pool (e.g., `"most_liquid"`).
+    /// Algorithm name for this worker pool (e.g., `"most_liquid"`).
     algorithm: String,
-    /// Number of worker threads for this pool.
+    /// Number of worker threads for this worker pool.
     #[serde(default = "num_cpus::get")]
     num_workers: usize,
-    /// Task queue capacity for this pool.
+    /// Task queue capacity for this worker pool.
     #[serde(default = "default_task_queue_capacity")]
     task_queue_capacity: usize,
     /// Minimum hops to search (must be >= 1).
@@ -160,15 +160,16 @@ pub struct PoolConfig {
     /// Absent = no restriction. Typically 3–10 entries (e.g. WETH, USDC, USDT, DAI).
     #[serde(default)]
     connector_tokens: Option<Vec<String>>,
-    /// Pool liquidity scope: `public_only` or `all` (routes through exclusive liquidity as
-    /// well). Setting this key (either value) declares exclusive routing intent and requires an
-    /// exclusivity policy; absent = plain deployment, no filtering.
+    /// Worker pool liquidity scope: `public_only` or `all` (routes through exclusive liquidity
+    /// as well). Setting this key (either value) declares exclusive routing intent and requires
+    /// an exclusivity policy; absent = plain deployment, no filtering.
     #[serde(default)]
     liquidity_scope: Option<LiquidityScope>,
 }
 
 impl PoolConfig {
-    /// Creates a new pool config with the given algorithm name and defaults for all other fields.
+    /// Creates a new worker pool config with the given algorithm name and defaults for all other
+    /// fields.
     pub fn new(algorithm: impl Into<String>) -> Self {
         Self {
             algorithm: algorithm.into(),
@@ -188,12 +189,12 @@ impl PoolConfig {
         &self.algorithm
     }
 
-    /// Returns the pool's liquidity scope.
+    /// Returns the worker pool's liquidity scope.
     pub fn liquidity_scope(&self) -> Option<LiquidityScope> {
         self.liquidity_scope
     }
 
-    /// Sets the pool's liquidity scope (public or exclusive-access).
+    /// Sets the worker pool's liquidity scope (public or exclusive-access).
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = Some(scope);
         self
@@ -304,7 +305,7 @@ pub enum SolverBuildError {
     /// The router fee fetcher could not be created (e.g. malformed RPC URL).
     #[error("failed to create router fee fetcher: {0}")]
     RouterFeeFetcher(String),
-    /// A pool referenced an algorithm name that is not registered.
+    /// A worker pool referenced an algorithm name that is not registered.
     #[error(transparent)]
     UnknownAlgorithm(#[from] UnknownAlgorithmError),
     /// No native gas token is defined for the requested chain.
@@ -314,7 +315,7 @@ pub enum SolverBuildError {
     #[error("no worker pools configured")]
     NoPools,
     /// A worker pool sets `liquidity_scope` but no exclusivity policy is configured. The
-    /// policy is what public pools filter by and what the router identifies exclusive legs
+    /// policy is what public worker pools filter by and what the router identifies exclusive legs
     /// with — without it, nothing distinguishes exclusive protocol components from public ones.
     #[error(
         "a worker pool sets liquidity_scope but no exclusivity policy is configured; \
@@ -342,7 +343,7 @@ pub enum SolverBuildError {
     StepControllerChannelClosed,
 }
 
-/// Internal pool entry — either a built-in algorithm (by name) or a custom one.
+/// Internal worker pool entry — either a built-in algorithm (by name) or a custom one.
 enum PoolEntry {
     BuiltIn {
         name: String,
@@ -369,7 +370,7 @@ impl PoolEntry {
     }
 }
 
-/// Pool entry backed by a custom [`Algorithm`] implementation.
+/// Worker pool entry backed by a custom [`Algorithm`] implementation.
 struct CustomPoolEntry {
     name: String,
     num_workers: usize,
@@ -378,7 +379,7 @@ struct CustomPoolEntry {
     max_hops: usize,
     timeout_ms: u64,
     max_routes: Option<usize>,
-    /// Pool liquidity scope: public (default) or exclusive-access.
+    /// Worker pool liquidity scope: public (default) or exclusive-access.
     liquidity_scope: Option<LiquidityScope>,
     /// Applies the custom algorithm to a `WorkerPoolBuilder`.
     configure: Box<dyn FnOnce(WorkerPoolBuilder) -> WorkerPoolBuilder + Send>,
@@ -432,9 +433,9 @@ pub struct FyndBuilder {
     price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
     pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
-    /// Predicate identifying exclusive components. Shared by all pools: public pools exclude
-    /// matching components, exclusive-access pools include them. `None` ⇒ no pool filters
-    /// anything.
+    /// Predicate identifying exclusive components. Shared by all worker pools: public worker
+    /// pools exclude matching components, exclusive-access worker pools include them. `None` ⇒
+    /// no worker pool filters anything.
     exclusivity_policy: Option<ExclusivityPolicy>,
 }
 
@@ -503,7 +504,7 @@ impl FyndBuilder {
         self
     }
 
-    /// Filters out pools whose last trade is older than `days` days (default: 3).
+    /// Filters out components whose last trade is older than `days` days (default: 3).
     pub fn traded_n_days_ago(mut self, days: u64) -> Self {
         self.traded_n_days_ago = days;
         self
@@ -561,7 +562,7 @@ impl FyndBuilder {
         self
     }
 
-    /// Shorthand: adds a single pool named `"default"` using a built-in algorithm by name.
+    /// Shorthand: adds a single worker pool named `"default"` using a built-in algorithm by name.
     pub fn algorithm(mut self, algorithm: impl Into<String>) -> Self {
         self.pools.push(PoolEntry::BuiltIn {
             name: "default".to_string(),
@@ -578,7 +579,7 @@ impl FyndBuilder {
         self
     }
 
-    /// Shorthand: adds a single pool with a custom [`Algorithm`] implementation.
+    /// Shorthand: adds a single worker pool with a custom [`Algorithm`] implementation.
     ///
     /// The `factory` closure is called once per worker thread.
     pub fn with_algorithm<A, F>(mut self, name: impl Into<String>, factory: F) -> Self
@@ -658,8 +659,8 @@ impl FyndBuilder {
 
     /// Sets the predicate that classifies components as exclusive.
     ///
-    /// Public pools exclude matching components from their graphs; exclusive-access pools
-    /// include them. Without a policy, no pool filters anything.
+    /// Public worker pools exclude matching components from their graphs; exclusive-access
+    /// worker pools include them. Without a policy, no worker pool filters anything.
     pub fn exclusivity_policy<F>(mut self, predicate: F) -> Self
     where
         F: Fn(&tycho_simulation::tycho_common::models::protocol::ProtocolComponent) -> bool
@@ -671,7 +672,7 @@ impl FyndBuilder {
         self
     }
 
-    /// Adds a named pool using the given [`PoolConfig`].
+    /// Adds a named worker pool using the given [`PoolConfig`].
     ///
     /// # Errors
     ///
@@ -705,11 +706,11 @@ impl FyndBuilder {
             return Err(SolverBuildError::NoPools);
         }
 
-        // Setting `liquidity_scope` on any pool (either value) declares exclusive routing
-        // intent, which requires a policy: public pools filter by it and the router identifies
-        // exclusive legs with it. Without one, a `public_only` pool could not honor its label
-        // and an `all` pool could not produce anything distinct. Pools with the key absent are
-        // plain deployments and need no policy.
+        // Setting `liquidity_scope` on any worker pool (either value) declares exclusive routing
+        // intent, which requires a policy: public worker pools filter by it and the router
+        // identifies exclusive legs with it. Without one, a `public_only` worker pool could not
+        // honor its label and an `all` worker pool could not produce anything distinct. Worker
+        // pools with the key absent are plain deployments and need no policy.
         if self.exclusivity_policy.is_none() &&
             self.pools
                 .iter()
@@ -762,15 +763,17 @@ impl FyndBuilder {
         let derived_data: SharedDerivedDataRef = computation_manager.store();
         let derived_event_tx = computation_manager.event_sender();
 
-        // Subscribe event channels before spawning (one for computation manager + one per pool)
+        // Subscribe event channels before spawning (one for computation manager + one per worker
+        // pool)
         let computation_event_rx = tycho_feed.subscribe();
         let (computation_shutdown_tx, computation_shutdown_rx) = broadcast::channel(1);
 
         let mut solver_pool_handles: Vec<SolverPoolHandle> = Vec::new();
         let mut worker_pools: Vec<WorkerPool> = Vec::new();
 
-        // Shared across all pools: public pools exclude exclusive components, exclusive-access
-        // pools include them. `None` ⇒ no pool filters anything (original behaviour).
+        // Shared across all worker pools: public worker pools exclude exclusive components,
+        // exclusive-access worker pools include them. `None` ⇒ no worker pool filters anything
+        // (original behaviour).
         let exclusivity_policy = self.exclusivity_policy.take();
         let pools = std::mem::take(&mut self.pools);
 
@@ -778,9 +781,9 @@ impl FyndBuilder {
             let pool_event_rx = tycho_feed.subscribe();
             let derived_rx = derived_event_tx.subscribe();
 
-            // Explicit `public_only` pools (and unscoped pools, harmlessly) get the policy so
-            // their workers filter exclusive components out; `all` pools get `None` and ingest
-            // everything.
+            // Explicit `public_only` worker pools (and unscoped ones, harmlessly) get the policy
+            // so their workers filter exclusive components out; `all` worker pools get `None`
+            // and ingest everything.
             let pool_scope = pool_entry
                 .liquidity_scope()
                 .unwrap_or_default();
@@ -1172,7 +1175,7 @@ impl Solver {
     ///
     /// # Errors
     ///
-    /// Returns [`SolveError`] if all pools fail or the router timeout elapses.
+    /// Returns [`SolveError`] if all worker pools fail or the router timeout elapses.
     pub async fn quote(&self, request: QuoteRequest) -> Result<Quote, SolveError> {
         self.router.quote(request).await
     }
@@ -1181,8 +1184,8 @@ impl Solver {
     ///
     /// Ready means:
     /// - The Tycho feed has delivered at least one market snapshot.
-    /// - The computation manager has completed at least one derived-data cycle (spot prices, pool
-    ///   depths, token gas prices).
+    /// - The computation manager has completed at least one derived-data cycle (spot prices,
+    ///   component depths, token gas prices).
     /// - Router fees have been loaded from the on-chain FeeCalculator at least once.
     ///
     /// The method polls every 500 ms and returns as soon as all conditions are
@@ -1231,7 +1234,7 @@ impl Solver {
     /// then [`quote`](Self::quote).
     ///
     /// VM-backed protocol states that couldn't be serialized will be absent from
-    /// the recording. Pools without states will be registered as components but
+    /// the recording. Components without states will still be registered but
     /// won't contribute to routing.
     ///
     /// Requires the `test-utils` feature.
@@ -1439,7 +1442,7 @@ impl Solver {
 pub struct SolverParts {
     /// Routes quote requests across worker pools.
     router: WorkerPoolRouter,
-    /// One [`WorkerPool`] per configured algorithm pool.
+    /// One [`WorkerPool`] per entry configured via [`FyndBuilder::add_pool`].
     worker_pools: Vec<WorkerPool>,
     /// Live market snapshot shared across all components.
     market_data: MarketData,

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -55,7 +55,7 @@ use crate::{
     Algorithm, Quote, QuoteRequest, SolveError,
 };
 
-/// Default values for [`FyndBuilder`] configuration and [`WorkerPoolConfig`] deserialization.
+/// Default values for [`FyndBuilder`] configuration and [`PoolConfig`] deserialization.
 ///
 /// These are the single source of truth for all tunable defaults. Downstream
 /// crates (e.g. `fynd-rpc`) should re-export or reference these rather than
@@ -82,13 +82,13 @@ pub mod defaults {
     /// all).
     pub const ROUTER_MIN_RESPONSES: usize = 0;
     /// Capacity of the task queue for each worker pool.
-    pub const WORKER_POOL_TASK_QUEUE_CAPACITY: usize = 1000;
+    pub const POOL_TASK_QUEUE_CAPACITY: usize = 1000;
     /// Minimum number of hops allowed in a route.
-    pub const WORKER_POOL_MIN_HOPS: usize = 1;
+    pub const POOL_MIN_HOPS: usize = 1;
     /// Maximum number of hops allowed in a route.
-    pub const WORKER_POOL_MAX_HOPS: usize = 3;
+    pub const POOL_MAX_HOPS: usize = 3;
     /// Per-worker-pool solve timeout in milliseconds.
-    pub const WORKER_POOL_TIMEOUT_MS: u64 = 100;
+    pub const POOL_TIMEOUT_MS: u64 = 100;
 }
 
 // Internal-only defaults not shared with downstream crates.
@@ -101,19 +101,19 @@ const DEFAULT_ROUTER_TIMEOUT: Duration = Duration::from_secs(10);
 // serde requires free functions for `#[serde(default = "...")]` — these delegate to the
 // defaults module so both deserialization and the builder stay in sync.
 fn default_task_queue_capacity() -> usize {
-    defaults::WORKER_POOL_TASK_QUEUE_CAPACITY
+    defaults::POOL_TASK_QUEUE_CAPACITY
 }
 
 fn default_min_hops() -> usize {
-    defaults::WORKER_POOL_MIN_HOPS
+    defaults::POOL_MIN_HOPS
 }
 
 fn default_max_hops() -> usize {
-    defaults::WORKER_POOL_MAX_HOPS
+    defaults::POOL_MAX_HOPS
 }
 
 fn default_algo_timeout_ms() -> u64 {
-    defaults::WORKER_POOL_TIMEOUT_MS
+    defaults::POOL_TIMEOUT_MS
 }
 
 fn parse_connector_tokens(
@@ -132,10 +132,10 @@ fn parse_connector_tokens(
     Ok(Some(set))
 }
 
-/// Configuration for one worker pool, used by [`FyndBuilder::add_worker_pool`].
+/// Configuration for one worker pool, used by [`FyndBuilder::add_pool`].
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WorkerPoolConfig {
+pub struct PoolConfig {
     /// Algorithm name for this worker pool (e.g., `"most_liquid"`).
     algorithm: String,
     /// Number of worker threads for this worker pool.
@@ -167,17 +167,17 @@ pub struct WorkerPoolConfig {
     liquidity_scope: Option<LiquidityScope>,
 }
 
-impl WorkerPoolConfig {
+impl PoolConfig {
     /// Creates a new worker pool config with the given algorithm name and defaults for all other
     /// fields.
     pub fn new(algorithm: impl Into<String>) -> Self {
         Self {
             algorithm: algorithm.into(),
             num_workers: num_cpus::get(),
-            task_queue_capacity: defaults::WORKER_POOL_TASK_QUEUE_CAPACITY,
-            min_hops: defaults::WORKER_POOL_MIN_HOPS,
-            max_hops: defaults::WORKER_POOL_MAX_HOPS,
-            timeout_ms: defaults::WORKER_POOL_TIMEOUT_MS,
+            task_queue_capacity: defaults::POOL_TASK_QUEUE_CAPACITY,
+            min_hops: defaults::POOL_MIN_HOPS,
+            max_hops: defaults::POOL_MAX_HOPS,
+            timeout_ms: defaults::POOL_TIMEOUT_MS,
             max_routes: None,
             connector_tokens: None,
             liquidity_scope: None,
@@ -313,7 +313,7 @@ pub enum SolverBuildError {
     GasToken,
     /// [`FyndBuilder::build`] was called without configuring any worker pools.
     #[error("no worker pools configured")]
-    NoWorkerPools,
+    NoPools,
     /// A worker pool sets `liquidity_scope` but no exclusivity policy is configured. The
     /// policy is what public worker pools filter by and what the router identifies exclusive legs
     /// with — without it, nothing distinguishes exclusive protocol components from public ones.
@@ -344,7 +344,7 @@ pub enum SolverBuildError {
 }
 
 /// Internal worker pool entry — either a built-in algorithm (by name) or a custom one.
-enum WorkerPoolEntry {
+enum PoolEntry {
     BuiltIn {
         name: String,
         algorithm: String,
@@ -357,21 +357,21 @@ enum WorkerPoolEntry {
         connector_tokens: Option<HashSet<Address>>,
         liquidity_scope: Option<LiquidityScope>,
     },
-    Custom(CustomWorkerPoolEntry),
+    Custom(CustomPoolEntry),
 }
 
-impl WorkerPoolEntry {
+impl PoolEntry {
     /// Returns the configured liquidity scope for this worker pool.
     fn liquidity_scope(&self) -> Option<LiquidityScope> {
         match self {
-            WorkerPoolEntry::BuiltIn { liquidity_scope, .. } => *liquidity_scope,
-            WorkerPoolEntry::Custom(custom) => custom.liquidity_scope,
+            PoolEntry::BuiltIn { liquidity_scope, .. } => *liquidity_scope,
+            PoolEntry::Custom(custom) => custom.liquidity_scope,
         }
     }
 }
 
 /// Worker pool entry backed by a custom [`Algorithm`] implementation.
-struct CustomWorkerPoolEntry {
+struct CustomPoolEntry {
     name: String,
     num_workers: usize,
     task_queue_capacity: usize,
@@ -429,7 +429,7 @@ pub struct FyndBuilder {
     router_timeout: Duration,
     router_min_responses: usize,
     encoder: Option<Encoder>,
-    pools: Vec<WorkerPoolEntry>,
+    pools: Vec<PoolEntry>,
     price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
     pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
@@ -564,19 +564,18 @@ impl FyndBuilder {
 
     /// Shorthand: adds a single worker pool named `"default"` using a built-in algorithm by name.
     pub fn algorithm(mut self, algorithm: impl Into<String>) -> Self {
-        self.pools
-            .push(WorkerPoolEntry::BuiltIn {
-                name: "default".to_string(),
-                algorithm: algorithm.into(),
-                num_workers: num_cpus::get(),
-                task_queue_capacity: defaults::WORKER_POOL_TASK_QUEUE_CAPACITY,
-                min_hops: defaults::WORKER_POOL_MIN_HOPS,
-                max_hops: defaults::WORKER_POOL_MAX_HOPS,
-                timeout_ms: defaults::WORKER_POOL_TIMEOUT_MS,
-                max_routes: None,
-                connector_tokens: None,
-                liquidity_scope: None,
-            });
+        self.pools.push(PoolEntry::BuiltIn {
+            name: "default".to_string(),
+            algorithm: algorithm.into(),
+            num_workers: num_cpus::get(),
+            task_queue_capacity: defaults::POOL_TASK_QUEUE_CAPACITY,
+            min_hops: defaults::POOL_MIN_HOPS,
+            max_hops: defaults::POOL_MAX_HOPS,
+            timeout_ms: defaults::POOL_TIMEOUT_MS,
+            max_routes: None,
+            connector_tokens: None,
+            liquidity_scope: None,
+        });
         self
     }
 
@@ -594,13 +593,13 @@ impl FyndBuilder {
         let configure =
             Box::new(move |builder: WorkerPoolBuilder| builder.with_algorithm(algo_name, factory));
         self.pools
-            .push(WorkerPoolEntry::Custom(CustomWorkerPoolEntry {
+            .push(PoolEntry::Custom(CustomPoolEntry {
                 name,
                 num_workers: num_cpus::get(),
-                task_queue_capacity: defaults::WORKER_POOL_TASK_QUEUE_CAPACITY,
-                min_hops: defaults::WORKER_POOL_MIN_HOPS,
-                max_hops: defaults::WORKER_POOL_MAX_HOPS,
-                timeout_ms: defaults::WORKER_POOL_TIMEOUT_MS,
+                task_queue_capacity: defaults::POOL_TASK_QUEUE_CAPACITY,
+                min_hops: defaults::POOL_MIN_HOPS,
+                max_hops: defaults::POOL_MAX_HOPS,
+                timeout_ms: defaults::POOL_TIMEOUT_MS,
                 max_routes: None,
                 liquidity_scope: None,
                 configure,
@@ -673,31 +672,30 @@ impl FyndBuilder {
         self
     }
 
-    /// Adds a named worker pool using the given [`WorkerPoolConfig`].
+    /// Adds a named worker pool using the given [`PoolConfig`].
     ///
     /// # Errors
     ///
     /// Returns [`SolverBuildError::AlgorithmConfig`] if any address in `connector_tokens` is not
     /// valid hex.
-    pub fn add_worker_pool(
+    pub fn add_pool(
         mut self,
         name: impl Into<String>,
-        config: &WorkerPoolConfig,
+        config: &PoolConfig,
     ) -> Result<Self, SolverBuildError> {
         let connector_tokens = parse_connector_tokens(config.connector_tokens())?;
-        self.pools
-            .push(WorkerPoolEntry::BuiltIn {
-                name: name.into(),
-                algorithm: config.algorithm().to_string(),
-                num_workers: config.num_workers(),
-                task_queue_capacity: config.task_queue_capacity(),
-                min_hops: config.min_hops(),
-                max_hops: config.max_hops(),
-                timeout_ms: config.timeout_ms(),
-                max_routes: config.max_routes(),
-                connector_tokens,
-                liquidity_scope: config.liquidity_scope(),
-            });
+        self.pools.push(PoolEntry::BuiltIn {
+            name: name.into(),
+            algorithm: config.algorithm().to_string(),
+            num_workers: config.num_workers(),
+            task_queue_capacity: config.task_queue_capacity(),
+            min_hops: config.min_hops(),
+            max_hops: config.max_hops(),
+            timeout_ms: config.timeout_ms(),
+            max_routes: config.max_routes(),
+            connector_tokens,
+            liquidity_scope: config.liquidity_scope(),
+        });
         Ok(self)
     }
 
@@ -705,7 +703,7 @@ impl FyndBuilder {
     /// [`build_with_pending`](Self::build_with_pending).
     fn assemble_components(mut self) -> Result<BuiltComponents, SolverBuildError> {
         if self.pools.is_empty() {
-            return Err(SolverBuildError::NoWorkerPools);
+            return Err(SolverBuildError::NoPools);
         }
 
         // Setting `liquidity_scope` on any worker pool (either value) declares exclusive routing
@@ -795,7 +793,7 @@ impl FyndBuilder {
             };
 
             let (worker_pool, task_handle) = match pool_entry {
-                WorkerPoolEntry::BuiltIn {
+                PoolEntry::BuiltIn {
                     name,
                     algorithm,
                     num_workers,
@@ -830,7 +828,7 @@ impl FyndBuilder {
                         derived_rx,
                     )?
                 }
-                WorkerPoolEntry::Custom(custom) => {
+                PoolEntry::Custom(custom) => {
                     let algo_cfg = AlgorithmConfig::new(
                         custom.min_hops,
                         custom.max_hops,
@@ -1244,11 +1242,11 @@ impl Solver {
     pub async fn from_recording(
         chain: Chain,
         updates: Vec<tycho_simulation::protocol::models::Update>,
-        pools: std::collections::HashMap<String, WorkerPoolConfig>,
+        pools: std::collections::HashMap<String, PoolConfig>,
         gas_price_wei: Option<num_bigint::BigUint>,
     ) -> Result<Self, SolverBuildError> {
         if pools.is_empty() {
-            return Err(SolverBuildError::NoWorkerPools);
+            return Err(SolverBuildError::NoPools);
         }
 
         let market_data = MarketData::new_shared();
@@ -1444,7 +1442,7 @@ impl Solver {
 pub struct SolverParts {
     /// Routes quote requests across worker pools.
     router: WorkerPoolRouter,
-    /// One [`WorkerPool`] per entry configured via [`FyndBuilder::add_worker_pool`].
+    /// One [`WorkerPool`] per entry configured via [`FyndBuilder::add_pool`].
     worker_pools: Vec<WorkerPool>,
     /// Live market snapshot shared across all components.
     market_data: MarketData,
@@ -1546,7 +1544,7 @@ mod tests {
     #[case::all(LiquidityScope::All)]
     #[case::public_only(LiquidityScope::PublicOnly)]
     fn test_build_rejects_scoped_pool_without_policy(#[case] scope: LiquidityScope) {
-        let config = WorkerPoolConfig::new("most_liquid").with_liquidity_scope(scope);
+        let config = PoolConfig::new("most_liquid").with_liquidity_scope(scope);
         let result = FyndBuilder::new(
             Chain::Ethereum,
             "wss://example.invalid",
@@ -1554,8 +1552,8 @@ mod tests {
             vec!["uniswap_v2".to_string()],
             100.0,
         )
-        .add_worker_pool("surplus", &config)
-        .expect("add_worker_pool should accept the config")
+        .add_pool("surplus", &config)
+        .expect("add_pool should accept the config")
         .build();
 
         assert!(matches!(result, Err(SolverBuildError::LiquidityScopeWithoutPolicy)));

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -160,7 +160,7 @@ pub enum SolveError {
     #[error("required data missing: {0}")]
     MissingData(String),
 
-    /// Pool simulation failed while evaluating a route.
+    /// Component simulation failed while evaluating a route.
     #[error("simulation failed: {0}")]
     SimulationFailed(String),
 }

--- a/fynd-core/src/types/internal.rs
+++ b/fynd-core/src/types/internal.rs
@@ -89,7 +89,7 @@ pub enum SolveError {
     InsufficientLiquidity {
         /// Amount the user requested.
         required: BigUint,
-        /// Maximum amount available in the pool.
+        /// Maximum amount available in the component.
         available: BigUint,
     },
 

--- a/fynd-core/src/types/mod.rs
+++ b/fynd-core/src/types/mod.rs
@@ -9,7 +9,7 @@
 
 /// Protocol gas costs and native token addresses per chain.
 pub mod constants;
-/// Internal task and solve-error types used between the worker pool and router.
+/// Internal task and solve-error types used between the worker component and router.
 pub mod internal;
 /// Primitive types: `ComponentId`, `ProtocolSystem`, `GasPrice`, `TaskId`.
 pub mod primitives;

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -1101,7 +1101,7 @@ impl BlockInfo {
 
 /// A route consisting of one or more swaps, either sequential or split.
 ///
-/// A route describes the path through liquidity pools to execute a swap.
+/// A route describes the path through components (liquidity pools) to execute a swap.
 /// For sequential (multi-hop) swaps, the output of each swap becomes the input
 /// of the next. For split swaps, the input is divided across multiple parallel
 /// paths (each swap carries a `split` fraction).
@@ -1602,11 +1602,11 @@ pub enum RouteValidationError {
 
 /// A single swap within a route.
 ///
-/// Represents an atomic swap on a specific liquidity pool (component).
+/// Represents an atomic swap on a specific component (liquidity pool).
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Swap {
-    /// Identifier of the liquidity pool component.
+    /// Identifier of the component (liquidity pool).
     component_id: ComponentId,
     /// Protocol system identifier (e.g., "uniswap_v2", "uniswap_v3", "vm:balancer").
     protocol: String,
@@ -1683,7 +1683,7 @@ impl Swap {
         self.committed_amount_out = Some(committed_amount_out);
     }
 
-    /// Returns the component ID of the liquidity pool.
+    /// Returns the component ID (liquidity pool) of the swap.
     pub fn component_id(&self) -> &str {
         &self.component_id
     }
@@ -1858,14 +1858,14 @@ mod tests {
         let token_in = token(token_in_byte, "TIN");
         let token_out = token(token_out_byte, "TOUT");
         Swap::new(
-            "pool-1".to_string(),
+            "component-1".to_string(),
             "uniswap_v2".to_string(),
             make_address(token_in_byte),
             make_address(token_out_byte),
             BigUint::from(amount_in),
             BigUint::from(amount_out),
             BigUint::from(100_000u64),
-            component("test-pool", &[token_in, token_out]),
+            component("test-component", &[token_in, token_out]),
             Box::new(MockProtocolSim::default()),
         )
     }
@@ -2310,7 +2310,7 @@ mod tests {
     #[test]
     fn test_swap_deserializes_amounts_from_strings() {
         let json = r#"{
-            "component_id": "pool-1",
+            "component_id": "component-1",
             "protocol": "uniswap_v2",
             "token_in": "0x0101010101010101010101010101010101010101",
             "token_out": "0x0202020202020202020202020202020202020202",
@@ -2319,7 +2319,7 @@ mod tests {
             "gas_estimate": "150000",
             "split": "0",
             "protocol_component": {
-                "id": "test-pool",
+                "id": "test-component",
                 "protocol_system": "uniswap_v2",
                 "protocol_type_name": "swap",
                 "chain": "ethereum",

--- a/fynd-core/src/types/quote.rs
+++ b/fynd-core/src/types/quote.rs
@@ -796,7 +796,7 @@ pub struct OrderQuote {
     #[serde(skip)]
     no_route_cause: Option<SolveError>,
     /// Order-level surplus summary, populated when this quote executes through an exclusive
-    /// pool.
+    /// component.
     ///
     /// Informational only (observability); the value the encoder acts on is the per-leg
     /// [`Swap::committed_amount_out`]. `None` for pure public quotes. `#[serde(skip)]` — internal

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -34,7 +34,7 @@ use crate::{
 
 /// Configuration for the worker pool.
 #[derive(Debug)]
-pub struct WorkerPoolSpawnConfig {
+pub struct WorkerPoolConfig {
     /// Human-readable name for this worker pool (used in logging/metrics).
     /// Can differ from algorithm to distinguish worker pools with same algorithm but different
     /// configs.
@@ -58,14 +58,14 @@ pub struct WorkerPoolSpawnConfig {
     exclusivity_policy: Option<ExclusivityPolicy>,
 }
 
-impl WorkerPoolSpawnConfig {
+impl WorkerPoolConfig {
     /// Returns the algorithm name for this worker pool.
     pub fn algorithm_name(&self) -> &str {
         self.spawner.algorithm_name()
     }
 }
 
-impl Default for WorkerPoolSpawnConfig {
+impl Default for WorkerPoolConfig {
     fn default() -> Self {
         Self {
             name: DEFAULT_ALGORITHM.to_string(),
@@ -109,7 +109,7 @@ impl WorkerPool {
     ///
     /// Returns an error if the algorithm name in config is not registered.
     pub fn spawn(
-        config: WorkerPoolSpawnConfig,
+        config: WorkerPoolConfig,
         task_rx: async_channel::Receiver<SolveTask>,
         market_data: MarketData,
         derived_data: SharedDerivedDataRef,
@@ -202,13 +202,13 @@ impl WorkerPool {
 /// registry entirely. See the `custom_algorithm` example for a full walkthrough.
 #[must_use = "a builder does nothing until .build() is called"]
 pub struct WorkerPoolBuilder {
-    config: WorkerPoolSpawnConfig,
+    config: WorkerPoolConfig,
 }
 
 impl WorkerPoolBuilder {
     /// Create a builder with default configuration values.
     pub fn new() -> Self {
-        Self { config: WorkerPoolSpawnConfig::default() }
+        Self { config: WorkerPoolConfig::default() }
     }
 
     /// Sets the worker pool name.

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -1,11 +1,11 @@
 //! Worker pool for processing solve tasks.
 //!
 //! The worker pool manages multiple dedicated OS threads for CPU-bound route finding.
-//! Each pool owns multiple SolverWorker instances that compete for tasks from the queue.
-//! A pool is configured with a specific algorithm (by name), allowing multiple pools
-//! with different algorithms to compete via the WorkerPoolRouter.
+//! Each worker pool owns multiple SolverWorker instances that compete for tasks from the queue.
+//! A worker pool is configured with a specific algorithm (by name), allowing multiple worker
+//! pools with different algorithms to compete via the WorkerPoolRouter.
 //!
-//! Pools can use either a built-in algorithm (by name via [`WorkerPoolBuilder::algorithm`])
+//! Worker pools can use either a built-in algorithm (by name via [`WorkerPoolBuilder::algorithm`])
 //! or a custom [`Algorithm`](crate::algorithm::Algorithm) implementation (via
 //! [`WorkerPoolBuilder::with_algorithm`]).
 use std::thread::JoinHandle;
@@ -35,8 +35,9 @@ use crate::{
 /// Configuration for the worker pool.
 #[derive(Debug)]
 pub struct WorkerPoolConfig {
-    /// Human-readable name for this pool (used in logging/metrics).
-    /// Can differ from algorithm to distinguish pools with same algorithm but different configs.
+    /// Human-readable name for this worker pool (used in logging/metrics).
+    /// Can differ from algorithm to distinguish worker pools with same algorithm but different
+    /// configs.
     name: String,
     /// How to spawn workers — either a built-in registry lookup or a custom factory.
     spawner: AlgorithmSpawner,
@@ -46,19 +47,19 @@ pub struct WorkerPoolConfig {
     algorithm_config: AlgorithmConfig,
     /// Task queue capacity (maximum number of pending tasks).
     task_queue_capacity: usize,
-    /// When set, exclusive components are filtered out of this pool's workers' graphs
+    /// When set, exclusive components are filtered out of this worker pool's workers' graphs
     /// (default: `None`, no filtering).
     ///
     /// `All` is safe as the default because it only applies when no `ExclusivityPolicy` is
     /// configured — meaning no exclusive components exist to exclude. When a policy is set,
     /// `FyndBuilder::assemble_components` always constructs
-    /// `Some(policy)` for `Public`-scoped pools, so this default is never relied on in
+    /// `Some(policy)` for `Public`-scoped worker pools, so this default is never relied on in
     /// that path.
     exclusivity_policy: Option<ExclusivityPolicy>,
 }
 
 impl WorkerPoolConfig {
-    /// Returns the algorithm name for this pool.
+    /// Returns the algorithm name for this worker pool.
     pub fn algorithm_name(&self) -> &str {
         self.spawner.algorithm_name()
     }
@@ -79,12 +80,12 @@ impl Default for WorkerPoolConfig {
 
 /// A pool of worker threads for processing solve tasks.
 ///
-/// Each pool is dedicated to a specific algorithm. Workers in the pool
+/// Each worker pool is dedicated to a specific algorithm. Workers in the pool
 /// compete for tasks from the shared queue.
 pub struct WorkerPool {
-    /// Human-readable name for this pool.
+    /// Human-readable name for this worker pool.
     name: String,
-    /// Algorithm name for this pool.
+    /// Algorithm name for this worker pool.
     algorithm: String,
     /// Handles to worker threads.
     workers: Vec<JoinHandle<()>>,
@@ -100,7 +101,7 @@ impl WorkerPool {
     /// * `config` - Worker pool configuration
     /// * `task_rx` - Receiver for tasks from the queue
     /// * `market_data` - Shared market data reference
-    /// * `derived_data` - Shared derived data reference (pool depths, token prices)
+    /// * `derived_data` - Shared derived data reference (component depths, token prices)
     /// * `event_rx` - Broadcast receiver for market events (workers subscribe to this)
     /// * `derived_event_rx` - Broadcast receiver for derived data events (resubscribed per worker)
     ///
@@ -149,12 +150,12 @@ impl WorkerPool {
         Ok(Self { name, algorithm, workers, shutdown_tx })
     }
 
-    /// Returns the pool name.
+    /// Returns the worker pool name.
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    /// Returns the algorithm name for this pool.
+    /// Returns the algorithm name for this worker pool.
     pub fn algorithm(&self) -> &str {
         &self.algorithm
     }
@@ -210,7 +211,7 @@ impl WorkerPoolBuilder {
         Self { config: WorkerPoolConfig::default() }
     }
 
-    /// Sets the pool name.
+    /// Sets the worker pool name.
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.config.name = name.into();
         self
@@ -269,8 +270,8 @@ impl WorkerPoolBuilder {
 
     /// Sets the policy that filters exclusive components out of each worker's graph.
     ///
-    /// Public pools receive `Some(policy)`; exclusive-access pools (and pools of solvers with
-    /// no exclusive components configured) receive `None` and keep every component.
+    /// Public worker pools receive `Some(policy)`; exclusive-access worker pools (and deployments
+    /// with no exclusive components configured) receive `None` and keep every component.
     pub fn exclusivity_policy(mut self, policy: Option<ExclusivityPolicy>) -> Self {
         self.config.exclusivity_policy = policy;
         self

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -34,7 +34,7 @@ use crate::{
 
 /// Configuration for the worker pool.
 #[derive(Debug)]
-pub struct WorkerPoolConfig {
+pub struct WorkerPoolSpawnConfig {
     /// Human-readable name for this worker pool (used in logging/metrics).
     /// Can differ from algorithm to distinguish worker pools with same algorithm but different
     /// configs.
@@ -58,14 +58,14 @@ pub struct WorkerPoolConfig {
     exclusivity_policy: Option<ExclusivityPolicy>,
 }
 
-impl WorkerPoolConfig {
+impl WorkerPoolSpawnConfig {
     /// Returns the algorithm name for this worker pool.
     pub fn algorithm_name(&self) -> &str {
         self.spawner.algorithm_name()
     }
 }
 
-impl Default for WorkerPoolConfig {
+impl Default for WorkerPoolSpawnConfig {
     fn default() -> Self {
         Self {
             name: DEFAULT_ALGORITHM.to_string(),
@@ -109,7 +109,7 @@ impl WorkerPool {
     ///
     /// Returns an error if the algorithm name in config is not registered.
     pub fn spawn(
-        config: WorkerPoolConfig,
+        config: WorkerPoolSpawnConfig,
         task_rx: async_channel::Receiver<SolveTask>,
         market_data: MarketData,
         derived_data: SharedDerivedDataRef,
@@ -202,13 +202,13 @@ impl WorkerPool {
 /// registry entirely. See the `custom_algorithm` example for a full walkthrough.
 #[must_use = "a builder does nothing until .build() is called"]
 pub struct WorkerPoolBuilder {
-    config: WorkerPoolConfig,
+    config: WorkerPoolSpawnConfig,
 }
 
 impl WorkerPoolBuilder {
     /// Create a builder with default configuration values.
     pub fn new() -> Self {
-        Self { config: WorkerPoolConfig::default() }
+        Self { config: WorkerPoolSpawnConfig::default() }
     }
 
     /// Sets the worker pool name.

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -41,7 +41,7 @@ pub(crate) const DEFAULT_ALGORITHM: &str = "most_liquid";
 pub(crate) struct SpawnWorkersParams {
     /// Algorithm name (e.g., "most_liquid") — used for thread naming and logging.
     pub algorithm: String,
-    /// Pool name from configuration (used as the `pool` metric label).
+    /// Worker pool name from configuration (used as the `pool` metric label).
     pub pool_name: String,
     /// Number of worker threads to spawn.
     pub num_workers: usize,
@@ -51,7 +51,7 @@ pub(crate) struct SpawnWorkersParams {
     pub task_rx: async_channel::Receiver<SolveTask>,
     /// Shared market data reference.
     pub market_data: MarketData,
-    /// Shared derived data reference (pool depths, token prices).
+    /// Shared derived data reference (component depths, token prices).
     pub derived_data: SharedDerivedDataRef,
     /// Broadcast receiver for market events.
     pub event_rx: broadcast::Receiver<MarketEvent>,
@@ -59,11 +59,11 @@ pub(crate) struct SpawnWorkersParams {
     pub derived_event_rx: broadcast::Receiver<DerivedDataEvent>,
     /// Sender for shutdown signals.
     pub shutdown_tx: broadcast::Sender<()>,
-    /// Exclusivity policy applied to every worker in this pool, cloned per worker.
+    /// Exclusivity policy applied to every worker in this worker pool, cloned per worker.
     ///
-    /// `Some(policy)` filters exclusive components out of each worker's graph (public pools);
-    /// `None` keeps every component (exclusive-access pools, or no exclusive components
-    /// configured).
+    /// `Some(policy)` filters exclusive components out of each worker's graph (public worker
+    /// pools); `None` keeps every component (exclusive-access worker pools, or no exclusive
+    /// components configured).
     pub exclusivity_policy: Option<ExclusivityPolicy>,
 }
 

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -33,7 +33,7 @@ use crate::{
     BlockInfo, Order, OrderQuote, QuoteStatus, SingleOrderQuote, SolveError, SolveParams,
 };
 
-/// Records per-pool queue metrics at task pickup: how long the task waited in the
+/// Records per-worker-pool queue metrics at task pickup: how long the task waited in the
 /// queue and the depth left behind it. Queue wait growing while solve time stays
 /// flat is the leading indicator of worker saturation.
 fn record_task_pickup_metrics(pool_name: &str, queue_wait: Duration, queue_depth: usize) {
@@ -55,7 +55,7 @@ where
     graph_manager: A::GraphManager,
     /// Reference to shared market data.
     market_data: MarketData,
-    /// Reference to shared derived data (pool depths, token prices).
+    /// Reference to shared derived data (component depths, token prices).
     derived_data: SharedDerivedDataRef,
     /// Algorithm's computation requirements (which derived data to react to).
     requirements: ComputationRequirements,
@@ -67,10 +67,10 @@ where
     initialized: bool,
     /// Worker identifier (for logging).
     worker_id: usize,
-    /// Pool name (used as the `pool` metric label).
+    /// Worker pool name (used as the `pool` metric label).
     pool_name: String,
     /// When set, exclusive components are filtered out of this worker's local graph
-    /// (public-pool workers). `None` means the worker ingests everything.
+    /// (workers of public worker pools). `None` means the worker ingests everything.
     ///
     /// `All` (the default) preserves the original non-filtered behaviour. A public worker
     /// is configured with `PublicOnly(policy)` so exclusive components never enter its graph; an
@@ -90,10 +90,10 @@ where
     /// # Arguments
     ///
     /// * `market_data` - Shared reference to market data
-    /// * `derived_data` - Shared reference to derived data (pool depths, token prices)
+    /// * `derived_data` - Shared reference to derived data (component depths, token prices)
     /// * `algorithm` - The algorithm to use for route finding
     /// * `worker_id` - Identifier for this worker (for logging)
-    /// * `pool_name` - Pool name (used as the `pool` metric label)
+    /// * `pool_name` - Worker pool name (used as the `pool` metric label)
     pub fn new(
         market_data: MarketData,
         derived_data: SharedDerivedDataRef,
@@ -428,7 +428,7 @@ where
     /// # Arguments
     ///
     /// * `event_rx` - Receiver for market events
-    /// * `derived_event_rx` - Receiver for derived data events (pool depths, etc.)
+    /// * `derived_event_rx` - Receiver for derived data events (component depths, etc.)
     /// * `task_rx` - Shared receiver for solve tasks
     /// * `shutdown_rx` - Receiver for shutdown signals
     pub async fn run(
@@ -480,7 +480,7 @@ where
                     }
                 }
 
-                // Process derived data events (pool depths, token prices)
+                // Process derived data events (component depths, token prices)
                 derived_result = derived_event_rx.recv(), if !derived_closed => {
                     match derived_result {
                         Ok(event) => {

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -11,11 +11,11 @@
 //!    customized, but initially it's set to relay to all solvers.
 //! 2. **Timeout**: Cancel if solver response takes too long
 //! 3. **Collection**: Wait for N responses OR timeout per order
-//! 4. **Gas refinement**: Before cross-pool ranking, replace each candidate's naive
-//!    `route.total_gas()` estimate (used internally by algorithms for intra-pool ranking) with the
-//!    more accurate `estimate_gas_usage` from tycho-execution, which accounts for token transfer
-//!    costs and router overhead. The `amount_out_net_gas` values are rescaled proportionally so the
-//!    final ranking reflects realistic execution cost.
+//! 4. **Gas refinement**: Before ranking across worker pools, replace each candidate's naive
+//!    `route.total_gas()` estimate (used internally by algorithms for ranking within a worker pool)
+//!    with the more accurate `estimate_gas_usage` from tycho-execution, which accounts for token
+//!    transfer costs and router overhead. The `amount_out_net_gas` values are rescaled
+//!    proportionally so the final ranking reflects realistic execution cost.
 //! 5. **Selection**: Choose best quote (max refined `amount_out_net_gas`)
 //! 6. **Encoding**: If [`EncodingOptions`](crate::EncodingOptions) are provided in the request,
 //!    encode winning solutions into executable on-chain transactions via the
@@ -104,10 +104,10 @@ fn user_margin(improvement: &BigUint, user_share_bps: u32) -> BigUint {
 /// Which liquidity a solver pool (a group of workers) routes through, and therefore what its
 /// candidates mean in a quote.
 ///
-/// A `Public` pool routes only through public liquidity and provides the committed (quoted)
+/// A public worker pool routes only through public liquidity and provides the committed (quoted)
 /// reference output; its workers are given the [`ExclusivityPolicy`] so exclusive components
-/// never enter their graphs. An `ExclusiveAccess` pool routes through all liquidity, public and
-/// exclusive components alike, and may beat that reference — in which case the protocol
+/// never enter their graphs. An exclusive-access worker pool routes through all liquidity, public
+/// and exclusive components alike, and may beat that reference — in which case the protocol
 /// captures the surplus.
 ///
 /// Serialized in snake_case (`"public_only"` / `"all"`) in `worker_pools.toml` via
@@ -128,11 +128,11 @@ pub enum LiquidityScope {
 /// Handle to a solver pool for dispatching orders.
 #[derive(Clone)]
 pub struct SolverPoolHandle {
-    /// Human-readable name for this pool (used in logging & metrics).
+    /// Human-readable name for this worker pool (used in logging & metrics).
     name: String,
-    /// Queue handle for this pool.
+    /// Queue handle for this worker pool.
     queue: TaskQueueHandle,
-    /// Whether this pool routes public-only or all liquidity.
+    /// Whether this worker pool routes public-only or all liquidity.
     liquidity_scope: LiquidityScope,
 }
 
@@ -142,15 +142,14 @@ impl SolverPoolHandle {
         Self { name: name.into(), queue, liquidity_scope: LiquidityScope::PublicOnly }
     }
 
-    /// Sets the pool's liquidity scope (e.g. [`LiquidityScope::All`] for a pool
-    /// that routes
-    /// through exclusive liquidity as well).
+    /// Sets the worker pool's liquidity scope (e.g. [`LiquidityScope::All`] for a worker pool
+    /// that routes through exclusive liquidity as well).
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = scope;
         self
     }
 
-    /// Returns the pool name.
+    /// Returns the worker pool name.
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -160,7 +159,7 @@ impl SolverPoolHandle {
         &self.queue
     }
 
-    /// Returns the pool's liquidity scope.
+    /// Returns the worker pool's liquidity scope.
     pub fn liquidity_scope(&self) -> LiquidityScope {
         self.liquidity_scope
     }
@@ -179,7 +178,7 @@ pub(crate) struct OrderResponses {
 }
 
 impl OrderResponses {
-    /// Returns a copy keeping only candidates from public-scoped pools.
+    /// Returns a copy keeping only candidates from public-scoped worker pools.
     ///
     /// These form the committed reference and the ranked fallback chain (ranked by `rank_quotes`,
     /// consumed by the price guard); exclusive-access candidates are overlaid separately by
@@ -286,8 +285,8 @@ impl WorkerPoolRouter {
             refine_gas_estimates(&mut order_responses, encoding_options)?;
         }
 
-        // Map each pool name to its liquidity scope so candidate quotes can be split into public vs
-        // exclusive-access.
+        // Map each worker pool name to its liquidity scope so candidate quotes can be split into
+        // public vs exclusive-access.
         let pool_scopes: HashMap<String, LiquidityScope> = self
             .solver_pools
             .iter()
@@ -299,7 +298,7 @@ impl WorkerPoolRouter {
 
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
         // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
-        // fallback chain. When an `ExclusiveAccess`-scoped pool is configured, the winning
+        // fallback chain. When an `ExclusiveAccess`-scoped worker pool is configured, the winning
         // exclusive-access candidate is overlaid
         // onto that ranked list (prepended) by `combine_with_surplus`, so the fallbacks are
         // preserved.
@@ -409,8 +408,8 @@ impl WorkerPoolRouter {
             })
             .collect();
 
-        // Pre-compute which pool names have the ExclusiveAccess scope, for scope-aware early
-        // return gating.
+        // Pre-compute which worker pool names have the ExclusiveAccess scope, for scope-aware
+        // early return gating.
         let exclusive_access_pool_names: HashSet<String> = self
             .solver_pools
             .iter()
@@ -439,7 +438,7 @@ impl WorkerPoolRouter {
 
                 // Timeout reached
                 _ = tokio::time::sleep_until(deadline_instant) => {
-                    // Mark all remaining pools as timed out
+                    // Mark all remaining worker pools as timed out
                     let elapsed_ms = deadline.saturating_duration_since(Instant::now())
                         .as_millis() as u64;
                     for pool_name in remaining_pools.drain() {
@@ -467,10 +466,10 @@ impl WorkerPoolRouter {
                             // Extract the OrderQuote from SingleOrderQuote
                             quotes.push((pool_name.clone(), single_quote.order().clone()));
 
-                            // Scope-aware early return: when an exclusive-access pool is
-                            // configured, only fire once we have ≥1 public AND the
-                            // exclusive-access pool (so the surplus overlay has both inputs).
-                            // Without an exclusive-access pool, use pure
+                            // Scope-aware early return: when an exclusive-access worker pool is
+                            // configured, only fire once we have ≥1 public response AND the
+                            // exclusive-access worker pool's response (so the surplus overlay has
+                            // both inputs). Without an exclusive-access worker pool, use pure
                             // count-based gating (original behaviour).
                             let scope_ready = if has_exclusive_access_pool {
                                 has_public_response && has_exclusive_access_response
@@ -493,10 +492,10 @@ impl WorkerPoolRouter {
                         }
                         Some((pool_name, Err(e))) => {
                             remaining_pools.remove(&pool_name);
-                            // A failed exclusive-access pool still counts as "responded" for
-                            // gating — we know it won't produce a surplus quote, so the public
-                            // pool can
-                            // early-return without waiting for a result that will never come.
+                            // A failed exclusive-access worker pool still counts as "responded"
+                            // for gating — we know it won't produce a surplus quote, so the
+                            // public worker pools can early-return without waiting for a result
+                            // that will never come.
                             if exclusive_access_pool_names.contains(&pool_name) {
                                 has_exclusive_access_response = true;
                             }
@@ -522,7 +521,7 @@ impl WorkerPoolRouter {
         histogram!("worker_router_solve_duration_seconds").record(duration);
         histogram!("worker_router_solver_responses").record(quotes.len() as f64);
 
-        // Record failures by pool and error type
+        // Record failures by worker pool and error type
         for (pool_name, error) in &failed_solvers {
             let error_type = match error {
                 SolveError::Timeout { .. } => "timeout",
@@ -687,10 +686,10 @@ impl WorkerPoolRouter {
 /// Builds the final ranked quote list for one order by deciding whether an exclusive-access
 /// route should execute instead of the best public route.
 ///
-/// Inputs: `public_ranked` is the ranking of public-pool quotes from `rank_quotes`; its head is
-/// the public reference from which the committed amount is derived. `responses` additionally
-/// holds the candidates from `ExclusiveAccess`-scoped pools (routes that may use exclusive
-/// components).
+/// Inputs: `public_ranked` is the ranking of public-worker-pool quotes from `rank_quotes`; its
+/// head is the public reference from which the committed amount is derived. `responses`
+/// additionally holds the candidates from `ExclusiveAccess`-scoped worker pools (routes that may
+/// use exclusive components).
 ///
 /// A candidate must at least match the public reference net of gas; what it produces on top,
 /// `improvement = exclusive_net − public_net`, is then split. The user's net target is
@@ -854,7 +853,7 @@ fn combine_with_surplus(
                 // its path (validator), so path_final_out equals the leg's output and this
                 // divides by itself — a plain subtraction. Once mid-path legs are allowed,
                 // the "user gets at least the committed amount" guarantee also requires the
-                // pools after the leg to have diminishing returns.
+                // components after the leg to have diminishing returns.
                 let captured_leg = if *path_final_out == BigUint::ZERO {
                     BigUint::ZERO
                 } else {
@@ -896,7 +895,7 @@ fn combine_with_surplus(
 ///
 /// Both constraints are v1 restrictions that keep per-leg surplus attribution exact and
 /// unambiguous: a mid-route leg would need inverse simulation to convert the surplus into its
-/// token, and multiple exclusive legs make the per-pool attribution non-unique. Both are
+/// token, and multiple exclusive legs make the per-component attribution non-unique. Both are
 /// deferred to a future version. Terminal is defined as producing the route's overall output
 /// token (`Route::output_token`).
 fn has_valid_exclusive_route(quote: &OrderQuote, policy: &ExclusivityPolicy) -> bool {
@@ -1751,9 +1750,9 @@ mod tests {
         make_exclusive_quote_with_leg(amount_out, amount_out, amount_out)
     }
 
-    /// Split route with two parallel branches (same token pair): a public pool producing
-    /// `public_leg_out` and an exclusive pool producing `exclusive_leg_out`. Route output is the
-    /// sum of the branches; zero gas cost.
+    /// Split route with two parallel branches (same token pair): a public component producing
+    /// `public_leg_out` and an exclusive component producing `exclusive_leg_out`. Route output is
+    /// the sum of the branches; zero gas cost.
     fn make_exclusive_split_quote(public_leg_out: u64, exclusive_leg_out: u64) -> SingleOrderQuote {
         let make_token = |addr: Address| Token {
             address: addr,
@@ -2275,7 +2274,7 @@ mod tests {
         true)]
     #[case::no_exclusive_leg(
         &[("uniswap_v2", 0x01, 0x02), ("uniswap_v2", 0x02, 0x03)], false)]
-    // Two exclusive legs: out of scope for v1 (ambiguous per-pool attribution).
+    // Two exclusive legs: out of scope for v1 (ambiguous per-component attribution).
     #[case::two_exclusive_legs(
         &[("vm:exclusive", 0x01, 0x02), ("vm:exclusive", 0x01, 0x02)], false)]
     // Diamond split: 0x01 splits into 0x01->0x02 (exclusive) and 0x01->0x03, both merging into

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -111,9 +111,9 @@ fn user_margin(improvement: &BigUint, user_share_bps: u32) -> BigUint {
 /// captures the surplus.
 ///
 /// Serialized in snake_case (`"public_only"` / `"all"`) in `worker_pools.toml` via
-/// [`PoolConfig`].
+/// [`WorkerPoolConfig`].
 ///
-/// [`PoolConfig`]: crate::PoolConfig
+/// [`WorkerPoolConfig`]: crate::WorkerPoolConfig
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LiquidityScope {

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -111,9 +111,9 @@ fn user_margin(improvement: &BigUint, user_share_bps: u32) -> BigUint {
 /// captures the surplus.
 ///
 /// Serialized in snake_case (`"public_only"` / `"all"`) in `worker_pools.toml` via
-/// [`WorkerPoolConfig`].
+/// [`PoolConfig`].
 ///
-/// [`WorkerPoolConfig`]: crate::WorkerPoolConfig
+/// [`PoolConfig`]: crate::PoolConfig
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LiquidityScope {

--- a/fynd-core/tests/fixtures/expected_outputs.json
+++ b/fynd-core/tests/fixtures/expected_outputs.json
@@ -1,12 +1,12 @@
 {
   "metadata": {
     "block_number": 24838913,
-    "num_pools": 2377,
+    "num_components": 2377,
     "num_tokens": 1688,
     "fynd_version": "0.77.0",
     "derived_data": {
-      "spot_price_pools": 1372,
-      "pool_depth_pools": 1308,
+      "components_with_spot_prices": 1372,
+      "components_with_depths": 1308,
       "token_prices": 1125
     }
   },

--- a/fynd-core/tests/integration/README.md
+++ b/fynd-core/tests/integration/README.md
@@ -21,7 +21,7 @@ nothing and reports zero tests.
 | `test_quality_within_expected_baseline` | Output amounts stay within 1% of baseline (regressions only) |
 | `test_quality_invariants` | Successful quotes have positive output, gas, and a route |
 | `test_unknown_token_returns_error` | Fake token addresses return error, not panic |
-| `test_all_derived_fields_computed` | Spot prices, pool depths, token prices all present |
+| `test_all_derived_fields_computed` | Spot prices, component depths, token prices all present |
 | `test_derived_data_matches_expected` | Exact equality of derived data counts vs baseline |
 | `test_solve_time_p95_within_threshold` | P95 solve time within 3x of baseline |
 | `test_no_solve_exceeds_absolute_cap` | No solve exceeds max pool timeout + 1s margin |

--- a/fynd-core/tests/integration/derived_data_tests.rs
+++ b/fynd-core/tests/integration/derived_data_tests.rs
@@ -14,7 +14,7 @@ async fn test_all_derived_fields_computed() {
     let derived = derived_ref.read().await;
 
     assert!(derived.spot_prices().is_some(), "spot_prices should be computed");
-    assert!(derived.pool_depths().is_some(), "pool_depths should be computed");
+    assert!(derived.component_depths().is_some(), "component_depths should be computed");
     assert!(derived.token_prices().is_some(), "token_prices should be computed");
 }
 
@@ -40,15 +40,15 @@ async fn test_derived_data_matches_expected() {
     let spot_prices = derived
         .spot_prices()
         .expect("spot prices not computed");
-    let actual_spot_price_pools: std::collections::HashSet<_> = spot_prices
+    let actual_components_with_spot_prices: std::collections::HashSet<_> = spot_prices
         .keys()
         .map(|(id, _, _)| id.clone())
         .collect();
 
-    let pool_depths = derived
-        .pool_depths()
-        .expect("pool depths not computed");
-    let actual_pool_depth_pools: std::collections::HashSet<_> = pool_depths
+    let component_depths = derived
+        .component_depths()
+        .expect("component depths not computed");
+    let actual_components_with_depths: std::collections::HashSet<_> = component_depths
         .keys()
         .map(|(id, _, _)| id.clone())
         .collect();
@@ -59,8 +59,8 @@ async fn test_derived_data_matches_expected() {
 
     assert_eq!(
         market.component_topology().len(),
-        expected_file.metadata.num_pools,
-        "pool count mismatch"
+        expected_file.metadata.num_components,
+        "component count mismatch"
     );
     assert_eq!(
         market.token_registry_ref().len(),
@@ -68,14 +68,14 @@ async fn test_derived_data_matches_expected() {
         "token count mismatch"
     );
     assert_eq!(
-        actual_spot_price_pools.len(),
-        expected.spot_price_pools,
-        "spot_price pool count mismatch"
+        actual_components_with_spot_prices.len(),
+        expected.components_with_spot_prices,
+        "spot-price component count mismatch"
     );
     assert_eq!(
-        actual_pool_depth_pools.len(),
-        expected.pool_depth_pools,
-        "pool_depth pool count mismatch"
+        actual_components_with_depths.len(),
+        expected.components_with_depths,
+        "component-depth component count mismatch"
     );
     assert_eq!(token_prices.len(), expected.token_prices, "token_prices count mismatch");
 }

--- a/fynd-core/tests/integration/harness.rs
+++ b/fynd-core/tests/integration/harness.rs
@@ -69,7 +69,7 @@ impl TestHarness {
     }
 }
 
-fn load_pools() -> HashMap<String, fynd_core::WorkerPoolConfig> {
+fn load_pools() -> HashMap<String, fynd_core::PoolConfig> {
     let toml_content = include_str!("../../../worker_pools.toml");
     fynd_test_fixtures::parse_pools_toml(toml_content).expect("failed to parse worker_pools.toml")
 }

--- a/fynd-core/tests/integration/harness.rs
+++ b/fynd-core/tests/integration/harness.rs
@@ -69,7 +69,7 @@ impl TestHarness {
     }
 }
 
-fn load_pools() -> HashMap<String, fynd_core::PoolConfig> {
+fn load_pools() -> HashMap<String, fynd_core::WorkerPoolConfig> {
     let toml_content = include_str!("../../../worker_pools.toml");
     fynd_test_fixtures::parse_pools_toml(toml_content).expect("failed to parse worker_pools.toml")
 }

--- a/fynd-core/tests/integration/solution_tests.rs
+++ b/fynd-core/tests/integration/solution_tests.rs
@@ -192,7 +192,7 @@ async fn regenerate_expected_outputs() {
     let derived_metrics = {
         let derived_ref = harness.solver().derived_data();
         let d = derived_ref.read().await;
-        let spot_price_pools = d
+        let components_with_spot_prices = d
             .spot_prices()
             .map(|sp| {
                 sp.keys()
@@ -201,8 +201,8 @@ async fn regenerate_expected_outputs() {
                     .len()
             })
             .unwrap_or(0);
-        let pool_depth_pools = d
-            .pool_depths()
+        let components_with_depths = d
+            .component_depths()
             .map(|pd| {
                 pd.keys()
                     .map(|(id, _, _)| id.clone())
@@ -214,7 +214,11 @@ async fn regenerate_expected_outputs() {
             .token_prices()
             .map(|tp| tp.len())
             .unwrap_or(0);
-        fynd_test_fixtures::DerivedDataMetrics { spot_price_pools, pool_depth_pools, token_prices }
+        fynd_test_fixtures::DerivedDataMetrics {
+            components_with_spot_prices,
+            components_with_depths,
+            token_prices,
+        }
     };
 
     let market_ref = harness.solver().market_data();
@@ -225,14 +229,14 @@ async fn regenerate_expected_outputs() {
         .last_updated()
         .map(|block| block.number())
         .unwrap_or(0);
-    let num_pools = market.component_topology().len();
+    let num_components = market.component_topology().len();
     let num_tokens = market.token_registry_ref().len();
     drop(market);
 
     let expected_file = fynd_test_fixtures::ExpectedFile {
         metadata: fynd_test_fixtures::ExpectedMetadata {
             block_number,
-            num_pools,
+            num_components,
             num_tokens,
             fynd_version: env!("CARGO_PKG_VERSION").to_string(),
             derived_data: Some(derived_metrics),

--- a/fynd-core/tests/integration/timing_tests.rs
+++ b/fynd-core/tests/integration/timing_tests.rs
@@ -66,7 +66,7 @@ async fn test_solve_time_p95_within_threshold() {
     );
 }
 
-/// No individual solve should exceed the router timeout (max pool timeout + margin).
+/// No individual solve should exceed the router timeout (max worker pool timeout + margin).
 #[tokio::test]
 async fn test_no_solve_exceeds_absolute_cap() {
     let harness = TestHarness::from_fixture().await;

--- a/fynd-rpc-types/src/lib.rs
+++ b/fynd-rpc-types/src/lib.rs
@@ -983,7 +983,7 @@ impl BlockInfo {
 
 /// A route consisting of one or more sequential swaps.
 ///
-/// A route describes the path through liquidity pools to execute a swap.
+/// A route describes the path through components (liquidity pools) to execute a swap.
 /// For multi-hop swaps, the output of each swap becomes the input of the next.
 #[must_use]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1012,12 +1012,12 @@ impl Route {
 
 /// A single swap within a route.
 ///
-/// Represents an atomic swap on a specific liquidity pool (component).
+/// Represents an atomic swap on a specific component (liquidity pool).
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "openapi", derive(utoipa::ToSchema))]
 pub struct Swap {
-    /// Identifier of the liquidity pool component.
+    /// Identifier of the component (liquidity pool).
     #[cfg_attr(
         feature = "openapi",
         schema(example = "0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc")
@@ -1084,7 +1084,7 @@ impl Swap {
         }
     }
 
-    /// Liquidity pool component identifier.
+    /// Component (liquidity pool) identifier.
     pub fn component_id(&self) -> &str {
         &self.component_id
     }
@@ -1491,7 +1491,7 @@ mod wire_format_tests {
             "price_impact_bps": 5,
             "block": { "number": 21000000, "hash": "0xdeadbeef", "timestamp": 1700000000 },
             "route": { "swaps": [{
-                "component_id": "pool-1",
+                "component_id": "component-1",
                 "protocol": "uniswap_v3",
                 "token_in":  "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "token_out": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -23,9 +23,9 @@ infrastructure.
 | Endpoint | Handler | Description |
 |---|---|---|
 | `POST /v1/quote` | `handlers::quote` | Submit orders, receive optimal routes |
-| `GET /v1/health` | `handlers::health` | Health check (data freshness, derived data readiness, gas-price staleness, pool count). Returns 503 when market data is stale, derived data is not ready, or the gas price is stale |
+| `GET /v1/health` | `handlers::health` | Health check (data freshness, derived data readiness, gas-price staleness, solver pool count). Returns 503 when market data is stale, derived data is not ready, or the gas price is stale |
 | `GET /v1/info` | `handlers::info` | Static metadata about this Fynd instance (version, chain, spender address) |
-| `GET /v1/prices` | `handlers::get_prices` | Token prices, spot prices, pool depths (experimental feature only) |
+| `GET /v1/prices` | `handlers::get_prices` | Token prices, spot prices, component depths (experimental feature only) |
 
 ## API Documentation
 

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -8,8 +8,8 @@ use tracing::{info, warn};
 use super::{dto, ApiError, AppState};
 #[cfg(feature = "experimental")]
 use crate::api::prices::{
-    price_to_f64, ComputationBlocks, IncludeField, PoolDepthEntry, PricesQuery, PricesResponse,
-    SpotPriceEntry, TokenPriceEntry,
+    price_to_f64, ComponentDepthEntry, ComputationBlocks, IncludeField, PricesQuery,
+    PricesResponse, SpotPriceEntry, TokenPriceEntry,
 };
 use crate::api::{
     error::{solve_error_code, ErrorResponse},
@@ -214,7 +214,7 @@ pub(crate) async fn info(state: web::Data<AppState>) -> HttpResponse {
 }
 
 #[cfg(feature = "experimental")]
-/// Default limit for spot_prices and pool_depths entries.
+/// Default limit for spot_prices and component_depths entries.
 const DEFAULT_PRICES_LIMIT: usize = 1000;
 
 #[cfg(feature = "experimental")]
@@ -226,7 +226,7 @@ const DEFAULT_PRICES_LIMIT: usize = 1000;
 /// # Query Parameters
 ///
 /// - `include` - Comma-separated list: `depths`, `spot_prices`
-/// - `limit` - Max entries for spot_prices / pool_depths (default: 1000)
+/// - `limit` - Max entries for spot_prices / component_depths (default: 1000)
 #[utoipa::path(
     get,
     path = "/v1/prices",
@@ -316,10 +316,10 @@ pub async fn get_prices(
 
     // Convert component depths if requested (sorted for deterministic limit)
     let component_depths = if want_depths {
-        let mut entries: Vec<PoolDepthEntry> = component_depths_data
+        let mut entries: Vec<ComponentDepthEntry> = component_depths_data
             .into_iter()
             .flatten()
-            .map(|((component_id, token_in, token_out), depth)| PoolDepthEntry {
+            .map(|((component_id, token_in, token_out), depth)| ComponentDepthEntry {
                 component_id,
                 token_in,
                 token_out,
@@ -345,16 +345,16 @@ pub async fn get_prices(
         blocks: ComputationBlocks {
             token_prices: token_prices_block,
             spot_prices: spot_prices_block,
-            pool_depths: component_depths_block,
+            component_depths: component_depths_block,
         },
         spot_prices,
-        pool_depths: component_depths,
+        component_depths,
     };
 
     info!(
         num_tokens = response.prices.len(),
         has_spot = response.spot_prices.is_some(),
-        has_depths = response.pool_depths.is_some(),
+        has_depths = response.component_depths.is_some(),
         "prices response"
     );
 

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -221,7 +221,7 @@ const DEFAULT_PRICES_LIMIT: usize = 1000;
 /// GET /v1/prices - Return derived token prices and optional market data.
 ///
 /// By default returns token gas prices only. Use `include` query parameter
-/// to add spot prices and/or pool depths.
+/// to add spot prices and/or component depths.
 ///
 /// # Query Parameters
 ///
@@ -262,14 +262,14 @@ pub async fn get_prices(
     if want_spot && store.spot_prices_block().is_none() {
         return Err(ApiError::StaleData { age_ms: u64::MAX });
     }
-    if want_depths && store.pool_depths_block().is_none() {
+    if want_depths && store.component_depths_block().is_none() {
         return Err(ApiError::StaleData { age_ms: u64::MAX });
     }
     let spot_prices_block = store.spot_prices_block();
-    let pool_depths_block = store.pool_depths_block();
+    let component_depths_block = store.component_depths_block();
     let token_prices = store.token_prices().cloned();
     let spot_prices_data = if want_spot { store.spot_prices().cloned() } else { None };
-    let pool_depths_data = if want_depths { store.pool_depths().cloned() } else { None };
+    let component_depths_data = if want_depths { store.component_depths().cloned() } else { None };
     drop(store);
 
     // Convert token gas prices
@@ -314,9 +314,9 @@ pub async fn get_prices(
         None
     };
 
-    // Convert pool depths if requested (sorted for deterministic limit)
-    let pool_depths = if want_depths {
-        let mut entries: Vec<PoolDepthEntry> = pool_depths_data
+    // Convert component depths if requested (sorted for deterministic limit)
+    let component_depths = if want_depths {
+        let mut entries: Vec<PoolDepthEntry> = component_depths_data
             .into_iter()
             .flatten()
             .map(|((component_id, token_in, token_out), depth)| PoolDepthEntry {
@@ -345,10 +345,10 @@ pub async fn get_prices(
         blocks: ComputationBlocks {
             token_prices: token_prices_block,
             spot_prices: spot_prices_block,
-            pool_depths: pool_depths_block,
+            pool_depths: component_depths_block,
         },
         spot_prices,
-        pool_depths,
+        pool_depths: component_depths,
     };
 
     info!(

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -68,7 +68,7 @@ pub struct ApiDoc;
         prices::PricesResponse,
         prices::TokenPriceEntry,
         prices::SpotPriceEntry,
-        prices::PoolDepthEntry,
+        prices::ComponentDepthEntry,
     ))
 )]
 pub struct ExperimentalApiDoc;

--- a/fynd-rpc/src/api/prices.rs
+++ b/fynd-rpc/src/api/prices.rs
@@ -22,7 +22,7 @@ pub struct PricesQuery {
 /// Parsed variant of the `include` query parameter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IncludeField {
-    /// Include pool depth data.
+    /// Include component depth data.
     Depths,
     /// Include spot price data.
     SpotPrices,
@@ -71,7 +71,7 @@ pub struct ComputationBlocks {
     /// Block at which spot prices were computed. `None` if not yet available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spot_prices: Option<u64>,
-    /// Block at which pool depths were computed. `None` if not yet available.
+    /// Block at which component depths were computed. `None` if not yet available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pool_depths: Option<u64>,
 }
@@ -86,10 +86,10 @@ pub struct PricesResponse {
     pub gas_token: Address,
     /// Block numbers at which each computation was last run.
     pub blocks: ComputationBlocks,
-    /// Spot prices per pool direction (only if requested via `include=spot_prices`).
+    /// Spot prices per component direction (only if requested via `include=spot_prices`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spot_prices: Option<Vec<SpotPriceEntry>>,
-    /// Pool depths per pool direction (only if requested via `include=depths`).
+    /// Component depths per component direction (only if requested via `include=depths`).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pool_depths: Option<Vec<PoolDepthEntry>>,
 }
@@ -104,10 +104,10 @@ pub struct TokenPriceEntry {
     pub price: f64,
 }
 
-/// A single directional spot price within a pool.
+/// A single directional spot price within a component (liquidity pool).
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SpotPriceEntry {
-    /// Pool / component identifier.
+    /// Component (liquidity pool) identifier.
     pub component_id: ComponentId,
     /// Input token address.
     #[schema(value_type = String, example = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]
@@ -119,10 +119,10 @@ pub struct SpotPriceEntry {
     pub price: f64,
 }
 
-/// A single directional pool depth.
+/// A single directional component depth.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct PoolDepthEntry {
-    /// Pool / component identifier.
+    /// Component (liquidity pool) identifier.
     pub component_id: ComponentId,
     /// Input token address.
     #[schema(value_type = String, example = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")]

--- a/fynd-rpc/src/api/prices.rs
+++ b/fynd-rpc/src/api/prices.rs
@@ -14,7 +14,7 @@ pub struct PricesQuery {
     /// Valid values: `depths`, `spot_prices`.
     #[param(example = "depths,spot_prices")]
     pub include: Option<String>,
-    /// Maximum number of spot_prices and pool_depths entries (default: 1000).
+    /// Maximum number of spot_prices and component_depths entries (default: 1000).
     #[param(example = 1000)]
     pub limit: Option<usize>,
 }
@@ -73,7 +73,7 @@ pub struct ComputationBlocks {
     pub spot_prices: Option<u64>,
     /// Block at which component depths were computed. `None` if not yet available.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pool_depths: Option<u64>,
+    pub component_depths: Option<u64>,
 }
 
 /// Top-level response for GET /v1/prices.
@@ -91,7 +91,7 @@ pub struct PricesResponse {
     pub spot_prices: Option<Vec<SpotPriceEntry>>,
     /// Component depths per component direction (only if requested via `include=depths`).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub pool_depths: Option<Vec<PoolDepthEntry>>,
+    pub component_depths: Option<Vec<ComponentDepthEntry>>,
 }
 
 /// A single token's gas price.
@@ -121,7 +121,7 @@ pub struct SpotPriceEntry {
 
 /// A single directional component depth.
 #[derive(Debug, Serialize, ToSchema)]
-pub struct PoolDepthEntry {
+pub struct ComponentDepthEntry {
     /// Component (liquidity pool) identifier.
     pub component_id: ComponentId,
     /// Input token address.

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -15,7 +15,7 @@ use tycho_simulation::tycho_common::models::{chain_config::TvlThresholdTier, Cha
 
 use crate::{
     api::{configure_app, AppState, HealthTracker},
-    config::{defaults, PoolConfig},
+    config::{defaults, WorkerPoolConfig},
 };
 
 /// Builder that assembles Fynd and returns a running server handle.
@@ -45,7 +45,7 @@ impl FyndRPCBuilder {
     /// hex address.
     pub fn new(
         chain: Chain,
-        pools: HashMap<String, PoolConfig>,
+        pools: HashMap<String, WorkerPoolConfig>,
         tycho_url: String,
         rpc_url: String,
         protocols: Vec<String>,
@@ -62,7 +62,7 @@ impl FyndRPCBuilder {
                     protocols,
                     chain.default_tvl_threshold(TvlThresholdTier::Low),
                 ),
-                |sb, (name, cfg)| sb.add_pool(name, cfg),
+                |sb, (name, cfg)| sb.add_worker_pool(name, cfg),
             )?
             .worker_router_timeout(Duration::from_millis(defaults::WORKER_ROUTER_TIMEOUT_MS));
         Ok(Self {

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -169,7 +169,7 @@ impl FyndRPCBuilder {
 
     /// Enables partial block (flashblock) updates from the Tycho stream (default: `false`).
     ///
-    /// When enabled, the stream delivers pool state updates mid-block rather than only at
+    /// When enabled, the stream delivers component state updates mid-block rather than only at
     /// finalization, reducing latency. Only supported for on-chain protocols; RFQ streams are
     /// unaffected.
     pub fn partial_blocks(mut self, enabled: bool) -> Self {

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -41,8 +41,8 @@ impl FyndRPCBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`SolverBuildError`] if any pool's `connector_tokens` contains a malformed hex
-    /// address.
+    /// Returns [`SolverBuildError`] if any worker pool's `connector_tokens` contains a malformed
+    /// hex address.
     pub fn new(
         chain: Chain,
         pools: HashMap<String, PoolConfig>,

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -15,7 +15,7 @@ use tycho_simulation::tycho_common::models::{chain_config::TvlThresholdTier, Cha
 
 use crate::{
     api::{configure_app, AppState, HealthTracker},
-    config::{defaults, WorkerPoolConfig},
+    config::{defaults, PoolConfig},
 };
 
 /// Builder that assembles Fynd and returns a running server handle.
@@ -45,7 +45,7 @@ impl FyndRPCBuilder {
     /// hex address.
     pub fn new(
         chain: Chain,
-        pools: HashMap<String, WorkerPoolConfig>,
+        pools: HashMap<String, PoolConfig>,
         tycho_url: String,
         rpc_url: String,
         protocols: Vec<String>,
@@ -62,7 +62,7 @@ impl FyndRPCBuilder {
                     protocols,
                     chain.default_tvl_threshold(TvlThresholdTier::Low),
                 ),
-                |sb, (name, cfg)| sb.add_worker_pool(name, cfg),
+                |sb, (name, cfg)| sb.add_pool(name, cfg),
             )?
             .worker_router_timeout(Duration::from_millis(defaults::WORKER_ROUTER_TIMEOUT_MS));
         Ok(Self {

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-pub use fynd_core::PoolConfig;
+pub use fynd_core::WorkerPoolConfig;
 use serde::{Deserialize, Serialize};
 
 /// The default worker pools configuration embedded at compile time.
@@ -39,22 +39,22 @@ timeout_ms = 500
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerPoolsConfig {
     /// Worker pool configurations (at least one worker pool must be specified)
-    pools: HashMap<String, PoolConfig>,
+    pools: HashMap<String, WorkerPoolConfig>,
 }
 
 impl WorkerPoolsConfig {
     /// Creates a new config from a map of worker pool configs.
-    pub fn new(pools: HashMap<String, PoolConfig>) -> Self {
+    pub fn new(pools: HashMap<String, WorkerPoolConfig>) -> Self {
         Self { pools }
     }
 
     /// Returns the worker pool configurations.
-    pub fn pools(&self) -> &HashMap<String, PoolConfig> {
+    pub fn pools(&self) -> &HashMap<String, WorkerPoolConfig> {
         &self.pools
     }
 
     /// Consumes the config and returns the map of worker pool configs.
-    pub fn into_pools(self) -> HashMap<String, PoolConfig> {
+    pub fn into_pools(self) -> HashMap<String, WorkerPoolConfig> {
         self.pools
     }
 
@@ -135,10 +135,10 @@ mod tests {
         assert_eq!(pool.algorithm(), "most_liquid");
         assert_eq!(pool.num_workers(), num_cpus::get());
         use fynd_core::solver::defaults as core_defaults;
-        assert_eq!(pool.task_queue_capacity(), core_defaults::POOL_TASK_QUEUE_CAPACITY);
-        assert_eq!(pool.min_hops(), core_defaults::POOL_MIN_HOPS);
-        assert_eq!(pool.max_hops(), core_defaults::POOL_MAX_HOPS);
-        assert_eq!(pool.timeout_ms(), core_defaults::POOL_TIMEOUT_MS);
+        assert_eq!(pool.task_queue_capacity(), core_defaults::WORKER_POOL_TASK_QUEUE_CAPACITY);
+        assert_eq!(pool.min_hops(), core_defaults::WORKER_POOL_MIN_HOPS);
+        assert_eq!(pool.max_hops(), core_defaults::WORKER_POOL_MAX_HOPS);
+        assert_eq!(pool.timeout_ms(), core_defaults::WORKER_POOL_TIMEOUT_MS);
         assert_eq!(pool.max_routes(), None);
     }
 

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-pub use fynd_core::WorkerPoolConfig;
+pub use fynd_core::PoolConfig;
 use serde::{Deserialize, Serialize};
 
 /// The default worker pools configuration embedded at compile time.
@@ -39,22 +39,22 @@ timeout_ms = 500
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerPoolsConfig {
     /// Worker pool configurations (at least one worker pool must be specified)
-    pools: HashMap<String, WorkerPoolConfig>,
+    pools: HashMap<String, PoolConfig>,
 }
 
 impl WorkerPoolsConfig {
     /// Creates a new config from a map of worker pool configs.
-    pub fn new(pools: HashMap<String, WorkerPoolConfig>) -> Self {
+    pub fn new(pools: HashMap<String, PoolConfig>) -> Self {
         Self { pools }
     }
 
     /// Returns the worker pool configurations.
-    pub fn pools(&self) -> &HashMap<String, WorkerPoolConfig> {
+    pub fn pools(&self) -> &HashMap<String, PoolConfig> {
         &self.pools
     }
 
     /// Consumes the config and returns the map of worker pool configs.
-    pub fn into_pools(self) -> HashMap<String, WorkerPoolConfig> {
+    pub fn into_pools(self) -> HashMap<String, PoolConfig> {
         self.pools
     }
 
@@ -135,10 +135,10 @@ mod tests {
         assert_eq!(pool.algorithm(), "most_liquid");
         assert_eq!(pool.num_workers(), num_cpus::get());
         use fynd_core::solver::defaults as core_defaults;
-        assert_eq!(pool.task_queue_capacity(), core_defaults::WORKER_POOL_TASK_QUEUE_CAPACITY);
-        assert_eq!(pool.min_hops(), core_defaults::WORKER_POOL_MIN_HOPS);
-        assert_eq!(pool.max_hops(), core_defaults::WORKER_POOL_MAX_HOPS);
-        assert_eq!(pool.timeout_ms(), core_defaults::WORKER_POOL_TIMEOUT_MS);
+        assert_eq!(pool.task_queue_capacity(), core_defaults::POOL_TASK_QUEUE_CAPACITY);
+        assert_eq!(pool.min_hops(), core_defaults::POOL_MIN_HOPS);
+        assert_eq!(pool.max_hops(), core_defaults::POOL_MAX_HOPS);
+        assert_eq!(pool.timeout_ms(), core_defaults::POOL_TIMEOUT_MS);
         assert_eq!(pool.max_routes(), None);
     }
 

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -78,7 +78,7 @@ impl WorkerPoolsConfig {
 /// Blocklist configuration for excluding components from the Tycho stream.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct BlocklistConfig {
-    /// Component IDs to exclude (e.g., pool addresses with simulation issues).
+    /// Component IDs to exclude (e.g., component addresses with simulation issues).
     #[serde(default)]
     components: HashSet<String>,
 }

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -24,9 +24,9 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
-# Example: an exclusive-access pool that also routes through exclusive liquidity (see repo-root
-# worker_pools.toml). Public pools (liquidity_scope omitted; defaults to "public_only") never see exclusive
-# components.
+# Example: an exclusive-access worker pool that also routes through exclusive liquidity (see
+# repo-root worker_pools.toml). Public worker pools (liquidity_scope omitted; defaults to
+# "public_only") never see exclusive components.
 # [pools.exclusive_access]
 # algorithm = "bellman_ford"
 # num_workers = 3
@@ -38,22 +38,22 @@ timeout_ms = 500
 /// Worker pools configuration loaded from TOML file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkerPoolsConfig {
-    /// Pool configurations (at least one pool must be specified)
+    /// Worker pool configurations (at least one worker pool must be specified)
     pools: HashMap<String, PoolConfig>,
 }
 
 impl WorkerPoolsConfig {
-    /// Creates a new config from a pools map.
+    /// Creates a new config from a map of worker pool configs.
     pub fn new(pools: HashMap<String, PoolConfig>) -> Self {
         Self { pools }
     }
 
-    /// Returns the pool configurations.
+    /// Returns the worker pool configurations.
     pub fn pools(&self) -> &HashMap<String, PoolConfig> {
         &self.pools
     }
 
-    /// Consumes the config and returns the pools map.
+    /// Consumes the config and returns the map of worker pool configs.
     pub fn into_pools(self) -> HashMap<String, PoolConfig> {
         self.pools
     }

--- a/fynd-rpc/src/lib.rs
+++ b/fynd-rpc/src/lib.rs
@@ -19,7 +19,7 @@
 pub mod api;
 /// Server builder and runner.
 pub mod builder;
-/// TOML-based pool configuration and server defaults.
+/// TOML-based worker pool configuration and server defaults.
 pub mod config;
 /// Protocol discovery via the Tycho RPC.
 pub mod protocols;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,7 +128,7 @@ pub struct ServeArgs {
     pub gas_price_stale_threshold_secs: Option<u64>,
 
     /// Enable partial block (flashblock) updates from the Tycho stream.
-    /// When enabled, pool state updates arrive mid-block rather than only at finalization,
+    /// When enabled, component state updates arrive mid-block rather than only at finalization,
     /// reducing latency. Only applies to on-chain protocols.
     #[arg(long)]
     pub partial_blocks: bool,

--- a/src/commands/derive_connector_tokens.rs
+++ b/src/commands/derive_connector_tokens.rs
@@ -13,7 +13,7 @@ use tycho_simulation::tycho_common::models::{chain_config::TvlThresholdTier, Add
 /// Derives recommended connector tokens from live Tycho market data.
 ///
 /// Connects to Tycho, waits for the initial market snapshot, then ranks every
-/// token by how many pools it appears in. The most-connected tokens are the best
+/// token by how many components it appears in. The most-connected tokens are the best
 /// candidates for intermediate ("connector") hops in multi-hop routes.
 ///
 /// Outputs a ranked list and a ready-to-paste TOML snippet.
@@ -43,7 +43,7 @@ pub struct DeriveConnectorTokensArgs {
     #[arg(short, long, value_delimiter = ',', value_name = "PROTO1,PROTO2")]
     pub protocols: Vec<String>,
 
-    /// Minimum TVL threshold in native token. Pools below this threshold are excluded.
+    /// Minimum TVL threshold in native token. Components below this threshold are excluded.
     /// Defaults to a chain-specific value if not set.
     #[arg(long)]
     pub min_tvl: Option<f64>,
@@ -52,9 +52,9 @@ pub struct DeriveConnectorTokensArgs {
     #[arg(long, default_value_t = 10)]
     pub top_n: usize,
 
-    /// Minimum number of pools a token must appear in to be included.
+    /// Minimum number of components a token must appear in to be included.
     #[arg(long, default_value_t = 2)]
-    pub min_pool_count: usize,
+    pub min_component_count: usize,
 
     /// Output format: "toml", "json", or "text".
     #[arg(long, default_value = "toml")]
@@ -113,7 +113,7 @@ pub async fn run(args: DeriveConnectorTokensArgs) -> Result<()> {
     let market_data = solver.market_data();
 
     // We only need component topology and token symbols — market data is sufficient.
-    // wait_until_ready also waits for derived computations (spot prices, pool depths, etc.)
+    // wait_until_ready also waits for derived computations (spot prices, component depths, etc.)
     // which is expensive and unnecessary here.
     info!("Waiting for Tycho initial snapshot (up to {}s)…", args.wait_secs);
     let deadline = tokio::time::Instant::now() + Duration::from_secs(args.wait_secs);
@@ -136,12 +136,12 @@ pub async fn run(args: DeriveConnectorTokensArgs) -> Result<()> {
 
     let scores = score_tokens(&market_data).await;
     let mut ranked: Vec<(Address, TokenScore)> = scores.into_iter().collect();
-    ranked.sort_by_key(|(_, s)| std::cmp::Reverse(s.pool_count));
+    ranked.sort_by_key(|(_, s)| std::cmp::Reverse(s.component_count));
     let total = ranked.len();
 
     let mut candidates: Vec<&(Address, TokenScore)> = ranked
         .iter()
-        .filter(|(_, s)| s.pool_count >= args.min_pool_count)
+        .filter(|(_, s)| s.component_count >= args.min_component_count)
         .take(args.top_n)
         .collect();
 
@@ -171,31 +171,31 @@ pub async fn run(args: DeriveConnectorTokensArgs) -> Result<()> {
 
 struct TokenScore {
     symbol: String,
-    pool_count: usize,
+    component_count: usize,
 }
 
 async fn score_tokens(market_data: &MarketData) -> HashMap<Address, TokenScore> {
     let guard = market_data.read().await;
     let topology = guard.component_topology();
 
-    // Count pool appearances per token.
-    let mut pool_count: HashMap<Address, usize> = HashMap::new();
+    // Count component appearances per token.
+    let mut component_count: HashMap<Address, usize> = HashMap::new();
     for tokens in topology.values() {
         for addr in tokens {
-            *pool_count
+            *component_count
                 .entry(addr.clone())
                 .or_insert(0) += 1;
         }
     }
 
-    pool_count
+    component_count
         .into_iter()
         .map(|(addr, count)| {
             let symbol = guard
                 .get_token(&addr)
                 .map(|t| t.symbol.clone())
                 .unwrap_or_else(|| "?".to_string());
-            (addr, TokenScore { symbol, pool_count: count })
+            (addr, TokenScore { symbol, component_count: count })
         })
         .collect()
 }
@@ -204,14 +204,14 @@ fn print_toml(candidates: &[&(Address, TokenScore)], chain: &str, total: usize) 
     use chrono::Utc;
     let date = Utc::now().format("%Y-%m-%d");
     println!("# Derived connector tokens for {chain} ({date})");
-    println!("# Score = pool_count. Top {} of {} tokens.", candidates.len(), total);
+    println!("# Score = component_count. Top {} of {} tokens.", candidates.len(), total);
     println!("connector_tokens = [");
     for (addr, score) in candidates {
         println!(
-            "    \"0x{}\",  # {}  — {} pools",
+            "    \"0x{}\",  # {}  — {} components",
             hex::encode(addr.as_ref()),
             score.symbol,
-            score.pool_count,
+            score.component_count,
         );
     }
     println!("]");
@@ -224,7 +224,7 @@ fn print_json(candidates: &[&(Address, TokenScore)], _total: usize) -> Result<()
             serde_json::json!({
                 "address": format!("0x{}", hex::encode(addr.as_ref())),
                 "symbol": score.symbol,
-                "pool_count": score.pool_count,
+                "component_count": score.component_count,
             })
         })
         .collect();
@@ -240,7 +240,7 @@ fn print_text(candidates: &[&(Address, TokenScore)], _total: usize) {
             "{:<5} {:<10} {:>6}  0x{}",
             i + 1,
             score.symbol,
-            score.pool_count,
+            score.component_count,
             hex::encode(addr.as_ref()),
         );
     }

--- a/test-fixtures/src/expected.rs
+++ b/test-fixtures/src/expected.rs
@@ -46,8 +46,8 @@ pub struct ExpectedFile {
 pub struct ExpectedMetadata {
     /// Block number of the last recorded update.
     pub block_number: u64,
-    /// Total registered pool count.
-    pub num_pools: usize,
+    /// Total registered component count.
+    pub num_components: usize,
     /// Total registered token count.
     pub num_tokens: usize,
     /// Fynd crate version at generation time.
@@ -60,10 +60,10 @@ pub struct ExpectedMetadata {
 /// Snapshot of derived data counts for deterministic replay assertions.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DerivedDataMetrics {
-    /// Number of unique pools with at least one spot price.
-    pub spot_price_pools: usize,
-    /// Number of unique pools with at least one pool depth.
-    pub pool_depth_pools: usize,
+    /// Number of unique components with at least one spot price.
+    pub components_with_spot_prices: usize,
+    /// Number of unique components with at least one component depth.
+    pub components_with_depths: usize,
     /// Number of tokens with gas price conversions.
     pub token_prices: usize,
 }

--- a/test-fixtures/src/lib.rs
+++ b/test-fixtures/src/lib.rs
@@ -17,10 +17,10 @@ pub use scenarios::{load_test_scenarios, TestScenario};
 /// Parse a `worker_pools.toml` string into a pool name → config map.
 pub fn parse_pools_toml(
     toml_content: &str,
-) -> anyhow::Result<std::collections::HashMap<String, fynd_core::PoolConfig>> {
+) -> anyhow::Result<std::collections::HashMap<String, fynd_core::WorkerPoolConfig>> {
     #[derive(serde::Deserialize)]
     struct PoolsFile {
-        pools: std::collections::HashMap<String, fynd_core::PoolConfig>,
+        pools: std::collections::HashMap<String, fynd_core::WorkerPoolConfig>,
     }
     let config: PoolsFile = toml::from_str(toml_content)?;
     Ok(config.pools)

--- a/test-fixtures/src/lib.rs
+++ b/test-fixtures/src/lib.rs
@@ -17,10 +17,10 @@ pub use scenarios::{load_test_scenarios, TestScenario};
 /// Parse a `worker_pools.toml` string into a pool name → config map.
 pub fn parse_pools_toml(
     toml_content: &str,
-) -> anyhow::Result<std::collections::HashMap<String, fynd_core::WorkerPoolConfig>> {
+) -> anyhow::Result<std::collections::HashMap<String, fynd_core::PoolConfig>> {
     #[derive(serde::Deserialize)]
     struct PoolsFile {
-        pools: std::collections::HashMap<String, fynd_core::WorkerPoolConfig>,
+        pools: std::collections::HashMap<String, fynd_core::PoolConfig>,
     }
     let config: PoolsFile = toml::from_str(toml_content)?;
     Ok(config.pools)

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -79,6 +79,6 @@ the integration tests in `fynd-core/tests/integration/`.
 
 Shared fixture types live in the `fynd-test-fixtures` crate. Worker pool configuration comes from
 the production `worker_pools.toml`; its SHA-256 is stored in the recording metadata so tests can
-detect drift. VM-backed protocol states (e.g. `vm:*` pools) cannot be serialized and are skipped.
+detect drift. VM-backed protocol states (e.g. `vm:*` components) cannot be serialized and are skipped.
 
 See [`tools/record-market/README.md`](record-market/README.md) for usage.

--- a/tools/benchmark/src/scale.rs
+++ b/tools/benchmark/src/scale.rs
@@ -16,7 +16,7 @@ use clap::Parser;
 use fynd_client::FyndClientBuilder;
 use fynd_rpc::{
     builder::{FyndRPC, FyndRPCBuilder},
-    config::{WorkerPoolConfig, WorkerPoolsConfig},
+    config::{PoolConfig, WorkerPoolsConfig},
     parse_chain,
     protocols::resolve_protocols,
 };
@@ -155,7 +155,7 @@ fn parse_worker_counts(s: &str) -> Result<Vec<usize>> {
     Ok(counts)
 }
 
-fn validate_single_pool(config: &WorkerPoolsConfig) -> Result<(String, WorkerPoolConfig)> {
+fn validate_single_pool(config: &WorkerPoolsConfig) -> Result<(String, PoolConfig)> {
     if config.pools().is_empty() {
         bail!("base config has no pools; exactly one pool is required");
     }
@@ -173,7 +173,7 @@ fn validate_single_pool(config: &WorkerPoolsConfig) -> Result<(String, WorkerPoo
 fn build_solver(
     args: &Args,
     pool_name: &str,
-    pool_config: &WorkerPoolConfig,
+    pool_config: &PoolConfig,
     protocols: &[String],
     workers: usize,
 ) -> Result<FyndRPC> {
@@ -475,7 +475,7 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             "test_pool".to_string(),
-            WorkerPoolConfig::new("most_liquid")
+            PoolConfig::new("most_liquid")
                 .with_num_workers(4)
                 .with_task_queue_capacity(1000)
                 .with_min_hops(1)
@@ -494,7 +494,7 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             "a".to_string(),
-            WorkerPoolConfig::new("most_liquid")
+            PoolConfig::new("most_liquid")
                 .with_num_workers(4)
                 .with_task_queue_capacity(1000)
                 .with_min_hops(1)
@@ -503,7 +503,7 @@ mod tests {
         );
         pools.insert(
             "b".to_string(),
-            WorkerPoolConfig::new("dijkstra")
+            PoolConfig::new("dijkstra")
                 .with_num_workers(2)
                 .with_task_queue_capacity(500)
                 .with_min_hops(1)

--- a/tools/benchmark/src/scale.rs
+++ b/tools/benchmark/src/scale.rs
@@ -16,7 +16,7 @@ use clap::Parser;
 use fynd_client::FyndClientBuilder;
 use fynd_rpc::{
     builder::{FyndRPC, FyndRPCBuilder},
-    config::{PoolConfig, WorkerPoolsConfig},
+    config::{WorkerPoolConfig, WorkerPoolsConfig},
     parse_chain,
     protocols::resolve_protocols,
 };
@@ -155,7 +155,7 @@ fn parse_worker_counts(s: &str) -> Result<Vec<usize>> {
     Ok(counts)
 }
 
-fn validate_single_pool(config: &WorkerPoolsConfig) -> Result<(String, PoolConfig)> {
+fn validate_single_pool(config: &WorkerPoolsConfig) -> Result<(String, WorkerPoolConfig)> {
     if config.pools().is_empty() {
         bail!("base config has no pools; exactly one pool is required");
     }
@@ -173,7 +173,7 @@ fn validate_single_pool(config: &WorkerPoolsConfig) -> Result<(String, PoolConfi
 fn build_solver(
     args: &Args,
     pool_name: &str,
-    pool_config: &PoolConfig,
+    pool_config: &WorkerPoolConfig,
     protocols: &[String],
     workers: usize,
 ) -> Result<FyndRPC> {
@@ -475,7 +475,7 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             "test_pool".to_string(),
-            PoolConfig::new("most_liquid")
+            WorkerPoolConfig::new("most_liquid")
                 .with_num_workers(4)
                 .with_task_queue_capacity(1000)
                 .with_min_hops(1)
@@ -494,7 +494,7 @@ mod tests {
         let mut pools = HashMap::new();
         pools.insert(
             "a".to_string(),
-            PoolConfig::new("most_liquid")
+            WorkerPoolConfig::new("most_liquid")
                 .with_num_workers(4)
                 .with_task_queue_capacity(1000)
                 .with_min_hops(1)
@@ -503,7 +503,7 @@ mod tests {
         );
         pools.insert(
             "b".to_string(),
-            PoolConfig::new("dijkstra")
+            WorkerPoolConfig::new("dijkstra")
                 .with_num_workers(2)
                 .with_task_queue_capacity(500)
                 .with_min_hops(1)

--- a/tools/common/src/aggregator.rs
+++ b/tools/common/src/aggregator.rs
@@ -77,7 +77,8 @@ pub struct AggregatorQuote {
     /// Encoded on-chain transaction. Present only when calldata was requested and the
     /// aggregator has an encoding endpoint. `None` otherwise.
     pub calldata: Option<AggregatorCalldata>,
-    /// Pool-level route: `[protocol, component_id]` pairs (Fynd only; `None` for aggregators).
+    /// Component-level route: `[protocol, component_id]` pairs (Fynd only; `None` for
+    /// aggregators).
     pub route: Option<Vec<[String; 2]>>,
 }
 

--- a/tools/fynd-swap-cli/src/main.rs
+++ b/tools/fynd-swap-cli/src/main.rs
@@ -144,14 +144,14 @@ async fn wait_for_health(client: &FyndClient, fynd_url: &str) -> anyhow::Result<
                 if tokio::time::Instant::now() >= deadline {
                     bail!(
                         "solver at {fynd_url} not healthy after 30s \
-                         (last update: {}ms ago, {} pools); \
+                         (last update: {}ms ago, {} solver pools); \
                          wait for market data to load",
                         h.last_update_ms(),
                         h.num_solver_pools()
                     );
                 }
                 info!(
-                    "Solver not ready yet ({} pools, last update {}ms ago), retrying...",
+                    "Solver not ready yet ({} solver pools, last update {}ms ago), retrying...",
                     h.num_solver_pools(),
                     h.last_update_ms()
                 );
@@ -430,7 +430,7 @@ async fn main() -> anyhow::Result<()> {
         println!("Route ({} hops):", route.swaps().len());
         for (i, swap) in route.swaps().iter().enumerate() {
             println!(
-                "  {}. 0x{} -> 0x{} via {} (pool: {})",
+                "  {}. 0x{} -> 0x{} via {} (component: {})",
                 i + 1,
                 hex::encode(swap.token_in()),
                 hex::encode(swap.token_out()),

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -374,7 +374,7 @@ async fn build_solver(
     }
     for (name, pool) in pools_config.pools() {
         builder = builder
-            .add_pool(name, pool)
+            .add_worker_pool(name, pool)
             .map_err(|e| anyhow::anyhow!("failed to add worker pool {name}: {e}"))?;
     }
     builder

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -374,7 +374,7 @@ async fn build_solver(
     }
     for (name, pool) in pools_config.pools() {
         builder = builder
-            .add_worker_pool(name, pool)
+            .add_pool(name, pool)
             .map_err(|e| anyhow::anyhow!("failed to add worker pool {name}: {e}"))?;
     }
     builder

--- a/tools/record-market/src/expected.rs
+++ b/tools/record-market/src/expected.rs
@@ -84,7 +84,7 @@ pub async fn generate_expected_outputs(
     let derived_metrics = {
         let derived_ref = solver.derived_data();
         let d = derived_ref.read().await;
-        let spot_price_pools = d
+        let components_with_spot_prices = d
             .spot_prices()
             .map(|sp| {
                 sp.keys()
@@ -93,8 +93,8 @@ pub async fn generate_expected_outputs(
                     .len()
             })
             .unwrap_or(0);
-        let pool_depth_pools = d
-            .pool_depths()
+        let components_with_depths = d
+            .component_depths()
             .map(|pd| {
                 pd.keys()
                     .map(|(id, _, _)| id.clone())
@@ -106,7 +106,7 @@ pub async fn generate_expected_outputs(
             .token_prices()
             .map(|tp| tp.len())
             .unwrap_or(0);
-        DerivedDataMetrics { spot_price_pools, pool_depth_pools, token_prices }
+        DerivedDataMetrics { components_with_spot_prices, components_with_depths, token_prices }
     };
 
     let market_ref = solver.market_data();
@@ -117,7 +117,7 @@ pub async fn generate_expected_outputs(
         .last_updated()
         .map(|block| block.number())
         .unwrap_or(0);
-    let num_pools = market.component_topology().len();
+    let num_components = market.component_topology().len();
     let num_tokens = market.token_registry_ref().len();
     drop(market);
 
@@ -126,7 +126,7 @@ pub async fn generate_expected_outputs(
     Ok(ExpectedFile {
         metadata: ExpectedMetadata {
             block_number,
-            num_pools,
+            num_components,
             num_tokens,
             fynd_version: env!("CARGO_PKG_VERSION").to_string(),
             derived_data: Some(derived_metrics),

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -12,10 +12,10 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
-# Example: an exclusive-access pool. `liquidity_scope = "all"` lets this pool route through
-# exclusive components (in addition to all public liquidity) to capture surplus above the best
-# public rate. Public pools (liquidity_scope omitted; defaults to "public_only") never see exclusive
-# components.
+# Example: an exclusive-access worker pool. `liquidity_scope = "all"` lets this worker pool route
+# through exclusive components (in addition to all public liquidity) to capture surplus above the
+# best public rate. Public worker pools (liquidity_scope omitted; defaults to "public_only") never
+# see exclusive components.
 # [pools.exclusive_access]
 # algorithm = "bellman_ford"
 # num_workers = 3
@@ -34,16 +34,16 @@ timeout_ms = 500
 # max_hops   = 3
 # timeout_ms = 500
 # connector_tokens = [
-#     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",  # WETH    — 1639 pools
-#     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",  # USDC    —  330 pools
-#     "0xdac17f958d2ee523a2206206994597c13d831ec7",  # USDT    —  237 pools
-#     "0x0000000000000000000000000000000000000000",  # ETH     —  195 pools
-#     "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",  # WBTC    —   78 pools
-#     "0x6b175474e89094c44da98b954eedeac495271d0f",  # DAI     —   43 pools
-#     "0x68749665ff8d2d112fa859aa293f07a622782f38",  # XAUt    —   23 pools
-#     "0x45804880de22913dafe09f4980848ece6ecbaf78",  # PAXG    —   19 pools
-#     "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",  # UNI     —   19 pools
-#     "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",  # wstETH  —   19 pools
+#     "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",  # WETH    — 1639 components
+#     "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",  # USDC    —  330 components
+#     "0xdac17f958d2ee523a2206206994597c13d831ec7",  # USDT    —  237 components
+#     "0x0000000000000000000000000000000000000000",  # ETH     —  195 components
+#     "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",  # WBTC    —   78 components
+#     "0x6b175474e89094c44da98b954eedeac495271d0f",  # DAI     —   43 components
+#     "0x68749665ff8d2d112fa859aa293f07a622782f38",  # XAUt    —   23 components
+#     "0x45804880de22913dafe09f4980848ece6ecbaf78",  # PAXG    —   19 components
+#     "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",  # UNI     —   19 components
+#     "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",  # wstETH  —   19 components
 # ]
 #
 # --- Base ---
@@ -52,14 +52,14 @@ timeout_ms = 500
 # max_hops   = 3
 # timeout_ms = 500
 # connector_tokens = [
-#     "0x4200000000000000000000000000000000000006",  # WETH    —  565 pools
-#     "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",  # USDC    —  259 pools
-#     "0xb20a4bd059f5914a2f8b9c18881c637f79efb7df",  # ADS     —  104 pools
-#     "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b",  # VIRTUAL —   89 pools
-#     "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",  # cbBTC   —   45 pools
-#     "0x0000000000000000000000000000000000000000",  # ETH     —   38 pools
-#     "0x940181a94a35a4569e4529a3cdfb74e38fd98631",  # AERO    —   13 pools
-#     "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",  # USDT    —   11 pools
-#     "0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf",  # VVV     —   11 pools
-#     "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",  # cbETH   —   10 pools
+#     "0x4200000000000000000000000000000000000006",  # WETH    —  565 components
+#     "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",  # USDC    —  259 components
+#     "0xb20a4bd059f5914a2f8b9c18881c637f79efb7df",  # ADS     —  104 components
+#     "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b",  # VIRTUAL —   89 components
+#     "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf",  # cbBTC   —   45 components
+#     "0x0000000000000000000000000000000000000000",  # ETH     —   38 components
+#     "0x940181a94a35a4569e4529a3cdfb74e38fd98631",  # AERO    —   13 components
+#     "0xfde4c96c8593536e31f229ea8f37b2ada2699bb2",  # USDT    —   11 components
+#     "0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf",  # VVV     —   11 components
+#     "0x2ae3f1ec7f1f5012cfeab0185bfc7aa3cf0dec22",  # cbETH   —   10 components
 # ]


### PR DESCRIPTION
Rename all liquidity-pool naming to "component" (matching Tycho's ProtocolComponent and the component_id wire field); "pool" alone now always means a worker pool -- docs, comments, tests, and internal identifiers only, with no behavior change.

 Breaking changes:

  - fynd-core public API: DerivedData pool-depth accessors are now component_depths() / component_depths_block() / set_component_depths() / clear_component_depths(); PoolDepths / PoolDepthKey are now ComponentDepths / ComponentDepthKey; PoolDepthComputation is now ComponentDepthComputation; MarketState::pool_counts_by_protocol() is now component_counts_by_protocol().
  - GET /v1/prices (experimental feature): response fields pool_depths → component_depths, both the top-level array and the entry in blocks. Request parameters (include=depths) are unchanged.
  - TypeScript client: Swap.poolId → Swap.componentId. The quote wire format is unchanged.
- PoolConfig -> WorkerPoolConfig
- WorkerPoolConfig (spawn-level) -> WorkerPoolSpawnConfig
- FyndBuilder::add_pool -> add_worker_pool
- SolverBuildError::NoPools -> NoWorkerPools
- defaults::{POOL_TASK_QUEUE_CAPACITY, POOL_MIN_HOPS, POOL_MAX_HOPS, POOL_TIMEOUT_MS} -> WORKER_POOL_*

Not changed (intentionally, to avoid breaking consumers): the quote API wire format, Prometheus metric names (market_pools, market_pools_per_protocol), and the pool_depths computation ID used as the computation metric label.