### PR TITLE
feat(core)!: allocate worker pools per request entitlement

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -58,7 +58,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 ### Core Components
 
 1. **RouterApi** (`fynd-rpc/src/api/`) — Actix Web HTTP handlers: `POST /v1/quote`, `GET /v1/health`, `GET /v1/info`
-2. **WorkerPoolRouter** (`fynd-core/src/worker_pool_router/`) — Fans out orders to all pools, selects best by `amount_out_net_gas`
+2. **WorkerPoolRouter** (`fynd-core/src/worker_pool_router/`) — Allocates the pools that serve each order, fans out to those, selects best by `amount_out_net_gas`
 3. **WorkerPool** (`fynd-core/src/worker_pool/`) — N `SolverWorker` instances on dedicated OS threads per pool
 4. **Algorithm trait** (`fynd-core/src/algorithm/`) — Pluggable route-finding; built-in:
    `MostLiquidAlgorithm`, `BellmanFordAlgorithm`, `PathFrankWolfeAlgorithm`, and
@@ -80,7 +80,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 
 **Quote request path** (`POST /v1/quote`):
 1. `RouterApi` validates the request
-2. `WorkerPoolRouter` fans out each order to all worker pools in parallel
+2. `WorkerPoolRouter` allocates the worker pools serving each order (an exclusive-access pool only for a request carrying the `x-exclusive-access` entitlement) and fans out to them in parallel
 3. Each pool's `TaskQueue` dispatches to a `SolverWorker` on a dedicated OS thread
 4. Worker calls `Algorithm::find_best_route` with its local graph + shared market/derived data
 5. `WorkerPoolRouter` collects results, ranks candidates by `amount_out_net_gas` descending; if price guard is enabled it validates in rank order

--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -80,7 +80,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 
 **Quote request path** (`POST /v1/quote`):
 1. `RouterApi` validates the request
-2. `WorkerPoolRouter` allocates the worker pools serving each order (an exclusive-access pool only for a request carrying the `x-exclusive-access` entitlement) and fans out to them in parallel
+2. `WorkerPoolRouter` allocates the worker pools serving each order (an exclusive-access pool only for a request granted access via the `x-exclusive-access` header) and fans out to them in parallel
 3. Each pool's `TaskQueue` dispatches to a `SolverWorker` on a dedicated OS thread
 4. Worker calls `Algorithm::find_best_route` with its local graph + shared market/derived data
 5. `WorkerPoolRouter` collects results, ranks candidates by `amount_out_net_gas` descending; if price guard is enabled it validates in rank order

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,12 +153,13 @@ Actix Web HTTP handlers. Validates requests, delegates to WorkerPoolRouter, retu
 
 Orchestrates quote requests across multiple worker pools:
 
-1. Fans out each order to all pools in parallel
-2. Manages per-request timeouts with optional early return
-3. Refines gas estimates using `estimate_gas_usage` (tycho-execution) before cross-pool ranking — algorithms use a fast naive estimate internally; this step applies a more accurate one that accounts for token transfers and protocol overhead
-4. Selects the best solution by refined `amount_out_net_gas`
-5. Optionally encodes winning solutions into on-chain transactions (when `EncodingOptions` are provided)
-6. Reports failures with error types and metrics
+1. Allocates the worker pools that serve each order, before dispatch. A worker pool declares which requests it serves (`WorkerPoolAdmission`) and each order is classified against it (`RequestClass`) — today on the caller's entitlement to exclusive liquidity, so an unentitled request is never dispatched to an exclusive-access worker pool
+2. Fans out each order to its allocated worker pools in parallel
+3. Manages per-request timeouts with optional early return
+4. Refines gas estimates using `estimate_gas_usage` (tycho-execution) before cross-pool ranking — algorithms use a fast naive estimate internally; this step applies a more accurate one that accounts for token transfers and protocol overhead
+5. Selects the best solution by refined `amount_out_net_gas`
+6. Optionally encodes winning solutions into on-chain transactions (when `EncodingOptions` are provided)
+7. Reports failures with error types and metrics
 
 ***
 
@@ -296,7 +297,7 @@ Client POST /v1/quote
 RouterApi (validate)
     │
     ▼
-WorkerPoolRouter (fan-out to all pools)
+WorkerPoolRouter (allocate pools, then fan out)
     │
     ├──► Pool A Queue ──► Worker ──► Algorithm ──► Quote
     ├──► Pool B Queue ──► Worker ──► Algorithm ──► Quote

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,7 +153,7 @@ Actix Web HTTP handlers. Validates requests, delegates to WorkerPoolRouter, retu
 
 Orchestrates quote requests across multiple worker pools:
 
-1. Allocates the worker pools that serve each order, before dispatch. A worker pool declares which requests it serves (`WorkerPoolAdmission`) and each order is classified against it (`RequestClass`) — today on the caller's entitlement to exclusive liquidity, so an unentitled request is never dispatched to an exclusive-access worker pool
+1. Allocates the worker pools that serve each order, before dispatch. Each order is classified (`OrderClass`) and matched against each worker pool's configuration (`SolverPoolHandle::serves`) — today on the caller's access to exclusive liquidity, so a request without access is never dispatched to an exclusive-access worker pool
 2. Fans out each order to its allocated worker pools in parallel
 3. Manages per-request timeouts with optional early return
 4. Refines gas estimates using `estimate_gas_usage` (tycho-execution) before cross-pool ranking — algorithms use a fast naive estimate internally; this step applies a more accurate one that accounts for token transfers and protocol overhead

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -10,7 +10,7 @@ applications.
 | `algorithm/`          | `Algorithm` trait + built-in `MostLiquidAlgorithm`, `BellmanFordAlgorithm`, `PathFrankWolfeAlgorithm`, `WaterFillAlgorithm`. Pluggable via associated graph types. `AlgorithmConfig` shared by built-ins |
 | `solver.rs`           | `FyndBuilder` assembles the full pipeline (feed + gas + computations + pools + encoder + router). `Solver` runs it                                                                 |
 | `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based |
-| `worker_pool_router/` | `WorkerPoolRouter` fans out orders to all pools, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes          |
+| `worker_pool_router/` | `WorkerPoolRouter` allocates the worker pools that serve each order (`allocation`: `RequestClass` × `WorkerPoolAdmission`), fans out to those, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes |
 | `feed/`               | `TychoFeed` (WebSocket → MarketState), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`                                                                           |
 | `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `ComponentDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
 | `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
@@ -92,7 +92,9 @@ recorded with `tools/record-market`. See `tests/integration/README.md`.
 
 **Solving** (`Solver::quote(request)`):
 
-1. `WorkerPoolRouter` fans out to all pools in parallel
+0. `WorkerPoolRouter` allocates the pools serving each order — today an exclusive-access pool is
+   allocated only to a request entitled to exclusive liquidity
+1. `WorkerPoolRouter` fans out to the allocated pools in parallel
 2. Each pool dispatches to a `SolverWorker` → `Algorithm::find_best_route` → `RouteResult`
 3. Selects best by `amount_out_net_gas` → optional `Encoder` → `Quote`
 

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -10,7 +10,7 @@ applications.
 | `algorithm/`          | `Algorithm` trait + built-in `MostLiquidAlgorithm`, `BellmanFordAlgorithm`, `PathFrankWolfeAlgorithm`, `WaterFillAlgorithm`. Pluggable via associated graph types. `AlgorithmConfig` shared by built-ins |
 | `solver.rs`           | `FyndBuilder` assembles the full pipeline (feed + gas + computations + pools + encoder + router). `Solver` runs it                                                                 |
 | `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based |
-| `worker_pool_router/` | `WorkerPoolRouter` allocates the worker pools that serve each order (`allocation`: `RequestClass` × `WorkerPoolAdmission`), fans out to those, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes |
+| `worker_pool_router/` | `WorkerPoolRouter` allocates the worker pools that serve each order (`allocation`: `OrderClass` matched by `SolverPoolHandle::serves`), fans out to those, ranks candidates by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes |
 | `feed/`               | `TychoFeed` (WebSocket → MarketState), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`                                                                           |
 | `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `ComponentDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
 | `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
@@ -93,7 +93,7 @@ recorded with `tools/record-market`. See `tests/integration/README.md`.
 **Solving** (`Solver::quote(request)`):
 
 0. `WorkerPoolRouter` allocates the pools serving each order — today an exclusive-access pool is
-   allocated only to a request entitled to exclusive liquidity
+   allocated only to a request granted exclusive access
 1. `WorkerPoolRouter` fans out to the allocated pools in parallel
 2. Each pool dispatches to a `SolverWorker` → `Algorithm::find_best_route` → `RouteResult`
 3. Selects best by `amount_out_net_gas` → optional `Encoder` → `Quote`

--- a/fynd-core/proptest-regressions/algorithm/pfw_e2e_tests.txt
+++ b/fynd-core/proptest-regressions/algorithm/pfw_e2e_tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a80ea37c0f7f76e5f05d6babd239172067baac97c4b66122ceeb460595d44bcc # shrinks to trade_fraction = 0.001

--- a/fynd-core/proptest-regressions/algorithm/pfw_e2e_tests.txt
+++ b/fynd-core/proptest-regressions/algorithm/pfw_e2e_tests.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc a80ea37c0f7f76e5f05d6babd239172067baac97c4b66122ceeb460595d44bcc # shrinks to trade_fraction = 0.001

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -89,5 +89,6 @@ pub use worker_pool::{
     TaskQueueHandle,
 };
 pub use worker_pool_router::{
-    config::WorkerPoolRouterConfig, LiquidityScope, SolverPoolHandle, WorkerPoolRouter,
+    config::WorkerPoolRouterConfig, ExclusiveAccess, LiquidityScope, SolverPoolHandle,
+    WorkerPoolRouter,
 };

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -1520,8 +1520,7 @@ mod tests {
     }
 
     /// A deployment of nothing but exclusive-access pools would serve requests without access
-    /// from no
-    /// pool at all.
+    /// from no pool at all.
     #[test]
     fn test_build_all_exclusive_pools() {
         let config =

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -1523,7 +1523,7 @@ mod tests {
     /// from no
     /// pool at all.
     #[test]
-    fn test_build_rejects_all_exclusive_pools() {
+    fn test_build_all_exclusive_pools() {
         let config =
             PoolConfig::new("most_liquid").with_liquidity_scope(LiquidityScope::IncludeExclusive);
         let result = FyndBuilder::new(

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -313,7 +313,7 @@ pub enum SolverBuildError {
     #[error("no worker pools configured")]
     NoPools,
     /// Every worker pool is `liquidity_scope = "include_exclusive"`, so a request without the
-    /// exclusive-access entitlement would be served by no worker pool at all. At least one worker
+    /// exclusive access would be served by no worker pool at all. At least one worker
     /// pool must route public liquidity.
     #[error(
         "every worker pool sets liquidity_scope = \"include_exclusive\"; requests without \
@@ -683,7 +683,7 @@ impl FyndBuilder {
             return Err(SolverBuildError::NoPools);
         }
 
-        // Exclusive-access worker pools only serve entitled requests, so a deployment made
+        // Exclusive-access worker pools only serve requests granted access, so a deployment made
         // entirely of them would allocate no worker pool at all to everyone else. Caught here
         // rather than per request: it is a configuration mistake, not a runtime condition.
         if self
@@ -1133,9 +1133,9 @@ impl Solver {
 
     /// Submits a [`QuoteRequest`] to the worker pools and returns the best [`Quote`].
     ///
-    /// Grants `ExclusiveAccess::Granted`: a library embedder configures its own pools and
-    /// exclusivity policy, so there is no untrusted caller to gate here. Entitlement is enforced
-    /// at the HTTP boundary, where requests do come from untrusted callers.
+    /// Grants `ExclusiveAccess::Granted`: a library embedder configures its own pools, so there
+    /// is no untrusted caller to gate here. Access is decided at the HTTP boundary, where
+    /// requests do come from untrusted callers.
     ///
     /// # Errors
     ///
@@ -1519,7 +1519,8 @@ mod tests {
         );
     }
 
-    /// A deployment of nothing but exclusive-access pools would serve unentitled requests from no
+    /// A deployment of nothing but exclusive-access pools would serve requests without access
+    /// from no
     /// pool at all.
     #[test]
     fn test_build_rejects_all_exclusive_pools() {

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -49,7 +49,8 @@ use crate::{
         registry::UnknownAlgorithmError,
     },
     worker_pool_router::{
-        config::WorkerPoolRouterConfig, LiquidityScope, SolverPoolHandle, WorkerPoolRouter,
+        config::WorkerPoolRouterConfig, ExclusiveAccess, LiquidityScope, SolverPoolHandle,
+        WorkerPoolRouter,
     },
     Algorithm, Quote, QuoteRequest, SolveError,
 };
@@ -311,6 +312,14 @@ pub enum SolverBuildError {
     /// [`FyndBuilder::build`] was called without configuring any worker pools.
     #[error("no worker pools configured")]
     NoPools,
+    /// Every worker pool is `liquidity_scope = "include_exclusive"`, so a request without the
+    /// exclusive-access entitlement would be served by no worker pool at all. At least one worker
+    /// pool must route public liquidity.
+    #[error(
+        "every worker pool sets liquidity_scope = \"include_exclusive\"; requests without \
+         exclusive access would be served by no pool. Configure at least one public_only pool"
+    )]
+    NoPublicPool,
     /// A recorded update failed to replay through the feed.
     #[cfg(feature = "test-utils")]
     #[error("replay failed: {0}")]
@@ -672,6 +681,17 @@ impl FyndBuilder {
     fn assemble_components(mut self) -> Result<BuiltComponents, SolverBuildError> {
         if self.pools.is_empty() {
             return Err(SolverBuildError::NoPools);
+        }
+
+        // Exclusive-access worker pools only serve entitled requests, so a deployment made
+        // entirely of them would allocate no worker pool at all to everyone else. Caught here
+        // rather than per request: it is a configuration mistake, not a runtime condition.
+        if self
+            .pools
+            .iter()
+            .all(|p| p.liquidity_scope() == Some(LiquidityScope::IncludeExclusive))
+        {
+            return Err(SolverBuildError::NoPublicPool);
         }
 
         // Add built-in providers if none were explicitly registered.
@@ -1113,11 +1133,17 @@ impl Solver {
 
     /// Submits a [`QuoteRequest`] to the worker pools and returns the best [`Quote`].
     ///
+    /// Grants `ExclusiveAccess::Granted`: a library embedder configures its own pools and
+    /// exclusivity policy, so there is no untrusted caller to gate here. Entitlement is enforced
+    /// at the HTTP boundary, where requests do come from untrusted callers.
+    ///
     /// # Errors
     ///
     /// Returns [`SolveError`] if all worker pools fail or the router timeout elapses.
     pub async fn quote(&self, request: QuoteRequest) -> Result<Quote, SolveError> {
-        self.router.quote(request).await
+        self.router
+            .quote(request, ExclusiveAccess::Granted)
+            .await
     }
 
     /// Waits until the solver is ready to answer quotes.
@@ -1491,5 +1517,25 @@ mod tests {
                 .unwrap_or_default(),
             LiquidityScope::PublicOnly
         );
+    }
+
+    /// A deployment of nothing but exclusive-access pools would serve unentitled requests from no
+    /// pool at all.
+    #[test]
+    fn test_build_rejects_all_exclusive_pools() {
+        let config =
+            PoolConfig::new("most_liquid").with_liquidity_scope(LiquidityScope::IncludeExclusive);
+        let result = FyndBuilder::new(
+            Chain::Ethereum,
+            "wss://example.invalid",
+            "https://example.invalid",
+            vec!["uniswap_v2".to_string()],
+            100.0,
+        )
+        .add_pool("exclusive", &config)
+        .expect("add_pool should accept the config")
+        .build();
+
+        assert!(matches!(result, Err(SolverBuildError::NoPublicPool)));
     }
 }

--- a/fynd-core/src/worker_pool_router/allocation.rs
+++ b/fynd-core/src/worker_pool_router/allocation.rs
@@ -1,0 +1,183 @@
+//! Decides which worker pools serve an order, before any work is dispatched.
+//!
+//! Each worker pool declares a [`WorkerPoolAdmission`] — which requests it serves. Each order is
+//! classified into a [`RequestClass`] — what it is and what it may reach. [`allocate`] intersects
+//! the two into an [`Allocation`], and the router fans out to those worker pools only.
+//!
+//! Deciding before fan-out rather than filtering candidates afterwards means a worker pool that
+//! does not serve a request costs it no CPU and no latency. It also leaves the router with a
+//! single source of truth: early-return gating, the ranking split and the surplus overlay all read
+//! the allocation, so an unentitled request cannot leak exclusive liquidity through a branch that
+//! was missed.
+//!
+//! Both sides grow one field per dimension. Trade size derived from `amount_in` — routing small
+//! orders to fast algorithms and large ones to algorithms that handle them better — is the next
+//! one: a field on `RequestClass`, a matching condition in `WorkerPoolAdmission::admits`.
+
+use std::collections::HashMap;
+
+use super::{LiquidityScope, SolverPoolHandle};
+
+/// Whether a single request may route through exclusive liquidity.
+///
+/// Exclusive liquidity is reserved for selected clients, so the entitlement is decided at the
+/// request boundary by the operator — the RPC layer reads it from a header set by the
+/// authenticating proxy — and never from anything a caller can put in a
+/// `QuoteRequest`.
+///
+/// `Denied` is not an error: the request is quoted from public liquidity alone, which is the same
+/// answer a deployment without exclusive worker pools would give. A missing entitlement costs
+/// price rather than breaking the request.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ExclusiveAccess {
+    /// Route through public liquidity only. Default: entitlement must be granted explicitly.
+    #[default]
+    Denied,
+    /// Route through exclusive components too, capturing surplus above the public reference.
+    Granted,
+}
+
+/// What an order is, and what it is allowed to reach.
+///
+/// Built once per order from the trust-boundary entitlement plus facts about the order itself.
+/// Matched against every worker pool's [`WorkerPoolAdmission`] to decide the fan-out.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RequestClass {
+    /// Whether this order may be served by exclusive-access worker pools.
+    exclusive_access: ExclusiveAccess,
+}
+
+impl RequestClass {
+    /// Classifies an order whose only distinguishing property is the caller's entitlement.
+    pub(crate) fn new(exclusive_access: ExclusiveAccess) -> Self {
+        Self { exclusive_access }
+    }
+}
+
+/// Which requests a worker pool serves.
+///
+/// Every field is a condition; a worker pool is selected only when all of them hold for the
+/// request. Built from the worker pool's `worker_pools.toml` entry and held by its
+/// [`SolverPoolHandle`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct WorkerPoolAdmission {
+    /// The liquidity this worker pool's threads can see. Decides which entitlements it serves.
+    liquidity_scope: LiquidityScope,
+}
+
+impl WorkerPoolAdmission {
+    /// Returns the liquidity scope this rule admits on.
+    pub(crate) fn liquidity_scope(self) -> LiquidityScope {
+        self.liquidity_scope
+    }
+
+    /// Sets the liquidity scope this rule admits on.
+    pub(crate) fn with_liquidity_scope(mut self, liquidity_scope: LiquidityScope) -> Self {
+        self.liquidity_scope = liquidity_scope;
+        self
+    }
+
+    /// Returns whether a worker pool with this rule serves `class`.
+    fn admits(self, class: RequestClass) -> bool {
+        match self.liquidity_scope {
+            // Public liquidity is available to every caller.
+            LiquidityScope::PublicOnly => true,
+            LiquidityScope::IncludeExclusive => class.exclusive_access == ExclusiveAccess::Granted,
+        }
+    }
+}
+
+/// The worker pools selected to serve one order.
+///
+/// The router's only source of scope facts once fan-out begins — nothing downstream re-derives
+/// them from the full worker pool list, so a worker pool that was not selected cannot reappear in
+/// the ranking.
+pub(crate) struct Allocation<'a> {
+    /// Selected worker pools, in configuration order.
+    worker_pools: Vec<&'a SolverPoolHandle>,
+    /// Liquidity scope of each selected worker pool, keyed by worker pool name.
+    scopes: HashMap<String, LiquidityScope>,
+    /// Whether both scopes are selected — the single fact that early-return gating and the
+    /// ranking split branch on. See [`Allocation::surplus_routing_active`].
+    surplus_routing_active: bool,
+}
+
+impl<'a> Allocation<'a> {
+    /// Returns the selected worker pools, in configuration order.
+    pub(crate) fn worker_pools(&self) -> &[&'a SolverPoolHandle] {
+        &self.worker_pools
+    }
+
+    /// Returns the liquidity scope of each selected worker pool, keyed by worker pool name.
+    pub(crate) fn scopes(&self) -> &HashMap<String, LiquidityScope> {
+        &self.scopes
+    }
+
+    /// Returns `true` when surplus routing is active for this allocation: it needs both scopes —
+    /// a [`LiquidityScope::PublicOnly`] worker pool for the committed reference and a
+    /// [`LiquidityScope::IncludeExclusive`] one that may beat it.
+    pub(crate) fn surplus_routing_active(&self) -> bool {
+        self.surplus_routing_active
+    }
+
+    /// Returns whether the named worker pool was selected and routes through exclusive liquidity.
+    pub(crate) fn is_exclusive(&self, worker_pool_name: &str) -> bool {
+        self.scopes.get(worker_pool_name) == Some(&LiquidityScope::IncludeExclusive)
+    }
+
+    /// Returns whether no worker pool serves the request.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.worker_pools.is_empty()
+    }
+}
+
+/// Selects the worker pools that serve `class`, preserving configuration order.
+pub(crate) fn allocate(worker_pools: &[SolverPoolHandle], class: RequestClass) -> Allocation<'_> {
+    let worker_pools: Vec<&SolverPoolHandle> = worker_pools
+        .iter()
+        .filter(|worker_pool| worker_pool.admission().admits(class))
+        .collect();
+
+    let scopes: HashMap<String, LiquidityScope> = worker_pools
+        .iter()
+        .map(|worker_pool| (worker_pool.name().to_string(), worker_pool.liquidity_scope()))
+        .collect();
+    let surplus_routing_active = scopes
+        .values()
+        .any(|scope| *scope == LiquidityScope::IncludeExclusive) &&
+        scopes
+            .values()
+            .any(|scope| *scope == LiquidityScope::PublicOnly);
+
+    Allocation { worker_pools, scopes, surplus_routing_active }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::public_scope_denied(LiquidityScope::PublicOnly, ExclusiveAccess::Denied, true)]
+    #[case::public_scope_granted(LiquidityScope::PublicOnly, ExclusiveAccess::Granted, true)]
+    #[case::exclusive_scope_denied(
+        LiquidityScope::IncludeExclusive,
+        ExclusiveAccess::Denied,
+        false
+    )]
+    #[case::exclusive_scope_granted(
+        LiquidityScope::IncludeExclusive,
+        ExclusiveAccess::Granted,
+        true
+    )]
+    fn test_admits(
+        #[case] scope: LiquidityScope,
+        #[case] access: ExclusiveAccess,
+        #[case] expected: bool,
+    ) {
+        let admission = WorkerPoolAdmission::default().with_liquidity_scope(scope);
+
+        assert_eq!(admission.admits(RequestClass::new(access)), expected);
+    }
+}

--- a/fynd-core/src/worker_pool_router/allocation.rs
+++ b/fynd-core/src/worker_pool_router/allocation.rs
@@ -77,9 +77,9 @@ pub(crate) struct Allocation<'a> {
     worker_pools: Vec<&'a SolverPoolHandle>,
     /// Liquidity scope of each selected worker pool, keyed by worker pool name.
     scopes: HashMap<String, LiquidityScope>,
-    /// Whether both scopes are selected — the single fact that early-return gating and the
-    /// ranking split branch on. See [`Allocation::surplus_routing_active`].
-    surplus_routing_active: bool,
+    /// Whether an exclusive-scope worker pool is selected — the single fact that early-return
+    /// gating and the ranking split branch on. See [`Allocation::exclusive_routing_active`].
+    exclusive_routing_active: bool,
 }
 
 impl<'a> Allocation<'a> {
@@ -93,11 +93,13 @@ impl<'a> Allocation<'a> {
         &self.scopes
     }
 
-    /// Returns `true` when surplus routing is active for this allocation: it needs both scopes —
-    /// a [`LiquidityScope::PublicOnly`] worker pool for the committed reference and a
-    /// [`LiquidityScope::IncludeExclusive`] one that may beat it.
-    pub(crate) fn surplus_routing_active(&self) -> bool {
-        self.surplus_routing_active
+    /// Returns `true` when a selected worker pool routes through exclusive liquidity
+    /// ([`LiquidityScope::IncludeExclusive`]). A [`LiquidityScope::PublicOnly`] worker pool is
+    /// then also selected — public worker pools serve every order, and startup rejects a
+    /// configuration without one — so the ranking always has a public reference to overlay the
+    /// exclusive candidate onto.
+    pub(crate) fn exclusive_routing_active(&self) -> bool {
+        self.exclusive_routing_active
     }
 
     /// Returns whether the named worker pool was selected and routes through exclusive liquidity.
@@ -122,14 +124,11 @@ pub(crate) fn allocate(worker_pools: &[SolverPoolHandle], class: OrderClass) -> 
         .iter()
         .map(|worker_pool| (worker_pool.name().to_string(), worker_pool.liquidity_scope()))
         .collect();
-    let surplus_routing_active = scopes
+    let exclusive_routing_active = scopes
         .values()
-        .any(|scope| *scope == LiquidityScope::IncludeExclusive) &&
-        scopes
-            .values()
-            .any(|scope| *scope == LiquidityScope::PublicOnly);
+        .any(|scope| *scope == LiquidityScope::IncludeExclusive);
 
-    Allocation { worker_pools, scopes, surplus_routing_active }
+    Allocation { worker_pools, scopes, exclusive_routing_active }
 }
 
 #[cfg(test)]

--- a/fynd-core/src/worker_pool_router/allocation.rs
+++ b/fynd-core/src/worker_pool_router/allocation.rs
@@ -1,18 +1,19 @@
 //! Decides which worker pools serve an order, before any work is dispatched.
 //!
-//! Each worker pool declares a [`WorkerPoolAdmission`] — which requests it serves. Each order is
-//! classified into a [`RequestClass`] — what it is and what it may reach. [`allocate`] intersects
-//! the two into an [`Allocation`], and the router fans out to those worker pools only.
+//! Each order is classified into an [`OrderClass`] — what it is and what it may reach. Each
+//! worker pool decides from its own configuration whether it serves a class
+//! ([`SolverPoolHandle::serves`]). [`allocate`] intersects the two into an [`Allocation`], and
+//! the router fans out to those worker pools only.
 //!
 //! Deciding before fan-out rather than filtering candidates afterwards means a worker pool that
 //! does not serve a request costs it no CPU and no latency. It also leaves the router with a
-//! single source of truth: early-return gating, the ranking split and the surplus overlay all read
-//! the allocation, so an unentitled request cannot leak exclusive liquidity through a branch that
-//! was missed.
+//! single source of truth: early-return gating and the ranking split both read the allocation, so
+//! a request without exclusive access cannot leak exclusive liquidity through a branch that was
+//! missed.
 //!
 //! Both sides grow one field per dimension. Trade size derived from `amount_in` — routing small
 //! orders to fast algorithms and large ones to algorithms that handle them better — is the next
-//! one: a field on `RequestClass`, a matching condition in `WorkerPoolAdmission::admits`.
+//! one: a field on [`OrderClass`], a matching condition in [`SolverPoolHandle::serves`].
 
 use std::collections::HashMap;
 
@@ -20,17 +21,16 @@ use super::{LiquidityScope, SolverPoolHandle};
 
 /// Whether a single request may route through exclusive liquidity.
 ///
-/// Exclusive liquidity is reserved for selected clients, so the entitlement is decided at the
-/// request boundary by the operator — the RPC layer reads it from a header set by the
-/// authenticating proxy — and never from anything a caller can put in a
-/// `QuoteRequest`.
+/// Exclusive liquidity is reserved for selected clients, so access is decided at the request
+/// boundary by the operator — the RPC layer reads it from a header set by the authenticating
+/// proxy — and never from anything a caller can put in a `QuoteRequest`.
 ///
 /// `Denied` is not an error: the request is quoted from public liquidity alone, which is the same
-/// answer a deployment without exclusive worker pools would give. A missing entitlement costs
-/// price rather than breaking the request.
+/// answer a deployment without exclusive worker pools would give. Missing access costs price
+/// rather than breaking the request.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ExclusiveAccess {
-    /// Route through public liquidity only. Default: entitlement must be granted explicitly.
+    /// Route through public liquidity only. Default: access must be granted explicitly.
     #[default]
     Denied,
     /// Route through exclusive components too, capturing surplus above the public reference.
@@ -39,47 +39,27 @@ pub enum ExclusiveAccess {
 
 /// What an order is, and what it is allowed to reach.
 ///
-/// Built once per order from the trust-boundary entitlement plus facts about the order itself.
-/// Matched against every worker pool's [`WorkerPoolAdmission`] to decide the fan-out.
+/// Built once per order from the trust-boundary access decision plus facts about the order
+/// itself. Each worker pool checks it in [`SolverPoolHandle::serves`] to decide the fan-out.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct RequestClass {
+pub(crate) struct OrderClass {
     /// Whether this order may be served by exclusive-access worker pools.
     exclusive_access: ExclusiveAccess,
 }
 
-impl RequestClass {
-    /// Classifies an order whose only distinguishing property is the caller's entitlement.
+impl OrderClass {
+    /// Classifies an order whose only distinguishing property is the caller's access.
     pub(crate) fn new(exclusive_access: ExclusiveAccess) -> Self {
         Self { exclusive_access }
     }
 }
 
-/// Which requests a worker pool serves.
-///
-/// Every field is a condition; a worker pool is selected only when all of them hold for the
-/// request. Built from the worker pool's `worker_pools.toml` entry and held by its
-/// [`SolverPoolHandle`].
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct WorkerPoolAdmission {
-    /// The liquidity this worker pool's threads can see. Decides which entitlements it serves.
-    liquidity_scope: LiquidityScope,
-}
-
-impl WorkerPoolAdmission {
-    /// Returns the liquidity scope this rule admits on.
-    pub(crate) fn liquidity_scope(self) -> LiquidityScope {
-        self.liquidity_scope
-    }
-
-    /// Sets the liquidity scope this rule admits on.
-    pub(crate) fn with_liquidity_scope(mut self, liquidity_scope: LiquidityScope) -> Self {
-        self.liquidity_scope = liquidity_scope;
-        self
-    }
-
-    /// Returns whether a worker pool with this rule serves `class`.
-    fn admits(self, class: RequestClass) -> bool {
-        match self.liquidity_scope {
+impl SolverPoolHandle {
+    /// Returns whether this worker pool serves orders of `class`.
+    ///
+    /// Every configured condition must hold; today the only one is the liquidity scope.
+    pub(crate) fn serves(&self, class: OrderClass) -> bool {
+        match self.liquidity_scope() {
             // Public liquidity is available to every caller.
             LiquidityScope::PublicOnly => true,
             LiquidityScope::IncludeExclusive => class.exclusive_access == ExclusiveAccess::Granted,
@@ -132,10 +112,10 @@ impl<'a> Allocation<'a> {
 }
 
 /// Selects the worker pools that serve `class`, preserving configuration order.
-pub(crate) fn allocate(worker_pools: &[SolverPoolHandle], class: RequestClass) -> Allocation<'_> {
+pub(crate) fn allocate(worker_pools: &[SolverPoolHandle], class: OrderClass) -> Allocation<'_> {
     let worker_pools: Vec<&SolverPoolHandle> = worker_pools
         .iter()
-        .filter(|worker_pool| worker_pool.admission().admits(class))
+        .filter(|worker_pool| worker_pool.serves(class))
         .collect();
 
     let scopes: HashMap<String, LiquidityScope> = worker_pools
@@ -157,6 +137,7 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::worker_pool::TaskQueueHandle;
 
     #[rstest]
     #[case::public_scope_denied(LiquidityScope::PublicOnly, ExclusiveAccess::Denied, true)]
@@ -171,13 +152,15 @@ mod tests {
         ExclusiveAccess::Granted,
         true
     )]
-    fn test_admits(
+    fn test_serves(
         #[case] scope: LiquidityScope,
         #[case] access: ExclusiveAccess,
         #[case] expected: bool,
     ) {
-        let admission = WorkerPoolAdmission::default().with_liquidity_scope(scope);
+        let (tx, _rx) = async_channel::bounded(1);
+        let worker_pool = SolverPoolHandle::new("worker_pool", TaskQueueHandle::from_sender(tx))
+            .with_liquidity_scope(scope);
 
-        assert_eq!(admission.admits(RequestClass::new(access)), expected);
+        assert_eq!(worker_pool.serves(OrderClass::new(access)), expected);
     }
 }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -332,15 +332,16 @@ impl WorkerPoolRouter {
 
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
         // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
-        // fallback chain. When the allocation holds both scopes, the winning exclusive-access
-        // candidate is overlaid onto that ranked list (prepended) by `combine_with_surplus`, so
-        // the fallbacks are preserved. If the public worker pools find nothing, that ranking is
-        // the `NoRouteFound` placeholder. The exclusive candidate then uses a default fee.
+        // fallback chain. When the allocation holds an exclusive-scope worker pool, the winning
+        // exclusive-access candidate is overlaid onto that ranked list (prepended) by
+        // `combine_with_surplus`, so the fallbacks are preserved. If the public worker pools find
+        // nothing, that ranking is the `NoRouteFound` placeholder. The exclusive candidate then
+        // uses a default fee.
         let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
             .zip(&allocations)
             .map(|(responses, allocation)| {
-                if allocation.surplus_routing_active() {
+                if allocation.exclusive_routing_active() {
                     let public_ranked = self.rank_quotes(
                         &responses.public_only(allocation.scopes()),
                         request.options(),
@@ -492,12 +493,12 @@ impl WorkerPoolRouter {
                             // Extract the OrderQuote from SingleOrderQuote
                             quotes.push((worker_pool_name.clone(), single_quote.order().clone()));
 
-                            // Scope-aware early return: when surplus routing is active for this
-                            // allocation, only fire once we have ≥1 public AND ≥1
+                            // Scope-aware early return: when the allocation routes through
+                            // exclusive liquidity, only fire once we have ≥1 public AND ≥1
                             // exclusive-access response (so the surplus overlay has both
                             // inputs). Otherwise, use pure count-based gating (original
                             // behaviour).
-                            let scope_ready = if allocation.surplus_routing_active() {
+                            let scope_ready = if allocation.exclusive_routing_active() {
                                 has_public_response && has_exclusive_access_response
                             } else {
                                 true

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -1395,14 +1395,20 @@ mod tests {
         worker_b.abort();
     }
 
+    /// The `denied_access` case sets `min_responses(2)`, which would hold a request with access
+    /// until both pools answer; a denied request's allocation holds only the public pool, so it
+    /// must return without waiting on the slow exclusive pool it will never use.
     #[rstest]
-    #[case::pending_exclusive_pool(0, Some(300), true)]
-    #[case::pending_public_pool(300, Some(0), true)]
-    #[case::failed_exclusive_pool(0, None, false)]
+    #[case::pending_exclusive_pool(ExclusiveAccess::Granted, 0, Some(300), 1, true)]
+    #[case::pending_public_pool(ExclusiveAccess::Granted, 300, Some(0), 1, true)]
+    #[case::failed_exclusive_pool(ExclusiveAccess::Granted, 0, None, 1, false)]
+    #[case::denied_access(ExclusiveAccess::Denied, 0, Some(500), 2, false)]
     #[tokio::test]
     async fn test_router_early_return_scope_gating(
+        #[case] access: ExclusiveAccess,
         #[case] public_delay_ms: u64,
         #[case] exclusive_delay_ms: Option<u64>,
+        #[case] min_responses: usize,
         #[case] expect_surplus: bool,
     ) {
         let (public_pool, public_worker) =
@@ -1423,19 +1429,20 @@ mod tests {
 
         let config = WorkerPoolRouterConfig::default()
             .with_timeout(Duration::from_millis(2000))
-            .with_min_responses(1);
+            .with_min_responses(min_responses);
         let worker_router =
             WorkerPoolRouter::new(vec![public_pool, exclusive_pool], config, default_encoder());
         let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
 
         let start = Instant::now();
         let result = worker_router
-            .quote(request, ExclusiveAccess::Granted)
+            .quote(request, access)
             .await
             .expect("quote should succeed");
         let elapsed = start.elapsed();
 
-        // Well under the 2s timeout: the gate releases as soon as both scopes have responded.
+        // Well under the 2s timeout: the gate releases as soon as every allocated scope has
+        // responded.
         assert!(elapsed < Duration::from_millis(500), "took {elapsed:?}");
         let order = &result.orders()[0];
         assert_eq!(order.status(), QuoteStatus::Success);
@@ -1500,41 +1507,6 @@ mod tests {
         // Either way the quoted output is the public reference, so denied access costs the
         // caller nothing they were promised.
         assert_eq!(*order.amount_out(), BigUint::from(990u64));
-
-        drop(worker_router);
-        public_worker.abort();
-        exclusive_worker.abort();
-    }
-
-    /// A denied request must not wait on the exclusive pool it will never use.
-    #[tokio::test]
-    async fn test_router_denied_does_not_wait_for_exclusive_pool() {
-        let (public_pool, public_worker) =
-            create_mock_worker_pool("public_pool", Ok(make_single_quote(800)), 0);
-        let (exclusive_pool, exclusive_worker) =
-            create_mock_worker_pool("exclusive_pool", Ok(make_exclusive_quote(1100)), 500);
-        let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::IncludeExclusive);
-
-        // `min_responses(2)` would hold a request with access until both pools answer.
-        let worker_router = WorkerPoolRouter::new(
-            vec![public_pool, exclusive_pool],
-            WorkerPoolRouterConfig::default()
-                .with_timeout(Duration::from_millis(2000))
-                .with_min_responses(2),
-            default_encoder(),
-        );
-        let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
-
-        let start = Instant::now();
-        let result = worker_router
-            .quote(request, ExclusiveAccess::Denied)
-            .await
-            .expect("quote should succeed");
-        let elapsed = start.elapsed();
-
-        // Only the public pool is allocated, so `min_responses` is satisfied by its answer alone.
-        assert!(elapsed < Duration::from_millis(300), "took {elapsed:?}");
-        assert_eq!(result.orders()[0].status(), QuoteStatus::Success);
 
         drop(worker_router);
         public_worker.abort();

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -21,6 +21,7 @@
 //!    encode winning solutions into executable on-chain transactions via the
 //!    [`encoding::encoder::Encoder`](crate::encoding::encoder::Encoder)
 
+mod allocation;
 pub mod config;
 
 use std::{
@@ -29,6 +30,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+pub use allocation::ExclusiveAccess;
+use allocation::{allocate, Allocation, RequestClass, WorkerPoolAdmission};
 use config::WorkerPoolRouterConfig;
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, histogram};
@@ -142,19 +145,21 @@ pub struct SolverPoolHandle {
     name: String,
     /// Queue handle for this worker pool.
     queue: TaskQueueHandle,
-    /// Which liquidity this worker pool routes through.
-    liquidity_scope: LiquidityScope,
+    /// Which requests this worker pool serves. Decides whether an order is dispatched to it.
+    admission: WorkerPoolAdmission,
 }
 
 impl SolverPoolHandle {
     /// Creates a new solver pool handle with the default [`LiquidityScope::PublicOnly`] scope.
     pub fn new(name: impl Into<String>, queue: TaskQueueHandle) -> Self {
-        Self { name: name.into(), queue, liquidity_scope: LiquidityScope::default() }
+        Self { name: name.into(), queue, admission: WorkerPoolAdmission::default() }
     }
 
     /// Sets the worker pool's liquidity scope.
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
-        self.liquidity_scope = scope;
+        self.admission = self
+            .admission
+            .with_liquidity_scope(scope);
         self
     }
 
@@ -170,7 +175,12 @@ impl SolverPoolHandle {
 
     /// Returns the worker pool's liquidity scope.
     pub fn liquidity_scope(&self) -> LiquidityScope {
-        self.liquidity_scope
+        self.admission.liquidity_scope()
+    }
+
+    /// Returns which requests this pool serves.
+    pub(crate) fn admission(&self) -> WorkerPoolAdmission {
+        self.admission
     }
 }
 
@@ -179,9 +189,9 @@ impl SolverPoolHandle {
 pub(crate) struct OrderResponses {
     /// ID of the order these responses correspond to.
     order_id: String,
-    /// Quotes received from each solver pool (pool_name, quote).
+    /// Quotes received from each worker pool (worker_pool_name, quote).
     quotes: Vec<(String, OrderQuote)>,
-    /// Solver pools that failed with their respective errors (pool_name, error).
+    /// Worker pools that failed with their respective errors (worker_pool_name, error).
     /// This captures all error types: timeouts, no routes, algorithm errors, etc.
     failed_solvers: Vec<(String, SolveError)>,
 }
@@ -245,27 +255,25 @@ impl WorkerPoolRouter {
         self.solver_pools.len()
     }
 
-    /// Returns `true` when surplus routing is active: it needs both scopes configured — a
-    /// [`LiquidityScope::PublicOnly`] pool for the committed reference and a
-    /// [`LiquidityScope::IncludeExclusive`] pool that may beat it.
-    fn surplus_routing_active(&self) -> bool {
-        self.solver_pools
-            .iter()
-            .any(|p| p.liquidity_scope() == LiquidityScope::IncludeExclusive) &&
-            self.solver_pools
-                .iter()
-                .any(|p| p.liquidity_scope() == LiquidityScope::PublicOnly)
-    }
-
-    /// Returns a quote by fanning out to all solver pools.
+    /// Returns a quote by fanning out to the worker pools that serve the request.
     ///
     /// For each order in the request:
-    /// 1. Sends the order to all solver pools in parallel
-    /// 2. Waits for responses with timeout
-    /// 3. Selects the best quote based on `amount_out_net_gas`
-    /// 4. If `encoding_options` are set on the request, encodes winning solutions into on-chain
+    /// 1. Allocates the worker pools that serve it (see the `allocation` module)
+    /// 2. Sends the order to those worker pools in parallel
+    /// 3. Waits for responses with timeout
+    /// 4. Selects the best quote based on `amount_out_net_gas`
+    /// 5. If `encoding_options` are set on the request, encodes winning solutions into on-chain
     ///    transactions
-    pub async fn quote(&self, request: QuoteRequest) -> Result<Quote, SolveError> {
+    ///
+    /// `access` is the caller's entitlement to exclusive liquidity, resolved at the trust
+    /// boundary. With [`ExclusiveAccess::Denied`] no exclusive-access worker pool is allocated, so
+    /// such worker pools do no work for the request and the quote is built from public liquidity
+    /// alone.
+    pub async fn quote(
+        &self,
+        request: QuoteRequest,
+        access: ExclusiveAccess,
+    ) -> Result<Quote, SolveError> {
         let start = Instant::now();
         let deadline = start + self.effective_timeout(request.options());
         let min_responses = request
@@ -282,11 +290,42 @@ impl WorkerPoolRouter {
             None => SolveParams::default(),
         };
 
+        counter!(
+            "worker_router_exclusive_access_total",
+            "access" => match access {
+                ExclusiveAccess::Granted => "granted",
+                ExclusiveAccess::Denied => "denied",
+            }
+        )
+        .increment(1);
+
+        // One allocation per order: which worker pools serve an order is a property of the order,
+        // not of the request. Today every order in a request classifies identically; once
+        // trade size joins `RequestClass` they will differ.
+        let class = RequestClass::new(access);
+        let allocations: Vec<Allocation<'_>> = request
+            .orders()
+            .iter()
+            .map(|_| allocate(&self.solver_pools, class))
+            .collect();
+
+        if allocations
+            .iter()
+            .any(Allocation::is_empty)
+        {
+            return Err(SolveError::Internal(format!(
+                "no worker pool serves this request: {class:?}"
+            )));
+        }
+
         // Process each order independently in parallel
         let order_futures: Vec<_> = request
             .orders()
             .iter()
-            .map(|order| self.solve_order(order.clone(), params.clone(), deadline, min_responses))
+            .zip(&allocations)
+            .map(|(order, allocation)| {
+                self.solve_order(order.clone(), params.clone(), deadline, min_responses, allocation)
+            })
             .collect();
 
         let mut order_responses = futures::future::join_all(order_futures).await;
@@ -297,30 +336,24 @@ impl WorkerPoolRouter {
             refine_gas_estimates(&mut order_responses, encoding_options)?;
         }
 
-        // Map each worker pool name to its liquidity scope so candidate quotes can be split into
-        // public vs exclusive-access.
-        let pool_scopes: HashMap<String, LiquidityScope> = self
-            .solver_pools
-            .iter()
-            .map(|p| (p.name().to_string(), p.liquidity_scope()))
-            .collect();
-        let surplus_routing_active = self.surplus_routing_active();
-
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
         // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
-        // fallback chain. When both scopes are configured, the winning exclusive-access
+        // fallback chain. When the allocation holds both scopes, the winning exclusive-access
         // candidate is overlaid onto that ranked list (prepended) by `combine_with_surplus`, so
         // the fallbacks are preserved. If the public worker pools find nothing, that ranking is
         // the `NoRouteFound` placeholder. The exclusive candidate then uses a default fee.
         let ranked_quotes: Vec<Vec<OrderQuote>> = order_responses
             .into_iter()
-            .map(|responses| {
-                if surplus_routing_active {
-                    let public_ranked =
-                        self.rank_quotes(&responses.public_only(&pool_scopes), request.options());
+            .zip(&allocations)
+            .map(|(responses, allocation)| {
+                if allocation.surplus_routing_active() {
+                    let public_ranked = self.rank_quotes(
+                        &responses.public_only(allocation.scopes()),
+                        request.options(),
+                    );
                     combine_with_surplus(
                         &responses,
-                        &pool_scopes,
+                        allocation.scopes(),
                         request.options(),
                         public_ranked,
                         *USER_IMPROVEMENT_SHARE_BPS,
@@ -385,55 +418,42 @@ impl WorkerPoolRouter {
         Ok(Quote::new(order_quotes, total_gas_estimate, solve_time_ms))
     }
 
-    /// Solves a single order by fanning out to all solver pools.
+    /// Solves a single order by fanning out to the worker pools allocated to it.
     async fn solve_order(
         &self,
         order: Order,
         params: SolveParams,
         deadline: Instant,
         min_responses: usize,
+        allocation: &Allocation<'_>,
     ) -> OrderResponses {
         let start_time = Instant::now();
         let order_id = order.id().to_string();
 
-        // Fan-out: send order to all solver pools
-        // perf: In the future, we can add new distribution algorithms, like sending short-timeout
-        // only to fast workers.
-        let mut pending: FuturesUnordered<_> = self
-            .solver_pools
+        // Fan-out: send order to the allocated worker pools. Worker pools that do not serve this
+        // order were already dropped by `allocate`, so nothing here filters by entitlement.
+        let mut pending: FuturesUnordered<_> = allocation
+            .worker_pools()
             .iter()
-            .map(|pool| {
+            .map(|worker_pool| {
                 let order_clone = order.clone();
-                let pool_name = pool.name().to_string();
-                let queue = pool.queue().clone();
+                let worker_pool_name = worker_pool.name().to_string();
+                let queue = worker_pool.queue().clone();
                 let task_params = params.clone();
 
                 async move {
                     let result = queue
                         .enqueue(order_clone, task_params)
                         .await;
-                    (pool_name, result)
+                    (worker_pool_name, result)
                 }
             })
             .collect();
 
-        // Pre-compute which worker pool names have the exclusive-access (`IncludeExclusive`)
-        // scope, for scope-aware early return gating. The gating only applies when surplus
-        // routing is
-        // active — the surplus overlay then needs one response from each scope; otherwise plain
-        // count-based gating applies.
-        let exclusive_access_pool_names: HashSet<String> = self
-            .solver_pools
-            .iter()
-            .filter(|p| p.liquidity_scope() == LiquidityScope::IncludeExclusive)
-            .map(|p| p.name().to_string())
-            .collect();
-        let surplus_routing_active = self.surplus_routing_active();
-
         let mut quotes = Vec::new();
         let mut failed_solvers: Vec<(String, SolveError)> = Vec::new();
-        let mut remaining_pools: HashSet<String> = self
-            .solver_pools
+        let mut remaining_worker_pools: HashSet<String> = allocation
+            .worker_pools()
             .iter()
             .map(|p| p.name().to_string())
             .collect();
@@ -453,9 +473,9 @@ impl WorkerPoolRouter {
                     // Mark all remaining worker pools as timed out
                     let elapsed_ms = deadline.saturating_duration_since(Instant::now())
                         .as_millis() as u64;
-                    for pool_name in remaining_pools.drain() {
+                    for worker_pool_name in remaining_worker_pools.drain() {
                         failed_solvers.push((
-                            pool_name,
+                            worker_pool_name,
                             SolveError::Timeout { elapsed_ms },
                         ));
                     }
@@ -465,24 +485,25 @@ impl WorkerPoolRouter {
                 // Response received
                 result = pending.next() => {
                     match result {
-                        Some((pool_name, Ok(single_quote))) => {
+                        Some((worker_pool_name, Ok(single_quote))) => {
                             // Remove from remaining
-                            remaining_pools.remove(&pool_name);
+                            remaining_worker_pools.remove(&worker_pool_name);
 
-                            if exclusive_access_pool_names.contains(&pool_name) {
+                            if allocation.is_exclusive(&worker_pool_name) {
                                 has_exclusive_access_response = true;
                             } else {
                                 has_public_response = true;
                             }
 
                             // Extract the OrderQuote from SingleOrderQuote
-                            quotes.push((pool_name.clone(), single_quote.order().clone()));
+                            quotes.push((worker_pool_name.clone(), single_quote.order().clone()));
 
-                            // Scope-aware early return: when surplus routing is active, only
-                            // fire once we have ≥1 public AND ≥1 exclusive-access response (so
-                            // the surplus overlay has both inputs). Otherwise, use pure
-                            // count-based gating (original behaviour).
-                            let scope_ready = if surplus_routing_active {
+                            // Scope-aware early return: when surplus routing is active for this
+                            // allocation, only fire once we have ≥1 public AND ≥1
+                            // exclusive-access response (so the surplus overlay has both
+                            // inputs). Otherwise, use pure count-based gating (original
+                            // behaviour).
+                            let scope_ready = if allocation.surplus_routing_active() {
                                 has_public_response && has_exclusive_access_response
                             } else {
                                 true
@@ -501,22 +522,22 @@ impl WorkerPoolRouter {
                                 break;
                             }
                         }
-                        Some((pool_name, Err(e))) => {
-                            remaining_pools.remove(&pool_name);
+                        Some((worker_pool_name, Err(e))) => {
+                            remaining_worker_pools.remove(&worker_pool_name);
                             // A failed exclusive-access worker pool still counts as "responded"
                             // for gating — we know it won't produce a surplus quote, so the
                             // public worker pools can early-return without waiting for a result
                             // that will never come.
-                            if exclusive_access_pool_names.contains(&pool_name) {
+                            if allocation.is_exclusive(&worker_pool_name) {
                                 has_exclusive_access_response = true;
                             }
                             debug!(
-                                pool = %pool_name,
+                                pool = %worker_pool_name,
                                 order_id = %order_id,
                                 error = %e,
                                 "solver pool failed"
                             );
-                            failed_solvers.push((pool_name, e));
+                            failed_solvers.push((worker_pool_name, e));
                         }
                         None => {
                             // All futures completed
@@ -533,7 +554,7 @@ impl WorkerPoolRouter {
         histogram!("worker_router_solver_responses").record(quotes.len() as f64);
 
         // Record failures by worker pool and error type
-        for (pool_name, error) in &failed_solvers {
+        for (worker_pool_name, error) in &failed_solvers {
             let error_type = match error {
                 SolveError::Timeout { .. } => "timeout",
                 SolveError::NoRouteFound { .. } => "no_route",
@@ -542,7 +563,7 @@ impl WorkerPoolRouter {
                 SolveError::PriceCheckFailed { .. } => "price_check_failed",
                 _ => "other",
             };
-            counter!("worker_router_solver_failures_total", "pool" => pool_name.clone(), "error_type" => error_type).increment(1);
+            counter!("worker_router_solver_failures_total", "pool" => worker_pool_name.clone(), "error_type" => error_type).increment(1);
         }
 
         if !failed_solvers.is_empty() {
@@ -588,8 +609,9 @@ impl WorkerPoolRouter {
 
         if !valid_quotes.is_empty() {
             counter!("worker_router_orders_total", "status" => "success").increment(1);
-            let (pool_name, best) = valid_quotes[0];
-            counter!("worker_router_best_quote_pool", "pool" => pool_name.clone()).increment(1);
+            let (worker_pool_name, best) = valid_quotes[0];
+            counter!("worker_router_best_quote_pool", "pool" => worker_pool_name.clone())
+                .increment(1);
             debug!(
                 order_id = %best.order_id(),
                 number_of_candidates = valid_quotes.len(),
@@ -1076,7 +1098,13 @@ fn derive_strategy(quote: &OrderQuote) -> Strategy {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{
+        collections::HashMap,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+    };
 
     use rstest::rstest;
     use tycho_execution::encoding::evm::swap_encoder::swap_encoder_registry::SwapEncoderRegistry;
@@ -1177,25 +1205,41 @@ mod tests {
         SingleOrderQuote::new(quote, 5)
     }
 
-    // Helper to create a mock solver pool that responds with a given solution
-    fn create_mock_pool(
+    // Helper to create a mock worker pool that responds with a given solution
+    fn create_mock_worker_pool(
         name: &str,
         response: Result<SingleOrderQuote, SolveError>,
         delay_ms: u64,
     ) -> (SolverPoolHandle, tokio::task::JoinHandle<()>) {
+        let (pool, worker, _) = create_counting_mock_worker_pool(name, response, delay_ms);
+        (pool, worker)
+    }
+
+    /// Mock worker pool that also counts the tasks it received, so a test can assert a worker pool
+    /// was never dispatched to rather than only that its quote did not win.
+    fn create_counting_mock_worker_pool(
+        name: &str,
+        response: Result<SingleOrderQuote, SolveError>,
+        delay_ms: u64,
+    ) -> (SolverPoolHandle, tokio::task::JoinHandle<()>, Arc<AtomicUsize>) {
         let (tx, rx) = async_channel::bounded::<SolveTask>(10);
         let handle = TaskQueueHandle::from_sender(tx);
+        let received = Arc::new(AtomicUsize::new(0));
 
-        let worker = tokio::spawn(async move {
-            while let Ok(task) = rx.recv().await {
-                if delay_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+        let worker = {
+            let received = Arc::clone(&received);
+            tokio::spawn(async move {
+                while let Ok(task) = rx.recv().await {
+                    received.fetch_add(1, Ordering::SeqCst);
+                    if delay_ms > 0 {
+                        tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                    }
+                    task.respond(response.clone());
                 }
-                task.respond(response.clone());
-            }
-        });
+            })
+        };
 
-        (SolverPoolHandle::new(name, handle), worker)
+        (SolverPoolHandle::new(name, handle), worker, received)
     }
 
     #[test]
@@ -1220,20 +1264,24 @@ mod tests {
             WorkerPoolRouter::new(vec![], WorkerPoolRouterConfig::default(), default_encoder());
         let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
 
-        let result = worker_router.quote(request).await;
+        let result = worker_router
+            .quote(request, ExclusiveAccess::Denied)
+            .await;
         assert!(matches!(result, Err(SolveError::Internal(_))));
     }
 
     #[tokio::test]
     async fn test_router_single_pool_success() {
-        let (pool, worker) = create_mock_pool("pool_a", Ok(make_single_quote(900)), 0);
+        let (pool, worker) = create_mock_worker_pool("pool_a", Ok(make_single_quote(900)), 0);
 
         let worker_router =
             WorkerPoolRouter::new(vec![pool], WorkerPoolRouterConfig::default(), default_encoder());
         let options = QuoteOptions::default().with_encoding_options(EncodingOptions::new(0.01));
         let request = QuoteRequest::new(vec![make_order()], options);
 
-        let result = worker_router.quote(request).await;
+        let result = worker_router
+            .quote(request, ExclusiveAccess::Denied)
+            .await;
         assert!(result.is_ok());
 
         let quote = result.unwrap();
@@ -1254,9 +1302,9 @@ mod tests {
     #[tokio::test]
     async fn test_router_selects_best_of_two() {
         // Pool A: worse quote (net gas = 800)
-        let (pool_a, worker_a) = create_mock_pool("pool_a", Ok(make_single_quote(800)), 0);
+        let (pool_a, worker_a) = create_mock_worker_pool("pool_a", Ok(make_single_quote(800)), 0);
         // Pool B: better quote (net gas = 950)
-        let (pool_b, worker_b) = create_mock_pool("pool_b", Ok(make_single_quote(950)), 0);
+        let (pool_b, worker_b) = create_mock_worker_pool("pool_b", Ok(make_single_quote(950)), 0);
 
         // Wait for both responses to test best selection logic
         let config = WorkerPoolRouterConfig::default().with_min_responses(2);
@@ -1264,7 +1312,9 @@ mod tests {
         let options = QuoteOptions::default().with_encoding_options(EncodingOptions::new(0.01));
         let request = QuoteRequest::new(vec![make_order()], options);
 
-        let result = worker_router.quote(request).await;
+        let result = worker_router
+            .quote(request, ExclusiveAccess::Denied)
+            .await;
         assert!(result.is_ok());
 
         let quote = result.unwrap();
@@ -1285,13 +1335,15 @@ mod tests {
     #[tokio::test]
     async fn test_router_timeout() {
         // Pool that takes too long
-        let (pool, worker) = create_mock_pool("slow_pool", Ok(make_single_quote(900)), 500);
+        let (pool, worker) = create_mock_worker_pool("slow_pool", Ok(make_single_quote(900)), 500);
 
         let config = WorkerPoolRouterConfig::default().with_timeout(Duration::from_millis(50));
         let worker_router = WorkerPoolRouter::new(vec![pool], config, default_encoder());
         let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
 
-        let result = worker_router.quote(request).await;
+        let result = worker_router
+            .quote(request, ExclusiveAccess::Denied)
+            .await;
         assert!(result.is_ok());
 
         let quote = result.unwrap();
@@ -1309,9 +1361,11 @@ mod tests {
     #[tokio::test]
     async fn test_router_early_return_on_min_responses() {
         // Pool A: fast
-        let (pool_a, worker_a) = create_mock_pool("fast_pool", Ok(make_single_quote(800)), 0);
+        let (pool_a, worker_a) =
+            create_mock_worker_pool("fast_pool", Ok(make_single_quote(800)), 0);
         // Pool B: slow (but we won't wait for it)
-        let (pool_b, worker_b) = create_mock_pool("slow_pool", Ok(make_single_quote(950)), 500);
+        let (pool_b, worker_b) =
+            create_mock_worker_pool("slow_pool", Ok(make_single_quote(950)), 500);
 
         let config = WorkerPoolRouterConfig::default()
             .with_timeout(Duration::from_millis(1000))
@@ -1322,7 +1376,9 @@ mod tests {
         let options = QuoteOptions::default().with_encoding_options(EncodingOptions::new(0.01));
         let request = QuoteRequest::new(vec![make_order()], options);
 
-        let result = worker_router.quote(request).await;
+        let result = worker_router
+            .quote(request, ExclusiveAccess::Denied)
+            .await;
         let elapsed = start.elapsed();
 
         assert!(result.is_ok());
@@ -1356,7 +1412,7 @@ mod tests {
         #[case] expect_surplus: bool,
     ) {
         let (public_pool, public_worker) =
-            create_mock_pool("public_pool", Ok(make_single_quote(800)), public_delay_ms);
+            create_mock_worker_pool("public_pool", Ok(make_single_quote(800)), public_delay_ms);
         let exclusive_response = match exclusive_delay_ms {
             Some(_) => Ok(make_exclusive_quote(1100)),
             None => {
@@ -1364,8 +1420,11 @@ mod tests {
             }
         };
         let public_pool = public_pool.with_liquidity_scope(LiquidityScope::PublicOnly);
-        let (exclusive_pool, exclusive_worker) =
-            create_mock_pool("exclusive_pool", exclusive_response, exclusive_delay_ms.unwrap_or(0));
+        let (exclusive_pool, exclusive_worker) = create_mock_worker_pool(
+            "exclusive_pool",
+            exclusive_response,
+            exclusive_delay_ms.unwrap_or(0),
+        );
         let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::IncludeExclusive);
 
         let config = WorkerPoolRouterConfig::default()
@@ -1377,7 +1436,7 @@ mod tests {
 
         let start = Instant::now();
         let result = worker_router
-            .quote(request)
+            .quote(request, ExclusiveAccess::Granted)
             .await
             .expect("quote should succeed");
         let elapsed = start.elapsed();
@@ -1388,6 +1447,99 @@ mod tests {
         assert_eq!(order.status(), QuoteStatus::Success);
         assert_eq!(*order.amount_out(), BigUint::from(990u64));
         assert_eq!(order.surplus_amount().is_some(), expect_surplus);
+
+        drop(worker_router);
+        public_worker.abort();
+        exclusive_worker.abort();
+    }
+
+    /// The exclusive pool offers a strictly better route (net 1100 vs 800), so it wins whenever it
+    /// is allocated. An unentitled request must never reach it: not merely lose to the public leg
+    /// in ranking, but cost the exclusive pool no work at all.
+    #[rstest]
+    #[case::denied(ExclusiveAccess::Denied, false)]
+    #[case::granted(ExclusiveAccess::Granted, true)]
+    #[tokio::test]
+    async fn test_router_exclusive_access_allocation(
+        #[case] access: ExclusiveAccess,
+        #[case] expect_exclusive_leg: bool,
+    ) {
+        let (public_pool, public_worker) =
+            create_mock_worker_pool("public_pool", Ok(make_single_quote(800)), 0);
+        let (exclusive_pool, exclusive_worker, exclusive_tasks) =
+            create_counting_mock_worker_pool("exclusive_pool", Ok(make_exclusive_quote(1100)), 0);
+        let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::IncludeExclusive);
+
+        let worker_router = WorkerPoolRouter::new(
+            vec![public_pool, exclusive_pool],
+            WorkerPoolRouterConfig::default().with_timeout(Duration::from_millis(2000)),
+            default_encoder(),
+        );
+        let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
+
+        let result = worker_router
+            .quote(request, access)
+            .await
+            .expect("quote should succeed");
+
+        // The gate is the dispatch, not the ranking: a denied request costs the exclusive pool no
+        // CPU and no latency.
+        assert_eq!(
+            exclusive_tasks.load(Ordering::SeqCst) > 0,
+            expect_exclusive_leg,
+            "exclusive pool dispatch"
+        );
+
+        let order = &result.orders()[0];
+        assert_eq!(order.status(), QuoteStatus::Success);
+
+        let routes_through_exclusive = order
+            .route()
+            .expect("successful quote has a route")
+            .swaps()
+            .iter()
+            .any(|swap| is_exclusive(swap.protocol_component()));
+        assert_eq!(routes_through_exclusive, expect_exclusive_leg);
+        assert_eq!(order.surplus_amount().is_some(), expect_exclusive_leg);
+
+        // Either way the quoted output is the public reference, so a denied entitlement costs the
+        // caller nothing they were promised.
+        assert_eq!(*order.amount_out(), BigUint::from(990u64));
+
+        drop(worker_router);
+        public_worker.abort();
+        exclusive_worker.abort();
+    }
+
+    /// A denied request must not wait on the exclusive pool it will never use.
+    #[tokio::test]
+    async fn test_router_denied_does_not_wait_for_exclusive_pool() {
+        let (public_pool, public_worker) =
+            create_mock_worker_pool("public_pool", Ok(make_single_quote(800)), 0);
+        let (exclusive_pool, exclusive_worker) =
+            create_mock_worker_pool("exclusive_pool", Ok(make_exclusive_quote(1100)), 500);
+        let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::IncludeExclusive);
+
+        // `min_responses(2)` would hold an entitled request until both pools answer.
+        let worker_router = WorkerPoolRouter::new(
+            vec![public_pool, exclusive_pool],
+            WorkerPoolRouterConfig::default()
+                .with_timeout(Duration::from_millis(2000))
+                .with_min_responses(2),
+            default_encoder(),
+        );
+        let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
+
+        let start = Instant::now();
+        let result = worker_router
+            .quote(request, ExclusiveAccess::Denied)
+            .await
+            .expect("quote should succeed");
+        let elapsed = start.elapsed();
+
+        // Only the public pool is allocated, so `min_responses` is satisfied by its answer alone.
+        assert!(elapsed < Duration::from_millis(300), "took {elapsed:?}");
+        assert_eq!(result.orders()[0].status(), QuoteStatus::Success);
 
         drop(worker_router);
         public_worker.abort();
@@ -1445,13 +1597,15 @@ mod tests {
     async fn test_router_captures_solver_errors() {
         // Pool that returns an error
         let (pool, worker) =
-            create_mock_pool("error_pool", Err(SolveError::no_route_found("test-order")), 0);
+            create_mock_worker_pool("error_pool", Err(SolveError::no_route_found("test-order")), 0);
 
         let worker_router =
             WorkerPoolRouter::new(vec![pool], WorkerPoolRouterConfig::default(), default_encoder());
         let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
 
-        let result = worker_router.quote(request).await;
+        let result = worker_router
+            .quote(request, ExclusiveAccess::Denied)
+            .await;
         assert!(result.is_ok());
 
         let quote = result.unwrap();

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -425,6 +425,17 @@ impl WorkerPoolRouter {
         let start_time = Instant::now();
         let order_id = order.id().to_string();
 
+        let allocated: Vec<(&str, LiquidityScope)> = allocation
+            .worker_pools()
+            .iter()
+            .map(|worker_pool| (worker_pool.name(), worker_pool.liquidity_scope()))
+            .collect();
+        debug!(
+            order_id = %order_id,
+            worker_pools = ?allocated,
+            "dispatching order to allocated worker pools"
+        );
+
         // Fan-out: send order to the allocated worker pools. Worker pools that do not serve this
         // order were already dropped by `allocate`, so nothing here filters by access.
         let mut pending: FuturesUnordered<_> = allocation

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -31,7 +31,7 @@ use std::{
 };
 
 pub use allocation::ExclusiveAccess;
-use allocation::{allocate, Allocation, RequestClass, WorkerPoolAdmission};
+use allocation::{allocate, Allocation, OrderClass};
 use config::WorkerPoolRouterConfig;
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, histogram};
@@ -145,21 +145,20 @@ pub struct SolverPoolHandle {
     name: String,
     /// Queue handle for this worker pool.
     queue: TaskQueueHandle,
-    /// Which requests this worker pool serves. Decides whether an order is dispatched to it.
-    admission: WorkerPoolAdmission,
+    /// Which liquidity this worker pool routes through. Decides whether an order is dispatched
+    /// to it ([`SolverPoolHandle::serves`]).
+    liquidity_scope: LiquidityScope,
 }
 
 impl SolverPoolHandle {
-    /// Creates a new solver pool handle with the default [`LiquidityScope::PublicOnly`] scope.
+    /// Creates a new solver pool handle with the default [`LiquidityScope`].
     pub fn new(name: impl Into<String>, queue: TaskQueueHandle) -> Self {
-        Self { name: name.into(), queue, admission: WorkerPoolAdmission::default() }
+        Self { name: name.into(), queue, liquidity_scope: LiquidityScope::default() }
     }
 
     /// Sets the worker pool's liquidity scope.
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
-        self.admission = self
-            .admission
-            .with_liquidity_scope(scope);
+        self.liquidity_scope = scope;
         self
     }
 
@@ -175,12 +174,7 @@ impl SolverPoolHandle {
 
     /// Returns the worker pool's liquidity scope.
     pub fn liquidity_scope(&self) -> LiquidityScope {
-        self.admission.liquidity_scope()
-    }
-
-    /// Returns which requests this pool serves.
-    pub(crate) fn admission(&self) -> WorkerPoolAdmission {
-        self.admission
+        self.liquidity_scope
     }
 }
 
@@ -265,7 +259,7 @@ impl WorkerPoolRouter {
     /// 5. If `encoding_options` are set on the request, encodes winning solutions into on-chain
     ///    transactions
     ///
-    /// `access` is the caller's entitlement to exclusive liquidity, resolved at the trust
+    /// `access` is the caller's access to exclusive liquidity, resolved at the trust
     /// boundary. With [`ExclusiveAccess::Denied`] no exclusive-access worker pool is allocated, so
     /// such worker pools do no work for the request and the quote is built from public liquidity
     /// alone.
@@ -301,8 +295,8 @@ impl WorkerPoolRouter {
 
         // One allocation per order: which worker pools serve an order is a property of the order,
         // not of the request. Today every order in a request classifies identically; once
-        // trade size joins `RequestClass` they will differ.
-        let class = RequestClass::new(access);
+        // trade size joins `OrderClass` they will differ.
+        let class = OrderClass::new(access);
         let allocations: Vec<Allocation<'_>> = request
             .orders()
             .iter()
@@ -431,7 +425,7 @@ impl WorkerPoolRouter {
         let order_id = order.id().to_string();
 
         // Fan-out: send order to the allocated worker pools. Worker pools that do not serve this
-        // order were already dropped by `allocate`, so nothing here filters by entitlement.
+        // order were already dropped by `allocate`, so nothing here filters by access.
         let mut pending: FuturesUnordered<_> = allocation
             .worker_pools()
             .iter()
@@ -1454,7 +1448,8 @@ mod tests {
     }
 
     /// The exclusive pool offers a strictly better route (net 1100 vs 800), so it wins whenever it
-    /// is allocated. An unentitled request must never reach it: not merely lose to the public leg
+    /// is allocated. A request without access must never reach it: not merely lose to the public
+    /// leg
     /// in ranking, but cost the exclusive pool no work at all.
     #[rstest]
     #[case::denied(ExclusiveAccess::Denied, false)]
@@ -1502,7 +1497,7 @@ mod tests {
         assert_eq!(routes_through_exclusive, expect_exclusive_leg);
         assert_eq!(order.surplus_amount().is_some(), expect_exclusive_leg);
 
-        // Either way the quoted output is the public reference, so a denied entitlement costs the
+        // Either way the quoted output is the public reference, so denied access costs the
         // caller nothing they were promised.
         assert_eq!(*order.amount_out(), BigUint::from(990u64));
 
@@ -1520,7 +1515,7 @@ mod tests {
             create_mock_worker_pool("exclusive_pool", Ok(make_exclusive_quote(1100)), 500);
         let exclusive_pool = exclusive_pool.with_liquidity_scope(LiquidityScope::IncludeExclusive);
 
-        // `min_responses(2)` would hold an entitled request until both pools answer.
+        // `min_responses(2)` would hold a request with access until both pools answer.
         let worker_router = WorkerPoolRouter::new(
             vec![public_pool, exclusive_pool],
             WorkerPoolRouterConfig::default()

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -308,7 +308,7 @@ impl WorkerPoolRouter {
             .any(Allocation::is_empty)
         {
             return Err(SolveError::Internal(format!(
-                "no worker pool serves this request: {class:?}"
+                "no solver pool serves this request: {class:?}"
             )));
         }
 
@@ -1456,8 +1456,7 @@ mod tests {
 
     /// The exclusive pool offers a strictly better route (net 1100 vs 800), so it wins whenever it
     /// is allocated. A request without access must never reach it: not merely lose to the public
-    /// leg
-    /// in ranking, but cost the exclusive pool no work at all.
+    /// leg in ranking, but cost the exclusive pool no work at all.
     #[rstest]
     #[case::denied(ExclusiveAccess::Denied, false)]
     #[case::granted(ExclusiveAccess::Granted, true)]

--- a/fynd-rpc/CLAUDE.md
+++ b/fynd-rpc/CLAUDE.md
@@ -22,7 +22,7 @@ infrastructure.
 
 | Endpoint | Handler | Description |
 |---|---|---|
-| `POST /v1/quote` | `handlers::quote` | Submit orders, receive optimal routes |
+| `POST /v1/quote` | `handlers::quote` | Submit orders, receive optimal routes. The `x-exclusive-access: true` request header (set by the authenticating proxy, never by the caller) allocates exclusive-access worker pools to the request; any other value or none restricts it to public pools. Only meaningful when the server is unreachable except through that proxy |
 | `GET /v1/health` | `handlers::health` | Health check (data freshness, derived data readiness, gas-price staleness, solver pool count). Returns 503 when market data is stale, derived data is not ready, or the gas price is stale |
 | `GET /v1/info` | `handlers::info` | Static metadata about this Fynd instance (version, chain, spender address) |
 | `GET /v1/prices` | `handlers::get_prices` | Token prices, spot prices, component depths (experimental feature only) |
@@ -48,6 +48,7 @@ annotations live in one place.
 | `handlers.rs` | Request handlers for `/v1/quote`, `/v1/health`, and `/v1/info` |
 | `dto.rs` | Re-exports wire types from `fynd-rpc-types` (conversions to `fynd-core` types live in `fynd-rpc-types` via the `core` feature) |
 | `error.rs` | `ApiError` type with HTTP status code mapping |
+| `exclusive_access.rs` | Reads the `x-exclusive-access` header into `fynd_core::ExclusiveAccess` |
 | `prices.rs` | Types and helpers for `GET /v1/prices`: query params, response DTOs (`PricesResponse`, `TokenPriceEntry`, etc.), `price_to_decimal_string` exact decimal serialization |
 | `middleware.rs` | HTTP metrics middleware: records `http_request_duration_seconds` (histogram) and `http_requests_total` (counter with per-client `user_identity`/`user_plan`/`client_version` labels sourced from proxy-injected headers) |
 

--- a/fynd-rpc/src/api/exclusive_access.rs
+++ b/fynd-rpc/src/api/exclusive_access.rs
@@ -1,4 +1,4 @@
-//! Resolves the caller's entitlement to exclusive liquidity from the request headers.
+//! Resolves the caller's access to exclusive liquidity from the request headers.
 
 use actix_web::http::header::HeaderMap;
 use fynd_core::ExclusiveAccess;
@@ -6,7 +6,7 @@ use fynd_core::ExclusiveAccess;
 /// Header through which the authenticating proxy grants access to exclusive liquidity.
 const EXCLUSIVE_ACCESS_HEADER: &str = "x-exclusive-access";
 
-/// Reads the exclusive-access entitlement the authenticating proxy resolved for this request.
+/// Reads the exclusive access the authenticating proxy resolved for this request.
 ///
 /// Only the exact value `true` (case-insensitive) grants access; absent, malformed, and all other
 /// values deny it. Fynd does not authenticate callers itself, so this header is only meaningful

--- a/fynd-rpc/src/api/exclusive_access.rs
+++ b/fynd-rpc/src/api/exclusive_access.rs
@@ -1,0 +1,54 @@
+//! Resolves the caller's entitlement to exclusive liquidity from the request headers.
+
+use actix_web::http::header::HeaderMap;
+use fynd_core::ExclusiveAccess;
+
+/// Header through which the authenticating proxy grants access to exclusive liquidity.
+const EXCLUSIVE_ACCESS_HEADER: &str = "x-exclusive-access";
+
+/// Reads the exclusive-access entitlement the authenticating proxy resolved for this request.
+///
+/// Only the exact value `true` (case-insensitive) grants access; absent, malformed, and all other
+/// values deny it. Fynd does not authenticate callers itself, so this header is only meaningful
+/// when the server is unreachable except through that proxy — otherwise a caller can set it
+/// themselves.
+pub(crate) fn from_headers(headers: &HeaderMap) -> ExclusiveAccess {
+    let granted = headers
+        .get(EXCLUSIVE_ACCESS_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"));
+
+    if granted {
+        ExclusiveAccess::Granted
+    } else {
+        ExclusiveAccess::Denied
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::http::header::{HeaderName, HeaderValue};
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::absent(None, ExclusiveAccess::Denied)]
+    #[case::lowercase_true(Some("true"), ExclusiveAccess::Granted)]
+    #[case::uppercase_true(Some("TRUE"), ExclusiveAccess::Granted)]
+    #[case::explicit_false(Some("false"), ExclusiveAccess::Denied)]
+    #[case::empty(Some(""), ExclusiveAccess::Denied)]
+    #[case::numeric_one(Some("1"), ExclusiveAccess::Denied)]
+    #[case::whitespace_padded(Some(" true "), ExclusiveAccess::Denied)]
+    fn test_from_headers(#[case] header_value: Option<&str>, #[case] expected: ExclusiveAccess) {
+        let mut headers = HeaderMap::new();
+        if let Some(value) = header_value {
+            headers.insert(
+                HeaderName::from_static(EXCLUSIVE_ACCESS_HEADER),
+                HeaderValue::from_str(value).expect("test header value is valid"),
+            );
+        }
+
+        assert_eq!(from_headers(&headers), expected);
+    }
+}

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -1,6 +1,6 @@
 //! HTTP request handlers for the solver API.
 
-use actix_web::{web, HttpResponse};
+use actix_web::{web, HttpRequest, HttpResponse};
 use tracing::instrument;
 #[cfg(feature = "experimental")]
 use tracing::{debug, info, warn};
@@ -13,6 +13,7 @@ use crate::api::prices::{
 };
 use crate::api::{
     error::{solve_error_code, ErrorResponse},
+    exclusive_access,
     request_capture::{
         self, failure_reason_slug, log_request_capture, log_slow_solve, quote_status_code,
         RequestOutcome,
@@ -54,11 +55,13 @@ pub(crate) fn configure_routes(cfg: &mut web::ServiceConfig) {
         (status = 503, description = "Queue full, overloaded, stale data, or timeout", body = ErrorResponse),
     )
 )]
-#[instrument(skip(state, request), fields(num_orders = request.orders().len()))]
+#[instrument(skip(state, request, http_request), fields(num_orders = request.orders().len()))]
 pub(crate) async fn quote(
     state: web::Data<AppState>,
     request: web::Json<dto::QuoteRequest>,
+    http_request: HttpRequest,
 ) -> Result<HttpResponse, ApiError> {
+    let access = exclusive_access::from_headers(http_request.headers());
     let dto_request = request.into_inner();
 
     // Validate request
@@ -84,7 +87,7 @@ pub(crate) async fn quote(
 
     let result = state
         .worker_router()
-        .quote(core_request)
+        .quote(core_request, access)
         .await;
 
     let outcome = match &result {

--- a/fynd-rpc/src/api/handlers.rs
+++ b/fynd-rpc/src/api/handlers.rs
@@ -73,7 +73,7 @@ pub(crate) async fn quote(
     // conversion consumes `dto_request`. This is cheap (no serialization); the
     // JSON encoding is deferred to the failure-only task below.
     let num_orders = dto_request.orders().len();
-    let replay_capture = request_capture::ReplayRequest::capture(&dto_request);
+    let replay_capture = request_capture::ReplayRequest::capture(&dto_request, access);
 
     // Convert DTO to core types
     let core_request: fynd_core::QuoteRequest = dto_request.into();

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -6,6 +6,8 @@ mod docs;
 pub mod dto;
 /// [`ApiError`] type with HTTP status code mapping.
 pub mod error;
+/// Resolves the caller's exclusive-liquidity entitlement from the request headers.
+pub(crate) mod exclusive_access;
 /// Request handlers for `/v1/quote`, `/v1/health`, and `/v1/info`.
 pub mod handlers;
 /// HTTP metrics middleware recording request duration and per-client usage.

--- a/fynd-rpc/src/api/mod.rs
+++ b/fynd-rpc/src/api/mod.rs
@@ -6,7 +6,7 @@ mod docs;
 pub mod dto;
 /// [`ApiError`] type with HTTP status code mapping.
 pub mod error;
-/// Resolves the caller's exclusive-liquidity entitlement from the request headers.
+/// Resolves the caller's access to exclusive liquidity from the request headers.
 pub(crate) mod exclusive_access;
 /// Request handlers for `/v1/quote`, `/v1/health`, and `/v1/info`.
 pub mod handlers;

--- a/fynd-rpc/src/api/request_capture.rs
+++ b/fynd-rpc/src/api/request_capture.rs
@@ -1,7 +1,7 @@
 //! Builds the routing-essential representation of a quote request for the
 //! replay-capture log emitted by the `/v1/quote` handler.
 
-use fynd_core::{NoPathReason, QuoteStatus, SolveError};
+use fynd_core::{ExclusiveAccess, NoPathReason, QuoteStatus, SolveError};
 use fynd_rpc_types::{Address, OrderSide, QuoteRequest};
 use serde::Serialize;
 use tracing::{info, warn};
@@ -35,19 +35,24 @@ struct ReplayOptions {
 ///
 /// Captured (the fields that determine the route): per order `token_in`,
 /// `token_out`, `amount`, `side`; plus the solve options `timeout_ms`,
-/// `min_responses`, `max_gas`. Everything else is dropped: `encoding_options`
-/// (slippage / transfer type / price guard, and every Permit2 / client-fee
-/// **signature**), the server-generated order `id`, and `sender` / `receiver`
+/// `min_responses`, `max_gas`; plus `exclusive_access` — the access the
+/// authenticating proxy granted, which decides the worker pool allocation.
+/// Everything else is dropped: `encoding_options` (slippage / transfer type /
+/// price guard, and every Permit2 / client-fee **signature**), the
+/// server-generated order `id`, and `sender` / `receiver`
 /// (routing-irrelevant and PII). Built from an explicit allowlist, so no
 /// request field can leak into the logs.
 ///
 /// This is NOT a full [`QuoteRequest`] — it omits the required `sender`, so a
-/// replay harness supplies a placeholder sender before re-issuing. An outcome
-/// that depended on `price_guard` may not reproduce on replay.
+/// replay harness supplies a placeholder sender before re-issuing.
+/// `exclusive_access` is not a body field either: a harness re-sends it as the
+/// `x-exclusive-access` header. An outcome that depended on `price_guard` may
+/// not reproduce on replay.
 #[derive(Serialize)]
 pub(crate) struct ReplayRequest {
     orders: Vec<ReplayOrder>,
     options: ReplayOptions,
+    exclusive_access: bool,
 }
 
 impl ReplayRequest {
@@ -55,7 +60,7 @@ impl ReplayRequest {
     /// few address clones and no JSON — so it is safe to run on the quote hot
     /// path; the serialization cost is deferred to [`ReplayRequest::to_json`],
     /// which the handler only calls off the response path.
-    pub(crate) fn capture(request: &QuoteRequest) -> Self {
+    pub(crate) fn capture(request: &QuoteRequest, access: ExclusiveAccess) -> Self {
         let orders = request
             .orders()
             .iter()
@@ -76,6 +81,7 @@ impl ReplayRequest {
                     .max_gas()
                     .map(ToString::to_string),
             },
+            exclusive_access: access == ExclusiveAccess::Granted,
         }
     }
 
@@ -88,8 +94,8 @@ impl ReplayRequest {
 /// Serializes `request` down to the routing-essential fields, as a JSON string.
 /// Convenience wrapper over [`ReplayRequest::capture`] + [`ReplayRequest::to_json`].
 #[cfg(test)]
-pub(crate) fn replay_json(request: &QuoteRequest) -> String {
-    ReplayRequest::capture(request).to_json()
+pub(crate) fn replay_json(request: &QuoteRequest, access: ExclusiveAccess) -> String {
+    ReplayRequest::capture(request, access).to_json()
 }
 
 /// Stable snake_case code for a per-order [`QuoteStatus`], matching the wire
@@ -270,6 +276,7 @@ mod tests {
         QuoteOptions, QuoteRequest,
     };
     use num_bigint::BigUint;
+    use rstest::rstest;
     use serde_json::Value;
     use tracing_subscriber::fmt::MakeWriter;
 
@@ -317,7 +324,7 @@ mod tests {
 
     #[test]
     fn replay_json_captures_only_routing_fields() {
-        let json = replay_json(&request_with_signatures());
+        let json = replay_json(&request_with_signatures(), ExclusiveAccess::Denied);
         // No encoding data or signatures.
         assert!(!json.contains("encoding_options"), "json was: {json}");
         assert!(!json.contains("signature"), "json was: {json}");
@@ -336,7 +343,7 @@ mod tests {
 
     #[test]
     fn replay_json_keeps_routing_essentials_and_options() {
-        let json = replay_json(&request_with_signatures());
+        let json = replay_json(&request_with_signatures(), ExclusiveAccess::Denied);
         let value: Value = serde_json::from_str(&json).unwrap();
         let order = &value["orders"][0];
         assert_eq!(order["token_in"], "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
@@ -352,7 +359,7 @@ mod tests {
     #[test]
     fn replay_json_output_keys_are_allowlisted() {
         let req = request_with_signatures();
-        let json = replay_json(&req);
+        let json = replay_json(&req, ExclusiveAccess::Denied);
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         let top_level: std::collections::BTreeSet<&str> = value
@@ -363,7 +370,9 @@ mod tests {
             .collect();
         assert_eq!(
             top_level,
-            ["orders", "options"].into_iter().collect(),
+            ["orders", "options", "exclusive_access"]
+                .into_iter()
+                .collect(),
             "unexpected top-level keys {top_level:?} — a new field may leak into replay logs; json: {json}"
         );
 
@@ -397,6 +406,18 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[rstest]
+    #[case::granted(ExclusiveAccess::Granted, true)]
+    #[case::denied(ExclusiveAccess::Denied, false)]
+    fn test_replay_json_captures_exclusive_access(
+        #[case] access: ExclusiveAccess,
+        #[case] expected: bool,
+    ) {
+        let json = replay_json(&request_with_signatures(), access);
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["exclusive_access"], expected, "json was: {json}");
     }
 
     #[test]

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -27,7 +27,8 @@ timeout_ms = 500
 # Example: an exclusive-access worker pool whose workers also route through exclusive components
 # to capture surplus above the committed public reference (see repo-root worker_pools.toml).
 # Worker pools with the key omitted default to "public_only": their workers drop exclusive
-# components.
+# components. Only requests entitled to exclusive liquidity are dispatched to such a worker pool,
+# so size num_workers to the entitled share of flow.
 # [pools.exclusive_access]
 # algorithm = "bellman_ford"
 # num_workers = 3

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -27,8 +27,8 @@ timeout_ms = 500
 # Example: an exclusive-access worker pool whose workers also route through exclusive components
 # to capture surplus above the committed public reference (see repo-root worker_pools.toml).
 # Worker pools with the key omitted default to "public_only": their workers drop exclusive
-# components. Only requests entitled to exclusive liquidity are dispatched to such a worker pool,
-# so size num_workers to the entitled share of flow.
+# components. Only requests granted exclusive access are dispatched to such a worker pool, so
+# size num_workers to that share of flow.
 # [pools.exclusive_access]
 # algorithm = "bellman_ford"
 # num_workers = 3

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -16,8 +16,8 @@ timeout_ms = 500
 # to capture surplus above the committed public reference. Worker pools with the key omitted
 # default to "public_only": their workers drop exclusive components.
 #
-# Such a worker pool is only dispatched to for requests entitled to exclusive liquidity, so size
-# num_workers to the entitled share of flow, not to total flow. At least one worker pool must be
+# Such a worker pool is only dispatched to for requests granted exclusive access, so size
+# num_workers to that share of flow, not to total flow. At least one worker pool must be
 # public — an all-exclusive configuration is rejected at startup.
 # [pools.exclusive_access]
 # algorithm = "bellman_ford"

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -15,6 +15,10 @@ timeout_ms = 500
 # Example: an exclusive-access worker pool whose workers also route through exclusive components
 # to capture surplus above the committed public reference. Worker pools with the key omitted
 # default to "public_only": their workers drop exclusive components.
+#
+# Such a worker pool is only dispatched to for requests entitled to exclusive liquidity, so size
+# num_workers to the entitled share of flow, not to total flow. At least one worker pool must be
+# public — an all-exclusive configuration is rejected at startup.
 # [pools.exclusive_access]
 # algorithm = "bellman_ford"
 # num_workers = 3


### PR DESCRIPTION
The router now picks which worker pools serve an order before dispatching it, instead of fanning out to all of them and filtering the results. An unentitled request is never enqueued to the exclusive-access pool — no CPU spent there, no waiting on it.

Entitlement comes from the `x-exclusive-access` header, set by the authenticating proxy. Only meaningful while Fynd is unreachable except through that proxy. A denied request isn't an error — it gets the public quote. Nothing changes on the wire.

Startup now rejects a config where every worker pool is `liquidity_scope = "all"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)