### PR TITLE
fix(hindsight): stop round trips and Relay fees decoding as trades

### DIFF
--- a/tools/hindsight/src/decoder/transfer_ledger.rs
+++ b/tools/hindsight/src/decoder/transfer_ledger.rs
@@ -122,6 +122,13 @@ impl TransferLedger {
     /// All three compare same-token amounts, so the proof needs no prices. Each condition
     /// closed a real mis-decode (the last: a wash-loop MEV bundle, tx `0x280b9939…`, whose $10k
     /// loops let a $51 position change pass the 1% test).
+    ///
+    /// # Round trips
+    ///
+    /// A net on both sides is not enough to prove a swap. When the tracked address both paid and
+    /// was repaid in *both* tokens it went out and came back — an arbitrage or liquidity probe —
+    /// and the two leftovers are what the round trip cost, not a conversion of one into the other.
+    /// Those are declined; see `is_round_trip`.
     pub(crate) fn net_swap(&self, tracked: Address) -> Option<NetSwap> {
         let mut amounts_by_token: HashMap<Address, TokenAmounts> = HashMap::new();
         for &(token, from, to, value) in &self.transfers {
@@ -272,7 +279,37 @@ fn net_trade(amounts_by_token: &HashMap<Address, TokenAmounts>) -> Option<NetSwa
     }
     let (&token_in, &amount_in) = net_sent.iter().next()?;
     let (&token_out, &amount_out) = net_received.iter().next()?;
+    if is_round_trip(amounts_by_token, token_in, token_out) {
+        debug!(?token_in, ?token_out, "declining round-trip flow");
+        return None;
+    }
     Some(NetSwap { token_in, amount_in, token_out, amount_out })
+}
+
+/// Whether the tracked address's flow in both swap tokens is bidirectional, which makes the net a
+/// round trip rather than a swap.
+///
+/// A swap is one-directional on at least one side: the trader pays `token_in` and is paid
+/// `token_out`. Routing can send part of one side back — a refunded input, an unspent hop — and
+/// that leaves only *that* side bidirectional, so it still decodes. Both sides bidirectional means
+/// the address went out and came back in both tokens, and the residues are the round trip's cost.
+///
+/// Pairing those residues as a trade invents enormous wins, because the leftovers bear no relation
+/// to each other: tx `0x9aa81b8a…` on Base sends 758.2556 SOSO and 251.500210 USDC into one pool
+/// and takes 758.1039 SOSO and 251.500211 USDC straight back out, netting -0.1517 SOSO and
+/// +0.000001 USDC. Read as a swap that is a 15,000x improvement for Fynd; it is a bot paying
+/// 0.15 SOSO of fees to gain a wei. One such bot produced 3,168 fake wins on Base in a day.
+fn is_round_trip(
+    amounts_by_token: &HashMap<Address, TokenAmounts>,
+    token_in: Address,
+    token_out: Address,
+) -> bool {
+    let bidirectional = |token: Address| {
+        amounts_by_token
+            .get(&token)
+            .is_some_and(|amounts| !amounts.sent.is_zero() && !amounts.received.is_zero())
+    };
+    bidirectional(token_in) && bidirectional(token_out)
 }
 
 /// Drop residue legs from one side of an ambiguous net, per the three-condition proof in
@@ -327,6 +364,45 @@ mod tests {
 
         let result = net_swap(&logs, &[], sender).unwrap();
         assert_eq!(result, swap(token_a, 1000, token_b, 2000));
+    }
+
+    #[test]
+    fn test_round_trip_through_one_pool_is_not_a_swap() {
+        // The shape of tx 0x9aa81b8a… on Base: the sender pushes both tokens into one pool and
+        // takes both straight back, netting a small loss in one and a wei of gain in the other.
+        // Pairing those residues reads as a 15,000x win for Fynd.
+        let sender = addr(1);
+        let pool = addr(50);
+        let soso = addr(10);
+        let usdc = addr(11);
+
+        let logs = vec![
+            make_transfer_log(usdc, pool, sender, U256::from(251_500_211u64)),
+            make_transfer_log(soso, sender, pool, U256::from(758_255u64)),
+            make_transfer_log(soso, pool, sender, U256::from(758_103u64)),
+            make_transfer_log(usdc, sender, pool, U256::from(251_500_210u64)),
+        ];
+
+        assert_eq!(net_swap(&logs, &[], sender), None);
+    }
+
+    #[test]
+    fn test_refunded_input_still_decodes() {
+        // Only the input side is bidirectional — the router hands back an unspent remainder. That
+        // is a real swap and must survive the round-trip check.
+        let sender = addr(1);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, sender, pool, U256::from(1000)),
+            make_transfer_log(token_in, pool, sender, U256::from(100)),
+            make_transfer_log(token_out, pool, sender, U256::from(2000)),
+        ];
+
+        let result = net_swap(&logs, &[], sender).unwrap();
+        assert_eq!(result, swap(token_in, 900, token_out, 2000));
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/venues/relay.rs
+++ b/tools/hindsight/src/decoder/venues/relay.rs
@@ -55,10 +55,16 @@ impl<P: Provider> TradeDecoder<P> for RelayNetting {
 /// no net flow (so sender netting finds nothing) and the swap moves Relay's own liquidity.
 ///
 /// Anchors on the fee collector, which always funds the input: `token_in` is the single token it
-/// net-sends. The output is one of two shapes — the token that comes back to the collector (an
-/// internal inventory rebalance), or the asset received by the single external recipient that
-/// only receives and never sends (a cross-chain order fill; see
-/// `TransferLedger::sink_receipts`).
+/// net-sends. The output is one of two shapes — the asset received by the single external recipient
+/// that only receives and never sends (a cross-chain order fill; see
+/// `TransferLedger::sink_receipts`), or, when there is no such recipient, the token that comes back
+/// to the collector (an internal inventory rebalance).
+///
+/// The external recipient is checked first because the collector also receives Relay's fee on a
+/// user fill, and a fee is not a rebalance output. Reading it as one values the trade at the fee
+/// instead of the payout: on tx `0x65286b53…` the user received 0.0255 ETH for 50.148 `USDe` while
+/// the collector took 0.000536 ETH, and anchoring on the collector reported a 468,826 bps win
+/// against a trade that actually beat Fynd by 45 bps.
 ///
 /// Declines (returns `None`) when the shape is ambiguous: not exactly one input token, a
 /// same-token "swap", more than one token back to the collector, or more than one external
@@ -77,19 +83,6 @@ fn decode_rebalance(
         return None;
     }
     let (token_in, amount_in) = net_in[0];
-
-    // C2 internal rebalance: the collector net-receives exactly one (different) token.
-    let net_recv: Vec<(Address, U256)> = transfer_ledger
-        .group_net_received(fee_collectors)
-        .into_iter()
-        .collect();
-    if !net_recv.is_empty() {
-        if net_recv.len() != 1 || net_recv[0].0 == token_in {
-            return None;
-        }
-        let (token_out, amount_out) = net_recv[0];
-        return Some(NetSwap { token_in, amount_in, token_out, amount_out });
-    }
 
     // C1 external fill: the single pure-sink recipient, excluding infrastructure (routers,
     // collector, the wrapped-native token, the zero address) and the input token.
@@ -112,10 +105,24 @@ fn decode_rebalance(
         }
         outputs.push((token, amount));
     }
-    if outputs.len() != 1 {
+    if !outputs.is_empty() {
+        if outputs.len() != 1 {
+            return None;
+        }
+        let (token_out, amount_out) = outputs[0];
+        return Some(NetSwap { token_in, amount_in, token_out, amount_out });
+    }
+
+    // C2 internal rebalance: nobody outside Relay was paid, so the token coming back to the
+    // collector is the output rather than a fee.
+    let net_recv: Vec<(Address, U256)> = transfer_ledger
+        .group_net_received(fee_collectors)
+        .into_iter()
+        .collect();
+    if net_recv.len() != 1 || net_recv[0].0 == token_in {
         return None;
     }
-    let (token_out, amount_out) = outputs[0];
+    let (token_out, amount_out) = net_recv[0];
     Some(NetSwap { token_in, amount_in, token_out, amount_out })
 }
 
@@ -222,6 +229,25 @@ mod tests {
         let got = decode_rebalance(&transfer_ledger(&logs, &[]), &collectors, &routers, addr(200))
             .unwrap();
         assert_eq!(got, swap(token_in, 1000, token_out, 1001));
+    }
+
+    #[test]
+    fn test_rebalance_prefers_the_payee_over_the_collector_fee() {
+        // The shape of tx 0x65286b53…: the collector funds the input and also takes its fee in the
+        // output token, while the user is paid the rest. The trade is the user's payout; reading
+        // the collector's fee as the output valued a 0.0255 ETH fill at 0.000536 ETH.
+        let fee = addr(99);
+        let pool = addr(50);
+        let user = addr(7);
+        let token_in = addr(10);
+        let collectors = HashSet::from([fee]);
+        let routers = HashSet::from([addr(2)]);
+        let logs = vec![make_transfer_log(token_in, fee, pool, U256::from(1000))];
+        let native = vec![(pool, user, U256::from(2000)), (pool, fee, U256::from(42))];
+        let got =
+            decode_rebalance(&transfer_ledger(&logs, &native), &collectors, &routers, addr(200))
+                .unwrap();
+        assert_eq!(got, swap(token_in, 1000, Address::ZERO, 2000));
     }
 
     #[test]


### PR DESCRIPTION
Two decoder bugs that produced fake wins, both verified on-chain.

## 1. Round trips read as swaps

tx `0x9aa81b8a…` on Base ends with `-0.1517 SOSO, +0.000001 USDC` — one token each way, so it passed
as a swap. What actually moved:

```
sent 758.2556 SOSO   AND received 758.1039 SOSO
sent 251.500210 USDC AND received 251.500211 USDC
```

Both tokens went into one pool and both came back. No SOSO became USDC; the two residues are just
what the round trip cost and earned. `raw_bps` came out at 120,100,000.

We already reject arbitrages whose *ending balances* look wrong — an extra leftover token, discarded
as dust by `drop_residue_legs`. That check only runs when there is something spare to discard, so it
never inspected this one. The new check asks a different question — was the trader repaid in both
tokens? — and runs on every trade. Being repaid in only one token is a refund, so real swaps still
decode.

One bot produced 3,168 of these on Base in a day (6.4% of its win count). Other chains: bsc 4,
ethereum 2, arbitrum/polygon/unichain 0.

## 2. Relay's fee read as the fill

`decode_rebalance` checked the fee collector before the external recipient, so on tx `0x65286b53…` it
valued the trade at Relay's 0.000536 ETH fee instead of the user's 0.0255 ETH payout — reported as a
468,826 bps / $48.82 win against a trade that actually beat Fynd by 45 bps. The recipient is now
checked first; the collector's receipt is only the output when nobody outside Relay was paid.

## Verification

Both fixes mutation-tested. Replaying block 25646159 keeps 18 of 19 trades and drops only the fake
one. fmt, clippy, rustdoc, 1218 tests clean.

The `ruint` bump is unrelated — `Cargo.lock` was untouched by the decoder work, and RUSTSEC-2026-0220
only started failing CI when the advisory database refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
