### PR TITLE
fix(hindsight): Decoding issues

### DIFF
--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -159,7 +159,10 @@ the swap. `MetaMaskNetting` backs the fee out to 991.
 
 What a solver's transactions reveal beyond its address — a calldata quote (KyberSwap's
 `clientData`, ParaSwap's word layout, 0x's positive-slippage action), a match-time veto (LiFi's
-bridge orders), or the integrator tag a frontend records in the solver's event (LiFi's Diamond).
+bridge orders), the integrator tag a frontend records in the solver's event (LiFi's Diamond), or
+the fee recipients its calldata names (KyberSwap's `feeReceivers`). A fee recipient read this way
+covers a frontend that has no address-book entry: the calldata says who is paid, and the transfer
+ledger says how much, so the cut is added back and the settled output stays gross.
 Every method defaults to "nothing to add", so most solvers are a single address-book line with no
 code; those with code are registered in `solvers::IMPLEMENTATIONS`.
 
@@ -173,6 +176,10 @@ trait SolverKnowledge {
 
     /// The order-flow integrator tag this solver records in its logs, when it exposes one.
     fn integrator(&self, logs: &[Log]) -> Option<String> { None }
+
+    /// The fee recipients this solver's calldata names, for routers that let an integrator
+    /// take a cut of the swap.
+    fn fee_recipients(&self, input: &[u8]) -> Vec<Address> { Vec::new() }
 }
 ```
 

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -302,6 +302,19 @@ impl<P: Provider> Decoder<P> {
             registry,
         );
 
+        // A frontend routing through the solver can take a cut of the output without owning a
+        // venue section, declaring its fee recipients in the solver's own calldata. Backed out
+        // here so the settled output is gross, like Fynd's re-solve; a no-op when a venue
+        // fingerprint already accounted an output fee.
+        if let Some(fee) = solvers::declared_output_fee(
+            &attribution.solver,
+            &root.input,
+            &transfer_ledger,
+            flow.swap.token_out,
+        ) {
+            flow.gross_output_fee(fee);
+        }
+
         // Gas the trader paid for the settled route, as a wei cost. The flow's gas scope says
         // which gas that is — see `GasScope`.
         let settled_gas = match flow.gas_scope {

--- a/tools/hindsight/src/decoder/solvers/kyberswap.rs
+++ b/tools/hindsight/src/decoder/solvers/kyberswap.rs
@@ -5,10 +5,52 @@
 //! valuable part — the off-chain quoted output (`AmountOut`) the route was chosen on. The settled
 //! amount tells us what the user got; the quote tells us what the solver promised at decision
 //! time, which is the number a venue like Relay actually compared against ours.
+//!
+//! The same calldata names the integrator's fee recipients, which is how a frontend's cut out of
+//! the swap is recovered even though the frontend itself is not in the address book.
 
-use alloy::primitives::U256;
+use alloy::{
+    primitives::{Address, U256},
+    sol,
+    sol_types::SolCall,
+};
 
 use crate::decoder::solvers::{SolverKnowledge, SolverQuote};
+
+sol! {
+    /// `MetaAggregationRouterV2`'s swap description. Only `feeReceivers` is read; the rest are
+    /// named to match the ABI so the decode lines up.
+    struct SwapDescriptionV2 {
+        address srcToken;
+        address dstToken;
+        address[] srcReceivers;
+        uint256[] srcAmounts;
+        address[] feeReceivers;
+        uint256[] feeAmounts;
+        address dstReceiver;
+        uint256 amount;
+        uint256 minReturnAmount;
+        uint256 flags;
+        bytes permit;
+    }
+
+    struct SwapExecutionParams {
+        address callTarget;
+        address approveTarget;
+        bytes targetData;
+        SwapDescriptionV2 desc;
+        bytes clientData;
+    }
+
+    function swap(SwapExecutionParams execution);
+
+    function swapSimpleMode(
+        address caller,
+        SwapDescriptionV2 desc,
+        bytes targetData,
+        bytes clientData
+    );
+}
 
 /// The `KyberSwap` solver.
 pub(crate) struct Kyberswap;
@@ -44,10 +86,59 @@ impl SolverKnowledge for Kyberswap {
             .and_then(serde_json::Value::as_u64);
         Some(SolverQuote { amount_out, source: Some(source), timestamp })
     }
+
+    /// The integrator fee recipients Kyber's router is told to pay out of the swap.
+    ///
+    /// Read from the root call only. A wrapper that nests Kyber's calldata (Relay, `MetaMask`)
+    /// owns the flow and accounts its own fee, so a nested fee is that venue's to report.
+    fn fee_recipients(&self, input: &[u8]) -> Vec<Address> {
+        if let Ok(call) = swapCall::abi_decode(input) {
+            return call.execution.desc.feeReceivers;
+        }
+        if let Ok(call) = swapSimpleModeCall::abi_decode(input) {
+            return call.desc.feeReceivers;
+        }
+        Vec::new()
+    }
+}
+
+/// A `MetaAggregationRouterV2.swap` call paying `fee_receivers`, for tests here and in
+/// `solvers::tests`. Only the fee tier is meaningful; the rest is the minimum a decode needs.
+///
+/// The layout is the one that decoded Base tx
+/// 0x78c70ca665a6e5d15e2af5a5b497cb3c1eb1214000308f1f0e2eb8e7e8c63e69, whose declared receiver
+/// 0x41ec04c3… is the address the trace shows taking 10% of the output.
+#[cfg(test)]
+pub(crate) fn swap_calldata(fee_receivers: Vec<alloy::primitives::Address>) -> Vec<u8> {
+    use alloy::primitives::{Address, Bytes};
+    swapCall {
+        execution: SwapExecutionParams {
+            callTarget: Address::ZERO,
+            approveTarget: Address::ZERO,
+            targetData: Bytes::default(),
+            desc: SwapDescriptionV2 {
+                srcToken: Address::ZERO,
+                dstToken: Address::ZERO,
+                srcReceivers: Vec::new(),
+                srcAmounts: Vec::new(),
+                feeReceivers: fee_receivers,
+                feeAmounts: vec![U256::from(1000)],
+                dstReceiver: Address::ZERO,
+                amount: U256::ZERO,
+                minReturnAmount: U256::ZERO,
+                flags: U256::from(704),
+                permit: Bytes::default(),
+            },
+            clientData: Bytes::default(),
+        },
+    }
+    .abi_encode()
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::address;
+
     use super::*;
 
     /// The real clientData blob of tx 0xf25ceafd… (the audited Relay+KyberSwap trade).
@@ -82,6 +173,26 @@ mod tests {
         assert!(Kyberswap
             .embedded_quote(&[], U256::ZERO)
             .is_none());
+    }
+
+    #[test]
+    fn test_fee_recipients_from_swap_calldata() {
+        let collector = address!("0x41ec04c311d54f787f9e6c83d3fc7036f572fea0");
+        assert_eq!(Kyberswap.fee_recipients(&swap_calldata(vec![collector])), vec![collector]);
+        // A swap with no integrator fee names nobody.
+        assert!(Kyberswap
+            .fee_recipients(&swap_calldata(Vec::new()))
+            .is_empty());
+    }
+
+    #[test]
+    fn test_fee_recipients_from_foreign_calldata() {
+        // Kyber's blob nested in a wrapper's calldata is not a root Kyber call: that venue owns
+        // the fee. Neither is an empty input.
+        assert!(Kyberswap
+            .fee_recipients(&calldata_with(BLOB))
+            .is_empty());
+        assert!(Kyberswap.fee_recipients(&[]).is_empty());
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -12,12 +12,14 @@ pub(crate) mod lifi;
 pub(crate) mod paraswap;
 pub(crate) mod zeroex;
 
+use std::collections::HashSet;
+
 use alloy::{
     primitives::{Address, U256},
     rpc::types::Log,
 };
 
-use crate::decoder::{registry::Registry, veto::Veto};
+use crate::decoder::{registry::Registry, transfer_ledger::TransferLedger, veto::Veto};
 
 /// A solver's own off-chain quote for the swap, recovered from calldata.
 ///
@@ -60,6 +62,12 @@ pub(crate) trait SolverKnowledge: Send + Sync {
     /// `crate::decoder::venue_attribution`).
     fn integrator(&self, _logs: &[Log]) -> Option<String> {
         None
+    }
+
+    /// The fee recipients this solver's calldata names, for routers that let an integrator take a
+    /// cut of the swap. Only who is paid — `declared_output_fee` reads how much off the ledger.
+    fn fee_recipients(&self, _input: &[u8]) -> Vec<Address> {
+        Vec::new()
     }
 }
 
@@ -109,6 +117,36 @@ pub(crate) fn embedded_quote(solver: &str, input: &[u8], amount_in: U256) -> Opt
         .iter()
         .find(|(name, _)| *name == solver)?;
     knowledge.embedded_quote(input, amount_in)
+}
+
+/// The output-token fee the solver's declared fee recipients were paid, when its calldata names
+/// any and they received some of the bought token.
+///
+/// The calldata says who is paid; the ledger says how much they got. Taking the amount from the
+/// ledger keeps this clear of each router's fee encoding — `KyberSwap` declares a bps rate, not an
+/// amount — and of whether the router paid the cut in the swap token or unwrapped it first.
+///
+/// A frontend's cut is not visible to the address book unless its wallet is registered, so without
+/// this every such trade reports the settled output short by exactly the fee, and Fynd — re-solved
+/// gross — appears to win by that much.
+pub(crate) fn declared_output_fee(
+    solver: &str,
+    input: &[u8],
+    ledger: &TransferLedger,
+    token_out: Address,
+) -> Option<U256> {
+    let (_, knowledge) = IMPLEMENTATIONS
+        .iter()
+        .find(|(name, _)| *name == solver)?;
+    let recipients: HashSet<Address> = knowledge
+        .fee_recipients(input)
+        .into_iter()
+        .collect();
+    ledger
+        .received_by(&recipients)
+        .get(&token_out)
+        .copied()
+        .filter(|fee| !fee.is_zero())
 }
 
 /// Whether a quoted output is in the same units as the settled one.
@@ -198,6 +236,52 @@ mod tests {
             &quote(120_001_117_253_254_637_416_284),
             U256::from(120_000_000_000u64)
         ));
+    }
+
+    #[test]
+    fn test_declared_output_fee_reads_the_integrator_cut() {
+        // Base tx 0x78c70ca6…: KyberSwap's calldata names a frontend's wallet, which took 10% of
+        // the ETH the trader bought. Without backing it out the settled output is 10% short and
+        // Fynd, re-solved gross, wins by 1111 bps on every one of that frontend's trades.
+        let collector = addr(41);
+        let trader = addr(1);
+        let router = addr(50);
+        let token_out = Address::ZERO;
+        let native = [
+            (router, trader, U256::from(45_157_884_343_657_075u64)),
+            (router, collector, U256::from(5_017_542_704_850_786u64)),
+        ];
+        let ledger = TransferLedger::from_transaction(&[], &native);
+        let input = kyberswap::swap_calldata(vec![collector]);
+
+        assert_eq!(
+            declared_output_fee("kyberswap", &input, &ledger, token_out),
+            Some(U256::from(5_017_542_704_850_786u64))
+        );
+        // Dispatched on the attributed solver: the same calldata under another solver's name
+        // declares nothing.
+        assert_eq!(declared_output_fee("1inch", &input, &ledger, token_out), None);
+        // A swap that names no fee recipient has no fee to back out.
+        assert_eq!(
+            declared_output_fee(
+                "kyberswap",
+                &kyberswap::swap_calldata(Vec::new()),
+                &ledger,
+                token_out
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_declared_output_fee_ignores_other_tokens() {
+        // The recipient was paid, but in a token the trade did not buy — that is not this swap's
+        // output fee.
+        let collector = addr(41);
+        let logs = vec![make_transfer_log(addr(10), addr(50), collector, U256::from(85))];
+        let ledger = TransferLedger::from_transaction(&logs, &[]);
+        let input = kyberswap::swap_calldata(vec![collector]);
+        assert_eq!(declared_output_fee("kyberswap", &input, &ledger, addr(11)), None);
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/transfer_ledger.rs
+++ b/tools/hindsight/src/decoder/transfer_ledger.rs
@@ -259,10 +259,8 @@ fn net_positive(
     net
 }
 
-/// A leg is residue when it is under this fraction of its token's gross transaction flow:
-/// `leg * RESIDUE_GROSS_RATIO < gross` (1%). A trade moves the bulk of its token's flow; a fee or
-/// a refund moves a sliver. Netting adds two more conditions before pruning a leg (see
-/// `drop_residue_legs`); decoders that only need the size test use the ratio directly.
+/// A net leg is residue when its token routed between third parties and the leg is under this
+/// fraction of the token's gross transaction flow: `net * RESIDUE_GROSS_RATIO < gross` (1%).
 pub(crate) const RESIDUE_GROSS_RATIO: u64 = 100;
 
 /// Net the per-token amounts into a single swap (see `TransferLedger::net_swap`).

--- a/tools/hindsight/src/decoder/transfer_ledger.rs
+++ b/tools/hindsight/src/decoder/transfer_ledger.rs
@@ -210,6 +210,18 @@ impl TransferLedger {
             .collect()
     }
 
+    /// Gross flow of one token through the transaction, counting every transfer of it in either
+    /// direction. The denominator of the residue test.
+    pub(crate) fn token_gross(&self, token: Address) -> U256 {
+        let mut gross = U256::ZERO;
+        for &(transferred, _, _, value) in &self.transfers {
+            if transferred == token {
+                gross = gross.saturating_add(value);
+            }
+        }
+        gross
+    }
+
     /// Gross sent and received per token, summed across the group.
     fn group_totals(
         &self,
@@ -247,9 +259,11 @@ fn net_positive(
     net
 }
 
-/// A net leg is residue when its token routed between third parties and the leg is under this
-/// fraction of the token's gross transaction flow: `net * RESIDUE_GROSS_RATIO < gross` (1%).
-const RESIDUE_GROSS_RATIO: u64 = 100;
+/// A leg is residue when it is under this fraction of its token's gross transaction flow:
+/// `leg * RESIDUE_GROSS_RATIO < gross` (1%). A trade moves the bulk of its token's flow; a fee or
+/// a refund moves a sliver. Netting adds two more conditions before pruning a leg (see
+/// `drop_residue_legs`); decoders that only need the size test use the ratio directly.
+pub(crate) const RESIDUE_GROSS_RATIO: u64 = 100;
 
 /// Net the per-token amounts into a single swap (see `TransferLedger::net_swap`).
 fn net_trade(amounts_by_token: &HashMap<Address, TokenAmounts>) -> Option<NetSwap> {

--- a/tools/hindsight/src/decoder/venues/relay.rs
+++ b/tools/hindsight/src/decoder/venues/relay.rs
@@ -15,7 +15,7 @@ use async_trait::async_trait;
 use crate::decoder::{
     decode::{DecodeContext, TradeDecoder, TraderFlow},
     netting_decoders::venue_flow,
-    transfer_ledger::{NetSwap, TransferLedger},
+    transfer_ledger::{NetSwap, TransferLedger, RESIDUE_GROSS_RATIO},
 };
 
 /// Relay's netting decoder.
@@ -66,6 +66,9 @@ impl<P: Provider> TradeDecoder<P> for RelayNetting {
 /// the collector took 0.000536 ETH, and anchoring on the collector reported a 468,826 bps win
 /// against a trade that actually beat Fynd by 45 bps.
 ///
+/// A candidate output under `RESIDUE_GROSS_RATIO` of its token's flow through the transaction is
+/// a fee leg rather than the fill, and is skipped.
+///
 /// Declines (returns `None`) when the shape is ambiguous: not exactly one input token, a
 /// same-token "swap", more than one token back to the collector, or more than one external
 /// recipient or output (a batched multi-order fill, like netting's multi-leg decline).
@@ -102,6 +105,15 @@ fn decode_rebalance(
         // something back and is therefore never a pure sink.
         if token == token_in {
             return None;
+        }
+        // A sliver of the token's flow is a fee, not the fill. On tx `0x3dc3f83e…` the executor
+        // paid 0.1% of the bought WETH to one address and 99.9% to the payee, who had also
+        // forwarded the input and so was not a pure sink — leaving the fee recipient as the only
+        // candidate. Read as the output it reported a 9,990,000 bps win on a trade Fynd matched.
+        if amount.saturating_mul(U256::from(RESIDUE_GROSS_RATIO)) <
+            transfer_ledger.token_gross(token)
+        {
+            continue;
         }
         outputs.push((token, amount));
     }
@@ -248,6 +260,49 @@ mod tests {
             decode_rebalance(&transfer_ledger(&logs, &native), &collectors, &routers, addr(200))
                 .unwrap();
         assert_eq!(got, swap(token_in, 1000, Address::ZERO, 2000));
+    }
+
+    #[test]
+    fn test_rebalance_skips_a_fee_sized_output_leg() {
+        // The shape of tx 0x3dc3f83e…: the executor splits the bought token 0.1% to a fee address
+        // and 99.9% to the payee, who also forwarded the input and is therefore not a pure sink.
+        // With only the fee address left as a candidate, its sliver was read as the whole output.
+        let fee_collector = addr(99);
+        let executor = addr(50);
+        let payee = addr(7);
+        let fee_recipient = addr(8);
+        let token_in = addr(10);
+        let token_out = addr(11);
+        let collectors = HashSet::from([fee_collector]);
+        let routers = HashSet::from([addr(2)]);
+        let logs = vec![
+            make_transfer_log(token_in, fee_collector, payee, U256::from(1000)),
+            make_transfer_log(token_in, payee, executor, U256::from(1000)),
+            make_transfer_log(token_out, executor, fee_recipient, U256::from(1)),
+            make_transfer_log(token_out, executor, payee, U256::from(999)),
+        ];
+        assert!(decode_rebalance(&transfer_ledger(&logs, &[]), &collectors, &routers, addr(200))
+            .is_none());
+    }
+
+    #[test]
+    fn test_rebalance_keeps_a_full_size_output_leg() {
+        // The same shape without the fee split: the sink recipient holds the whole output, so it
+        // is the fill and still decodes.
+        let fee_collector = addr(99);
+        let pool = addr(50);
+        let recipient = addr(7);
+        let token_in = addr(10);
+        let token_out = addr(11);
+        let collectors = HashSet::from([fee_collector]);
+        let routers = HashSet::from([addr(2)]);
+        let logs = vec![
+            make_transfer_log(token_in, fee_collector, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, recipient, U256::from(999)),
+        ];
+        let got = decode_rebalance(&transfer_ledger(&logs, &[]), &collectors, &routers, addr(200))
+            .unwrap();
+        assert_eq!(got, swap(token_in, 1000, token_out, 999));
     }
 
     #[test]

--- a/tools/hindsight/src/report/aggregate.rs
+++ b/tools/hindsight/src/report/aggregate.rs
@@ -5,7 +5,20 @@
 
 use std::collections::HashMap;
 
-use crate::report::record::Comparison;
+use crate::{
+    report::record::{Comparison, State},
+    resolve::MIN_NOTIONAL_USD,
+};
+
+/// Whether a state's settled notional clears the dust floor the routing-quality views apply.
+///
+/// A trade too small to price is kept, matching `telemetry`: we do not drop what we cannot
+/// measure.
+fn above_dust_floor(state: &State) -> bool {
+    state
+        .settled_value_usd
+        .is_none_or(|usd| usd >= MIN_NOTIONAL_USD)
+}
 
 /// Number of trades listed in the biggest-wins and biggest-losses tables.
 const TOP_TRADES: usize = 10;
@@ -52,13 +65,20 @@ pub(crate) struct VerdictStat {
 
 /// Routing-quality view over scored (win/loss) trades. The losses are not summarised here — the
 /// report lists each one instead, so a single bad-liquidity snapshot cannot pass for a trend.
+///
+/// The win rate and the median are taken over trades above `MIN_NOTIONAL_USD` only, as the
+/// equivalent Prometheus metrics are: a sub-dollar trade wins by thousands of bps on rounding
+/// alone and would carry the unweighted median. `won_usd` keeps every trade, so the headline
+/// savings stays the run's true total.
 pub(crate) struct Savings {
+    /// Scored trades above the dust floor — the denominator of `wins`.
     pub scored: usize,
     pub wins: usize,
-    /// Median net bps over winning trades — the typical savings when Fynd wins.
+    /// Median net bps over winning trades above the dust floor — the typical savings when Fynd
+    /// wins.
     pub median_win_bps: Option<f64>,
     /// USD gained on winning trades, the signed gross Fynd-vs-settled delta on wins (the
-    /// `hindsight_savings_usd` metric).
+    /// `hindsight_savings_usd` metric). Every trade counts, dust included.
     pub won_usd: f64,
 }
 
@@ -134,9 +154,14 @@ fn verdict_stats(records: &[Comparison]) -> Vec<VerdictStat> {
 }
 
 fn savings(records: &[Comparison]) -> Savings {
+    let won_usd: f64 = records
+        .iter()
+        .filter(|r| r.top.verdict == "win")
+        .filter_map(|r| r.top.improvement_usd)
+        .sum();
     let scored: Vec<&Comparison> = records
         .iter()
-        .filter(|r| r.top.is_scored())
+        .filter(|r| r.top.is_scored() && above_dust_floor(&r.top))
         .collect();
     // The savings-bps headline is over wins only — how much better Fynd was when it won, not
     // diluted by the losses.
@@ -152,11 +177,7 @@ fn savings(records: &[Comparison]) -> Savings {
             .filter(|r| r.top.verdict == "win")
             .count(),
         median_win_bps: median(&mut win_bps),
-        won_usd: scored
-            .iter()
-            .filter(|r| r.top.verdict == "win")
-            .filter_map(|r| r.top.improvement_usd)
-            .sum(),
+        won_usd,
     }
 }
 
@@ -173,7 +194,7 @@ fn group_stats(records: &[Comparison], key: impl Fn(&Comparison) -> &String) -> 
         .map(|(name, group)| {
             let mut net_bps: Vec<f64> = group
                 .iter()
-                .filter(|r| r.top.is_scored())
+                .filter(|r| r.top.is_scored() && above_dust_floor(&r.top))
                 .filter_map(|r| r.top.net_bps)
                 .collect();
             GroupStats {
@@ -312,6 +333,57 @@ mod tests {
             },
         }))
         .unwrap()
+    }
+
+    /// A record whose settled notional is set explicitly, for the dust floor.
+    fn record_worth(
+        block: u64,
+        verdict: &str,
+        bps: f64,
+        settled_value_usd: Option<f64>,
+    ) -> Comparison {
+        let mut comparison = record(block, "venue", "solver", verdict, Some(bps));
+        comparison.top.settled_value_usd = settled_value_usd;
+        comparison
+    }
+
+    #[test]
+    fn test_savings_leaves_dust_out_of_the_win_rate_and_median() {
+        // One real $1000 win at 10 bps, one 50-cent win at 9000 bps: dust wins by thousands of bps
+        // on rounding alone, and unfiltered it would carry both the median and the win rate.
+        let records = vec![
+            record_worth(1, "win", 10.0, Some(1000.0)),
+            record_worth(2, "win", 9000.0, Some(0.5)),
+            record_worth(3, "loss", -5.0, Some(1000.0)),
+        ];
+        let savings = savings(&records);
+        assert_eq!(savings.scored, 2);
+        assert_eq!(savings.wins, 1);
+        assert_eq!(savings.median_win_bps, Some(10.0));
+        // Every win's uplift still counts, dust included: 10/10 + 9000/10.
+        assert!((savings.won_usd - 901.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_savings_keeps_a_trade_it_cannot_price() {
+        // An unpriced trade is not provably dust, so it is scored rather than dropped.
+        let records = vec![record_worth(1, "win", 25.0, None)];
+        let savings = savings(&records);
+        assert_eq!(savings.scored, 1);
+        assert_eq!(savings.median_win_bps, Some(25.0));
+    }
+
+    #[test]
+    fn test_group_median_leaves_dust_out() {
+        let records = vec![
+            record_worth(1, "win", 10.0, Some(1000.0)),
+            record_worth(2, "win", 9000.0, Some(0.5)),
+        ];
+        let groups = group_stats(&records, |r| &r.venue);
+        assert_eq!(groups[0].median_net_bps, Some(10.0));
+        // The verdict counts still describe every trade in the group.
+        assert_eq!(groups[0].count, 2);
+        assert_eq!(groups[0].wins, 2);
     }
 
     #[test]

--- a/tools/hindsight/src/report/html.rs
+++ b/tools/hindsight/src/report/html.rs
@@ -89,11 +89,11 @@ fn hero_section(savings: &Savings, summary: &Summary, filter: Option<&str>) -> S
            <div class=\"herofoot\">{}{}{}</div>\
          </section>",
         big(&fmt_usd(savings.won_usd), "Fynd savings (wins uplift)", "pos big"),
-        big(&pct(savings.wins, savings.scored), "win rate", "pos"),
-        big(&fmt_bps_signed(savings.median_win_bps), "median savings bps (wins)", "pos"),
+        big(&pct(savings.wins, savings.scored), "win rate (non-dust)", "pos"),
+        big(&fmt_bps_signed(savings.median_win_bps), "median savings bps (wins, non-dust)", "pos"),
         mini(&fmt_count(summary.distinct_blocks), "blocks"),
         mini(&fmt_count(summary.total), "comparisons"),
-        mini(&fmt_count(savings.scored), "scored"),
+        mini(&fmt_count(savings.scored), "scored (non-dust)"),
     )
 }
 
@@ -516,7 +516,7 @@ mod tests {
     fn test_render_states_the_run_size_as_counts() {
         let html = render(&sample_report(), None);
         // Two records over two blocks, one of them scored — plain counts, no sentence.
-        for (value, label) in [("2", "blocks"), ("2", "comparisons"), ("1", "scored")] {
+        for (value, label) in [("2", "blocks"), ("2", "comparisons"), ("1", "scored (non-dust)")] {
             assert!(
                 html.contains(&format!(">{value}</div><div class=\"minilab\">{label}<")),
                 "{label}"

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -83,17 +83,13 @@ pub(crate) enum Verdict {
 /// loss. Without this cut, a single un-fillable whale trade dominates the USD aggregate.
 const MIN_FILL_RATIO: f64 = 0.5;
 
-/// Settled USD notional below which a trade is left out of the unweighted views — the win rate and
-/// the bps quantiles, in both the Prometheus metrics and the offline report.
+/// Settled USD notional below which a trade is left out of the unweighted views: the win rate and
+/// the bps quantiles. USD-weighted views keep every trade, as does a trade too small to price.
 ///
-/// On a dust trade a few wei of rounding is tens to thousands of bps, so dust dominates an
-/// unweighted median or win count while contributing nothing real. USD-weighted views keep every
-/// trade — a $5 win adds $5 — so total savings and volume stay complete, and a trade whose
-/// notional cannot be priced is kept: we do not drop what we cannot measure.
-///
-/// It lives here, beside `MIN_FILL_RATIO`, because both are scoring policy: every surface that
-/// reports a verdict reads them from one place rather than each choosing its own cut-off.
-pub(crate) const MIN_NOTIONAL_USD: f64 = 100.0;
+/// Below a dollar a few wei of rounding is thousands of bps, which carries an unweighted median.
+/// Above it the spread is real — small trades are genuinely easier to beat — so the floor sits
+/// just past the rounding noise rather than where the win rate stops moving.
+pub(crate) const MIN_NOTIONAL_USD: f64 = 10.0;
 
 /// Reclassify a Fynd quote that covers far less than the settled amount as a coverage miss.
 ///

--- a/tools/hindsight/src/resolve/compare.rs
+++ b/tools/hindsight/src/resolve/compare.rs
@@ -83,6 +83,18 @@ pub(crate) enum Verdict {
 /// loss. Without this cut, a single un-fillable whale trade dominates the USD aggregate.
 const MIN_FILL_RATIO: f64 = 0.5;
 
+/// Settled USD notional below which a trade is left out of the unweighted views — the win rate and
+/// the bps quantiles, in both the Prometheus metrics and the offline report.
+///
+/// On a dust trade a few wei of rounding is tens to thousands of bps, so dust dominates an
+/// unweighted median or win count while contributing nothing real. USD-weighted views keep every
+/// trade — a $5 win adds $5 — so total savings and volume stay complete, and a trade whose
+/// notional cannot be priced is kept: we do not drop what we cannot measure.
+///
+/// It lives here, beside `MIN_FILL_RATIO`, because both are scoring policy: every surface that
+/// reports a verdict reads them from one place rather than each choosing its own cut-off.
+pub(crate) const MIN_NOTIONAL_USD: f64 = 100.0;
+
 /// Reclassify a Fynd quote that covers far less than the settled amount as a coverage miss.
 ///
 /// Fynd does not do price-constrained partial fills, but when liquidity is thin it can return a

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 
 use alloy::primitives::{Address, TxHash, U256};
 use async_trait::async_trait;
-pub(crate) use compare::{Deltas, Slippage, Verdict};
+pub(crate) use compare::{Deltas, Slippage, Verdict, MIN_NOTIONAL_USD};
 use fynd_core::types::{Route, Swap};
 use serde::Serialize;
 use tycho_simulation::tycho_common::models::Address as CoreAddress;

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -106,7 +106,7 @@ pub(crate) fn describe() {
         "Re-solved trades above the dust floor, labeled by venue / solver / chain / outcome / \
          algorithm / state (top|back). `algorithm` is the worker pool whose route won the quote, \
          so a per-venue split answers which algorithm serves that venue's flow best; it is \
-         \"none\" when Fynd did not solve. Sub-$100-notional trades are excluded so the win-rate \
+         \"none\" when Fynd did not solve. Trades below the notional floor are excluded so the win-rate \
          reflects trades that matter; total volume stays complete in VOLUME_USD. Per-pair detail \
          lives in the JSONL comparison output; a token-pair label here is unbounded on mainnet and \
          would explode Prometheus series cardinality over a long run."
@@ -115,7 +115,7 @@ pub(crate) fn describe() {
         SAVINGS_BPS,
         Unit::Count,
         "Gross bps delta of Fynd vs settled (positive = Fynd better), labeled by venue / solver / \
-         chain / outcome / algorithm / state (top|back). Sub-$100-notional trades are excluded — a \
+         chain / outcome / algorithm / state (top|back). Trades below the notional floor are excluded — a \
          few wei of rounding is thousands of bps on dust and would swamp the quantiles."
     );
     describe_histogram!(

--- a/tools/hindsight/src/telemetry.rs
+++ b/tools/hindsight/src/telemetry.rs
@@ -12,7 +12,7 @@ use tracing::{error, info, warn};
 
 use crate::{
     decoder::Registry,
-    resolve::{render_route, Outcome, RangeComparison, StateResult, Verdict},
+    resolve::{render_route, Outcome, RangeComparison, StateResult, Verdict, MIN_NOTIONAL_USD},
     usd::Prices,
 };
 
@@ -35,14 +35,6 @@ const UNTRACED_TRANSACTIONS: &str = "hindsight_untraced_transactions_total";
 /// outliers can be traced and classified (a genuinely large trade vs a token-mispricing artifact
 /// from the gas-token-anchored valuation).
 const USD_OUTLIER_THRESHOLD: f64 = 1_000.0;
-
-/// Settled USD notional below which a trade is excluded from the win-rate (`TRADES_TOTAL`) and bps
-/// (`SAVINGS_BPS`) metrics. On a dust trade a few wei of rounding is tens to thousands of bps, so
-/// dust dominates those unweighted quantiles and win counts while contributing nothing real. The
-/// USD-weighted histograms (`VOLUME_USD`/`SAVINGS_USD`/`IMPROVEMENT_USD`) keep every trade — a $5
-/// win adds $5 — so total savings and volume stay complete. A trade whose notional cannot be
-/// priced is kept: we do not drop what we cannot measure.
-const MIN_NOTIONAL_USD: f64 = 100.0;
 
 /// Whether a USD savings value is large enough to log for inspection.
 fn is_usd_outlier(usd: f64) -> bool {
@@ -239,8 +231,10 @@ pub(crate) fn record_range(
     }
 
     // Dust guard: sub-`MIN_NOTIONAL_USD` trades distort the unweighted win-rate and bps quantiles,
-    // so they are kept out of `TRADES_TOTAL` and `SAVINGS_BPS`. An unpriced trade has no known
-    // notional and is kept. The notional is a per-trade quantity, so both states share this gate.
+    // so they are kept out of `TRADES_TOTAL` and `SAVINGS_BPS`. The USD-weighted histograms
+    // (`VOLUME_USD`/`SAVINGS_USD`/`IMPROVEMENT_USD`) keep every trade — a $5 win adds $5 — so
+    // total savings and volume stay complete. An unpriced trade has no known notional and is
+    // kept. The notional is a per-trade quantity, so both states share this gate.
     let above_floor = volume.is_none_or(|usd| usd >= MIN_NOTIONAL_USD);
 
     let savings_top = record_state(range, &range.top, "top", &labels, prices_top, above_floor);


### PR DESCRIPTION
Three decoding faults from prod Base hindsight over 2026-08-01/02, plus two changes from review.

### 1. KyberSwap: a venue's fee was counted against Fynd

KyberSwap's router lets the venue that sent the order keep a share of what the user buys, listing
the addresses to pay in the transaction's calldata. The venue here is not in the address book, so
nothing else identifies it.

- **Before:** hindsight never read that list. It recorded only the part that reached the trader,
  while Fynd's re-solve was measured before any fee came out, so every trade from that venue
  looked like a Fynd win of exactly the fee — 20 on 2026-08-02, all at 1109–1112 bps, which is
  the 10% it charged.
- **Added:** `SolverKnowledge::fee_recipients`, implemented for KyberSwap by decoding its `swap`
  and `swapSimpleMode` calldata, plus `declared_output_fee`, which adds back what those addresses
  were actually paid. Taking the amount from the transfers means no router's fee format has to be
  decoded — KyberSwap writes "1000 bps", not a number of tokens.
- **Unchanged:** trades where a venue already accounted for the fee, and KyberSwap calldata
  nested inside another venue's transaction.

### 2. Relay: a fee payment was recorded as the whole trade

On a Relay fill, `decode_rebalance` finds the address that receives the bought token without
sending anything, and treats what it received as the trade's output.

- **Before:** if the person being paid had also passed the input token along earlier in the same
  transaction, they both sent and received, so they were skipped — leaving whoever took a fee as
  the only candidate. On tx `0x3dc3f83e` the trader was paid 0.12076 WETH and a fee address got
  0.000121 WETH (0.1%). The 0.1% became the trade, so Fynd — which routed the same pair to the
  same amount — appeared to win by 9,990,000 bps, or $225. That was the largest single saving
  reported across those two days on Base.
- **Added:** one check in that loop — a candidate holding under 1% of the token's movement through
  the transaction is skipped. The 1% is netting's existing cut-off, not a new number.
- **Unchanged:** every other reason `decode_rebalance` accepts or declines a shape.

### 3. The report counted trades the dashboards leave out

- **Before:** Prometheus dropped trades below the notional floor from the win rate and the bps
  percentiles, while the offline report counted all of them, so the two disagreed about the same
  run.
- **Added:** the report applies the same floor to its win rate and medians, and the constant moved
  from `telemetry.rs` to `resolve/compare.rs` beside the existing fill-ratio threshold, so both
  surfaces read it from one place.
- **Unchanged:** dollar totals, verdict counts and the trade tables still cover every record.

### 4. The floor drops from $100 to $10 (from review)

Every implausible reading sits below $1, so $100 was well past what the floor needs and excluded
63% of scored trades. Over 2026-08-02's 22,167 scored trades:

| floor | scored | kept | median win bps | max win bps |
|---|---|---|---|---|
| $0 | 22,167 | 100% | 10.3 | 4.4e15 |
| $1 | 18,217 | 82% | 7.0 | 1,220 |
| **$10** | **14,157** | **64%** | **4.4** | **1,111** |
| $100 | 8,225 | 37% | 2.8 | 1,111 |

Past a dollar the spread is real rather than noise — small trades are genuinely easier to beat —
so raising the floor further trades coverage for a lower median, not for accuracy. This moves the
existing Prometheus win rate and bps quantiles, not just the report.

### 5. Residue-ratio comment restored (from review)

Making the constant `pub(crate)` came with a rewritten comment that read worse than the original.
Reverted to the original sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)