### PR TITLE
feat!: replace ExclusivityPolicy with scope based filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7907,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "tycho-client"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
+source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7936,7 +7936,7 @@ dependencies = [
 [[package]]
 name = "tycho-common"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
+source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "tycho-ethereum"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
+source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "tycho-execution"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
+source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
 dependencies = [
  "alloy",
  "chrono",
@@ -8005,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "tycho-simulation"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
+source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7907,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "tycho-client"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
+source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7936,7 +7936,7 @@ dependencies = [
 [[package]]
 name = "tycho-common"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
+source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "tycho-ethereum"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
+source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "tycho-execution"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
+source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
 dependencies = [
  "alloy",
  "chrono",
@@ -8005,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "tycho-simulation"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
+source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7907,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "tycho-client"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
+source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7936,7 +7936,7 @@ dependencies = [
 [[package]]
 name = "tycho-common"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
+source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7964,7 +7964,7 @@ dependencies = [
 [[package]]
 name = "tycho-ethereum"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
+source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "tycho-execution"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
+source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
 dependencies = [
  "alloy",
  "chrono",
@@ -8005,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "tycho-simulation"
 version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0#6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0"
+source = "git+https://github.com/propeller-heads/tycho?rev=fdc37336ee8372f8c9488feeff1e5e21203513d4#fdc37336ee8372f8c9488feeff1e5e21203513d4"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7906,9 +7906,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.345.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22632608b3a9c9b1c91fdbadf0da30241aa1025b4f3c017df75eea6b37dd1f61"
+version = "0.342.0"
+source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7936,9 +7935,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.345.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f98e5f753debf2abf2469f82ae539d93c48f066434b1029a7b4c3ecab057b9"
+version = "0.342.0"
+source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7965,9 +7963,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.345.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a4f5ec77a621a700691a728d2d8097457913d4cb4baeeb90457e205ee29e99"
+version = "0.342.0"
+source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7987,9 +7984,8 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.345.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869ee1c63145af651a6d06dc2e12bfaff97ea0e98dc62808cf1e5fcc0a7efee8"
+version = "0.342.0"
+source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
 dependencies = [
  "alloy",
  "chrono",
@@ -8003,15 +7999,13 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tracing",
  "tycho-common",
 ]
 
 [[package]]
 name = "tycho-simulation"
-version = "0.345.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e27699ebbd7d02c170625b6a9441a3f5dc808a573a4eed80e70db55a69bd092"
+version = "0.342.0"
+source = "git+https://github.com/propeller-heads/tycho?rev=d85d3fcbd6731129858c964da7ced371d5547c42#d85d3fcbd6731129858c964da7ced371d5547c42"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7906,8 +7906,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
+version = "0.349.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd93ae713167232747ce250d2bbcda9e28febf6c2a5d3449317bed6b6278f7c"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7935,8 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
+version = "0.349.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e3bd537f5079a098ee63f51325e1e84c8e57e6a27661a07b4070145dffde3b"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7963,8 +7965,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
+version = "0.349.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed0ebe7ef0a3b7b1f6be90c69c398a27cb75a0dc67634e42261c04476b51748"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7984,8 +7987,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
+version = "0.349.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf45f13323037a1ab0c958f1fd6f9528e1eedd465277be9f3de97169ee261751"
 dependencies = [
  "alloy",
  "chrono",
@@ -7999,13 +8003,15 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "tycho-common",
 ]
 
 [[package]]
 name = "tycho-simulation"
-version = "0.342.0"
-source = "git+https://github.com/propeller-heads/tycho?rev=f0eb6035d8bcf72fa3369c21ce233787e53d2a78#f0eb6035d8bcf72fa3369c21ce233787e53d2a78"
+version = "0.349.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53ae449a03c2ce030ff4decbc1c4641d00269248cb98a0802c8748536f0816fe"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ metrics-util = "0.20"
 # Tycho
 # TEMPORARY: pinned to propeller-heads/tycho#1254 for the unreleased `EXCLUSIVE_EXTENSIONS`
 # export.
-tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0" }
-tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "fdc37336ee8372f8c9488feeff1e5e21203513d4" }
+tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "fdc37336ee8372f8c9488feeff1e5e21203513d4" }
 typetag = "0.2"
 
 # Compression

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,10 +141,8 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-# TEMPORARY: pinned to propeller-heads/tycho#1254 for the unreleased `EXCLUSIVE_EXTENSIONS`
-# export.
-tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "f0eb6035d8bcf72fa3369c21ce233787e53d2a78" }
-tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "f0eb6035d8bcf72fa3369c21ce233787e53d2a78" }
+tycho-execution = ">=0.349.0"
+tycho-simulation = ">=0.349.0"
 typetag = "0.2"
 
 # Compression

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ metrics-util = "0.20"
 # Tycho
 # TEMPORARY: pinned to propeller-heads/tycho#1254 for the unreleased `EXCLUSIVE_EXTENSIONS`
 # export.
-tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "fdc37336ee8372f8c9488feeff1e5e21203513d4" }
-tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "fdc37336ee8372f8c9488feeff1e5e21203513d4" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "f0eb6035d8bcf72fa3369c21ce233787e53d2a78" }
+tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "f0eb6035d8bcf72fa3369c21ce233787e53d2a78" }
 typetag = "0.2"
 
 # Compression

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,8 +143,8 @@ metrics-util = "0.20"
 # Tycho
 # TEMPORARY: pinned to propeller-heads/tycho#1254 for the unreleased `EXCLUSIVE_EXTENSIONS`
 # export.
-tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "d85d3fcbd6731129858c964da7ced371d5547c42" }
-tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "d85d3fcbd6731129858c964da7ced371d5547c42" }
+tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0" }
+tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "6d2fd4d1943792ea971f2b6c4f1cb1976afb36d0" }
 typetag = "0.2"
 
 # Compression

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,10 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-tycho-execution = ">=0.345.1"
-tycho-simulation = ">=0.345.1"
+# TEMPORARY: pinned to propeller-heads/tycho#1254 for the unreleased `EXCLUSIVE_EXTENSIONS`
+# export.
+tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "d85d3fcbd6731129858c964da7ced371d5547c42" }
+tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "d85d3fcbd6731129858c964da7ced371d5547c42" }
 typetag = "0.2"
 
 # Compression

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -15,8 +15,8 @@
 use std::collections::HashMap;
 
 use tycho_simulation::{
+    evm::protocol::ekubo_v3::EXCLUSIVE_EXTENSIONS,
     tycho_common::models::{protocol::ProtocolComponent, Address},
-    EXCLUSIVE_EXTENSIONS,
 };
 
 use crate::{

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -14,10 +14,7 @@
 
 use std::collections::HashMap;
 
-use tycho_simulation::{
-    evm::protocol::ekubo_v3::EXCLUSIVE_EXTENSIONS,
-    tycho_common::models::{protocol::ProtocolComponent, Address},
-};
+use tycho_simulation::tycho_common::models::{protocol::ProtocolComponent, Address};
 
 use crate::{
     feed::{events::MarketEvent, market_data::MarketState},
@@ -25,16 +22,12 @@ use crate::{
 };
 
 /// Returns `true` when the component offers exclusive liquidity, i.e. is swappable only with
-/// off-chain authorization.
+/// off-chain authorization. The `is_exclusive` static attribute is stamped by tycho-simulation's
+/// decoder; absence means the component is public.
 pub(crate) fn is_exclusive(component: &ProtocolComponent) -> bool {
     component
         .static_attributes
-        .get("extension")
-        .is_some_and(|extension| {
-            EXCLUSIVE_EXTENSIONS
-                .iter()
-                .any(|addr| addr.as_slice() == &extension[..])
-        })
+        .contains_key("is_exclusive")
 }
 
 /// Removes exclusive components from a full topology map.
@@ -77,22 +70,18 @@ fn filter_component_ids(market: &MarketState, ids: &[ComponentId]) -> Vec<Compon
         .collect()
 }
 
-/// Stamps the signed-exclusive-swap extension onto a component's static attributes so tests can
-/// build exclusive components without protocol-specific fixtures.
+/// Stamps the `is_exclusive` attribute onto a component's static attributes, mirroring
+/// tycho-simulation's decoder tagging, so tests can build exclusive components without
+/// protocol-specific fixtures.
 #[cfg(test)]
 pub(crate) fn mark_exclusive(component: &mut ProtocolComponent) {
-    component.static_attributes.insert(
-        "extension".to_string(),
-        EXCLUSIVE_EXTENSIONS[0]
-            .as_slice()
-            .into(),
-    );
+    component
+        .static_attributes
+        .insert("is_exclusive".to_string(), vec![1u8].into());
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::address;
-
     use super::*;
     use crate::{
         algorithm::test_utils::{component, token},
@@ -115,23 +104,17 @@ mod tests {
         market
     }
 
-    fn component_with_extension(extension: Vec<u8>) -> ProtocolComponent {
+    fn component_with_extension() -> ProtocolComponent {
         let mut c = public_component("pub-1");
         c.static_attributes
-            .insert("extension".to_string(), extension.into());
+            .insert("extension".to_string(), vec![0x55, 0x19].into());
         c
     }
 
     #[rstest::rstest]
-    #[case::exclusive_extension(exclusive_component("excl-1"), true)]
+    #[case::tagged(exclusive_component("excl-1"), true)]
     #[case::missing_attribute(public_component("pub-1"), false)]
-    #[case::other_extension(
-        component_with_extension(
-            address!("0x517E506700271AEa091b02f42756F5E174Af5230").as_slice().to_vec()
-        ),
-        false
-    )]
-    #[case::garbage_attribute(component_with_extension(vec![0x55, 0x19]), false)]
+    #[case::untagged_extension(component_with_extension(), false)]
     fn test_is_exclusive(#[case] component: ProtocolComponent, #[case] expected: bool) {
         assert_eq!(is_exclusive(&component), expected);
     }

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -22,8 +22,8 @@ use crate::{
 };
 
 /// Returns `true` when the component offers exclusive liquidity, i.e. is swappable only with
-/// off-chain authorization. The `is_exclusive` static attribute is stamped by tycho-simulation's
-/// decoder; absence means the component is public.
+/// off-chain authorization. Signaled by the `is_exclusive` static attribute; absence means the
+/// component is public.
 pub(crate) fn is_exclusive(component: &ProtocolComponent) -> bool {
     component
         .static_attributes
@@ -70,9 +70,8 @@ fn filter_component_ids(market: &MarketState, ids: &[ComponentId]) -> Vec<Compon
         .collect()
 }
 
-/// Stamps the `is_exclusive` attribute onto a component's static attributes, mirroring
-/// tycho-simulation's decoder tagging, so tests can build exclusive components without
-/// protocol-specific fixtures.
+/// Stamps the `is_exclusive` attribute onto a component's static attributes, so tests can build
+/// exclusive components without protocol-specific fixtures.
 #[cfg(test)]
 pub(crate) fn mark_exclusive(component: &mut ProtocolComponent) {
     component

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -6,8 +6,8 @@
 //! pool kinds serve the same request; they differ only in which liquidity their workers may route
 //! through. Isolation is achieved by filtering each worker's local graph topology/events through
 //! `remove_exclusive_components`/`scope_event` when the worker pool's `LiquidityScope` is
-//! `PublicOnly` — the shared `MarketState` is never duplicated. Workers of `All`-scoped worker
-//! pools ingest everything.
+//! `PublicOnly` — the shared `MarketState` is never duplicated. Workers of
+//! `IncludeExclusive`-scoped worker pools ingest everything.
 //!
 //! A component is classified from its own data via `is_exclusive`, applied generically to every
 //! ingested component.

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -5,9 +5,9 @@
 //! through them to capture the surplus they offer above the best public-market rate. Both worker
 //! pool kinds serve the same request; they differ only in which liquidity their workers may route
 //! through. Isolation is achieved by filtering each worker's local graph topology/events through
-//! `filter_topology`/`scope_event` when the worker pool's `LiquidityScope` is `PublicOnly` — the
-//! shared `MarketState` is never duplicated. Workers of `All`-scoped worker pools ingest
-//! everything.
+//! `remove_exclusive_components`/`scope_event` when the worker pool's `LiquidityScope` is
+//! `PublicOnly` — the shared `MarketState` is never duplicated. Workers of `All`-scoped worker
+//! pools ingest everything.
 //!
 //! A component is classified from its own data via `is_exclusive`, applied generically to every
 //! ingested component.
@@ -31,7 +31,7 @@ pub(crate) fn is_exclusive(component: &ProtocolComponent) -> bool {
 }
 
 /// Removes exclusive components from a full topology map.
-pub(crate) fn filter_topology(
+pub(crate) fn remove_exclusive_components(
     market: &MarketState,
     topology: HashMap<ComponentId, Vec<Address>>,
 ) -> HashMap<ComponentId, Vec<Address>> {
@@ -51,7 +51,7 @@ pub(crate) fn scope_event(market: &MarketState, event: MarketEvent) -> MarketEve
     let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
         event;
 
-    let added_components = filter_topology(market, added_components);
+    let added_components = remove_exclusive_components(market, added_components);
     let removed_components = filter_component_ids(market, &removed_components);
     let updated_components = filter_component_ids(market, &updated_components);
 
@@ -120,11 +120,11 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_topology() {
+    fn test_remove_exclusive_components() {
         let market = market_with(vec![public_component("pub-1"), exclusive_component("excl-1")]);
         let topology = market.component_topology();
 
-        let filtered = filter_topology(&market, topology);
+        let filtered = remove_exclusive_components(&market, topology);
         assert!(filtered.contains_key("pub-1"));
         assert!(!filtered.contains_key("excl-1"));
     }

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -1,115 +1,108 @@
 //! Exclusive-component classification and per-worker graph filtering.
 //!
-//! "Exclusive" means accessible only to Fynd: such components must never enter the route a
-//! public worker pool returns, while an exclusive-access worker pool routes through them to
-//! capture the surplus they offer above the best public-market rate. Both worker pool kinds
-//! serve the same request; they differ only in which liquidity their workers may route through.
-//! Isolation is achieved by filtering each worker's local graph topology/events through the
-//! worker pool's `ExclusivityPolicy` — the shared `MarketState` is never duplicated. Workers of
-//! public worker pools hold `Some(policy)` and filter; workers of exclusive-access worker pools
-//! hold `None` and ingest everything.
+//! "Exclusive" means swappable only with off-chain authorization: such components must never
+//! enter the route a public worker pool returns, while an exclusive-access worker pool routes
+//! through them to capture the surplus they offer above the best public-market rate. Both worker
+//! pool kinds serve the same request; they differ only in which liquidity their workers may route
+//! through. Isolation is achieved by filtering each worker's local graph topology/events through
+//! `filter_topology`/`scope_event` when the worker pool's `LiquidityScope` is `PublicOnly` — the
+//! shared `MarketState` is never duplicated. Workers of `All`-scoped worker pools ingest
+//! everything.
+//!
+//! A component is classified from its own data, whatever its protocol: its `extension` static
+//! attribute is matched against tycho-simulation's exported `EXCLUSIVE_EXTENSIONS` — the same
+//! knowledge the stream filters use, applied generically to every ingested component.
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
-use tycho_simulation::tycho_common::models::{protocol::ProtocolComponent, Address};
+use tycho_simulation::{
+    tycho_common::models::{protocol::ProtocolComponent, Address},
+    EXCLUSIVE_EXTENSIONS,
+};
 
 use crate::{
     feed::{events::MarketEvent, market_data::MarketState},
     types::ComponentId,
 };
 
-/// Classifies a `ProtocolComponent` as exclusive or public, and filters worker inputs
-/// accordingly.
-///
-/// The predicate is supplied by the caller rather than hard-coded against an id or protocol name,
-/// so the notion of "exclusive" can evolve (e.g. a hook address allowlist) without touching the
-/// routing core.
-#[derive(Clone)]
-pub struct ExclusivityPolicy {
-    /// Returns `true` when the component is exclusive and therefore excluded from public
-    /// quotes.
-    is_exclusive: Arc<dyn Fn(&ProtocolComponent) -> bool + Send + Sync>,
+/// Returns `true` when the component's `extension` static attribute names a known exclusive
+/// extension contract.
+pub(crate) fn is_exclusive(component: &ProtocolComponent) -> bool {
+    component
+        .static_attributes
+        .get("extension")
+        .is_some_and(|extension| {
+            EXCLUSIVE_EXTENSIONS
+                .iter()
+                .any(|addr| addr.as_slice() == &extension[..])
+        })
 }
 
-impl ExclusivityPolicy {
-    /// Creates a policy from a predicate identifying exclusive components.
-    pub fn new<F>(predicate: F) -> Self
-    where
-        F: Fn(&ProtocolComponent) -> bool + Send + Sync + 'static,
-    {
-        Self { is_exclusive: Arc::new(predicate) }
-    }
-
-    /// Returns `true` if the component is exclusive.
-    pub fn is_exclusive(&self, component: &ProtocolComponent) -> bool {
-        (self.is_exclusive)(component)
-    }
-
-    /// Removes exclusive components from a full topology map.
-    pub(crate) fn filter_topology(
-        &self,
-        market: &MarketState,
-        topology: HashMap<ComponentId, Vec<Address>>,
-    ) -> HashMap<ComponentId, Vec<Address>> {
-        topology
-            .into_iter()
-            .filter(|(id, _)| {
-                market
-                    .get_component(id)
-                    .is_none_or(|c| !self.is_exclusive(c))
-            })
-            .collect()
-    }
-
-    /// Removes exclusive component ids from a market event's added/updated/removed lists, so an
-    /// exclusive component is never ingested mid-stream.
-    pub(crate) fn scope_event(&self, market: &MarketState, event: MarketEvent) -> MarketEvent {
-        let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
-            event;
-
-        let added_components = self.filter_topology(market, added_components);
-        let removed_components = self.filter_component_ids(market, &removed_components);
-        let updated_components = self.filter_component_ids(market, &updated_components);
-
-        MarketEvent::MarketUpdated { added_components, removed_components, updated_components }
-    }
-
-    /// Keeps only the component ids that are NOT exclusive.
-    fn filter_component_ids(&self, market: &MarketState, ids: &[ComponentId]) -> Vec<ComponentId> {
-        ids.iter()
-            .filter(|id| {
-                market
-                    .get_component(id)
-                    .is_none_or(|c| !self.is_exclusive(c))
-            })
-            .cloned()
-            .collect()
-    }
+/// Removes exclusive components from a full topology map.
+pub(crate) fn filter_topology(
+    market: &MarketState,
+    topology: HashMap<ComponentId, Vec<Address>>,
+) -> HashMap<ComponentId, Vec<Address>> {
+    topology
+        .into_iter()
+        .filter(|(id, _)| {
+            market
+                .get_component(id)
+                .is_none_or(|c| !is_exclusive(c))
+        })
+        .collect()
 }
 
-impl std::fmt::Debug for ExclusivityPolicy {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ExclusivityPolicy")
-            .finish_non_exhaustive()
-    }
+/// Removes exclusive component ids from a market event's added/updated/removed lists, so an
+/// exclusive component is never ingested mid-stream.
+pub(crate) fn scope_event(market: &MarketState, event: MarketEvent) -> MarketEvent {
+    let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
+        event;
+
+    let added_components = filter_topology(market, added_components);
+    let removed_components = filter_component_ids(market, &removed_components);
+    let updated_components = filter_component_ids(market, &updated_components);
+
+    MarketEvent::MarketUpdated { added_components, removed_components, updated_components }
+}
+
+/// Keeps only the component ids that are NOT exclusive.
+fn filter_component_ids(market: &MarketState, ids: &[ComponentId]) -> Vec<ComponentId> {
+    ids.iter()
+        .filter(|id| {
+            market
+                .get_component(id)
+                .is_none_or(|c| !is_exclusive(c))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Stamps the signed-exclusive-swap extension onto a component's static attributes so tests can
+/// build exclusive components without protocol-specific fixtures.
+#[cfg(test)]
+pub(crate) fn mark_exclusive(component: &mut ProtocolComponent) {
+    component.static_attributes.insert(
+        "extension".to_string(),
+        EXCLUSIVE_EXTENSIONS[0]
+            .as_slice()
+            .into(),
+    );
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::address;
+
     use super::*;
     use crate::{
         algorithm::test_utils::{component, token},
         feed::{events::MarketEvent, market_data::MarketState},
     };
 
-    /// A predicate that treats the `vm:exclusive` protocol system as exclusive.
-    fn exclusive_protocol_policy() -> ExclusivityPolicy {
-        ExclusivityPolicy::new(|c: &ProtocolComponent| c.protocol_system == "vm:exclusive")
-    }
-
     fn exclusive_component(id: &str) -> ProtocolComponent {
         let mut c = component(id, &[token(0x01, "A"), token(0x02, "B")]);
-        c.protocol_system = "vm:exclusive".to_string();
+        mark_exclusive(&mut c);
         c
     }
 
@@ -123,27 +116,39 @@ mod tests {
         market
     }
 
-    #[test]
-    fn test_is_exclusive_reflects_predicate() {
-        let policy = exclusive_protocol_policy();
-        assert!(policy.is_exclusive(&exclusive_component("excl-1")));
-        assert!(!policy.is_exclusive(&public_component("pub-1")));
+    fn component_with_extension(extension: Vec<u8>) -> ProtocolComponent {
+        let mut c = public_component("pub-1");
+        c.static_attributes
+            .insert("extension".to_string(), extension.into());
+        c
+    }
+
+    #[rstest::rstest]
+    #[case::exclusive_extension(exclusive_component("excl-1"), true)]
+    #[case::missing_attribute(public_component("pub-1"), false)]
+    #[case::other_extension(
+        component_with_extension(
+            address!("0x517E506700271AEa091b02f42756F5E174Af5230").as_slice().to_vec()
+        ),
+        false
+    )]
+    #[case::garbage_attribute(component_with_extension(vec![0x55, 0x19]), false)]
+    fn test_is_exclusive(#[case] component: ProtocolComponent, #[case] expected: bool) {
+        assert_eq!(is_exclusive(&component), expected);
     }
 
     #[test]
-    fn test_filter_topology_excludes_exclusive() {
-        let policy = exclusive_protocol_policy();
+    fn test_filter_topology() {
         let market = market_with(vec![public_component("pub-1"), exclusive_component("excl-1")]);
         let topology = market.component_topology();
 
-        let filtered = policy.filter_topology(&market, topology);
+        let filtered = filter_topology(&market, topology);
         assert!(filtered.contains_key("pub-1"));
         assert!(!filtered.contains_key("excl-1"));
     }
 
     #[test]
-    fn test_scope_event_excludes_exclusive() {
-        let policy = exclusive_protocol_policy();
+    fn test_scope_event() {
         let market = market_with(vec![public_component("pub-1"), exclusive_component("excl-1")]);
         let event = MarketEvent::MarketUpdated {
             added_components: HashMap::from([
@@ -155,7 +160,7 @@ mod tests {
         };
 
         let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
-            policy.scope_event(&market, event);
+            scope_event(&market, event);
         assert!(added_components.contains_key("pub-1"));
         assert!(!added_components.contains_key("excl-1"));
         assert_eq!(removed_components, vec!["pub-1".to_string()]);

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -9,9 +9,8 @@
 //! shared `MarketState` is never duplicated. Workers of `All`-scoped worker pools ingest
 //! everything.
 //!
-//! A component is classified from its own data, whatever its protocol: its `extension` static
-//! attribute is matched against tycho-simulation's exported `EXCLUSIVE_EXTENSIONS` — the same
-//! knowledge the stream filters use, applied generically to every ingested component.
+//! A component is classified from its own data via `is_exclusive`, applied generically to every
+//! ingested component.
 
 use std::collections::HashMap;
 
@@ -25,8 +24,8 @@ use crate::{
     types::ComponentId,
 };
 
-/// Returns `true` when the component's `extension` static attribute names a known exclusive
-/// extension contract.
+/// Returns `true` when the component offers exclusive liquidity, i.e. is swappable only with
+/// off-chain authorization.
 pub(crate) fn is_exclusive(component: &ProtocolComponent) -> bool {
     component
         .static_attributes

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -33,7 +33,6 @@ use crate::{
     encoding::{encoder::Encoder, fee_fetcher::RouterFeeFetcher, router_fees::SharedRouterFees},
     feed::{
         events::{MarketEvent, MarketEventHandler},
-        exclusivity::ExclusivityPolicy,
         gas::GasPriceFetcher,
         market_data::MarketData,
         metrics_sampler::MetricsSampler,
@@ -160,9 +159,10 @@ pub struct PoolConfig {
     /// Absent = no restriction. Typically 3–10 entries (e.g. WETH, USDC, USDT, DAI).
     #[serde(default)]
     connector_tokens: Option<Vec<String>>,
-    /// Worker pool liquidity scope: `public_only` or `all` (routes through exclusive liquidity
-    /// as well). Setting this key (either value) declares exclusive routing intent and requires
-    /// an exclusivity policy; absent = plain deployment, no filtering.
+    /// Worker pool liquidity scope: `all` (default — no filtering; workers ingest whatever the
+    /// deployment's stream delivers, which includes exclusive components only if the deployment
+    /// opted into them) or `public_only` (workers drop exclusive components, establishing the
+    /// public reference output for surplus routing). Absent = `all`.
     #[serde(default)]
     liquidity_scope: Option<LiquidityScope>,
 }
@@ -314,14 +314,6 @@ pub enum SolverBuildError {
     /// [`FyndBuilder::build`] was called without configuring any worker pools.
     #[error("no worker pools configured")]
     NoPools,
-    /// A worker pool sets `liquidity_scope` but no exclusivity policy is configured. The
-    /// policy is what public worker pools filter by and what the router identifies exclusive legs
-    /// with — without it, nothing distinguishes exclusive protocol components from public ones.
-    #[error(
-        "a worker pool sets liquidity_scope but no exclusivity policy is configured; \
-         set one via FyndBuilder::exclusivity_policy"
-    )]
-    LiquidityScopeWithoutPolicy,
     /// A recorded update failed to replay through the feed.
     #[cfg(feature = "test-utils")]
     #[error("replay failed: {0}")]
@@ -433,10 +425,6 @@ pub struct FyndBuilder {
     price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
     pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
-    /// Predicate identifying exclusive components. Shared by all worker pools: public worker
-    /// pools exclude matching components, exclusive-access worker pools include them. `None` ⇒
-    /// no worker pool filters anything.
-    exclusivity_policy: Option<ExclusivityPolicy>,
 }
 
 impl FyndBuilder {
@@ -470,7 +458,6 @@ impl FyndBuilder {
             price_guard_enabled: false,
             price_providers: Vec::new(),
             pending_indexers: Vec::new(),
-            exclusivity_policy: None,
         }
     }
 
@@ -657,21 +644,6 @@ impl FyndBuilder {
         self
     }
 
-    /// Sets the predicate that classifies components as exclusive.
-    ///
-    /// Public worker pools exclude matching components from their graphs; exclusive-access
-    /// worker pools include them. Without a policy, no worker pool filters anything.
-    pub fn exclusivity_policy<F>(mut self, predicate: F) -> Self
-    where
-        F: Fn(&tycho_simulation::tycho_common::models::protocol::ProtocolComponent) -> bool
-            + Send
-            + Sync
-            + 'static,
-    {
-        self.exclusivity_policy = Some(ExclusivityPolicy::new(predicate));
-        self
-    }
-
     /// Adds a named worker pool using the given [`PoolConfig`].
     ///
     /// # Errors
@@ -704,19 +676,6 @@ impl FyndBuilder {
     fn assemble_components(mut self) -> Result<BuiltComponents, SolverBuildError> {
         if self.pools.is_empty() {
             return Err(SolverBuildError::NoPools);
-        }
-
-        // Setting `liquidity_scope` on any worker pool (either value) declares exclusive routing
-        // intent, which requires a policy: public worker pools filter by it and the router
-        // identifies exclusive legs with it. Without one, a `public_only` worker pool could not
-        // honor its label and an `all` worker pool could not produce anything distinct. Worker
-        // pools with the key absent are plain deployments and need no policy.
-        if self.exclusivity_policy.is_none() &&
-            self.pools
-                .iter()
-                .any(|p| p.liquidity_scope().is_some())
-        {
-            return Err(SolverBuildError::LiquidityScopeWithoutPolicy);
         }
 
         // Add built-in providers if none were explicitly registered.
@@ -771,26 +730,17 @@ impl FyndBuilder {
         let mut solver_pool_handles: Vec<SolverPoolHandle> = Vec::new();
         let mut worker_pools: Vec<WorkerPool> = Vec::new();
 
-        // Shared across all worker pools: public worker pools exclude exclusive components,
-        // exclusive-access worker pools include them. `None` ⇒ no worker pool filters anything
-        // (original behaviour).
-        let exclusivity_policy = self.exclusivity_policy.take();
         let pools = std::mem::take(&mut self.pools);
 
         for pool_entry in pools {
             let pool_event_rx = tycho_feed.subscribe();
             let derived_rx = derived_event_tx.subscribe();
 
-            // Explicit `public_only` worker pools (and unscoped ones, harmlessly) get the policy
-            // so their workers filter exclusive components out; `all` worker pools get `None`
-            // and ingest everything.
+            // `public_only` worker pools filter exclusive components out of their workers'
+            // graphs; unscoped worker pools default to `all` and ingest everything.
             let pool_scope = pool_entry
                 .liquidity_scope()
                 .unwrap_or_default();
-            let pool_policy = match pool_scope {
-                LiquidityScope::PublicOnly => exclusivity_policy.clone(),
-                LiquidityScope::All => None,
-            };
 
             let (worker_pool, task_handle) = match pool_entry {
                 PoolEntry::BuiltIn {
@@ -820,7 +770,7 @@ impl FyndBuilder {
                         .algorithm_config(algo_cfg)
                         .num_workers(num_workers)
                         .task_queue_capacity(task_queue_capacity)
-                        .exclusivity_policy(pool_policy.clone());
+                        .liquidity_scope(pool_scope);
                     builder.build(
                         market_data.clone(),
                         Arc::clone(&derived_data),
@@ -840,7 +790,7 @@ impl FyndBuilder {
                         .algorithm_config(algo_cfg)
                         .num_workers(custom.num_workers)
                         .task_queue_capacity(custom.task_queue_capacity)
-                        .exclusivity_policy(pool_policy.clone());
+                        .liquidity_scope(pool_scope);
                     let builder = (custom.configure)(builder);
                     builder.build(
                         market_data.clone(),
@@ -898,10 +848,6 @@ impl FyndBuilder {
             .with_timeout(self.router_timeout)
             .with_min_responses(self.router_min_responses);
         let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
-
-        if let Some(ref policy) = exclusivity_policy {
-            router = router.with_exclusivity_policy(policy.clone());
-        }
 
         if self.price_guard_enabled {
             let mut registry = PriceProviderRegistry::new();
@@ -1539,23 +1485,16 @@ impl SolverParts {
 mod tests {
     use super::*;
 
-    /// Setting `liquidity_scope` (either value) without an exclusivity policy fails the build.
-    #[rstest::rstest]
-    #[case::all(LiquidityScope::All)]
-    #[case::public_only(LiquidityScope::PublicOnly)]
-    fn test_build_rejects_scoped_pool_without_policy(#[case] scope: LiquidityScope) {
-        let config = PoolConfig::new("most_liquid").with_liquidity_scope(scope);
-        let result = FyndBuilder::new(
-            Chain::Ethereum,
-            "wss://example.invalid",
-            "https://example.invalid",
-            vec!["uniswap_v2".to_string()],
-            100.0,
-        )
-        .add_pool("surplus", &config)
-        .expect("add_pool should accept the config")
-        .build();
-
-        assert!(matches!(result, Err(SolverBuildError::LiquidityScopeWithoutPolicy)));
+    /// An unscoped pool resolves to `All` — no filtering.
+    #[test]
+    fn test_unscoped_pool_resolves_to_all() {
+        let config = PoolConfig::new("most_liquid");
+        assert_eq!(config.liquidity_scope(), None);
+        assert_eq!(
+            config
+                .liquidity_scope()
+                .unwrap_or_default(),
+            LiquidityScope::All
+        );
     }
 }

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -159,7 +159,7 @@ pub struct PoolConfig {
     /// Absent = no restriction. Typically 3–10 entries (e.g. WETH, USDC, USDT, DAI).
     #[serde(default)]
     connector_tokens: Option<Vec<String>>,
-    /// The worker pool's liquidity scope; see [`LiquidityScope`].
+    /// Which liquidity this worker pool routes through.
     #[serde(default)]
     liquidity_scope: Option<LiquidityScope>,
 }

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -159,10 +159,7 @@ pub struct PoolConfig {
     /// Absent = no restriction. Typically 3–10 entries (e.g. WETH, USDC, USDT, DAI).
     #[serde(default)]
     connector_tokens: Option<Vec<String>>,
-    /// Worker pool liquidity scope: `all` (default — no filtering; workers ingest whatever the
-    /// deployment's stream delivers, which includes exclusive components only if the deployment
-    /// opted into them) or `public_only` (workers drop exclusive components, establishing the
-    /// public reference output for surplus routing). Absent = `all`.
+    /// The worker pool's liquidity scope; see [`LiquidityScope`].
     #[serde(default)]
     liquidity_scope: Option<LiquidityScope>,
 }
@@ -194,7 +191,7 @@ impl PoolConfig {
         self.liquidity_scope
     }
 
-    /// Sets the worker pool's liquidity scope (public or exclusive-access).
+    /// Sets the worker pool's liquidity scope.
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = Some(scope);
         self
@@ -371,7 +368,6 @@ struct CustomPoolEntry {
     max_hops: usize,
     timeout_ms: u64,
     max_routes: Option<usize>,
-    /// Worker pool liquidity scope: public (default) or exclusive-access.
     liquidity_scope: Option<LiquidityScope>,
     /// Applies the custom algorithm to a `WorkerPoolBuilder`.
     configure: Box<dyn FnOnce(WorkerPoolBuilder) -> WorkerPoolBuilder + Send>,
@@ -736,8 +732,6 @@ impl FyndBuilder {
             let pool_event_rx = tycho_feed.subscribe();
             let derived_rx = derived_event_tx.subscribe();
 
-            // `public_only` worker pools filter exclusive components out of their workers'
-            // graphs; unscoped worker pools default to `all` and ingest everything.
             let pool_scope = pool_entry
                 .liquidity_scope()
                 .unwrap_or_default();

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -1479,16 +1479,17 @@ impl SolverParts {
 mod tests {
     use super::*;
 
-    /// An unscoped pool resolves to `All` — no filtering.
+    /// An unscoped pool resolves to `PublicOnly` — exclusive components are filtered out unless
+    /// a pool explicitly opts in with `IncludeExclusive`.
     #[test]
-    fn test_unscoped_pool_resolves_to_all() {
+    fn test_unscoped_pool_resolves_to_public_only() {
         let config = PoolConfig::new("most_liquid");
         assert_eq!(config.liquidity_scope(), None);
         assert_eq!(
             config
                 .liquidity_scope()
                 .unwrap_or_default(),
-            LiquidityScope::All
+            LiquidityScope::PublicOnly
         );
     }
 }

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -47,8 +47,7 @@ pub struct WorkerPoolConfig {
     algorithm_config: AlgorithmConfig,
     /// Task queue capacity (maximum number of pending tasks).
     task_queue_capacity: usize,
-    /// Which liquidity this worker pool's workers ingest: `PublicOnly` filters exclusive
-    /// components out of each worker's graph; `All` (the default) applies no filtering.
+    /// Which liquidity this worker pool's workers ingest; see [`LiquidityScope`].
     liquidity_scope: LiquidityScope,
 }
 
@@ -262,10 +261,7 @@ impl WorkerPoolBuilder {
         self
     }
 
-    /// Sets which liquidity this pool's workers ingest.
-    ///
-    /// `PublicOnly` filters exclusive components out of each worker's graph; `All` (the
-    /// default) applies no filtering.
+    /// Sets which liquidity this pool's workers ingest; see [`LiquidityScope`].
     pub fn liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.config.liquidity_scope = scope;
         self

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -47,7 +47,7 @@ pub struct WorkerPoolConfig {
     algorithm_config: AlgorithmConfig,
     /// Task queue capacity (maximum number of pending tasks).
     task_queue_capacity: usize,
-    /// Which liquidity this worker pool's workers ingest; see [`LiquidityScope`].
+    /// Which liquidity this worker pool's workers ingest.
     liquidity_scope: LiquidityScope,
 }
 
@@ -261,7 +261,7 @@ impl WorkerPoolBuilder {
         self
     }
 
-    /// Sets which liquidity this pool's workers ingest; see [`LiquidityScope`].
+    /// Sets which liquidity this pool's workers ingest.
     pub fn liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.config.liquidity_scope = scope;
         self

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -18,7 +18,6 @@ use crate::{
     derived::{events::DerivedDataEvent, SharedDerivedDataRef},
     feed::{
         events::{MarketEvent, MarketEventHandler},
-        exclusivity::ExclusivityPolicy,
         market_data::MarketData,
     },
     graph::EdgeWeightUpdaterWithDerived,
@@ -30,6 +29,7 @@ use crate::{
         },
         task_queue::{TaskQueue, TaskQueueConfig, TaskQueueHandle},
     },
+    worker_pool_router::LiquidityScope,
 };
 
 /// Configuration for the worker pool.
@@ -47,15 +47,9 @@ pub struct WorkerPoolConfig {
     algorithm_config: AlgorithmConfig,
     /// Task queue capacity (maximum number of pending tasks).
     task_queue_capacity: usize,
-    /// When set, exclusive components are filtered out of this worker pool's workers' graphs
-    /// (default: `None`, no filtering).
-    ///
-    /// `All` is safe as the default because it only applies when no `ExclusivityPolicy` is
-    /// configured — meaning no exclusive components exist to exclude. When a policy is set,
-    /// `FyndBuilder::assemble_components` always constructs
-    /// `Some(policy)` for `Public`-scoped worker pools, so this default is never relied on in
-    /// that path.
-    exclusivity_policy: Option<ExclusivityPolicy>,
+    /// Which liquidity this worker pool's workers ingest: `PublicOnly` filters exclusive
+    /// components out of each worker's graph; `All` (the default) applies no filtering.
+    liquidity_scope: LiquidityScope,
 }
 
 impl WorkerPoolConfig {
@@ -73,7 +67,7 @@ impl Default for WorkerPoolConfig {
             num_workers: num_cpus::get(),
             algorithm_config: AlgorithmConfig::default(),
             task_queue_capacity: 1000,
-            exclusivity_policy: None,
+            liquidity_scope: LiquidityScope::default(),
         }
     }
 }
@@ -124,7 +118,7 @@ impl WorkerPool {
             .to_string();
 
         // Spawn workers
-        let exclusivity_policy = config.exclusivity_policy.clone();
+        let liquidity_scope = config.liquidity_scope;
         let params = SpawnWorkersParams {
             algorithm: algorithm.clone(),
             pool_name: name.clone(),
@@ -136,7 +130,7 @@ impl WorkerPool {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
-            exclusivity_policy,
+            liquidity_scope,
         };
         let workers = config.spawner.spawn(params)?;
 
@@ -268,12 +262,12 @@ impl WorkerPoolBuilder {
         self
     }
 
-    /// Sets the policy that filters exclusive components out of each worker's graph.
+    /// Sets which liquidity this pool's workers ingest.
     ///
-    /// Public worker pools receive `Some(policy)`; exclusive-access worker pools (and deployments
-    /// with no exclusive components configured) receive `None` and keep every component.
-    pub fn exclusivity_policy(mut self, policy: Option<ExclusivityPolicy>) -> Self {
-        self.config.exclusivity_policy = policy;
+    /// `PublicOnly` filters exclusive components out of each worker's graph; `All` (the
+    /// default) applies no filtering.
+    pub fn liquidity_scope(mut self, scope: LiquidityScope) -> Self {
+        self.config.liquidity_scope = scope;
         self
     }
 

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -60,7 +60,7 @@ pub(crate) struct SpawnWorkersParams {
     pub derived_event_rx: broadcast::Receiver<DerivedDataEvent>,
     /// Sender for shutdown signals.
     pub shutdown_tx: broadcast::Sender<()>,
-    /// Liquidity scope applied to every worker in this worker pool; see [`LiquidityScope`].
+    /// Liquidity scope applied to every worker in this worker pool.
     pub liquidity_scope: LiquidityScope,
 }
 

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -60,8 +60,7 @@ pub(crate) struct SpawnWorkersParams {
     pub derived_event_rx: broadcast::Receiver<DerivedDataEvent>,
     /// Sender for shutdown signals.
     pub shutdown_tx: broadcast::Sender<()>,
-    /// Liquidity scope applied to every worker in this worker pool: `PublicOnly` filters
-    /// exclusive components out of each worker's graph; `All` applies no filtering.
+    /// Liquidity scope applied to every worker in this worker pool; see [`LiquidityScope`].
     pub liquidity_scope: LiquidityScope,
 }
 

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -25,9 +25,10 @@ use crate::{
         MostLiquidAlgorithm, PathFrankWolfeAlgorithm, WaterFillAlgorithm,
     },
     derived::{events::DerivedDataEvent, SharedDerivedDataRef},
-    feed::{events::MarketEvent, exclusivity::ExclusivityPolicy, market_data::MarketData},
+    feed::{events::MarketEvent, market_data::MarketData},
     types::internal::SolveTask,
     worker_pool::worker::SolverWorker,
+    worker_pool_router::LiquidityScope,
 };
 
 /// List of available built-in algorithm names (for registry-based dispatch).
@@ -59,12 +60,9 @@ pub(crate) struct SpawnWorkersParams {
     pub derived_event_rx: broadcast::Receiver<DerivedDataEvent>,
     /// Sender for shutdown signals.
     pub shutdown_tx: broadcast::Sender<()>,
-    /// Exclusivity policy applied to every worker in this worker pool, cloned per worker.
-    ///
-    /// `Some(policy)` filters exclusive components out of each worker's graph (public worker
-    /// pools); `None` keeps every component (exclusive-access worker pools, or no exclusive
-    /// components configured).
-    pub exclusivity_policy: Option<ExclusivityPolicy>,
+    /// Liquidity scope applied to every worker in this worker pool: `PublicOnly` filters
+    /// exclusive components out of each worker's graph; `All` applies no filtering.
+    pub liquidity_scope: LiquidityScope,
 }
 
 /// Error returned when algorithm registration fails.
@@ -170,7 +168,7 @@ where
         let algorithm_name = params.algorithm.clone();
         let pool_name = params.pool_name.clone();
         let factory = factory.clone();
-        let exclusivity_policy = params.exclusivity_policy.clone();
+        let liquidity_scope = params.liquidity_scope;
 
         let handle = thread::Builder::new()
             .name(format!("{}-worker-{}", algorithm_name, worker_id))
@@ -190,7 +188,7 @@ where
                         worker_id,
                         pool_name,
                     )
-                    .with_exclusivity_policy(exclusivity_policy);
+                    .with_liquidity_scope(liquidity_scope);
 
                     worker.initialize_graph().await;
                     worker
@@ -269,7 +267,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx,
-            exclusivity_policy: None,
+            liquidity_scope: LiquidityScope::default(),
         }
     }
 
@@ -308,7 +306,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
-            exclusivity_policy: None,
+            liquidity_scope: LiquidityScope::default(),
         };
 
         let workers =
@@ -350,7 +348,7 @@ mod tests {
                 event_rx: event_tx.subscribe(),
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
-                exclusivity_policy: None,
+                liquidity_scope: LiquidityScope::default(),
             });
         assert!(registry_err.is_err());
 
@@ -378,7 +376,7 @@ mod tests {
                 event_rx: event_tx.subscribe(),
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
-                exclusivity_policy: None,
+                liquidity_scope: LiquidityScope::default(),
             });
 
         assert!(workers.is_ok());
@@ -407,7 +405,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
-            exclusivity_policy: None,
+            liquidity_scope: LiquidityScope::default(),
         };
 
         let workers =
@@ -439,7 +437,7 @@ mod tests {
             event_rx,
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
-            exclusivity_policy: None,
+            liquidity_scope: LiquidityScope::default(),
         };
 
         let workers =

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -25,7 +25,7 @@ use crate::{
     },
     feed::{
         events::{MarketEvent, MarketEventHandler},
-        exclusivity::{filter_topology, scope_event},
+        exclusivity::{remove_exclusive_components, scope_event},
         market_data::MarketData,
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
@@ -70,7 +70,7 @@ where
     worker_id: usize,
     /// Worker pool name (used as the `pool` metric label).
     pool_name: String,
-    /// Which liquidity this worker ingests; see [`LiquidityScope`].
+    /// Which liquidity this worker ingests.
     liquidity_scope: LiquidityScope,
 }
 
@@ -113,7 +113,7 @@ where
         }
     }
 
-    /// Sets which liquidity this worker ingests; see [`LiquidityScope`].
+    /// Sets which liquidity this worker ingests.
     pub(crate) fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = scope;
         self
@@ -129,7 +129,9 @@ where
             let market = self.market_data.read().await;
             let topology = market.component_topology().clone(); // clone to avoid holding the lock
             match self.liquidity_scope {
-                LiquidityScope::PublicOnly => filter_topology(market.base_market_state(), topology),
+                LiquidityScope::PublicOnly => {
+                    remove_exclusive_components(market.base_market_state(), topology)
+                }
                 LiquidityScope::All => topology,
             }
         };

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -132,7 +132,7 @@ where
                 LiquidityScope::PublicOnly => {
                     remove_exclusive_components(market.base_market_state(), topology)
                 }
-                LiquidityScope::All => topology,
+                LiquidityScope::IncludeExclusive => topology,
             }
         };
 
@@ -147,7 +147,7 @@ where
             let market = self.market_data.read().await;
             match self.liquidity_scope {
                 LiquidityScope::PublicOnly => scope_event(market.base_market_state(), event),
-                LiquidityScope::All => event,
+                LiquidityScope::IncludeExclusive => event,
             }
         };
         match event {

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -25,11 +25,12 @@ use crate::{
     },
     feed::{
         events::{MarketEvent, MarketEventHandler},
-        exclusivity::ExclusivityPolicy,
+        exclusivity::{filter_topology, scope_event},
         market_data::MarketData,
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
     types::internal::SolveTask,
+    worker_pool_router::LiquidityScope,
     BlockInfo, Order, OrderQuote, QuoteStatus, SingleOrderQuote, SolveError, SolveParams,
 };
 
@@ -69,13 +70,9 @@ where
     worker_id: usize,
     /// Worker pool name (used as the `pool` metric label).
     pool_name: String,
-    /// When set, exclusive components are filtered out of this worker's local graph
-    /// (workers of public worker pools). `None` means the worker ingests everything.
-    ///
-    /// `All` (the default) preserves the original non-filtered behaviour. A public worker
-    /// is configured with `PublicOnly(policy)` so exclusive components never enter its graph; an
-    /// exclusive-access worker uses `All`.
-    exclusivity_policy: Option<ExclusivityPolicy>,
+    /// Which liquidity this worker ingests: `PublicOnly` filters exclusive components out of
+    /// the local graph; `All` (the default) applies no filtering.
+    liquidity_scope: LiquidityScope,
 }
 
 impl<A> SolverWorker<A>
@@ -113,15 +110,14 @@ where
             initialized: false,
             worker_id,
             pool_name,
-            exclusivity_policy: None,
+            liquidity_scope: LiquidityScope::default(),
         }
     }
 
-    /// Configures the policy that filters exclusive components out of this worker's graph.
-    ///
-    /// Public workers use `PublicOnly(policy)`; exclusive-access workers use `All`.
-    pub(crate) fn with_exclusivity_policy(mut self, policy: Option<ExclusivityPolicy>) -> Self {
-        self.exclusivity_policy = policy;
+    /// Sets which liquidity this worker ingests. `PublicOnly` workers filter exclusive
+    /// components out of their graphs; `All` workers apply no filtering.
+    pub(crate) fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
+        self.liquidity_scope = scope;
         self
     }
 
@@ -134,9 +130,9 @@ where
             // read lock on market data
             let market = self.market_data.read().await;
             let topology = market.component_topology().clone(); // clone to avoid holding the lock
-            match &self.exclusivity_policy {
-                Some(policy) => policy.filter_topology(market.base_market_state(), topology),
-                None => topology,
+            match self.liquidity_scope {
+                LiquidityScope::PublicOnly => filter_topology(market.base_market_state(), topology),
+                LiquidityScope::All => topology,
             }
         };
 
@@ -149,9 +145,9 @@ where
     pub async fn process_event(&mut self, event: MarketEvent) {
         let event = {
             let market = self.market_data.read().await;
-            match &self.exclusivity_policy {
-                Some(policy) => policy.scope_event(market.base_market_state(), event),
-                None => event,
+            match self.liquidity_scope {
+                LiquidityScope::PublicOnly => scope_event(market.base_market_state(), event),
+                LiquidityScope::All => event,
             }
         };
         match event {

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -70,8 +70,7 @@ where
     worker_id: usize,
     /// Worker pool name (used as the `pool` metric label).
     pool_name: String,
-    /// Which liquidity this worker ingests: `PublicOnly` filters exclusive components out of
-    /// the local graph; `All` (the default) applies no filtering.
+    /// Which liquidity this worker ingests; see [`LiquidityScope`].
     liquidity_scope: LiquidityScope,
 }
 
@@ -114,8 +113,7 @@ where
         }
     }
 
-    /// Sets which liquidity this worker ingests. `PublicOnly` workers filter exclusive
-    /// components out of their graphs; `All` workers apply no filtering.
+    /// Sets which liquidity this worker ingests; see [`LiquidityScope`].
     pub(crate) fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = scope;
         self

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -42,10 +42,9 @@ use tycho_execution::encoding::{
 use tycho_simulation::tycho_common::Bytes;
 
 use crate::{
-    encoding::encoder::Encoder, feed::exclusivity::ExclusivityPolicy,
-    price_guard::guard::PriceGuard, worker_pool::task_queue::TaskQueueHandle, BlockInfo,
-    EncodingOptions, Order, OrderQuote, Quote, QuoteOptions, QuoteRequest, QuoteStatus, SolveError,
-    SolveParams, SurplusInfo,
+    encoding::encoder::Encoder, feed::exclusivity::is_exclusive, price_guard::guard::PriceGuard,
+    worker_pool::task_queue::TaskQueueHandle, BlockInfo, EncodingOptions, Order, OrderQuote, Quote,
+    QuoteOptions, QuoteRequest, QuoteStatus, SolveError, SolveParams, SurplusInfo,
 };
 
 /// Environment variable overriding [`DEFAULT_USER_IMPROVEMENT_SHARE_BPS`]. Read once, on the
@@ -104,11 +103,13 @@ fn user_margin(improvement: &BigUint, user_share_bps: u32) -> BigUint {
 /// Which liquidity a solver pool (a group of workers) routes through, and therefore what its
 /// candidates mean in a quote.
 ///
-/// A public worker pool routes only through public liquidity and provides the committed (quoted)
-/// reference output; its workers are given the [`ExclusivityPolicy`] so exclusive components
-/// never enter their graphs. An exclusive-access worker pool routes through all liquidity, public
-/// and exclusive components alike, and may beat that reference — in which case the protocol
-/// captures the surplus.
+/// A `PublicOnly` worker pool routes only through public liquidity and provides the committed
+/// (quoted) reference output; its workers filter exclusive components out of their graphs. An
+/// `All` worker pool applies no filtering — its workers ingest whatever the deployment's stream
+/// delivers. In a deployment opted into exclusive components at the stream filter, an `All`
+/// worker pool may beat the public reference — in which case the protocol captures the surplus.
+/// Without that opt-in, no exclusive components ever arrive and the two scopes behave
+/// identically.
 ///
 /// Serialized in snake_case (`"public_only"` / `"all"`) in `worker_pools.toml` via
 /// [`PoolConfig`].
@@ -117,11 +118,12 @@ fn user_margin(improvement: &BigUint, user_share_bps: u32) -> BigUint {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LiquidityScope {
-    /// Routes through public liquidity only. Establishes the committed reference output. Default.
-    #[default]
+    /// Routes through public liquidity only, establishing the committed reference output.
     PublicOnly,
-    /// Routes through all liquidity, public and exclusive components alike; candidates from
-    /// this scope may capture surplus above the public reference.
+    /// No filtering: routes through whatever the stream delivers, exclusive components
+    /// included if the deployment opted into them. Candidates from this scope may capture
+    /// surplus above the public reference.
+    #[default]
     All,
 }
 
@@ -137,13 +139,13 @@ pub struct SolverPoolHandle {
 }
 
 impl SolverPoolHandle {
-    /// Creates a new solver pool handle with the default [`LiquidityScope::PublicOnly`] scope.
+    /// Creates a new solver pool handle with the default [`LiquidityScope::All`] scope.
     pub fn new(name: impl Into<String>, queue: TaskQueueHandle) -> Self {
-        Self { name: name.into(), queue, liquidity_scope: LiquidityScope::PublicOnly }
+        Self { name: name.into(), queue, liquidity_scope: LiquidityScope::default() }
     }
 
-    /// Sets the worker pool's liquidity scope (e.g. [`LiquidityScope::All`] for a worker pool
-    /// that routes through exclusive liquidity as well).
+    /// Sets the worker pool's liquidity scope (e.g. [`LiquidityScope::PublicOnly`] for a worker
+    /// pool that establishes the committed public reference).
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = scope;
         self
@@ -210,9 +212,6 @@ pub struct WorkerPoolRouter {
     /// Validates solution outputs against external price sources.
     /// Present when the server has price guard enabled; `None` when disabled.
     price_guard: Option<PriceGuard>,
-    /// Predicate identifying the exclusive legs in exclusive-access routes. `None` when no
-    /// exclusive components are configured.
-    exclusivity_policy: Option<ExclusivityPolicy>,
 }
 
 impl WorkerPoolRouter {
@@ -222,13 +221,7 @@ impl WorkerPoolRouter {
         config: WorkerPoolRouterConfig,
         encoder: Encoder,
     ) -> Self {
-        Self { solver_pools, config, encoder, price_guard: None, exclusivity_policy: None }
-    }
-
-    /// Attaches the policy used to identify exclusive legs in exclusive-access routes.
-    pub fn with_exclusivity_policy(mut self, policy: ExclusivityPolicy) -> Self {
-        self.exclusivity_policy = Some(policy);
-        self
+        Self { solver_pools, config, encoder, price_guard: None }
     }
 
     /// Makes price guard validation available for this router.
@@ -292,20 +285,24 @@ impl WorkerPoolRouter {
             .iter()
             .map(|p| (p.name().to_string(), p.liquidity_scope()))
             .collect();
-        let has_exclusive_access_pool = pool_scopes
+        // Surplus routing needs both scopes: a `public_only` pool for the committed reference
+        // and an `all` pool that may beat it.
+        let surplus_routing_active = pool_scopes
             .values()
-            .any(|r| *r == LiquidityScope::All);
+            .any(|r| *r == LiquidityScope::All) &&
+            pool_scopes
+                .values()
+                .any(|r| *r == LiquidityScope::PublicOnly);
 
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
         // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
-        // fallback chain. When an `ExclusiveAccess`-scoped worker pool is configured, the winning
-        // exclusive-access candidate is overlaid
-        // onto that ranked list (prepended) by `combine_with_surplus`, so the fallbacks are
-        // preserved.
+        // fallback chain. When both scopes are configured, the winning exclusive-access
+        // candidate is overlaid onto that ranked list (prepended) by `combine_with_surplus`, so
+        // the fallbacks are preserved.
         let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
             .map(|responses| {
-                if has_exclusive_access_pool {
+                if surplus_routing_active {
                     let public_ranked =
                         self.rank_quotes(&responses.public_only(&pool_scopes), request.options());
                     combine_with_surplus(
@@ -313,7 +310,6 @@ impl WorkerPoolRouter {
                         &pool_scopes,
                         request.options(),
                         public_ranked,
-                        self.exclusivity_policy.as_ref(),
                         *USER_IMPROVEMENT_SHARE_BPS,
                     )
                 } else {
@@ -408,15 +404,18 @@ impl WorkerPoolRouter {
             })
             .collect();
 
-        // Pre-compute which worker pool names have the ExclusiveAccess scope, for scope-aware
-        // early return gating.
+        // Pre-compute which worker pool names have the exclusive-access (`All`) scope, for
+        // scope-aware early return gating. The gating only applies when both scopes are
+        // configured — the surplus overlay then needs one response from each; with a single
+        // scope (e.g. every worker pool on the `All` default), plain count-based gating applies.
         let exclusive_access_pool_names: HashSet<String> = self
             .solver_pools
             .iter()
             .filter(|p| p.liquidity_scope() == LiquidityScope::All)
             .map(|p| p.name().to_string())
             .collect();
-        let has_exclusive_access_pool = !exclusive_access_pool_names.is_empty();
+        let surplus_routing_active = !exclusive_access_pool_names.is_empty() &&
+            exclusive_access_pool_names.len() < self.solver_pools.len();
 
         let mut quotes = Vec::new();
         let mut failed_solvers: Vec<(String, SolveError)> = Vec::new();
@@ -466,12 +465,11 @@ impl WorkerPoolRouter {
                             // Extract the OrderQuote from SingleOrderQuote
                             quotes.push((pool_name.clone(), single_quote.order().clone()));
 
-                            // Scope-aware early return: when an exclusive-access worker pool is
-                            // configured, only fire once we have ≥1 public response AND the
-                            // exclusive-access worker pool's response (so the surplus overlay has
-                            // both inputs). Without an exclusive-access worker pool, use pure
+                            // Scope-aware early return: when surplus routing is active, only
+                            // fire once we have ≥1 public AND ≥1 exclusive-access response (so
+                            // the surplus overlay has both inputs). Otherwise, use pure
                             // count-based gating (original behaviour).
-                            let scope_ready = if has_exclusive_access_pool {
+                            let scope_ready = if surplus_routing_active {
                                 has_public_response && has_exclusive_access_response
                             } else {
                                 true
@@ -741,13 +739,8 @@ fn combine_with_surplus(
     pool_scopes: &HashMap<String, LiquidityScope>,
     options: &QuoteOptions,
     public_ranked: Vec<OrderQuote>,
-    exclusivity_policy: Option<&ExclusivityPolicy>,
     user_share_bps: u32,
 ) -> Vec<OrderQuote> {
-    let Some(policy) = exclusivity_policy else {
-        return public_ranked;
-    };
-
     let committed = match public_ranked.first() {
         Some(q) if q.status() == QuoteStatus::Success => q,
         _ => return public_ranked,
@@ -765,7 +758,7 @@ fn combine_with_surplus(
                 .map(|max| q.gas_estimate() <= max)
                 .unwrap_or(true)
         })
-        .filter(|(_, q)| has_valid_exclusive_route(q, policy))
+        .filter(|(_, q)| has_valid_exclusive_route(q))
         .max_by(|(_, a), (_, b)| {
             a.amount_out_net_gas()
                 .cmp(b.amount_out_net_gas())
@@ -841,7 +834,7 @@ fn combine_with_surplus(
         // Each leg absorbs up to its path's capacity; any remainder is left with the user.
         let mut surplus = exclusive_route_amount_out - &committed_amount_out;
         for (i, swap) in route.swaps_mut().iter_mut().enumerate() {
-            if policy.is_exclusive(swap.protocol_component()) {
+            if is_exclusive(swap.protocol_component()) {
                 let Some(path_final_out) = path_final_outs.get(i) else {
                     continue;
                 };
@@ -898,7 +891,7 @@ fn combine_with_surplus(
 /// token, and multiple exclusive legs make the per-component attribution non-unique. Both are
 /// deferred to a future version. Terminal is defined as producing the route's overall output
 /// token (`Route::output_token`).
-fn has_valid_exclusive_route(quote: &OrderQuote, policy: &ExclusivityPolicy) -> bool {
+fn has_valid_exclusive_route(quote: &OrderQuote) -> bool {
     let Some(route) = quote.route() else {
         return false;
     };
@@ -915,7 +908,7 @@ fn has_valid_exclusive_route(quote: &OrderQuote, policy: &ExclusivityPolicy) -> 
     let mut exclusive_count = 0;
 
     for swap in swaps {
-        if !policy.is_exclusive(swap.protocol_component()) {
+        if !is_exclusive(swap.protocol_component()) {
             continue;
         }
 
@@ -1024,6 +1017,7 @@ mod tests {
     use super::*;
     use crate::{
         algorithm::test_utils::{component, MockProtocolSim},
+        feed::exclusivity::mark_exclusive,
         types::internal::SolveTask,
         EncodingOptions, OrderSide, Route, SingleOrderQuote, Swap,
     };
@@ -1295,6 +1289,7 @@ mod tests {
                 Err(SolveError::NoRouteFound { order_id: "test-order".to_string(), reason: None })
             }
         };
+        let public_pool = public_pool.with_liquidity_scope(LiquidityScope::PublicOnly);
         let (exclusive_pool, exclusive_worker) =
             create_mock_pool("exclusive_pool", exclusive_response, exclusive_delay_ms.unwrap_or(0));
         let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::All);
@@ -1303,8 +1298,7 @@ mod tests {
             .with_timeout(Duration::from_millis(2000))
             .with_min_responses(1);
         let worker_router =
-            WorkerPoolRouter::new(vec![public_pool, exclusive_pool], config, default_encoder())
-                .with_exclusivity_policy(exclusive_policy());
+            WorkerPoolRouter::new(vec![public_pool, exclusive_pool], config, default_encoder());
         let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
 
         let start = Instant::now();
@@ -1685,10 +1679,6 @@ mod tests {
         assert_eq!(*result[1].amount_out_net_gas(), BigUint::from(800u64));
     }
 
-    fn exclusive_policy() -> ExclusivityPolicy {
-        ExclusivityPolicy::new(|c| c.protocol_system == "vm:exclusive")
-    }
-
     /// Like `make_single_quote` but the swap uses an exclusive protocol component. The swap's own
     /// output is `leg_amount_out`, letting tests exercise per-leg attribution where the leg
     /// differs from the route total
@@ -1714,7 +1704,7 @@ mod tests {
             "0x0000000000000000000000000000000000000002",
             &[tin_token.clone(), tout_token.clone()],
         );
-        comp.protocol_system = "vm:exclusive".to_string();
+        mark_exclusive(&mut comp);
         let swap = Swap::new(
             "pool-perm".to_string(),
             "vm:exclusive".to_string(),
@@ -1785,7 +1775,7 @@ mod tests {
             "0x0000000000000000000000000000000000000002",
             &[tin_token.clone(), tout_token.clone()],
         );
-        exclusive_comp.protocol_system = "vm:exclusive".to_string();
+        mark_exclusive(&mut exclusive_comp);
         let exclusive_swap = Swap::new(
             "pool-perm".to_string(),
             "vm:exclusive".to_string(),
@@ -1941,13 +1931,11 @@ mod tests {
         let public_ranked = vec![make_public_quote_with_net(public_out, public_net)
             .order()
             .clone()];
-        let policy = exclusive_policy();
         let combined = combine_with_surplus(
             &responses,
             &exclusive_access_pool_scopes(),
             &QuoteOptions::default(),
             public_ranked,
-            Some(&policy),
             user_share_bps,
         );
 
@@ -1997,13 +1985,11 @@ mod tests {
         let public_ranked = vec![make_public_quote_zero_gas(900)
             .order()
             .clone()];
-        let policy = exclusive_policy();
         let combined = combine_with_surplus(
             &responses,
             &exclusive_access_pool_scopes(),
             &options,
             public_ranked,
-            Some(&policy),
             1_000,
         );
 
@@ -2018,13 +2004,11 @@ mod tests {
         let public_ranked = vec![make_public_quote_zero_gas(900)
             .order()
             .clone()];
-        let policy = exclusive_policy();
         let combined = combine_with_surplus(
             &responses,
             &exclusive_access_pool_scopes(),
             &QuoteOptions::default(),
             public_ranked,
-            Some(&policy),
             1_000,
         );
 
@@ -2035,7 +2019,7 @@ mod tests {
         let perm_swap = route
             .swaps()
             .iter()
-            .find(|s| policy.is_exclusive(s.protocol_component()))
+            .find(|s| exclusivity::is_exclusive(s.protocol_component()))
             .expect("should have an exclusive swap");
 
         // committed_leg = leg.amount_out * committed_route_out / realized_route_out
@@ -2068,13 +2052,11 @@ mod tests {
         let public_ranked = vec![make_public_quote_zero_gas(900)
             .order()
             .clone()];
-        let policy = exclusive_policy();
         let combined = combine_with_surplus(
             &responses,
             &exclusive_access_pool_scopes(),
             &QuoteOptions::default(),
             public_ranked,
-            Some(&policy),
             1_000,
         );
 
@@ -2084,7 +2066,7 @@ mod tests {
         let perm_swap = route
             .swaps()
             .iter()
-            .find(|s| policy.is_exclusive(s.protocol_component()))
+            .find(|s| exclusivity::is_exclusive(s.protocol_component()))
             .expect("should have an exclusive swap");
         assert_eq!(perm_swap.committed_amount_out(), Some(&BigUint::from(905u64)));
     }
@@ -2099,25 +2081,6 @@ mod tests {
     #[case::empty("", None)]
     fn test_parse_user_improvement_share_bps(#[case] raw: &str, #[case] expected: Option<u32>) {
         assert_eq!(parse_user_improvement_share_bps(raw), expected);
-    }
-
-    #[test]
-    fn test_combine_without_exclusivity_policy() {
-        let responses = exclusive_access_responses(900, 950);
-        let public_ranked = vec![make_public_quote_zero_gas(900)
-            .order()
-            .clone()];
-        let combined = combine_with_surplus(
-            &responses,
-            &exclusive_access_pool_scopes(),
-            &QuoteOptions::default(),
-            public_ranked.clone(),
-            None,
-            1_000,
-        );
-
-        assert_eq!(combined.len(), 1);
-        assert_eq!(combined[0].surplus_amount(), None);
     }
 
     #[test]
@@ -2146,13 +2109,11 @@ mod tests {
         let public_ranked = vec![make_public_quote_zero_gas(1000)
             .order()
             .clone()];
-        let policy = exclusive_policy();
         let combined = combine_with_surplus(
             &responses,
             &exclusive_access_pool_scopes(),
             &QuoteOptions::default(),
             public_ranked,
-            Some(&policy),
             1_000,
         );
 
@@ -2163,7 +2124,7 @@ mod tests {
         let public_leg = route
             .swaps()
             .iter()
-            .find(|s| !policy.is_exclusive(s.protocol_component()))
+            .find(|s| !is_exclusive(s.protocol_component()))
             .expect("should have a public swap");
         assert_eq!(public_leg.committed_amount_out(), None);
 
@@ -2174,7 +2135,7 @@ mod tests {
         let exclusive_leg = route
             .swaps()
             .iter()
-            .find(|s| policy.is_exclusive(s.protocol_component()))
+            .find(|s| is_exclusive(s.protocol_component()))
             .expect("should have an exclusive swap");
         assert_eq!(exclusive_leg.committed_amount_out(), Some(&BigUint::from(410u64)));
     }
@@ -2230,6 +2191,9 @@ mod tests {
                 &[tin_token.clone(), tout_token.clone()],
             );
             comp.protocol_system = protocol_system.to_string();
+            if *protocol_system == "vm:exclusive" {
+                mark_exclusive(&mut comp);
+            }
             swaps.push(Swap::new(
                 format!("pool-{tin_byte}-{tout_byte}"),
                 protocol_system.to_string(),
@@ -2313,6 +2277,6 @@ mod tests {
         true)]
     fn test_exclusive_route_validation(#[case] legs: &[(&str, u8, u8)], #[case] expected: bool) {
         let quote = make_route_quote(legs);
-        assert_eq!(has_valid_exclusive_route(&quote, &exclusive_policy()), expected);
+        assert_eq!(has_valid_exclusive_route(&quote), expected);
     }
 }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -2019,7 +2019,7 @@ mod tests {
         let perm_swap = route
             .swaps()
             .iter()
-            .find(|s| exclusivity::is_exclusive(s.protocol_component()))
+            .find(|s| is_exclusive(s.protocol_component()))
             .expect("should have an exclusive swap");
 
         // committed_leg = leg.amount_out * committed_route_out / realized_route_out
@@ -2066,7 +2066,7 @@ mod tests {
         let perm_swap = route
             .swaps()
             .iter()
-            .find(|s| exclusivity::is_exclusive(s.protocol_component()))
+            .find(|s| is_exclusive(s.protocol_component()))
             .expect("should have an exclusive swap");
         assert_eq!(perm_swap.committed_amount_out(), Some(&BigUint::from(905u64)));
     }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -134,7 +134,7 @@ pub struct SolverPoolHandle {
     name: String,
     /// Queue handle for this worker pool.
     queue: TaskQueueHandle,
-    /// Whether this worker pool routes public-only or all liquidity.
+    /// Which liquidity this worker pool routes through; see [`LiquidityScope`].
     liquidity_scope: LiquidityScope,
 }
 
@@ -144,8 +144,7 @@ impl SolverPoolHandle {
         Self { name: name.into(), queue, liquidity_scope: LiquidityScope::default() }
     }
 
-    /// Sets the worker pool's liquidity scope (e.g. [`LiquidityScope::PublicOnly`] for a worker
-    /// pool that establishes the committed public reference).
+    /// Sets the worker pool's liquidity scope.
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = scope;
         self

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -105,13 +105,13 @@ fn user_margin(improvement: &BigUint, user_share_bps: u32) -> BigUint {
 ///
 /// A `PublicOnly` worker pool routes only through public liquidity and provides the committed
 /// (quoted) reference output; its workers filter exclusive components out of their graphs. An
-/// `All` worker pool applies no filtering — its workers ingest whatever the deployment's stream
-/// delivers. In a deployment opted into exclusive components at the stream filter, an `All`
-/// worker pool may beat the public reference — in which case the protocol captures the surplus.
-/// Without that opt-in, no exclusive components ever arrive and the two scopes behave
-/// identically.
+/// `IncludeExclusive` worker pool applies no filtering — its workers ingest whatever the
+/// deployment's stream delivers. In a deployment opted into exclusive components at the stream
+/// filter, an `IncludeExclusive` worker pool may beat the public reference — in which case the
+/// protocol captures the surplus. Without that opt-in, no exclusive components ever arrive and
+/// the two scopes behave identically.
 ///
-/// Serialized in snake_case (`"public_only"` / `"all"`) in `worker_pools.toml` via
+/// Serialized in snake_case (`"public_only"` / `"include_exclusive"`) in `worker_pools.toml` via
 /// [`PoolConfig`].
 ///
 /// [`PoolConfig`]: crate::PoolConfig
@@ -119,12 +119,12 @@ fn user_margin(improvement: &BigUint, user_share_bps: u32) -> BigUint {
 #[serde(rename_all = "snake_case")]
 pub enum LiquidityScope {
     /// Routes through public liquidity only, establishing the committed reference output.
+    #[default]
     PublicOnly,
     /// No filtering: routes through whatever the stream delivers, exclusive components
     /// included if the deployment opted into them. Candidates from this scope may capture
     /// surplus above the public reference.
-    #[default]
-    All,
+    IncludeExclusive,
 }
 
 /// Handle to a solver pool for dispatching orders.
@@ -139,7 +139,7 @@ pub struct SolverPoolHandle {
 }
 
 impl SolverPoolHandle {
-    /// Creates a new solver pool handle with the default [`LiquidityScope::All`] scope.
+    /// Creates a new solver pool handle with the default [`LiquidityScope::PublicOnly`] scope.
     pub fn new(name: impl Into<String>, queue: TaskQueueHandle) -> Self {
         Self { name: name.into(), queue, liquidity_scope: LiquidityScope::default() }
     }
@@ -189,7 +189,7 @@ impl OrderResponses {
         let quotes = self
             .quotes
             .iter()
-            .filter(|(pool, _)| pool_scopes.get(pool) != Some(&LiquidityScope::All))
+            .filter(|(pool, _)| pool_scopes.get(pool) != Some(&LiquidityScope::IncludeExclusive))
             .cloned()
             .collect();
         OrderResponses {
@@ -239,11 +239,11 @@ impl WorkerPoolRouter {
 
     /// Returns `true` when surplus routing is active: it needs both scopes configured — a
     /// [`LiquidityScope::PublicOnly`] pool for the committed reference and a
-    /// [`LiquidityScope::All`] pool that may beat it.
+    /// [`LiquidityScope::IncludeExclusive`] pool that may beat it.
     fn surplus_routing_active(&self) -> bool {
         self.solver_pools
             .iter()
-            .any(|p| p.liquidity_scope() == LiquidityScope::All) &&
+            .any(|p| p.liquidity_scope() == LiquidityScope::IncludeExclusive) &&
             self.solver_pools
                 .iter()
                 .any(|p| p.liquidity_scope() == LiquidityScope::PublicOnly)
@@ -408,14 +408,15 @@ impl WorkerPoolRouter {
             })
             .collect();
 
-        // Pre-compute which worker pool names have the exclusive-access (`All`) scope, for
-        // scope-aware early return gating. The gating only applies when surplus routing is
+        // Pre-compute which worker pool names have the exclusive-access (`IncludeExclusive`)
+        // scope, for scope-aware early return gating. The gating only applies when surplus
+        // routing is
         // active — the surplus overlay then needs one response from each scope; otherwise plain
         // count-based gating applies.
         let exclusive_access_pool_names: HashSet<String> = self
             .solver_pools
             .iter()
-            .filter(|p| p.liquidity_scope() == LiquidityScope::All)
+            .filter(|p| p.liquidity_scope() == LiquidityScope::IncludeExclusive)
             .map(|p| p.name().to_string())
             .collect();
         let surplus_routing_active = self.surplus_routing_active();
@@ -753,7 +754,7 @@ fn combine_with_surplus(
     let best_exclusive_access_candidate = responses
         .quotes
         .iter()
-        .filter(|(pool, _)| pool_scopes.get(pool) == Some(&LiquidityScope::All))
+        .filter(|(pool, _)| pool_scopes.get(pool) == Some(&LiquidityScope::IncludeExclusive))
         .filter(|(_, q)| q.status() == QuoteStatus::Success)
         .filter(|(_, q)| {
             options
@@ -1295,7 +1296,7 @@ mod tests {
         let public_pool = public_pool.with_liquidity_scope(LiquidityScope::PublicOnly);
         let (exclusive_pool, exclusive_worker) =
             create_mock_pool("exclusive_pool", exclusive_response, exclusive_delay_ms.unwrap_or(0));
-        let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::All);
+        let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::IncludeExclusive);
 
         let config = WorkerPoolRouterConfig::default()
             .with_timeout(Duration::from_millis(2000))
@@ -1889,7 +1890,7 @@ mod tests {
     fn exclusive_access_pool_scopes() -> HashMap<String, LiquidityScope> {
         HashMap::from([
             ("public_pool".to_string(), LiquidityScope::PublicOnly),
-            ("exclusive_access_pool".to_string(), LiquidityScope::All),
+            ("exclusive_access_pool".to_string(), LiquidityScope::IncludeExclusive),
         ])
     }
 

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -237,6 +237,18 @@ impl WorkerPoolRouter {
         self.solver_pools.len()
     }
 
+    /// Returns `true` when surplus routing is active: it needs both scopes configured — a
+    /// [`LiquidityScope::PublicOnly`] pool for the committed reference and a
+    /// [`LiquidityScope::All`] pool that may beat it.
+    fn surplus_routing_active(&self) -> bool {
+        self.solver_pools
+            .iter()
+            .any(|p| p.liquidity_scope() == LiquidityScope::All) &&
+            self.solver_pools
+                .iter()
+                .any(|p| p.liquidity_scope() == LiquidityScope::PublicOnly)
+    }
+
     /// Returns a quote by fanning out to all solver pools.
     ///
     /// For each order in the request:
@@ -284,14 +296,7 @@ impl WorkerPoolRouter {
             .iter()
             .map(|p| (p.name().to_string(), p.liquidity_scope()))
             .collect();
-        // Surplus routing needs both scopes: a `public_only` pool for the committed reference
-        // and an `all` pool that may beat it.
-        let surplus_routing_active = pool_scopes
-            .values()
-            .any(|r| *r == LiquidityScope::All) &&
-            pool_scopes
-                .values()
-                .any(|r| *r == LiquidityScope::PublicOnly);
+        let surplus_routing_active = self.surplus_routing_active();
 
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
         // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
@@ -404,17 +409,16 @@ impl WorkerPoolRouter {
             .collect();
 
         // Pre-compute which worker pool names have the exclusive-access (`All`) scope, for
-        // scope-aware early return gating. The gating only applies when both scopes are
-        // configured — the surplus overlay then needs one response from each; with a single
-        // scope (e.g. every worker pool on the `All` default), plain count-based gating applies.
+        // scope-aware early return gating. The gating only applies when surplus routing is
+        // active — the surplus overlay then needs one response from each scope; otherwise plain
+        // count-based gating applies.
         let exclusive_access_pool_names: HashSet<String> = self
             .solver_pools
             .iter()
             .filter(|p| p.liquidity_scope() == LiquidityScope::All)
             .map(|p| p.name().to_string())
             .collect();
-        let surplus_routing_active = !exclusive_access_pool_names.is_empty() &&
-            exclusive_access_pool_names.len() < self.solver_pools.len();
+        let surplus_routing_active = self.surplus_routing_active();
 
         let mut quotes = Vec::new();
         let mut failed_solvers: Vec<(String, SolveError)> = Vec::new();

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -134,7 +134,7 @@ pub struct SolverPoolHandle {
     name: String,
     /// Queue handle for this worker pool.
     queue: TaskQueueHandle,
-    /// Which liquidity this worker pool routes through; see [`LiquidityScope`].
+    /// Which liquidity this worker pool routes through.
     liquidity_scope: LiquidityScope,
 }
 

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -24,16 +24,16 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
-# Example: a public-only worker pool whose workers drop exclusive components, establishing the
-# committed public reference for surplus routing (see repo-root worker_pools.toml). Worker pools
-# with the key omitted default to "all" and route through everything, exclusive components
-# included.
-# [pools.public_baseline]
+# Example: an exclusive-access worker pool whose workers also route through exclusive components
+# to capture surplus above the committed public reference (see repo-root worker_pools.toml).
+# Worker pools with the key omitted default to "public_only": their workers drop exclusive
+# components.
+# [pools.exclusive_access]
 # algorithm = "bellman_ford"
 # num_workers = 3
 # max_hops = 2
 # timeout_ms = 500
-# liquidity_scope = "public_only"
+# liquidity_scope = "include_exclusive"
 "#;
 
 /// Worker pools configuration loaded from TOML file.
@@ -154,7 +154,7 @@ mod tests {
             max_hops = 4
             timeout_ms = 200
             max_routes = 50
-            liquidity_scope = "all"
+            liquidity_scope = "include_exclusive"
         "#;
         let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
         let pool = &config.pools()["custom"];
@@ -165,7 +165,7 @@ mod tests {
         assert_eq!(pool.max_hops(), 4);
         assert_eq!(pool.timeout_ms(), 200);
         assert_eq!(pool.max_routes(), Some(50));
-        assert_eq!(pool.liquidity_scope(), Some(LiquidityScope::All));
+        assert_eq!(pool.liquidity_scope(), Some(LiquidityScope::IncludeExclusive));
     }
 }
 

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -24,15 +24,16 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
-# Example: an exclusive-access worker pool that also routes through exclusive liquidity (see
-# repo-root worker_pools.toml). Public worker pools (liquidity_scope omitted; defaults to
-# "public_only") never see exclusive components.
-# [pools.exclusive_access]
+# Example: a public-only worker pool whose workers drop exclusive components, establishing the
+# committed public reference for surplus routing (see repo-root worker_pools.toml). Worker pools
+# with the key omitted default to "all" and route through everything, exclusive components
+# included.
+# [pools.public_baseline]
 # algorithm = "bellman_ford"
 # num_workers = 3
 # max_hops = 2
 # timeout_ms = 500
-# liquidity_scope = "all"
+# liquidity_scope = "public_only"
 "#;
 
 /// Worker pools configuration loaded from TOML file.

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -12,16 +12,17 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
-# Example: an exclusive-access worker pool. `liquidity_scope = "all"` lets this worker pool route
-# through exclusive components (in addition to all public liquidity) to capture surplus above the
-# best public rate. Public worker pools (liquidity_scope omitted; defaults to "public_only") never
-# see exclusive components.
-# [pools.exclusive_access]
+# Example: a public-only worker pool. `liquidity_scope = "public_only"` makes this worker pool's
+# workers drop exclusive components, establishing the committed public reference for surplus
+# routing. Worker pools with the key omitted default to "all" and route through everything,
+# exclusive components included — which only differs from public once the deployment's stream
+# carries exclusive components.
+# [pools.public_baseline]
 # algorithm = "bellman_ford"
 # num_workers = 3
 # max_hops = 2
 # timeout_ms = 500
-# liquidity_scope = "all"
+# liquidity_scope = "public_only"
 
 # Example: connector_tokens restricts intermediate hops to trusted, liquid tokens,
 # reducing on-chain reversion risk. Absent = all tokens reachable (default behaviour).

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -12,17 +12,15 @@ task_queue_capacity = 1000
 max_hops = 2
 timeout_ms = 500
 
-# Example: a public-only worker pool. `liquidity_scope = "public_only"` makes this worker pool's
-# workers drop exclusive components, establishing the committed public reference for surplus
-# routing. Worker pools with the key omitted default to "all" and route through everything,
-# exclusive components included — which only differs from public once the deployment's stream
-# carries exclusive components.
-# [pools.public_baseline]
+# Example: an exclusive-access worker pool whose workers also route through exclusive components
+# to capture surplus above the committed public reference. Worker pools with the key omitted
+# default to "public_only": their workers drop exclusive components.
+# [pools.exclusive_access]
 # algorithm = "bellman_ford"
 # num_workers = 3
 # max_hops = 2
 # timeout_ms = 500
-# liquidity_scope = "public_only"
+# liquidity_scope = "include_exclusive"
 
 # Example: connector_tokens restricts intermediate hops to trusted, liquid tokens,
 # reducing on-chain reversion risk. Absent = all tokens reachable (default behaviour).


### PR DESCRIPTION
Some liquidity is exclusive to Fynd: components that can only be swapped with off-chain authorization. Quotes must keep them out of the committed public reference, while still routing through them to capture surplus above the best  public rate.

 Previously, deciding what counts as "exclusive" was the deployer's job -- a user-supplied policy predicate wired through the builder, with a build error when scoped pools lacked one. This PR removes that configuration surface entirely. Components are now classified from their own data, using the same marker list tycho-simulation's stream filters use, so what a deployment ingests and what it classifies as exclusive can never disagree, and new exclusive pool kinds arrive with a dependency bump instead of a code change.

What a deployment configures is reduced to one per-pool setting: its liquidity scope. A `public_only` pool establishes the committed public reference; an `all` pool (the default) routes through everything the stream delivers.
Deployments that never opt into exclusive components configure nothing and behave exactly as before.