### PR TITLE
feat(feed): stream exclusive pools via the exclusive: protocol prefix

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -106,6 +106,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 | `HTTP_PORT` | API port (default: `3000`) |
 | `WORKER_POOLS_CONFIG` | Worker pools config file (default: `worker_pools.toml`) |
 | `BLOCKLIST_CONFIG` | Blocklist config file |
+| `EXCLUSIVE_SWAP_CONTROLLER_KEY` | Restricted exclusive-liquidity deployments only — see [Exclusive liquidity](#exclusive-liquidity-restricted). Unset in ordinary deployments |
 | `RUST_LOG` | Tracing filter (e.g. `info,fynd=debug`) |
 | `METRICS_PORT` | Prometheus metrics server port (default: `9898`, requires `metrics` feature) |
 | `FYND_HOSTED_SWAGGER_URL` | Server URL advertised by the hosted OpenAPI spec. When unset, the hosted Swagger UI (`/docs/hosted/`) is not served — only the self-hosted `/docs/` |
@@ -134,6 +135,35 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 - `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --locked --package fynd-core --package fynd-rpc-types --package fynd-rpc --package fynd-client` — doc build (broken links, missing docs)
 - OpenAPI drift: `cargo run -- openapi | jq 'del(.info.version)'` vs `clients/openapi.json`
 - TypeScript: `pnpm --dir clients/typescript install && pnpm --dir clients/typescript --filter @kayibal/fynd-client run test`
+
+## Exclusive Liquidity (restricted)
+
+A limited, opt-in service offered to specific deployments — **not** part of the normal routing path.
+Ordinary deployments configure no exclusivity policy, every pool stays `LiquidityScope::PublicOnly`,
+and nothing below applies. Treat it as out of scope unless a task names it.
+
+Worker pools are partitioned by `LiquidityScope` (`fynd-core/src/worker_pool_router/`):
+
+- `PublicOnly` (default) — public liquidity only. Its best candidate is the **committed amount out**,
+  the reference output a quote must at least deliver
+- `All` — also routes through components an `ExclusivityPolicy`
+  (`fynd-core/src/feed/exclusivity.rs`, a caller-supplied `ProtocolComponent` predicate) classifies
+  as exclusive. Its candidates may beat the public reference; the difference is **surplus**, tracked
+  in `SurplusInfo` / `OrderQuote::surplus_amount()` and never serialized on the wire
+
+Exclusive components only reach `MarketState` if the protocol's stream filter admits them. That is
+opt-in per protocol via the `exclusive:` prefix on a `--protocols` entry (e.g.
+`--protocols all_onchain,exclusive:ekubo_v3`), handled in
+`fynd-core/src/feed/protocol_registry.rs`; `EXCLUSIVE_CAPABLE_PROTOCOLS` lists the protocols that
+have such a variant (`ekubo_v3` only) and the prefix is rejected for any other. Stream admission is
+independent of the routing policy below — opting in without an `ExclusivityPolicy` leaves those
+pools indistinguishable from public liquidity.
+
+Enabled per pool via `liquidity_scope = "all"` in `worker_pools.toml`; a pool that sets it without a
+configured policy fails the build (`SolverBuildError::LiquidityScopeWithoutPolicy`). Encoding a leg
+that carries a committed amount is protocol-specific and lives in
+`fynd-core/src/encoding/exclusive_swap.rs`, which needs `EXCLUSIVE_SWAP_CONTROLLER_KEY`. See
+`fynd-core/CLAUDE.md` for the crate-level detail.
 
 ## Related Repositories
 

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -95,3 +95,52 @@ recorded with `tools/record-market`. See `tests/integration/README.md`.
 1. `WorkerPoolRouter` fans out to all pools in parallel
 2. Each pool dispatches to a `SolverWorker` → `Algorithm::find_best_route` → `RouteResult`
 3. Selects best by `amount_out_net_gas` → optional `Encoder` → `Quote`
+
+## Exclusive Liquidity (restricted)
+
+A limited, opt-in service for specific deployments — **not** part of the normal routing path. With no
+`ExclusivityPolicy` configured (the default) every pool is `LiquidityScope::PublicOnly`, none of this
+code runs, and the flows above are complete. Skip this section unless a task names it.
+
+Exclusive components must first be admitted to the stream. `feed/protocol_registry.rs` parses each
+`--protocols` entry into a `ProtocolSpec { system, exclusive }` (`Display` renders it back to the
+entry form): the `exclusive:` prefix (e.g. `exclusive:ekubo_v3`) selects the protocol's
+exclusive-inclusive filter — for Ekubo V3,
+`ekubo_v3_extension_filter_with_signed_exclusive_swap` instead of the default
+`ekubo_v3_extension_filter`, which drops SignedExclusiveSwap pools. The private
+`EXCLUSIVE_CAPABLE_PROTOCOLS` is the single source of truth for which protocols accept the prefix;
+applying it elsewhere is a `DataFeedError::Config`. The prefix is stripped before registration, so
+Tycho only sees the bare system name.
+
+`parse_protocols` also rejects a list naming one protocol both with and without the prefix. Registration
+is keyed by system name (the stream builder and decoder both hold `HashMap`s), so such a list would
+otherwise stream whichever variant happened to come last. Callers going through
+`fynd_rpc::protocols::resolve_protocols` never hit this — it merges the variants first — but a
+`Vec<String>` assembled by hand for `FyndBuilder::new` can, and gets an error rather than an
+order-dependent stream.
+
+Pools are partitioned by `LiquidityScope` (`worker_pool_router/`, re-exported at the crate root):
+
+- `PublicOnly` (default) — public liquidity only. Its best candidate is the **committed amount out**,
+  the reference output the quote must at least deliver.
+- `All` — also routes through components the configured `ExclusivityPolicy`
+  (`feed/exclusivity.rs`) classifies as exclusive.
+
+Isolation is per worker, not per state: `MarketState` is never duplicated. `PublicOnly` workers hold
+`Some(policy)` and filter exclusive components out of their local graph topology and incoming
+`MarketEvent`s; `All` workers hold `None` and ingest everything.
+
+After public ranking, `combine_with_surplus` overlays any `All`-scope candidate that beats the
+committed amount and records the difference as `SurplusInfo` (`OrderQuote::surplus_amount()`,
+`committed_amount_out()`, `Swap::committed_amount_out()`). All are `#[serde(skip)]` — internal, not
+on the wire.
+
+Enable with `FyndBuilder::exclusivity_policy(predicate)` (`Fn(&ProtocolComponent) -> bool`), then set
+the scope per pool via `PoolConfig::with_liquidity_scope()` or `liquidity_scope = "all"` in
+`worker_pools.toml`. A pool with a scope but no policy fails the build
+(`SolverBuildError::LiquidityScopeWithoutPolicy`).
+
+Encoding a committed leg is protocol-specific: `encoding/exclusive_swap.rs` is Ekubo-only. It signs
+an EIP-712 authorization with `EXCLUSIVE_SWAP_CONTROLLER_KEY` and packs it, plus a derived Q32 fee,
+into the `SignedExclusiveSwap` extension's `user_data`. Encoding an exclusive leg without that env
+var fails.

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, env, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    env, fmt,
+    time::Duration,
+};
 
 use tracing::{info, warn};
 use tycho_simulation::{
@@ -9,10 +13,12 @@ use tycho_simulation::{
             aerodrome_v1::state::AerodromeV1State,
             curve::CurveState,
             ekubo::state::EkuboState,
-            ekubo_v3::{self, state::EkuboV3State},
+            ekubo_v3::state::EkuboV3State,
             erc4626::state::ERC4626State,
             filters::{
-                balancer_v2_pool_filter, curve_filter, erc4626_filter, fluid_v1_paused_pools_filter,
+                balancer_v2_pool_filter, curve_filter, ekubo_v3_extension_filter,
+                ekubo_v3_extension_filter_with_signed_exclusive_swap, erc4626_filter,
+                fluid_v1_paused_pools_filter,
             },
             fluid::FluidV1,
             lunarbase::state::LunarBaseState,
@@ -38,6 +44,73 @@ use tycho_simulation::{
 
 use super::DataFeedError;
 
+/// Opts a protocol into streaming its exclusive pools, e.g. `exclusive:ekubo_v3`.
+///
+/// Fynd-side only: stripped before registration, so Tycho sees the bare system name.
+const EXCLUSIVE_PREFIX: &str = "exclusive:";
+
+/// Protocol systems that offer an exclusive-liquidity stream variant, i.e. the ones that may be
+/// requested with the `exclusive:` prefix.
+const EXCLUSIVE_CAPABLE_PROTOCOLS: &[&str] = &["ekubo_v3"];
+
+/// The `exclusive:` prefix was applied to a protocol system that has no exclusive variant.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "protocol '{requested}' has no exclusive-liquidity variant; '{EXCLUSIVE_PREFIX}' is only \
+     supported for: {supported}",
+    supported = EXCLUSIVE_CAPABLE_PROTOCOLS.join(", ")
+)]
+pub struct UnsupportedExclusiveProtocol {
+    /// The protocol system the prefix was applied to.
+    requested: String,
+}
+
+/// A requested protocol system together with the liquidity variant to stream for it.
+///
+/// `parse` and the `Display` impl round-trip: displaying one yields a `--protocols` entry that
+/// parses back to the same value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolSpec {
+    /// Tycho protocol system name. Never carries the `exclusive:` prefix.
+    pub system: String,
+    /// Whether to register the filter that also admits exclusive pools.
+    pub exclusive: bool,
+}
+
+impl ProtocolSpec {
+    /// A protocol system streaming public liquidity only.
+    pub fn public(system: impl Into<String>) -> Self {
+        Self { system: system.into(), exclusive: false }
+    }
+
+    /// Parses a single `--protocols` entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns `UnsupportedExclusiveProtocol` when the `exclusive:` prefix is applied to a protocol
+    /// system that has no exclusive variant. Unrecognised protocol systems without the prefix are
+    /// accepted here and skipped with a warning during registration.
+    pub fn parse(entry: &str) -> Result<Self, UnsupportedExclusiveProtocol> {
+        let Some(system) = entry.strip_prefix(EXCLUSIVE_PREFIX) else {
+            return Ok(Self::public(entry));
+        };
+        if !EXCLUSIVE_CAPABLE_PROTOCOLS.contains(&system) {
+            return Err(UnsupportedExclusiveProtocol { requested: system.to_string() });
+        }
+        Ok(Self { system: system.to_string(), exclusive: true })
+    }
+}
+
+impl fmt::Display for ProtocolSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.exclusive {
+            write!(f, "{EXCLUSIVE_PREFIX}{}", self.system)
+        } else {
+            f.write_str(&self.system)
+        }
+    }
+}
+
 /// Register DEX protocol decoders for test tooling (record-market).
 ///
 /// Wrapper over [`register_exchanges`] so the recorder builds the same protocol stream as
@@ -46,19 +119,51 @@ use super::DataFeedError;
 pub fn register_exchanges_for_recording(
     builder: ProtocolStreamBuilder,
     tvl_filter: ComponentFilter,
-    protocols: &[String],
+    entries: &[String],
 ) -> Result<ProtocolStreamBuilder, String> {
-    register_exchanges(builder, tvl_filter, protocols).map_err(|e| e.to_string())
+    register_exchanges(builder, tvl_filter, entries).map_err(|e| e.to_string())
+}
+
+/// Parses every `--protocols` entry, rejecting a list with no unambiguous reading.
+///
+/// Registration is keyed by protocol system, so naming one system both with and without the
+/// `exclusive:` prefix would silently keep whichever entry came last. Callers that expand a
+/// protocol list (`fynd_rpc::protocols::resolve_protocols`) merge the variants before getting here;
+/// a hand-assembled list gets an error instead of an order-dependent stream.
+fn parse_protocols(entries: &[String]) -> Result<Vec<ProtocolSpec>, DataFeedError> {
+    let mut protocols = Vec::with_capacity(entries.len());
+    for entry in entries {
+        protocols
+            .push(ProtocolSpec::parse(entry).map_err(|e| DataFeedError::Config(e.to_string()))?);
+    }
+
+    let mut variants: HashMap<&str, bool> = HashMap::new();
+    for protocol in &protocols {
+        if variants
+            .insert(protocol.system.as_str(), protocol.exclusive)
+            .is_some_and(|previous| previous != protocol.exclusive)
+        {
+            return Err(DataFeedError::Config(format!(
+                "protocol '{}' requested both with and without the '{EXCLUSIVE_PREFIX}' prefix",
+                protocol.system
+            )));
+        }
+    }
+    Ok(protocols)
 }
 
 /// Register DEX protocol decoders on a [`ProtocolStreamBuilder`].
+///
+/// Entries may carry the `exclusive:` prefix to select the protocol's exclusive-liquidity stream
+/// variant; doing so for a protocol without one is a configuration error, as is naming one protocol
+/// both with and without the prefix.
 pub(crate) fn register_exchanges(
     mut builder: ProtocolStreamBuilder,
     tvl_filter: ComponentFilter,
-    protocols: &[String],
+    entries: &[String],
 ) -> Result<ProtocolStreamBuilder, DataFeedError> {
-    for protocol in protocols {
-        match protocol.as_str() {
+    for protocol in parse_protocols(entries)? {
+        match protocol.system.as_str() {
             "uniswap_v2" => {
                 builder =
                     builder.exchange::<UniswapV2State>("uniswap_v2", tvl_filter.clone(), None);
@@ -168,11 +273,16 @@ pub(crate) fn register_exchanges(
                 );
             }
             "ekubo_v3" => {
-                builder = builder.exchange::<EkuboV3State>(
-                    "ekubo_v3",
-                    tvl_filter.clone(),
-                    Some(ekubo_v3::filter_fn),
-                );
+                // SignedExclusiveSwap pools need a controller signature per swap, so they are
+                // only streamed when the deployment explicitly opts in.
+                let filter = if protocol.exclusive {
+                    info!("Including exclusive liquidity for ekubo_v3");
+                    ekubo_v3_extension_filter_with_signed_exclusive_swap
+                } else {
+                    ekubo_v3_extension_filter
+                };
+                builder =
+                    builder.exchange::<EkuboV3State>("ekubo_v3", tvl_filter.clone(), Some(filter));
             }
             "quickswap_v2" => {
                 builder =
@@ -237,4 +347,103 @@ pub(crate) fn register_rfq(
 
 fn get_env(var: &str) -> Result<String, DataFeedError> {
     env::var(var).map_err(|_| DataFeedError::Config(format!("{} env var not set", var)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn register(entries: &[&str]) -> Result<ProtocolStreamBuilder, DataFeedError> {
+        register_exchanges(
+            ProtocolStreamBuilder::new("localhost:0", Chain::Ethereum),
+            ComponentFilter::with_tvl_range(1.0, 10.0),
+            &entries
+                .iter()
+                .map(|entry| (*entry).to_string())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn test_parse_plain_protocol() {
+        let protocol = ProtocolSpec::parse("uniswap_v3").unwrap();
+        assert_eq!(protocol, ProtocolSpec { system: "uniswap_v3".to_string(), exclusive: false });
+    }
+
+    #[test]
+    fn test_parse_exclusive_protocol() {
+        let protocol = ProtocolSpec::parse("exclusive:ekubo_v3").unwrap();
+        assert_eq!(protocol, ProtocolSpec { system: "ekubo_v3".to_string(), exclusive: true });
+    }
+
+    #[test]
+    fn test_parse_exclusive_unsupported_protocol() {
+        let err = ProtocolSpec::parse("exclusive:uniswap_v3").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("has no exclusive-liquidity variant"));
+    }
+
+    #[test]
+    fn test_parse_exclusive_without_protocol() {
+        assert!(ProtocolSpec::parse("exclusive:").is_err());
+    }
+
+    #[test]
+    fn test_parse_leaves_other_prefixes_intact() {
+        assert_eq!(
+            ProtocolSpec::parse("rfq:bebop").unwrap(),
+            ProtocolSpec { system: "rfq:bebop".to_string(), exclusive: false }
+        );
+        assert_eq!(
+            ProtocolSpec::parse("vm:curve").unwrap(),
+            ProtocolSpec { system: "vm:curve".to_string(), exclusive: false }
+        );
+    }
+
+    #[test]
+    fn test_display_round_trips() {
+        for entry in ["uniswap_v3", "exclusive:ekubo_v3", "rfq:bebop", "vm:curve"] {
+            let protocol = ProtocolSpec::parse(entry).unwrap();
+            assert_eq!(protocol.to_string(), entry);
+            assert_eq!(ProtocolSpec::parse(&protocol.to_string()).unwrap(), protocol);
+        }
+    }
+
+    #[test]
+    fn test_register_exchanges_accepts_exclusive_ekubo_v3() {
+        assert!(register(&["uniswap_v3", "exclusive:ekubo_v3"]).is_ok());
+    }
+
+    #[test]
+    fn test_register_exchanges_rejects_unsupported_exclusive() {
+        let Err(err) = register(&["exclusive:uniswap_v3"]) else {
+            panic!("expected `exclusive:uniswap_v3` to be rejected");
+        };
+        assert!(matches!(err, DataFeedError::Config(_)), "expected a config error, got {err:?}");
+    }
+
+    #[test]
+    fn test_register_exchanges_skips_unknown_protocol() {
+        assert!(register(&["not_a_protocol"]).is_ok());
+    }
+
+    #[test]
+    fn test_register_exchanges_rejects_conflicting_variants() {
+        for protocols in [["ekubo_v3", "exclusive:ekubo_v3"], ["exclusive:ekubo_v3", "ekubo_v3"]] {
+            let Err(err) = register(&protocols) else {
+                panic!("expected {protocols:?} to be rejected");
+            };
+            assert!(
+                err.to_string()
+                    .contains("both with and without"),
+                "unexpected error for {protocols:?}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_register_exchanges_allows_repeated_protocol() {
+        assert!(register(&["uniswap_v3", "uniswap_v3"]).is_ok());
+    }
 }

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -9,7 +9,7 @@ infrastructure.
 |---|---|
 | `builder.rs` | `FyndRPCBuilder` wraps `FyndBuilder`, adds HTTP server config. `FyndRPC` struct runs the server with graceful shutdown |
 | `config.rs` | `WorkerPoolsConfig` (TOML loader), `BlocklistConfig`, `defaults` module re-exporting `fynd-core` defaults + HTTP-specific ones |
-| `protocols.rs` | `fetch_protocol_systems()` — paginated Tycho RPC call to discover available protocols; `resolve_protocols()` — higher-level wrapper used by `serve` and `scale` that expands `all_onchain`/`native_onchain` tokens and applies min-TVL filtering |
+| `protocols.rs` | `fetch_protocol_systems()` — Tycho RPC call to discover available protocols; `resolve_protocols()` — higher-level wrapper used by `serve` and `scale` that parses each explicit entry into a `ProtocolSpec` (before the RPC call, so a bad `exclusive:` prefix fails fast), expands `all_onchain`/`native_onchain` tokens, and merges the two by protocol system — one entry per system, exclusive winning over public regardless of order |
 | `api/` | HTTP endpoint handlers and OpenAPI documentation |
 
 ## Features

--- a/fynd-rpc/src/protocols.rs
+++ b/fynd-rpc/src/protocols.rs
@@ -1,6 +1,7 @@
 //! Tycho protocol system discovery.
 
 use anyhow::{bail, Result};
+use fynd_core::feed::protocol_registry::ProtocolSpec;
 use tracing::info;
 use tycho_simulation::{
     tycho_client::rpc::{HttpRPCClient, HttpRPCClientOptions, ProtocolSystemsParams, RPCClient},
@@ -47,9 +48,15 @@ pub async fn fetch_protocol_systems(
 /// - `native_onchain` → fetch every on-chain protocol system, then drop the VM-simulated ones
 ///   (those prefixed `vm:`), keeping only native-Rust protocols.
 ///
-/// Explicit entries other than the expansion tokens (e.g. `rfq:bebop`, `uniswap_v3`) are appended
-/// if not already present. When no expansion token is given the list is returned unchanged.
-/// Returns an error if the resolved list is empty.
+/// Explicit entries other than the expansion tokens (e.g. `rfq:bebop`, `uniswap_v3`,
+/// `exclusive:ekubo_v3`) are merged in by protocol system, so `all_onchain,exclusive:ekubo_v3`
+/// streams `ekubo_v3` exactly once — with its exclusive pools included. Requesting a protocol both
+/// with and without the `exclusive:` prefix streams it with exclusive pools included.
+///
+/// # Errors
+///
+/// Returns an error if an entry requests exclusive liquidity for a protocol that has no exclusive
+/// variant, or if the resolved list is empty.
 pub async fn resolve_protocols(
     tycho_url: &str,
     auth_key: Option<&str>,
@@ -57,6 +64,9 @@ pub async fn resolve_protocols(
     chain: Chain,
     requested: &[String],
 ) -> Result<Vec<String>> {
+    // Parsed before the RPC call so a malformed entry fails without waiting on Tycho.
+    let explicit = parse_explicit(requested)?;
+
     let want_native = requested
         .iter()
         .any(|p| p == NATIVE_ONCHAIN);
@@ -65,23 +75,118 @@ pub async fn resolve_protocols(
             .iter()
             .any(|p| p == ALL_ONCHAIN);
 
-    let protocols = if want_all || want_native {
+    let mut protocols: Vec<ProtocolSpec> = if want_all || want_native {
         let mut fetched = fetch_protocol_systems(tycho_url, auth_key, use_tls, chain).await?;
         if want_native {
             fetched.retain(|p| !p.starts_with(VM_PREFIX));
         }
-        for p in requested {
-            if p != ALL_ONCHAIN && p != NATIVE_ONCHAIN && !fetched.contains(p) {
-                fetched.push(p.clone());
-            }
-        }
         fetched
+            .into_iter()
+            .map(ProtocolSpec::public)
+            .collect()
     } else {
-        requested.to_vec()
+        Vec::new()
     };
+    merge_explicit(&mut protocols, explicit);
 
     if protocols.is_empty() {
         bail!("no supported protocols found. Provide --protocols or check Tycho connectivity.");
     }
-    Ok(protocols)
+    Ok(protocols
+        .iter()
+        .map(ProtocolSpec::to_string)
+        .collect())
+}
+
+/// Parses the requested entries that name a protocol system, skipping the expansion tokens.
+fn parse_explicit(entries: &[String]) -> Result<Vec<ProtocolSpec>> {
+    entries
+        .iter()
+        .filter(|entry| *entry != ALL_ONCHAIN && *entry != NATIVE_ONCHAIN)
+        .map(|entry| ProtocolSpec::parse(entry).map_err(Into::into))
+        .collect()
+}
+
+/// Merges the explicitly requested protocols into `protocols`, one entry per protocol system.
+///
+/// A protocol requested with the `exclusive:` prefix keeps its exclusive pools no matter how the
+/// other entries for the same system are written, so no ordering silently downgrades it.
+fn merge_explicit(protocols: &mut Vec<ProtocolSpec>, explicit: Vec<ProtocolSpec>) {
+    for protocol in explicit {
+        match protocols
+            .iter_mut()
+            .find(|existing| existing.system == protocol.system)
+        {
+            Some(existing) => existing.exclusive |= protocol.exclusive,
+            None => protocols.push(protocol),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(entries: &[&str]) -> Vec<String> {
+        entries
+            .iter()
+            .map(|e| (*e).to_string())
+            .collect()
+    }
+
+    /// Resolves `requested` the way `resolve_protocols` does, against a fixed expansion.
+    fn merge(expanded: &[&str], requested: &[&str]) -> Vec<String> {
+        let mut protocols = expanded
+            .iter()
+            .map(|system| ProtocolSpec::public(*system))
+            .collect();
+        merge_explicit(&mut protocols, parse_explicit(&strings(requested)).unwrap());
+        protocols
+            .iter()
+            .map(ProtocolSpec::to_string)
+            .collect()
+    }
+
+    #[test]
+    fn test_merge_exclusive_replaces_expanded() {
+        let merged = merge(&["uniswap_v3", "ekubo_v3"], &[ALL_ONCHAIN, "exclusive:ekubo_v3"]);
+        assert_eq!(merged, strings(&["uniswap_v3", "exclusive:ekubo_v3"]));
+    }
+
+    #[test]
+    fn test_merge_appends_unexpanded_entries() {
+        let merged = merge(&["uniswap_v3"], &[ALL_ONCHAIN, "rfq:bebop"]);
+        assert_eq!(merged, strings(&["uniswap_v3", "rfq:bebop"]));
+    }
+
+    #[test]
+    fn test_merge_keeps_exclusive_regardless_of_order() {
+        for requested in [["ekubo_v3", "exclusive:ekubo_v3"], ["exclusive:ekubo_v3", "ekubo_v3"]] {
+            assert_eq!(merge(&[], &requested), strings(&["exclusive:ekubo_v3"]));
+        }
+    }
+
+    #[test]
+    fn test_merge_without_expansion() {
+        let merged = merge(&[], &["uniswap_v2", "uniswap_v3"]);
+        assert_eq!(merged, strings(&["uniswap_v2", "uniswap_v3"]));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_protocols_rejects_unsupported_exclusive() {
+        let result = resolve_protocols(
+            "localhost:0",
+            None,
+            false,
+            Chain::Ethereum,
+            &strings(&["exclusive:uniswap_v3"]),
+        )
+        .await;
+        let Err(err) = result else {
+            panic!("expected `exclusive:uniswap_v3` to be rejected");
+        };
+        assert!(err
+            .to_string()
+            .contains("has no exclusive-liquidity variant"));
+    }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,6 +67,8 @@ pub struct ServeArgs {
     /// If omitted, all on-chain protocols are fetched from Tycho RPC.
     /// Use "all_onchain" to fetch all on-chain protocols and combine with explicit entries,
     /// e.g., --protocols all_onchain,rfq:bebop.
+    /// Prefix a protocol with "exclusive:" to also stream its exclusive pools,
+    /// e.g., --protocols all_onchain,exclusive:ekubo_v3.
     #[arg(short, long, value_delimiter = ',', value_name = "PROTO1,PROTO2")]
     pub protocols: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,10 @@
 //! # Or specify protocols explicitly:
 //! fynd serve --tycho-url tycho-fynd-ethereum.propellerheads.xyz \
 //!            --protocols uniswap_v2,uniswap_v3
+//!
+//! # Opt a protocol into streaming its exclusive pools:
+//! fynd serve --tycho-url tycho-fynd-ethereum.propellerheads.xyz \
+//!            --protocols all_onchain,exclusive:ekubo_v3
 //! ```
 //!
 //! `--rpc-url` defaults to a chain-specific public endpoint. For production, provide a dedicated

--- a/tools/benchmark/src/scale.rs
+++ b/tools/benchmark/src/scale.rs
@@ -47,7 +47,8 @@ pub struct Args {
     pub worker_counts: String,
 
     /// Comma-separated protocols for the solver. Supports the `all_onchain` and `native_onchain`
-    /// expansion tokens (the latter drops VM-simulated `vm:*` protocols).
+    /// expansion tokens (the latter drops VM-simulated `vm:*` protocols), and the `exclusive:`
+    /// prefix for streaming a protocol's exclusive pools.
     #[arg(long)]
     pub protocols: String,
 


### PR DESCRIPTION
Allows Fynd users to opt-in to streaming exclusive pools. Currently only supported on Ekubo v3 and controlled by switching out which tycho filter is applied. 

Also synced the claude docs to reflect the current state of the exclusive liquidity feature. Do not worry about reviewing the doc changes too closely, I will update them with our final version of the feature once we're done. 