### PR TITLE
perf(feed): share market state via Arc instead of deep-copying per solve

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,8 +79,8 @@ This modular architecture allows users to:
 ┌────────────────────────────────────────────────────────────────────────────────────┐
 │                         MarketState (Arc<RwLock<>>, via MarketData handle)          │
 │  ┌────────────────────────────────────────────────────────────────────────────┐    │
-│  │  components: HashMap<ComponentId, ProtocolComponent>                       │    │
-│  │  simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>>             │    │
+│  │  components: HashMap<ComponentId, Arc<ProtocolComponent>>                  │    │
+│  │  simulation_states: HashMap<ComponentId, Arc<dyn ProtocolSim>>             │    │
 │  │  tokens: HashMap<Address, Token>                                           │    │
 │  │  gas_price: Option<BlockGasPrice>                                          │    │
 │  │  protocol_sync_status: HashMap<String, SynchronizerState>                  │    │
@@ -235,7 +235,7 @@ Graph management infrastructure:
 
 `MarketState` is the single source of truth for all market state. Contains components, simulation states, tokens, gas prices, sync status, and block info. Protected by `Arc<RwLock<>>` (write-preferring). `MarketData` is the cheap-to-clone shared handle used to access it — call `read()` for a base view or `read_labeled(label)` for an overlay-aware view.
 
-Provides `extract_subset_with_overlay()` for creating filtered snapshots that algorithms can use without holding the main lock.
+Provides `extract_subset_with_overlay()` for creating filtered snapshots that algorithms can use without holding the main lock. Snapshots share the `Arc`-wrapped components and simulation states with the base state rather than copying them; this is safe because those entries are never mutated in place — every update replaces whole map entries.
 
 ***
 

--- a/fynd-core/src/derived/manager.rs
+++ b/fynd-core/src/derived/manager.rs
@@ -43,7 +43,7 @@ impl ChangedComponents {
     /// Used for startup and lag recovery scenarios.
     pub fn all(market: MarketDataView) -> Self {
         Self {
-            added: market.component_topology().clone(),
+            added: market.component_topology(),
             removed: vec![],
             updated: vec![],
             is_full_recompute: true,

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -310,7 +310,10 @@ pub struct MarketState {
     /// is applied.
     label: StateLabel,
     /// All components indexed by their ID.
-    components: HashMap<ComponentId, ProtocolComponent>,
+    ///
+    /// Like `simulation_states`, components are `Arc`-shared and never mutated in
+    /// place: `upsert_components` replaces whole entries.
+    components: HashMap<ComponentId, Arc<ProtocolComponent>>,
     /// All states indexed by their component ID.
     ///
     /// States are `Arc`-shared, never mutated in place: block updates replace whole
@@ -396,7 +399,9 @@ impl MarketState {
 
     /// Gets a component by ID.
     pub fn get_component(&self, id: &str) -> Option<&ProtocolComponent> {
-        self.components.get(id)
+        self.components
+            .get(id)
+            .map(|component| component.as_ref())
     }
 
     /// Gets a simulation state by ID.
@@ -427,7 +432,7 @@ impl MarketState {
             let protocol_system = component.protocol_system.clone();
             let previous = self
                 .components
-                .insert(component.id.clone(), component);
+                .insert(component.id.clone(), Arc::new(component));
             if previous.is_none() {
                 *self
                     .pool_counts
@@ -501,12 +506,11 @@ impl MarketState {
     /// - Tokens referenced by those components
     /// - Gas price and block info
     pub fn extract_subset(&self, component_ids: &HashSet<ComponentId>) -> MarketState {
-        // Filter components
-        let components: HashMap<ComponentId, ProtocolComponent> = self
+        let components: HashMap<ComponentId, Arc<ProtocolComponent>> = self
             .components
             .iter()
             .filter(|(id, _)| component_ids.contains(*id))
-            .map(|(id, component)| (id.clone(), component.clone()))
+            .map(|(id, component)| (id.clone(), Arc::clone(component)))
             .collect();
 
         // Collect all token addresses from the filtered components
@@ -515,7 +519,6 @@ impl MarketState {
             .flat_map(|c| &c.tokens)
             .collect();
 
-        // Filter tokens
         let tokens: HashMap<Address, Token> = self
             .tokens
             .iter()
@@ -684,6 +687,24 @@ mod tests {
             &market.simulation_states["pool_ab"],
             &subset.simulation_states["pool_ab"],
         ));
+    }
+
+    /// Components in the subset must also be shared, not copied.
+    #[test]
+    fn extract_subset_shares_components() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let mut market = MarketState::new();
+        market.upsert_components([component("pool_ab", &[token_a.clone(), token_b.clone()])]);
+        market.upsert_tokens([token_a.clone(), token_b]);
+        market.update_states([(
+            "pool_ab".to_string(),
+            Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+        )]);
+
+        let subset = market.extract_subset(&HashSet::from(["pool_ab".to_string()]));
+
+        assert!(Arc::ptr_eq(&market.components["pool_ab"], &subset.components["pool_ab"],));
     }
 
     /// A subset extracted before a block update must keep the state it was

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -707,6 +707,35 @@ mod tests {
         assert!(Arc::ptr_eq(&market.components["pool_ab"], &subset.components["pool_ab"],));
     }
 
+    /// A subset extracted before a component upsert must keep the component it
+    /// was extracted with: `upsert_components` replaces whole entries and must
+    /// never mutate a shared component in place.
+    #[test]
+    fn extracted_subset_is_isolated_from_later_component_upserts() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let mut market = MarketState::new();
+        market.upsert_components([component("pool_ab", &[token_a.clone(), token_b.clone()])]);
+        market.upsert_tokens([token_a.clone(), token_b.clone()]);
+        market.update_states([(
+            "pool_ab".to_string(),
+            Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+        )]);
+
+        let subset = market.extract_subset(&HashSet::from(["pool_ab".to_string()]));
+        let mut replacement = component("pool_ab", &[token_a, token_b]);
+        replacement.protocol_system = "replacement_protocol".to_string();
+        market.upsert_components([replacement]);
+
+        let old_component = subset
+            .get_component("pool_ab")
+            .expect("subset keeps its entry");
+        assert_ne!(
+            old_component.protocol_system, "replacement_protocol",
+            "subset must keep the pre-upsert component"
+        );
+    }
+
     /// A subset extracted before a block update must keep the state it was
     /// extracted with: `update_states` replaces whole entries and must never
     /// mutate a shared state in place.

--- a/fynd-core/src/feed/market_data.rs
+++ b/fynd-core/src/feed/market_data.rs
@@ -38,7 +38,7 @@ use crate::types::{BlockInfo, ComponentId};
 pub type StateLabel = String;
 
 /// An immutable snapshot of per-component simulation states for one overlay layer.
-pub type OverlayStates = Arc<HashMap<ComponentId, Box<dyn ProtocolSim>>>;
+pub type OverlayStates = Arc<HashMap<ComponentId, Arc<dyn ProtocolSim>>>;
 
 /// A named simulation-state overlay with a block-number expiry.
 pub struct OverlayEntry {
@@ -152,6 +152,10 @@ impl MarketData {
         states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
         valid_until: u64,
     ) {
+        let states: HashMap<ComponentId, Arc<dyn ProtocolSim>> = states
+            .into_iter()
+            .map(|(id, state)| (id, Arc::from(state)))
+            .collect();
         self.overlays
             .write()
             .await
@@ -244,7 +248,7 @@ impl<'a> MarketDataView<'a> {
                 {
                     subset
                         .simulation_states
-                        .insert(id.clone(), state.clone_box());
+                        .insert(id.clone(), Arc::clone(state));
                 }
             }
             subset.label = label.clone();
@@ -308,7 +312,11 @@ pub struct MarketState {
     /// All components indexed by their ID.
     components: HashMap<ComponentId, ProtocolComponent>,
     /// All states indexed by their component ID.
-    simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>>,
+    ///
+    /// States are `Arc`-shared, never mutated in place: block updates replace whole
+    /// entries via [`MarketState::update_states`], so `extract_subset` can hand out
+    /// cheap shared references instead of deep-copying every pool state.
+    simulation_states: HashMap<ComponentId, Arc<dyn ProtocolSim>>,
     /// All tokens indexed by their address.
     tokens: HashMap<Address, Token>,
     /// Current gas price. None if not fetched yet.
@@ -469,7 +477,8 @@ impl MarketState {
         states: impl IntoIterator<Item = (ComponentId, Box<dyn ProtocolSim>)>,
     ) {
         for (id, state) in states {
-            self.simulation_states.insert(id, state);
+            self.simulation_states
+                .insert(id, Arc::from(state));
         }
     }
 
@@ -488,7 +497,7 @@ impl MarketState {
     /// This is used to create a local snapshot of market data that can be used for
     /// simulation without holding the main lock. The subset includes:
     /// - Components matching the provided IDs
-    /// - Simulation states for those components (cloned via `clone_box`)
+    /// - Simulation states for those components (`Arc`-shared with the base state)
     /// - Tokens referenced by those components
     /// - Gas price and block info
     pub fn extract_subset(&self, component_ids: &HashSet<ComponentId>) -> MarketState {
@@ -514,12 +523,11 @@ impl MarketState {
             .map(|(addr, token)| (addr.clone(), token.clone()))
             .collect();
 
-        // Clone simulation states using clone_box
-        let simulation_states: HashMap<ComponentId, Box<dyn ProtocolSim>> = self
+        let simulation_states: HashMap<ComponentId, Arc<dyn ProtocolSim>> = self
             .simulation_states
             .iter()
             .filter(|(id, _)| component_ids.contains(*id))
-            .map(|(id, state)| (id.clone(), state.clone_box()))
+            .map(|(id, state)| (id.clone(), Arc::clone(state)))
             .collect();
 
         MarketState {
@@ -654,6 +662,59 @@ mod tests {
         assert!(empty_subset
             .simulation_states
             .is_empty());
+    }
+
+    /// The subset must share simulation states with the base state, not copy them:
+    /// the perf property this module provides rests entirely on this.
+    #[test]
+    fn extract_subset_shares_simulation_states() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let mut market = MarketState::new();
+        market.upsert_components([component("pool_ab", &[token_a.clone(), token_b.clone()])]);
+        market.upsert_tokens([token_a, token_b]);
+        market.update_states([(
+            "pool_ab".to_string(),
+            Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+        )]);
+
+        let subset = market.extract_subset(&HashSet::from(["pool_ab".to_string()]));
+
+        assert!(Arc::ptr_eq(
+            &market.simulation_states["pool_ab"],
+            &subset.simulation_states["pool_ab"],
+        ));
+    }
+
+    /// A subset extracted before a block update must keep the state it was
+    /// extracted with: `update_states` replaces whole entries and must never
+    /// mutate a shared state in place.
+    #[test]
+    fn extracted_subset_is_isolated_from_later_updates() {
+        let token_a = token(0x0A, "A");
+        let token_b = token(0x0B, "B");
+        let mut market = MarketState::new();
+        market.upsert_components([component("pool_ab", &[token_a.clone(), token_b.clone()])]);
+        market.upsert_tokens([token_a, token_b]);
+        market.update_states([(
+            "pool_ab".to_string(),
+            Box::new(MockProtocolSim::new(2.0)) as Box<dyn ProtocolSim>,
+        )]);
+
+        let subset = market.extract_subset(&HashSet::from(["pool_ab".to_string()]));
+        market.update_states([(
+            "pool_ab".to_string(),
+            Box::new(MockProtocolSim::new(9.0)) as Box<dyn ProtocolSim>,
+        )]);
+
+        let old_state = subset
+            .get_simulation_state("pool_ab")
+            .expect("subset keeps its entry");
+        let sim = old_state
+            .as_any()
+            .downcast_ref::<MockProtocolSim>()
+            .expect("mock state");
+        assert_eq!(sim.spot_price, 2.0, "subset must keep the pre-update state");
     }
 
     // ==================== MarketData overlay tests ====================


### PR DESCRIPTION
## Summary

`MarketState::extract_subset` deep-copied every candidate pool state (`clone_box`) and every `ProtocolComponent` (3 Strings, 2 Vecs, `static_attributes` map each) on every solve — solely so the read lock could be released before simulating. None of that data is ever mutated in place: simulation is `&self`-only, and every update replaces whole map entries. This PR stores both maps as `Arc`-shared values so subsets are refcount bumps instead of deep copies, plus one dropped redundant topology clone. **No public API changes**: `get_component`/`get_token`/`token_registry_ref` keep their exact signatures.

## Measured impact

- **Quality: byte-identical and fully deterministic on all four algorithms** (bellman_ford, most_liquid, path_frank_wolfe, water_fill; offline replay, 3 iterations/side, zero output differences vs main).
- **Offline solve time vs main:** mean **-15.5%**, p50 -12.5%, p90/p95 -18.2%. Per algorithm: bellman_ford -12.7%, path_frank_wolfe -11.8%, water_fill -2.4%, most_liquid -2.9%.
- **Live concurrent (states commit alone):** paired same-block A/B, 60 blocks, 24k quotes/side at 32-way concurrency: faster on 42/60 blocks (sign test p = 0.0013), mean paired delta -5.1% (95% CI [-9.8, -0.4]).
- **Attribution (samply, solver threads):** `clone_box` 1.9% -> 0.0%, native tick-map clones 1.3% -> 0.0%, `RwLock` wait 4.5% -> 1.6%.

## Safety argument and tradeoffs, explicitly

**Invariant:** stored states and components are never mutated in place — updates replace whole entries (`upsert_components`, `update_states`; `delta_transition` is never called on stored states). Already true before this PR; now enforced by construction, since `Arc` cannot hand out `&mut` while shared. Documented on the fields and in ARCHITECTURE.md; pinned by `Arc::ptr_eq` sharing tests and two subset-isolation tests.

1. **Refcount contention:** concurrent solves bump/drop hot pools' refcounts (~ns, per-candidate cache-line traffic). The measured win is net of it.
2. **Constraint on future `ProtocolSim` impls:** an impl with a per-instance `Mutex` cache would share it across concurrent solves instead of per-copy. No current impl has one (verified against tycho-simulation 0.341 source; `PreCachedDB`'s internal lock was already shared through `clone_box`). A populate-only cache stays correct when shared.
3. **Writer-side cost:** `upsert_components`/`update_states` now allocate one Arc per changed entry per block — a per-block cost traded for a per-solve win; net measured above.
4. **Drop timing:** replaced entries free on last-holder drop, occasionally on a solver thread; the feed's write-lock section got cheaper (refcount decrement instead of synchronous dealloc).
5. **`.clone()` on these maps is now shallow**; changed sites spell `Arc::clone` explicitly. `clippy::clone_on_ref_ptr` would enforce crate-wide (separate PR).

## Considered and rejected, with data

- **Arc-sharing tokens:** measured per-algorithm at 0-4% (noise) — `Token` is two heap allocations and candidate sets hold few unique tokens — while forcing a breaking `token_registry_ref` change. Not worth it.
- **Arc-threading into `Swap`/encoder, `HopDescriptor`/`Route.tokens`:** profiled at 0.00-0.08% of solver CPU on both bellman and split-algorithm workloads; would also require serde's workspace-wide `rc` feature. Rejected.
- **Upstream:** `QueryPoolSwapParams::new` (tycho-common) takes owned `Token`s, forcing one deep clone per pool-pair per block in `pool_depth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)