### PR TITLE
feat(metrics): add per-pool solve duration histogram

### DIFF
--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -44,6 +44,17 @@ fn record_task_pickup_metrics(pool_name: &str, queue_wait: Duration, queue_depth
         .set(queue_depth as f64);
 }
 
+/// Records per-pool solve latency: one algorithm's own working time for one order, excluding
+/// queue wait. Unlike `worker_router_solve_duration_seconds`, which times the router racing every
+/// pool and so belongs to no single pool, this is attributable per pool.
+///
+/// Successful solves only — a pool that exhausts its timeout returns before this point and is
+/// counted in `worker_router_solver_failures_total{error_type="timeout"}` instead.
+fn record_solve_duration(pool_name: &str, solve_time: Duration) {
+    metrics::histogram!("worker_pool_solve_duration_seconds", "pool" => pool_name.to_string())
+        .record(solve_time.as_secs_f64());
+}
+
 /// A solver worker instance that maintains a market graph and processes solve requests.
 pub(crate) struct SolverWorker<A>
 where
@@ -341,9 +352,10 @@ where
             }
         };
 
-        let solve_time_ms = start_time.elapsed().as_millis() as u64;
+        let solve_time = start_time.elapsed();
+        record_solve_duration(&self.pool_name, solve_time);
 
-        Ok(SingleOrderQuote::new(order_quote, solve_time_ms))
+        Ok(SingleOrderQuote::new(order_quote, solve_time.as_millis() as u64))
     }
 
     /// Waits for required derived data to become ready, or until timeout.
@@ -1233,6 +1245,37 @@ mod tests {
         }
         assert!(wait_seen, "queue wait histogram not recorded");
         assert!(depth_seen, "queue depth gauge not recorded");
+    }
+
+    #[test]
+    fn solve_duration_metric_recorded() {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        metrics::with_local_recorder(&recorder, || {
+            record_solve_duration("test_pool", std::time::Duration::from_millis(120));
+        });
+
+        let mut solve_seen = false;
+        for (key, _unit, _description, value) in snapshotter.snapshot().into_vec() {
+            let key = key.key();
+            if key.name() != "worker_pool_solve_duration_seconds" {
+                continue;
+            }
+            let pool_label = key
+                .labels()
+                .find(|label| label.key() == "pool")
+                .map(|label| label.value().to_string());
+            assert_eq!(pool_label.as_deref(), Some("test_pool"));
+            let DebugValue::Histogram(samples) = value else {
+                panic!("expected histogram, got {value:?}");
+            };
+            assert_eq!(samples.len(), 1);
+            assert!((samples[0].into_inner() - 0.120).abs() < 1e-9);
+            solve_seen = true;
+        }
+        assert!(solve_seen, "solve duration histogram not recorded");
     }
 
     #[test]

--- a/monitoring/grafana/dashboards/fynd.json
+++ b/monitoring/grafana/dashboards/fynd.json
@@ -289,6 +289,27 @@
         },
         "overrides": []
       }
+    },
+    {
+      "id": 12,
+      "title": "Solve Duration by Pool (p95)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 48 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, pool) (rate(worker_pool_solve_duration_seconds_bucket[1m])))",
+          "legendFormat": "{{pool}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 }
+        },
+        "overrides": []
+      }
     }
   ],
   "schemaVersion": 39


### PR DESCRIPTION
Adds `worker_pool_solve_duration_seconds{pool}` plus a panel on the local dev dashboard. The Grafana panel for the hosted API dashboard follows in `terraform-infrastructure`, gated on this reaching prod.

## Why a new metric instead of a `pool` label on the existing one

`worker_router_solve_duration_seconds` is recorded once per order *after* the router has raced every pool, so it measures the fan-out and belongs to no single pool — labelling it with the winner would attribute the whole race to whoever won. Reusing the name would also silently change what 21 existing queries measure (12 VMRule exprs, 9 panels, all aggregating with `sum by (le)`), including the 6 prod `FyndQuoteLatencyHighP95` rules.

## Why the worker, not the router

On early return the router drops the remaining `pending` futures, so pools that hadn't answered yet never report. Emitting there would systematically omit the slowest pools — the ones this metric exists to find.

## Successes only

A pool that exhausts its timeout returns before the timing site, so it is absent here rather than slow; those land in `worker_router_solver_failures_total{error_type="timeout"}`. Same for solves failing in `wait_until_ready`. Worth knowing when a pool looks suspiciously fast.

## Review notes

- No exporter change needed — `src/main.rs` already maps the `_seconds` suffix onto `LATENCY_BUCKETS_SECONDS`, so this renders as a bucketed histogram, not a summary.
- Bucket edges near the pool timeouts are `0.25, 0.5, 1.0`, so p95 for a pool pressed against a 500ms budget is coarsely interpolated.
- The local dashboard panel is appended full-width at the bottom; inserting it beside the existing solve panel would have reflowed nine panels. Shows one series until a second pool is configured in `worker_pools.toml`.

Verified with the CI-pinned `nightly-2026-06-28`: `fmt --all --check` and `clippy -p fynd-core --all-targets --all-features` clean, `test -p fynd-core --lib worker_pool::worker` 20/20 including the new `solve_duration_metric_recorded`. Full-workspace clippy/tests left to CI.

Draft until the dashboard PR is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)