### PR TITLE
fix(derived): recover from broadcast lag incrementally

### DIFF
--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -38,18 +38,6 @@ pub struct ChangedComponents {
 }
 
 impl ChangedComponents {
-    /// Creates a marker for full recompute where all components are considered changed.
-    ///
-    /// Used for startup and lag recovery scenarios.
-    pub fn all(market: MarketDataView) -> Self {
-        Self {
-            added: market.component_topology().clone(),
-            removed: vec![],
-            updated: vec![],
-            is_full_recompute: true,
-        }
-    }
-
     /// Returns true if this update changes the graph topology (adds or removes components).
     pub fn is_topology_change(&self) -> bool {
         !self.added.is_empty() || !self.removed.is_empty()
@@ -73,8 +61,6 @@ impl ChangedComponents {
 /// Returns `None` when the batch carries no net changes. The result always has
 /// `is_full_recompute: false` — this is the bounded lag-recovery path, never a
 /// whole-topology recompute.
-// Not yet called: wired up by the lag-recovery path added in a follow-up task.
-#[allow(dead_code)]
 fn coalesce_market_events(events: &[MarketEvent]) -> Option<ChangedComponents> {
     let mut added: HashMap<ComponentId, Vec<Address>> = HashMap::new();
     let mut removed: HashSet<ComponentId> = HashSet::new();
@@ -127,7 +113,7 @@ use super::{
 };
 use crate::feed::{
     events::{EventError, MarketEvent, MarketEventHandler},
-    market_data::{MarketData, MarketDataView},
+    market_data::MarketData,
 };
 
 /// Thread-safe handle to shared derived data store.
@@ -317,12 +303,13 @@ impl ComputationManager {
                         Err(broadcast::error::RecvError::Lagged(skipped)) => {
                             warn!(
                                 skipped,
-                                "computation manager lagged, skipped {} events. Recomputing from current state.",
-                                skipped
+                                "computation manager lagged; draining buffered events and \
+                                 recomputing changed components incrementally"
                             );
-                            let market = self.market_data.read().await;
-                            let changed = ChangedComponents::all(market);
-                            self.compute_all(&changed).await;
+                            counter!("derived_manager_lag_recoveries_total").increment(1);
+                            counter!("derived_manager_lagged_events_total")
+                                .increment(skipped);
+                            self.recover_from_lag(&mut event_rx).await;
                         }
                     }
                 }
@@ -483,6 +470,31 @@ impl ComputationManager {
             total_ms = total_start.elapsed().as_millis(),
             "all derived computations complete"
         );
+    }
+
+    /// Recovers from a broadcast lag without a full-topology recompute.
+    ///
+    /// Drains every event still buffered in `event_rx` (returning the receiver to
+    /// the live tail so it cannot immediately re-lag), coalesces them into one
+    /// incremental `ChangedComponents`, and recomputes just that union.
+    ///
+    /// Trade-off: components carried only by the *dropped* (skipped) events are not
+    /// refreshed here — they update on their next `MarketUpdated`. This keeps
+    /// recovery O(recent changes) instead of O(all pools), which is what let fast
+    /// chains spiral into back-to-back full recomputes.
+    async fn recover_from_lag(&self, event_rx: &mut broadcast::Receiver<MarketEvent>) {
+        let mut drained = Vec::new();
+        loop {
+            match event_rx.try_recv() {
+                Ok(event) => drained.push(event),
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(broadcast::error::TryRecvError::Closed) => break,
+            }
+        }
+        if let Some(changed) = coalesce_market_events(&drained) {
+            self.compute_all(&changed).await;
+        }
     }
 }
 
@@ -682,6 +694,47 @@ mod tests {
         assert!(!c.added.contains_key("eth_usdc"));
         assert!(c.removed.contains(&"eth_usdc".to_string()));
         assert!(!c.updated.contains(&"eth_usdc".to_string()));
+    }
+
+    #[tokio::test]
+    async fn lag_recovery_recomputes_incrementally_and_drains_to_tail() {
+        let eth = token(1, "ETH");
+        let usdc = token(2, "USDC");
+        let (market, _) = setup_market_weighted(vec![(
+            "eth_usdc",
+            &eth,
+            &usdc,
+            MockProtocolSim::new(2000.0).with_gas(0),
+        )]);
+        let config = ComputationManagerConfig::new().with_gas_token(eth.address.clone());
+        let (manager, _out_rx) = ComputationManager::new(config, market).unwrap();
+
+        // Capacity-2 input channel; send 5 without reading to force Lagged on recv.
+        let (tx, mut rx) = broadcast::channel::<MarketEvent>(2);
+        for _ in 0..5 {
+            tx.send(MarketEvent::MarketUpdated {
+                added_components: HashMap::from([(
+                    "eth_usdc".to_string(),
+                    vec![eth.address.clone(), usdc.address.clone()],
+                )]),
+                removed_components: vec![],
+                updated_components: vec![],
+            })
+            .unwrap();
+        }
+        let err = rx.recv().await.expect_err("receiver must have lagged");
+        assert!(matches!(err, broadcast::error::RecvError::Lagged(_)));
+
+        manager.recover_from_lag(&mut rx).await;
+
+        // Recovery recomputed the coalesced change incrementally...
+        let store = manager.store();
+        let guard = store.read().await;
+        assert!(guard.spot_prices().is_some());
+        assert!(guard.token_prices().is_some());
+        drop(guard);
+        // ...and the receiver is back at the live tail (buffer drained).
+        assert!(matches!(rx.try_recv(), Err(broadcast::error::TryRecvError::Empty)));
     }
 
     // --- build_schedule: dependency staging (pure) --------------------------------

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -677,9 +677,13 @@ mod tests {
         assert!(!c.is_full_recompute);
         // eth_usdc was added, so it stays in `added` (not double-counted in `updated`)
         assert!(c.added.contains_key("eth_usdc"));
-        assert!(!c.updated.contains(&"eth_usdc".to_string()));
+        assert!(!c
+            .updated
+            .contains(&"eth_usdc".to_string()));
         // dai_usdc only ever appeared as updated
-        assert!(c.updated.contains(&"dai_usdc".to_string()));
+        assert!(c
+            .updated
+            .contains(&"dai_usdc".to_string()));
     }
 
     #[test]
@@ -701,8 +705,12 @@ mod tests {
         };
         let c = coalesce_market_events(&[add, remove]).expect("net removal present");
         assert!(!c.added.contains_key("eth_usdc"));
-        assert!(c.removed.contains(&"eth_usdc".to_string()));
-        assert!(!c.updated.contains(&"eth_usdc".to_string()));
+        assert!(c
+            .removed
+            .contains(&"eth_usdc".to_string()));
+        assert!(!c
+            .updated
+            .contains(&"eth_usdc".to_string()));
     }
 
     #[tokio::test]
@@ -731,7 +739,10 @@ mod tests {
             })
             .unwrap();
         }
-        let err = rx.recv().await.expect_err("receiver must have lagged");
+        let err = rx
+            .recv()
+            .await
+            .expect_err("receiver must have lagged");
         assert!(matches!(err, broadcast::error::RecvError::Lagged(_)));
 
         manager.recover_from_lag(&mut rx).await;

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -65,6 +65,58 @@ impl ChangedComponents {
     }
 }
 
+/// Coalesces a drained batch of [`MarketEvent`]s into a single incremental
+/// [`ChangedComponents`], applying net semantics: a component that is added
+/// then removed within the batch nets to removed; an add supersedes a prior
+/// update; a remove supersedes a prior add/update.
+///
+/// Returns `None` when the batch carries no net changes. The result always has
+/// `is_full_recompute: false` — this is the bounded lag-recovery path, never a
+/// whole-topology recompute.
+// Not yet called: wired up by the lag-recovery path added in a follow-up task.
+#[allow(dead_code)]
+fn coalesce_market_events(events: &[MarketEvent]) -> Option<ChangedComponents> {
+    let mut added: HashMap<ComponentId, Vec<Address>> = HashMap::new();
+    let mut removed: HashSet<ComponentId> = HashSet::new();
+    let mut updated: HashSet<ComponentId> = HashSet::new();
+
+    for event in events {
+        match event {
+            MarketEvent::MarketUpdated {
+                added_components,
+                removed_components,
+                updated_components,
+            } => {
+                for (id, tokens) in added_components {
+                    removed.remove(id);
+                    updated.remove(id);
+                    added.insert(id.clone(), tokens.clone());
+                }
+                for id in removed_components {
+                    added.remove(id);
+                    updated.remove(id);
+                    removed.insert(id.clone());
+                }
+                for id in updated_components {
+                    if !added.contains_key(id) && !removed.contains(id) {
+                        updated.insert(id.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    if added.is_empty() && removed.is_empty() && updated.is_empty() {
+        return None;
+    }
+    Some(ChangedComponents {
+        added,
+        removed: removed.into_iter().collect(),
+        updated: updated.into_iter().collect(),
+        is_full_recompute: false,
+    })
+}
+
 use super::{
     computation::{ComputationId, ComputationRequirements, DerivedComputation},
     computations::{PoolDepthComputation, SpotPriceComputation, TokenGasPriceComputation},
@@ -574,6 +626,62 @@ mod tests {
             }
         }
         events
+    }
+
+    // --- coalesce_market_events: net semantics over a drained batch (pure) ---------
+
+    #[test]
+    fn coalesce_empty_batch_returns_none() {
+        assert!(coalesce_market_events(&[]).is_none());
+    }
+
+    #[test]
+    fn coalesce_unions_added_and_updated_across_events() {
+        let eth = token(1, "ETH");
+        let usdc = token(2, "USDC");
+        let e1 = MarketEvent::MarketUpdated {
+            added_components: HashMap::from([(
+                "eth_usdc".to_string(),
+                vec![eth.address.clone(), usdc.address.clone()],
+            )]),
+            removed_components: vec![],
+            updated_components: vec![],
+        };
+        let e2 = MarketEvent::MarketUpdated {
+            added_components: HashMap::new(),
+            removed_components: vec![],
+            updated_components: vec!["eth_usdc".to_string(), "dai_usdc".to_string()],
+        };
+        let c = coalesce_market_events(&[e1, e2]).expect("net changes present");
+        assert!(!c.is_full_recompute);
+        // eth_usdc was added, so it stays in `added` (not double-counted in `updated`)
+        assert!(c.added.contains_key("eth_usdc"));
+        assert!(!c.updated.contains(&"eth_usdc".to_string()));
+        // dai_usdc only ever appeared as updated
+        assert!(c.updated.contains(&"dai_usdc".to_string()));
+    }
+
+    #[test]
+    fn coalesce_add_then_remove_nets_to_removed() {
+        let eth = token(1, "ETH");
+        let usdc = token(2, "USDC");
+        let add = MarketEvent::MarketUpdated {
+            added_components: HashMap::from([(
+                "eth_usdc".to_string(),
+                vec![eth.address.clone(), usdc.address.clone()],
+            )]),
+            removed_components: vec![],
+            updated_components: vec![],
+        };
+        let remove = MarketEvent::MarketUpdated {
+            added_components: HashMap::new(),
+            removed_components: vec!["eth_usdc".to_string()],
+            updated_components: vec![],
+        };
+        let c = coalesce_market_events(&[add, remove]).expect("net removal present");
+        assert!(!c.added.contains_key("eth_usdc"));
+        assert!(c.removed.contains(&"eth_usdc".to_string()));
+        assert!(!c.updated.contains(&"eth_usdc".to_string()));
     }
 
     // --- build_schedule: dependency staging (pure) --------------------------------

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -472,22 +472,16 @@ impl ComputationManager {
         );
     }
 
-    /// Recovers from a broadcast lag without a full-topology recompute.
+    ////// Recovers from a broadcast lag without a full-topology recompute.
     ///
-    /// Drains every event still buffered in `event_rx` (returning the receiver to
-    /// the live tail so it cannot immediately re-lag), coalesces them into one
-    /// incremental `ChangedComponents`, and recomputes just that union.
+    /// Drains the events still buffered in `event_rx` (returning the receiver to the live tail so
+    /// it cannot immediately re-lag), coalesces them into one incremental `ChangedComponents`,
+    /// and recomputes just that union.
     ///
-    /// Trade-off: this only recomputes components named in the *drained* events, not
-    /// the ones lost in the *dropped* (skipped) window. Added/updated components missed
-    /// there self-correct on their next `MarketUpdated`. Components REMOVED only in the
-    /// dropped window are different: they are already gone from market topology, so they
-    /// never reappear in a future event, and this path never prunes them either — their
-    /// stale `spot_prices`/`pool_depths` entries persist for the life of the process
-    /// (production runs no full recompute anymore). This is bounded and does not affect
-    /// routing correctness (the routing graph is gated separately and self-resyncs), but
-    /// it is a known limitation; a topology-reconciliation follow-up is tracked to prune
-    /// these entries without resorting to a full recompute.
+    /// Components lost in the dropped window are not recomputed. Added and updated ones
+    /// self-correct on their next `MarketUpdated`; removed ones never reappear, leaving stale
+    /// `spot_prices`/`pool_depths` entries for the life of the process. Routing is unaffected:
+    /// derived data is only read per graph edge, and a removed component has no edges.
     async fn recover_from_lag(&self, event_rx: &mut broadcast::Receiver<MarketEvent>) {
         let mut drained = Vec::new();
         loop {

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -478,17 +478,26 @@ impl ComputationManager {
     /// the live tail so it cannot immediately re-lag), coalesces them into one
     /// incremental `ChangedComponents`, and recomputes just that union.
     ///
-    /// Trade-off: components carried only by the *dropped* (skipped) events are not
-    /// refreshed here — they update on their next `MarketUpdated`. This keeps
-    /// recovery O(recent changes) instead of O(all pools), which is what let fast
-    /// chains spiral into back-to-back full recomputes.
+    /// Trade-off: this only recomputes components named in the *drained* events, not
+    /// the ones lost in the *dropped* (skipped) window. Added/updated components missed
+    /// there self-correct on their next `MarketUpdated`. Components REMOVED only in the
+    /// dropped window are different: they are already gone from market topology, so they
+    /// never reappear in a future event, and this path never prunes them either — their
+    /// stale `spot_prices`/`pool_depths` entries persist for the life of the process
+    /// (production runs no full recompute anymore). This is bounded and does not affect
+    /// routing correctness (the routing graph is gated separately and self-resyncs), but
+    /// it is a known limitation; a topology-reconciliation follow-up is tracked to prune
+    /// these entries without resorting to a full recompute.
     async fn recover_from_lag(&self, event_rx: &mut broadcast::Receiver<MarketEvent>) {
         let mut drained = Vec::new();
         loop {
             match event_rx.try_recv() {
                 Ok(event) => drained.push(event),
                 Err(broadcast::error::TryRecvError::Empty) => break,
-                Err(broadcast::error::TryRecvError::Lagged(_)) => continue,
+                Err(broadcast::error::TryRecvError::Lagged(n)) => {
+                    counter!("derived_manager_lagged_events_total").increment(n);
+                    continue;
+                }
                 Err(broadcast::error::TryRecvError::Closed) => break,
             }
         }


### PR DESCRIPTION
`ComputationManager` handled `broadcast::RecvError::Lagged` by treating the whole topology as changed and recomputing every pool. On busy chains that recompute took long enough to lag again on the next `recv()`, leaving the manager in back-to-back full recomputes.

Recovery now drains the buffered events with `try_recv`, coalesces them into one incremental `ChangedComponents`, and recomputes just that union. Removes the now-unused `ChangedComponents::all`. Adds `derived_manager_lag_recoveries_total` and `derived_manager_lagged_events_total`.

Components removed only within the dropped window keep stale `spot_prices`/`pool_depths` entries until restart — documented on `recover_from_lag`, with a topology-reconciliation follow-up tracked. Routing is unaffected: derived lookups are driven by existing graph edges, and worker graphs reinitialize from live `MarketState` on lag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)