### PR TITLE
ci: drop the stale version requirement on erc20-overrides

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,10 +172,11 @@ fynd-core = { path = "fynd-core", version = "0.97.14" }
 fynd-rpc = { path = "fynd-rpc", version = "0.97.14" }
 fynd-rpc-types = { path = "fynd-rpc-types", version = "0.97.14" }
 fynd-client = { path = "clients/rust", version = "0.97.14" }
-erc20-overrides = { path = "tools/erc20-overrides", version = "0.97.1" }
-# Path-only (like fynd-test-fixtures): unpublished internal crate, so it must not carry a
-# version requirement -- release.config.js bumps the workspace version without bumping
-# requirements it does not know about, and a stale requirement sends cargo to crates.io.
+# Path-only: unpublished internal crates (release = false in release-plz.toml), so they must not
+# carry a version requirement -- release-plz bumps the workspace version and rewrites the
+# requirements for the crates it releases, but leaves these untouched. A stale requirement stops
+# matching the workspace version on the next minor bump and fails resolution.
+erc20-overrides = { path = "tools/erc20-overrides" }
 fynd-tools-common = { path = "tools/common" }
 fynd-test-fixtures = { path = "test-fixtures" }
 


### PR DESCRIPTION
Releases have been broken on main since 4 Aug. This unblocks them.

## What happened

`Cargo.toml` asked for `erc20-overrides` version `^0.97.1`. That matched every `0.97.x` release, so nobody noticed.

Then PR #395 landed a `refactor!:` commit. The `!` means breaking, and for a 0.x version that bumps the minor — so the next release is `0.98.0`, not `0.97.15`.

`0.98.0` does not match `^0.97.1`. Release-plz bumps every crate in the workspace to `0.98.0`, then `cargo update` cannot satisfy the old requirement and dies:

```
error: failed to select a version for the requirement `erc20-overrides = "^0.97.1"`
candidate versions found which did not match: 0.98.0
```

Release-plz would normally keep that requirement current, but only for crates it publishes. `erc20-overrides` is marked `release = false`, so it was left behind at whatever was written when the crate was first added.

## The fix

Drop the version requirement, keep the path:

```toml
erc20-overrides = { path = "tools/erc20-overrides" }
```

`fynd-tools-common` and `fynd-test-fixtures` are unpublished in the same way and are already written like this, with a comment explaining why. `erc20-overrides` was just missed.

## How I checked

Set the workspace version to `0.98.0` by hand and rewrote the published crates' requirements the way release-plz does. `cargo metadata` failed with the same error as CI, and passed once the requirement was gone.

Also: the nearby comment mentioned `release.config.js`, which no longer exists in this repo. It says release-plz now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)