### PR TITLE
test: add regression test for ENG-6255 split-route encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7907,8 +7907,7 @@ dependencies = [
 [[package]]
 name = "tycho-client"
 version = "0.349.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd93ae713167232747ce250d2bbcda9e28febf6c2a5d3449317bed6b6278f7c"
+source = "git+https://github.com/propeller-heads/tycho?rev=41178af22ae4221d4ed757da260f2639024c4a4d#41178af22ae4221d4ed757da260f2639024c4a4d"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7937,8 +7936,7 @@ dependencies = [
 [[package]]
 name = "tycho-common"
 version = "0.349.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e3bd537f5079a098ee63f51325e1e84c8e57e6a27661a07b4070145dffde3b"
+source = "git+https://github.com/propeller-heads/tycho?rev=41178af22ae4221d4ed757da260f2639024c4a4d#41178af22ae4221d4ed757da260f2639024c4a4d"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7966,8 +7964,7 @@ dependencies = [
 [[package]]
 name = "tycho-ethereum"
 version = "0.349.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0ebe7ef0a3b7b1f6be90c69c398a27cb75a0dc67634e42261c04476b51748"
+source = "git+https://github.com/propeller-heads/tycho?rev=41178af22ae4221d4ed757da260f2639024c4a4d#41178af22ae4221d4ed757da260f2639024c4a4d"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7988,8 +7985,7 @@ dependencies = [
 [[package]]
 name = "tycho-execution"
 version = "0.349.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf45f13323037a1ab0c958f1fd6f9528e1eedd465277be9f3de97169ee261751"
+source = "git+https://github.com/propeller-heads/tycho?rev=41178af22ae4221d4ed757da260f2639024c4a4d#41178af22ae4221d4ed757da260f2639024c4a4d"
 dependencies = [
  "alloy",
  "chrono",
@@ -8010,8 +8006,7 @@ dependencies = [
 [[package]]
 name = "tycho-simulation"
 version = "0.349.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53ae449a03c2ce030ff4decbc1c4641d00269248cb98a0802c8748536f0816fe"
+source = "git+https://github.com/propeller-heads/tycho?rev=41178af22ae4221d4ed757da260f2639024c4a4d#41178af22ae4221d4ed757da260f2639024c4a4d"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,10 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-tycho-execution = ">=0.349.0"
-tycho-simulation = ">=0.349.0"
+# TEMPORARY: pinned to propeller-heads/tycho for the unreleased wrap-injection fix
+# (no bridge swaps into split solutions whose ETH/WETH balance is not dangling).
+tycho-execution = { git = "https://github.com/propeller-heads/tycho", rev = "41178af22ae4221d4ed757da260f2639024c4a4d" }
+tycho-simulation = { git = "https://github.com/propeller-heads/tycho", rev = "41178af22ae4221d4ed757da260f2639024c4a4d" }
 typetag = "0.2"
 
 # Compression

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -910,6 +910,55 @@ mod tests {
         encoder
     }
 
+    /// Regression test: a split route where one branch hops through WETH and a parallel branch
+    /// hops through native ETH. The route itself is valid (per-token remainder splits are last),
+    /// but tycho-execution 0.349.0's `add_native_wrap_swaps` treats the adjacency between the
+    /// USDT→ETH branch and the WETH→USDC branch as a sequential ETH→WETH gap and injects a
+    /// 0%-split wrap swap mid-list, which then fails split validation with
+    /// "The 0% split for token ... must be the last swap".
+    #[tokio::test]
+    async fn test_encode_split_route_with_native_and_wrapped_intermediates() {
+        let usdt: Address = "0xdac17f958d2ee523a2206206994597c13d831ec7"
+            .parse()
+            .unwrap();
+        let usdc: Address = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+            .parse()
+            .unwrap();
+        let weth: Address = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+            .parse()
+            .unwrap();
+        let eth = Address::from([0u8; 20]);
+
+        let split_swap = |tin: &Address, tout: &Address, split: f64| {
+            make_route_swap_addrs(tin.clone(), tout.clone()).with_split(split)
+        };
+        // Topological emission order from build_split_route: the USDT batch (remainder last),
+        // then one batch per intermediate token.
+        let swaps = vec![
+            split_swap(&usdt, &weth, 0.7),
+            split_swap(&usdt, &eth, 0.0),
+            split_swap(&weth, &usdc, 0.0),
+            split_swap(&eth, &usdc, 0.0),
+        ];
+        let tokens = [&usdt, &usdc, &weth, &eth]
+            .into_iter()
+            .map(|a| (a.clone(), make_token(a.clone())))
+            .collect();
+        let route = crate::types::Route::new(swaps, tokens).expect("non-empty route");
+        assert!(route.validate().is_ok(), "the solver-side route is valid");
+
+        let quote = make_order_quote(990).with_route(route);
+        let result = real_encoder()
+            .encode(vec![quote], EncodingOptions::new(0.01))
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "split route mixing WETH and native ETH branches must encode, got: {:?}",
+            result.err()
+        );
+    }
+
     #[tokio::test]
     async fn test_encode_sets_transaction_on_successful_solution() {
         let encoder = real_encoder();


### PR DESCRIPTION
[Task](https://propeller-heads.atlassian.net/browse/ENG-6255)

A split route can send one branch through WETH and a parallel branch through native ETH. The route is valid. tycho-execution 0.349.0 sees the branch boundary as a sequential ETH/WETH gap. It puts a 0%-split wrap swap between the branches. Split validation then fails with "The 0% split for token ... must be the last swap". The quote is lost. Fails after the first commit.


The second commit point to the branch with the fix, the test passes.
