### PR TITLE
feat(hindsight): measure route decay over the blocks after a quote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3922,6 +3922,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "tracing",

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -55,7 +55,7 @@ See [`docs/guides/swap-cli.md`](../docs/guides/swap-cli.md) for usage instructio
 
 See [`tools/hindsight/CLAUDE.md`](hindsight/CLAUDE.md) for the full module overview.
 
-Four subcommands via `cargo run -p hindsight --release --`:
+Five subcommands via `cargo run -p hindsight --release --`:
 
 - **`decode`** — Fetch block receipts, match and trace solver transactions, emit decoded trades
   (token in/out, amounts, client, solver, settled gas). Accepts `--block N`, `--range START-END`
@@ -65,6 +65,11 @@ Four subcommands via `cargo run -p hindsight --release --`:
 - **`monitor`** — Live mode: drives an in-process `fynd-core` solver block-by-block, solving
   each settled trade at top-of-block (N-1) and again at back-of-block (N), where the top route
   is also re-executed to measure slippage. Emits JSONL and exposes Prometheus metrics.
+- **`decay`** — Live: quote a sample of trade shapes drawn from a `monitor` run's JSONL, then replay
+  those exact routes at each of the next `--offsets` blocks, splitting each move into unavoidable
+  market drift and stale-route loss. The sampled trades never execute, so the measurement is free of
+  the self-impact that contaminates `monitor`'s own `slippage` field.
+
 - **`report`** — Offline: render a self-contained HTML report from a `monitor` run's comparison
   JSONL (`--comparisons-dir`). No chain or network access.
 

--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -8,10 +8,10 @@ actually settled.
 
 ## Commands
 
-Four subcommands via `cargo run -p hindsight --release --`. The on-chain ones (`decode`,
-`verify`, `monitor`) take `--chain` (default `ethereum`), which selects the decoder's address book,
-and `--registry <path>` / `HINDSIGHT_REGISTRY` to load a custom address book. `report` is offline
-and takes neither.
+Five subcommands via `cargo run -p hindsight --release --`. The on-chain ones (`decode`,
+`verify`, `monitor`, `decay`) take `--chain` (default `ethereum`), which selects the decoder's
+address book, and `--registry <path>` / `HINDSIGHT_REGISTRY` to load a custom address book.
+`report` is offline and takes neither.
 
 Built-in address books: `ethereum`, `base`, `unichain`, `arbitrum`, `bsc`, `polygon`. Any other
 name needs `--registry`.
@@ -33,6 +33,23 @@ name needs `--registry`.
   records. Exposes a Prometheus metrics endpoint (`--metrics-port`). `--max-lag-blocks` (default
   100, ~20 min on mainnet) bounds how far it may fall behind chain head before rebuilding the
   solver.
+
+- **`decay`** — Route decay in non-overlapping rounds: draw a sample of trade shapes, quote them at
+  one block, then replay those exact routes at each of the next `--offsets` blocks (default 5). Each
+  offset records the total move (the route replayed via `fynd_core::replay_route`), the unavoidable
+  market drift (a fresh solve at the same state), and the difference — what holding a stale route
+  cost. Emits `decay-YYYY-MM-DD.jsonl` (`--output-dir`) plus a per-offset summary at exit.
+
+  Trade shapes come from a `monitor` run's `comparisons-*.jsonl` (`--comparisons-dir`), filtered to
+  `--venue` (default `relay`); only each record's token pair and input amount are read. **The
+  sampled trades never execute**, which is the point: `monitor`'s own `slippage` field solves a
+  settled trade at N-1 and replays it at N — a state that already contains that trade's own price
+  impact — so it measures the route eating its own shadow. Re-quoting the shape at unrelated live
+  blocks removes that contamination.
+
+  `--sample-size` (default 25) sets per-block load, since every sampled trade is replayed *and*
+  re-solved at every offset; a run warns when a block's work exceeds half the chain's block time.
+  `--seed` makes the draw reproducible.
 
 - **`report`** — Offline: read the `comparisons-YYYY-MM-DD.jsonl` files a `monitor` run wrote
   (`--comparisons-dir`) and render a single self-contained HTML file (`-o`, defaults to
@@ -95,8 +112,21 @@ their solver in calldata — `solver_aliases`).
 |---|---|
 | `mod.rs` | `SteppingSolver` trait; `resolve_block_range` — solve all trades at top, advance, then re-execute each top route and solve each trade fresh at back |
 | `compare.rs` | `Verdict` / `Deltas` / `Slippage` — bps diff, win/loss/coverage-miss classification, quote-vs-re-execution slippage |
-| `monitor.rs` | Production `monitor` subcommand: in-process solver, block subscription, JSONL emission |
-| `jsonl.rs` | Append-only JSONL writer used by `monitor` |
+| `step.rs` | `StepAdapter`, the live `SteppingSolver`: solve / replay via `fynd_core::replay_route` / step one block. Shared by `monitor` and `decay`; `Encoding` opts calldata generation out for callers that only read `amount_out` |
+| `session.rs` | `SolverArgs` (the solver flags both live commands share) and `Session` — protocol expansion, worker-pool loading, build, and rebuild-with-backoff after a feed death |
+| `monitor.rs` | Production `monitor` subcommand: block subscription, decode, JSONL emission |
+| `jsonl.rs` | Append-only day-rotating JSONL writer, prefixed per record kind (`comparisons` / `decay`) |
+
+### Decay (`src/decay/`)
+
+The `decay` subcommand — route decay over the blocks following a quote, on synthetic trades.
+
+| File | Purpose |
+|---|---|
+| `mod.rs` | `DecayArgs`; the non-overlapping round loop (quote a sample, then replay + re-solve at each offset) and the per-offset run report |
+| `sample.rs` | Loads venue-filtered trade *shapes* from a `monitor` run's comparison JSONL, and the seeded sampler (pinned `SplitMix64`, so `--seed` survives dependency bumps) |
+| `record.rs` | `DecayBps` (total / market drift / stale-route split), `ReplayFailure`, and the per-(trade, offset) JSONL record |
+| `summary.rs` | Per-offset aggregation: mean, winsorized mean, percentiles, degraded and tail shares, market-vs-execution split |
 
 ### Report (`src/report/`)
 

--- a/tools/hindsight/Cargo.toml
+++ b/tools/hindsight/Cargo.toml
@@ -59,6 +59,8 @@ toml = { workspace = true }
 # Test-only route fixtures (resolve::test_support): a throwaway ProtocolComponent's creation
 # timestamp needs a concrete NaiveDateTime.
 chrono = { workspace = true }
+# Throwaway comparison-JSONL directories for the decay sampler's tests.
+tempfile = { workspace = true }
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -14,8 +14,10 @@ measurable value of adding Fynd to a venue.
 | `decode` | Decode the solver trades in a block or range and print/JSON them |
 | `verify` | Diff decoded trades against Allium's `aggregator_trades` ground truth (dev check) |
 | `monitor` | Live: drive an in-process Fynd solver block-by-block, re-solve every settled trade, emit JSONL + Prometheus metrics |
+| `decay` | Live: quote a sample of trade shapes, replay those routes at the next N blocks, and split the move into market drift vs stale-route loss |
+| `report` | Offline: render a self-contained HTML report from a `monitor` run's comparison JSONL |
 
-All take `--chain` (selects the address book) and `--registry` /
+All except `report` take `--chain` (selects the address book) and `--registry` /
 `HINDSIGHT_REGISTRY` to load a custom address book. See `--help` per subcommand and
 [CLAUDE.md](CLAUDE.md) for environment variables.
 

--- a/tools/hindsight/src/decay/mod.rs
+++ b/tools/hindsight/src/decay/mod.rs
@@ -1,0 +1,763 @@
+//! Route decay measured in non-overlapping rounds: quote a sample of trades at one block, then
+//! replay those exact routes at each of the following `--offsets` blocks.
+//!
+//! Each offset yields three numbers. The quoted route replayed at the later state gives the **total
+//! move**; a freshly solved quote at that same state gives the part of it that was **unavoidable
+//! market drift**; the difference is what holding a **stale route** cost. Only the last is
+//! something better routing or faster submission can recover.
+//!
+//! The trades are synthetic on purpose. `monitor`'s existing `slippage` field solves a settled
+//! trade at N-1 and replays it at N — a state that already contains that trade's own price impact,
+//! so it measures the route eating its own shadow. Here the sampled shapes never execute: they are
+//! drawn from historical flow (see [`sample`]) and re-quoted at unrelated live blocks, so nothing
+//! but genuine market movement and route staleness can move the measurement.
+//!
+//! Rounds do not overlap — a new sample is drawn only once the previous round's last offset is
+//! measured — so per-block work is `sample_size` replays plus `sample_size` solves regardless of
+//! how many offsets are configured.
+
+pub(crate) mod record;
+pub(crate) mod sample;
+mod summary;
+
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+
+use tracing::{info, warn};
+
+use crate::{
+    decay::{
+        record::{DecayRecord, Measurement, QuotedTrade, ReplayFailure},
+        sample::{Sampler, TradeShape},
+        summary::Summary,
+    },
+    resolve::{
+        jsonl::RotatingWriter,
+        session::{self, Session, SolverArgs},
+        step::{Encoding, StepAdapter},
+        Outcome, SteppingSolver,
+    },
+    telemetry,
+};
+
+/// Filename prefix for decay output. Deliberately not `comparisons`, which [`sample`] globs as its
+/// input — sharing it would let a run read its own output back as trade shapes.
+const DECAY_PREFIX: &str = "decay";
+
+/// Fraction of a block's time the per-block measurement may occupy before it is warned about. Above
+/// this there is no margin left for feed jitter, and the run is one slow solve away from sliding
+/// behind head.
+const PACING_WARN_FRACTION: f64 = 0.5;
+
+/// Inputs for the decay measurement — the `decay` subcommand's CLI arguments.
+#[derive(clap::Args)]
+pub(crate) struct DecayArgs {
+    #[command(flatten)]
+    pub solver: SolverArgs,
+
+    /// Directory of a `monitor` run's `comparisons-*.jsonl` to draw trade shapes from. Only each
+    /// record's token pair and input amount are read; nothing about how it settled is used
+    #[arg(long)]
+    pub comparisons_dir: PathBuf,
+
+    /// Venue whose flow to sample, matched case-insensitively against each record's `venue`
+    #[arg(long, default_value = sample::RELAY_VENUE)]
+    pub venue: String,
+
+    /// Trades quoted per round. Every one is re-solved at every offset, so this sets the per-block
+    /// solver load: budget roughly 30ms per trade and keep the total well inside one block (on
+    /// Base's 2s blocks, 25 trades ≈ 750ms worst case)
+    #[arg(long, default_value_t = 25)]
+    pub sample_size: usize,
+
+    /// How many blocks after the quote to measure. Decay is front-loaded, so the first few offsets
+    /// carry most of the signal
+    #[arg(long, default_value_t = 5)]
+    pub offsets: u32,
+
+    /// Seed for the trade draw, so a run's sample is reproducible
+    #[arg(long, default_value_t = 0)]
+    pub seed: u64,
+
+    /// Write one JSON line per (trade, offset) into this directory as `decay-YYYY-MM-DD.jsonl`,
+    /// rotated at each UTC day boundary
+    #[arg(long)]
+    pub output_dir: Option<PathBuf>,
+}
+
+/// One session's terminal condition: the run completed (`--max-blocks` reached) or the session is
+/// unhealthy — the feed died — and the caller should rebuild the solver.
+enum SessionEnd {
+    Complete,
+    Unhealthy(String),
+}
+
+/// Counters that survive feed rebuilds, so `--max-blocks` and the final tally span the whole run.
+#[derive(Default)]
+struct Totals {
+    /// Blocks whose measurement work completed, the unit `--max-blocks` counts.
+    blocks: u64,
+    rounds: u64,
+    /// Rounds abandoned because the feed died before their last offset.
+    abandoned_rounds: u64,
+    records: u64,
+    /// Sampled shapes the solver could not quote at all, so they never entered a round.
+    unquotable: u64,
+    pool_gone: u64,
+    simulation_failed: u64,
+    no_market_reference: u64,
+}
+
+impl Totals {
+    fn count_failure(&mut self, failure: ReplayFailure) {
+        match failure {
+            ReplayFailure::PoolGone => self.pool_gone += 1,
+            ReplayFailure::SimulationFailed => self.simulation_failed += 1,
+            ReplayFailure::NoMarketReference => self.no_market_reference += 1,
+        }
+    }
+}
+
+/// Build the in-process stepped solver and measure route decay in rounds until `--max-blocks` or
+/// Ctrl-C. When the tycho feed dies the solver is torn down and rebuilt in place, and the round in
+/// flight is abandoned rather than finished against a different solver's states.
+pub(crate) async fn run(cfg: DecayArgs) -> anyhow::Result<()> {
+    anyhow::ensure!(cfg.offsets >= 1, "--offsets must be at least 1");
+    anyhow::ensure!(cfg.sample_size >= 1, "--sample-size must be at least 1");
+
+    let shapes = sample::load_shapes(&cfg.comparisons_dir, &cfg.venue)?;
+    // Taken before the solver args are moved into the session, which owns them from here on.
+    let rounds = RoundConfig {
+        sample_size: cfg.sample_size,
+        offsets: cfg.offsets,
+        max_blocks: cfg.solver.max_blocks,
+    };
+    let session = Session::prepare(cfg.solver).await?;
+    let block_budget = session::block_time(session.chain()).mul_f64(PACING_WARN_FRACTION);
+    info!(
+        sample_size = cfg.sample_size,
+        offsets = cfg.offsets,
+        pool = shapes.len(),
+        seed = cfg.seed,
+        block_budget_ms = block_budget.as_millis(),
+        "measuring route decay in rounds"
+    );
+
+    if let Some(port) = session.args().metrics_port {
+        telemetry::install_exporter(port)?;
+        info!(port, "serving Prometheus metrics at /metrics");
+    }
+
+    let output = match cfg.output_dir.as_ref() {
+        Some(dir) => {
+            let writer = RotatingWriter::open(dir, DECAY_PREFIX)?;
+            info!(path = %writer.current_path().display(), "appending decay records to JSONL");
+            Some(writer)
+        }
+        None => None,
+    };
+
+    let mut state = RunState {
+        sampler: Sampler::new(cfg.seed, shapes.len()),
+        summary: Summary::new(cfg.offsets),
+        totals: Totals::default(),
+        output,
+        block_budget,
+    };
+
+    // Resolves on Ctrl-C, so a long run stops cleanly at any await below — including the
+    // multi-minute solver builds. On shutdown the round in flight is abandoned and the output
+    // writer flushes as it drops.
+    let shutdown = session::shutdown_signal();
+    tokio::pin!(shutdown);
+
+    // The first build fails fast — an error here is a configuration problem. Rebuilds after a feed
+    // death retry forever, since the config is known good and failures are transient.
+    let (mut solver, mut controller) = tokio::select! {
+        biased;
+        () = &mut shutdown => return Ok(()),
+        built = session.build() => built?,
+    };
+    loop {
+        // Encoding off: decay reads only `amount_out`, so calldata is work we would throw away —
+        // and an encode failure would drop a route that measures perfectly well.
+        let adapter =
+            StepAdapter::new(&solver, &controller, session.args().timeout_ms, Encoding::Skipped);
+        let reason = tokio::select! {
+            biased;
+            () = &mut shutdown => {
+                info!("received Ctrl-C; shutting down");
+                break;
+            }
+            end = run_session(&adapter, &rounds, &shapes, &mut state) => match end {
+                SessionEnd::Complete => break,
+                SessionEnd::Unhealthy(reason) => reason,
+            },
+        };
+        warn!(reason, "session unhealthy; rebuilding the solver to resubscribe");
+        telemetry::record_feed_rebuild();
+        solver.shutdown();
+        let Some(built) = session.rebuild(shutdown.as_mut()).await else {
+            info!("received Ctrl-C during rebuild; shutting down");
+            report(&state);
+            return Ok(());
+        };
+        (solver, controller) = built;
+    }
+    solver.shutdown();
+    report(&state);
+    Ok(())
+}
+
+/// The round-shaping knobs, lifted out of [`DecayArgs`] before its solver args are moved into the
+/// [`Session`] that owns them.
+struct RoundConfig {
+    sample_size: usize,
+    offsets: u32,
+    max_blocks: Option<u64>,
+}
+
+/// Run state that outlives any one solver session, so a feed rebuild loses only the round in
+/// flight.
+struct RunState {
+    sampler: Sampler,
+    summary: Summary,
+    totals: Totals,
+    output: Option<RotatingWriter>,
+    block_budget: Duration,
+}
+
+/// Drive one solver session: draw a sample, quote it, measure it across the configured offsets, and
+/// repeat until the run completes or the feed dies.
+async fn run_session<S: SteppingSolver + ?Sized>(
+    adapter: &S,
+    cfg: &RoundConfig,
+    shapes: &[TradeShape],
+    state: &mut RunState,
+) -> SessionEnd {
+    // A quote needs an applied state to be quoted against.
+    if adapter.current_block().await.is_none() {
+        info!("waiting for solver to apply its first block…");
+        if let Err(e) = adapter.advance().await {
+            return SessionEnd::Unhealthy(e.to_string());
+        }
+    }
+
+    loop {
+        let Some(quote_block) = adapter.current_block().await else {
+            warn!("no applied block yet; advancing");
+            if let Err(e) = adapter.advance().await {
+                return SessionEnd::Unhealthy(e.to_string());
+            }
+            continue;
+        };
+
+        let quoted = quote_round(adapter, cfg, shapes, state, quote_block).await;
+        state.totals.rounds += 1;
+        let round_id = state.totals.rounds;
+        if quoted.is_empty() {
+            // Nothing to replay, but the offsets must still elapse — otherwise the next round would
+            // quote against the very state this one did.
+            warn!(
+                block = quote_block,
+                round_id, "no sampled trade could be quoted; skipping the round"
+            );
+            for _ in 0..cfg.offsets {
+                if let Err(e) = adapter.advance().await {
+                    return SessionEnd::Unhealthy(e.to_string());
+                }
+            }
+            continue;
+        }
+
+        for offset in 1..=cfg.offsets {
+            if let Err(e) = adapter.advance().await {
+                // The round dies with the session: its remaining offsets would be measured against
+                // a rebuilt solver's states, which are not continuous with this
+                // round's quote.
+                state.totals.abandoned_rounds += 1;
+                return SessionEnd::Unhealthy(e.to_string());
+            }
+            let started = Instant::now();
+            let Some(measured_block) = adapter.current_block().await else {
+                warn!(round_id, offset, "no applied block after advancing; abandoning the round");
+                state.totals.abandoned_rounds += 1;
+                break;
+            };
+            let at = RoundAt { round_id, quote_block, measured_block, offset };
+            measure_offset(adapter, state, &quoted, at).await;
+
+            let elapsed = started.elapsed();
+            telemetry::record_block_seconds(elapsed.as_secs_f64());
+            if elapsed > state.block_budget {
+                warn!(
+                    round_id,
+                    offset,
+                    elapsed_ms = elapsed.as_millis(),
+                    budget_ms = state.block_budget.as_millis(),
+                    trades = quoted.len(),
+                    "measurement exceeded its per-block budget; lower --sample-size"
+                );
+            }
+
+            state.totals.blocks += 1;
+            info!(
+                block = measured_block,
+                round_id,
+                offset,
+                trades = quoted.len(),
+                elapsed_s = elapsed.as_secs_f64(),
+                "measured offset"
+            );
+            if cfg
+                .max_blocks
+                .is_some_and(|max| state.totals.blocks >= max)
+            {
+                info!(blocks = state.totals.blocks, "reached --max-blocks");
+                return SessionEnd::Complete;
+            }
+        }
+    }
+}
+
+/// Identifies one offset measurement within a round.
+struct RoundAt {
+    round_id: u64,
+    quote_block: u64,
+    measured_block: u64,
+    offset: u32,
+}
+
+/// Draw a fresh sample and quote each of its trades at the current state.
+///
+/// Only quotes carrying a route are kept: [`SteppingSolver::reexecute`] has nothing to replay
+/// without one, so such a trade could never be measured and is counted as unquotable instead.
+async fn quote_round<S: SteppingSolver + ?Sized>(
+    adapter: &S,
+    cfg: &RoundConfig,
+    shapes: &[TradeShape],
+    state: &mut RunState,
+    quote_block: u64,
+) -> Vec<QuotedTrade> {
+    let started = Instant::now();
+    let mut quoted = Vec::with_capacity(cfg.sample_size);
+    for index in state.sampler.draw(cfg.sample_size) {
+        let Some(shape) = shapes.get(index) else {
+            continue;
+        };
+        match adapter
+            .solve(shape.token_in, shape.token_out, shape.amount_in)
+            .await
+        {
+            Outcome::Solved(quote) if quote.solved_route.is_some() => {
+                quoted.push(QuotedTrade { shape: shape.clone(), quote });
+            }
+            Outcome::Solved(_) | Outcome::Partial(_) | Outcome::Unsolvable(_) => {
+                state.totals.unquotable += 1;
+            }
+        }
+    }
+    info!(
+        block = quote_block,
+        quoted = quoted.len(),
+        requested = cfg.sample_size,
+        elapsed_s = started.elapsed().as_secs_f64(),
+        "quoted a fresh sample"
+    );
+    quoted
+}
+
+/// Measure every quoted trade at the solver's current state: replay its route, solve it fresh for
+/// the market-movement reference, and emit one record per trade.
+async fn measure_offset<S: SteppingSolver + ?Sized>(
+    adapter: &S,
+    state: &mut RunState,
+    quoted: &[QuotedTrade],
+    at: RoundAt,
+) {
+    let mut records = Vec::with_capacity(quoted.len());
+    for trade in quoted {
+        let replayed = match adapter.reexecute(&trade.quote).await {
+            Outcome::Solved(replay) => Ok(replay.amount_out),
+            Outcome::Partial(reason) | Outcome::Unsolvable(reason) => {
+                Err(ReplayFailure::classify(&reason))
+            }
+        };
+        // The fresh solve is the market-movement reference: what any router would have got at this
+        // state, so whatever the replay lost beyond it is down to the route being stale.
+        let fresh = match adapter
+            .solve(trade.shape.token_in, trade.shape.token_out, trade.shape.amount_in)
+            .await
+        {
+            Outcome::Solved(quote) => Some(quote.amount_out),
+            Outcome::Partial(_) | Outcome::Unsolvable(_) => None,
+        };
+        let record = DecayRecord::build(
+            trade,
+            Measurement {
+                round_id: at.round_id,
+                offset: at.offset,
+                quote_block: at.quote_block,
+                measured_block: at.measured_block,
+                replayed,
+                fresh,
+            },
+        );
+        if let Some(failure) = record.failure {
+            state.totals.count_failure(failure);
+        }
+        if let Some(bps) = record.bps {
+            state.summary.record(at.offset, bps);
+        }
+        records.push(record);
+    }
+    state.totals.records += records.len() as u64;
+    if let Some(writer) = state.output.as_mut() {
+        write_records(writer, &records);
+    }
+}
+
+/// Append one JSON line per record. A write failure is logged and abandons the batch rather than
+/// taking the run down: the measurement is still valid, and a long run should not die on a full
+/// disk.
+fn write_records(rotating: &mut RotatingWriter, records: &[DecayRecord]) {
+    use std::io::Write;
+
+    let writer = rotating.writer();
+    for record in records {
+        let Ok(line) = serde_json::to_string(record) else {
+            continue;
+        };
+        if let Err(e) = writeln!(writer, "{line}") {
+            warn!(error = %e, "failed to write decay record");
+            return;
+        }
+    }
+    if let Err(e) = writer.flush() {
+        warn!(error = %e, "failed to flush decay writer");
+    }
+}
+
+/// Log the run's per-offset statistics and coverage tally.
+fn report(state: &RunState) {
+    let totals = &state.totals;
+    info!(
+        rounds = totals.rounds,
+        blocks = totals.blocks,
+        records = totals.records,
+        abandoned_rounds = totals.abandoned_rounds,
+        unquotable_samples = totals.unquotable,
+        pool_gone = totals.pool_gone,
+        simulation_failed = totals.simulation_failed,
+        no_market_reference = totals.no_market_reference,
+        "decay run finished"
+    );
+    let stats = state.summary.stats();
+    if stats.is_empty() {
+        warn!("no complete measurements — nothing to summarize");
+        return;
+    }
+    // Positive is surplus throughout, so degradation reads negative and the bad tail is p05/p01.
+    // PR #297 reported the opposite sign; flip these before comparing against its numbers.
+    for offset in &stats {
+        info!(
+            offset = offset.offset,
+            count = offset.count,
+            mean_bps = offset.mean_bps,
+            winsorized_mean_bps = offset.winsorized_mean_bps,
+            p50_bps = offset.p50_bps,
+            p05_bps = offset.p05_bps,
+            p01_bps = offset.p01_bps,
+            degraded_share = offset.degraded_share,
+            tail_share_beyond_20bps = offset.tail_share,
+            market_share = offset.market_share,
+            execution_share = offset.execution_share,
+            "offset summary (positive bps = surplus)"
+        );
+    }
+    match serde_json::to_string(&stats) {
+        Ok(json) => info!(summary = %json, "decay summary json"),
+        Err(e) => warn!(error = %e, "failed to serialize the decay summary"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    };
+
+    use alloy::primitives::{Address, U256};
+    use async_trait::async_trait;
+
+    use super::*;
+    use crate::resolve::SolvedAmount;
+
+    /// A stepping mock that walks a scripted list of per-block outputs.
+    ///
+    /// `advance()` moves to the next block. At each block, `solve` returns that block's `fresh`
+    /// output and `reexecute` returns its `replayed` output, so a test can dictate the exact bps at
+    /// every offset. `advance` fails once the script runs out, which stands in for a dead feed.
+    struct ScriptedSolver {
+        /// `(replayed, fresh)` per block, indexed by how many times `advance` has run.
+        script: Vec<(Option<u64>, Option<u64>)>,
+        block: AtomicUsize,
+        /// Every `(token_in, amount_in)` handed to `solve`, so a test can see what was quoted.
+        solved: Mutex<Vec<(Address, U256)>>,
+    }
+
+    impl ScriptedSolver {
+        fn new(script: Vec<(Option<u64>, Option<u64>)>) -> Self {
+            Self { script, block: AtomicUsize::new(0), solved: Mutex::new(Vec::new()) }
+        }
+
+        fn step(&self) -> usize {
+            self.block.load(Ordering::Relaxed)
+        }
+
+        fn outcome(amount: Option<u64>, with_route: bool) -> Outcome {
+            let Some(amount) = amount else {
+                return Outcome::Unsolvable("scripted miss".to_string());
+            };
+            Outcome::Solved(SolvedAmount {
+                amount_out: U256::from(amount),
+                amount_out_net_gas: U256::from(amount),
+                gas_estimate: U256::from(21_000),
+                algorithm: "scripted".to_string(),
+                quote_json: None,
+                // A quote must carry a route to be replayable; a re-execution never does.
+                solved_route: with_route.then(|| {
+                    Box::new(crate::resolve::test_support::route(&[("uniswap_v2", "USDC", "WETH")]))
+                }),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl SteppingSolver for ScriptedSolver {
+        async fn current_block(&self) -> Option<u64> {
+            Some(1_000 + u64::try_from(self.step()).unwrap_or(0))
+        }
+
+        async fn solve(&self, token_in: Address, _: Address, amount_in: U256) -> Outcome {
+            self.solved
+                .lock()
+                .expect("lock")
+                .push((token_in, amount_in));
+            let fresh = self
+                .script
+                .get(self.step())
+                .and_then(|(_, fresh)| *fresh);
+            Self::outcome(fresh, true)
+        }
+
+        async fn advance(&self) -> anyhow::Result<()> {
+            let next = self
+                .block
+                .fetch_add(1, Ordering::Relaxed) +
+                1;
+            anyhow::ensure!(next < self.script.len(), "scripted feed exhausted");
+            Ok(())
+        }
+
+        async fn reexecute(&self, _: &SolvedAmount) -> Outcome {
+            let replayed = self
+                .script
+                .get(self.step())
+                .and_then(|(replayed, _)| *replayed);
+            Self::outcome(replayed, false)
+        }
+    }
+
+    fn shapes(count: usize) -> Vec<TradeShape> {
+        (0..count)
+            .map(|i| TradeShape {
+                token_in: Address::repeat_byte(u8::try_from(i + 1).unwrap_or(0xff)),
+                token_out: Address::repeat_byte(0xee),
+                amount_in: U256::from(1_000 + i),
+            })
+            .collect()
+    }
+
+    fn state(offsets: u32, pool_len: usize) -> RunState {
+        RunState {
+            sampler: Sampler::new(1, pool_len),
+            summary: Summary::new(offsets),
+            totals: Totals::default(),
+            output: None,
+            block_budget: Duration::from_secs(1),
+        }
+    }
+
+    fn config(sample_size: usize, offsets: u32, max_blocks: Option<u64>) -> RoundConfig {
+        RoundConfig { sample_size, offsets, max_blocks }
+    }
+
+    #[tokio::test]
+    async fn a_round_measures_every_offset_exactly_once() {
+        // Block 0 quotes at 10_000; blocks 1..=5 each replay and re-solve.
+        let mut script = vec![(None, Some(10_000))];
+        script.extend((1..=5).map(|_| (Some(9_900), Some(9_950))));
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(5, pool.len());
+
+        // --max-blocks equals the offsets, so the run stops exactly at the round's end.
+        let end = run_session(&solver, &config(1, 5, Some(5)), &pool, &mut run).await;
+        assert!(matches!(end, SessionEnd::Complete));
+
+        let stats = run.summary.stats();
+        assert_eq!(
+            stats
+                .iter()
+                .map(|s| s.offset)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3, 4, 5],
+            "each offset must be measured"
+        );
+        assert!(stats.iter().all(|s| s.count == 1), "and measured exactly once");
+        assert_eq!(run.totals.rounds, 1);
+        assert_eq!(run.totals.records, 5);
+    }
+
+    #[tokio::test]
+    async fn offsets_are_measured_against_the_original_quote_not_the_previous_block() {
+        // The quote is 10_000 and every later block replays at 9_900. If an offset were measured
+        // against the previous block instead of the quote, offsets 2+ would read 0 bps.
+        let mut script = vec![(None, Some(10_000))];
+        script.extend((1..=3).map(|_| (Some(9_900), Some(10_000))));
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(3, pool.len());
+
+        run_session(&solver, &config(1, 3, Some(3)), &pool, &mut run).await;
+
+        for offset in run.summary.stats() {
+            // -100 bps at every offset, all of it execution slippage (the fresh solve never moved).
+            assert!(
+                (offset.p50_bps + 100.0).abs() < 0.01,
+                "offset {} read {} bps",
+                offset.offset,
+                offset.p50_bps
+            );
+            assert!((offset.execution_share - 1.0).abs() < 1e-9);
+        }
+    }
+
+    #[tokio::test]
+    async fn the_measured_block_advances_with_the_offset() {
+        let mut script = vec![(None, Some(10_000))];
+        script.extend((1..=3).map(|_| (Some(9_900), Some(9_900))));
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(3, pool.len());
+
+        run_session(&solver, &config(1, 3, Some(3)), &pool, &mut run).await;
+
+        // The scripted solver reports block 1000+step, so a quote at 1000 must be measured at
+        // 1001..1003 — a stuck measured_block would mean the loop reads the state before advancing.
+        assert_eq!(solver.current_block().await, Some(1_003));
+    }
+
+    #[tokio::test]
+    async fn a_dead_feed_mid_round_abandons_it_rather_than_mixing_states() {
+        // The script dies after two offsets, so the round cannot finish.
+        let script =
+            vec![(None, Some(10_000)), (Some(9_900), Some(9_950)), (Some(9_800), Some(9_900))];
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(5, pool.len());
+
+        let end = run_session(&solver, &config(1, 5, None), &pool, &mut run).await;
+        assert!(matches!(end, SessionEnd::Unhealthy(_)), "a dead feed must end the session");
+        assert_eq!(run.totals.abandoned_rounds, 1);
+        // Only the offsets that completed before the feed died are recorded.
+        assert_eq!(
+            run.summary
+                .stats()
+                .iter()
+                .map(|s| s.offset)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unquotable_sample_skips_the_round_without_measuring() {
+        // No quote at block 0, so there is nothing to replay.
+        let mut script = vec![(None, None)];
+        script.extend((1..=5).map(|_| (Some(9_900), Some(9_950))));
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(2);
+        let mut run = state(2, pool.len());
+
+        let end = run_session(&solver, &config(2, 2, None), &pool, &mut run).await;
+        // The round is skipped, then the next round quotes fine and runs until the script ends.
+        assert!(matches!(end, SessionEnd::Unhealthy(_)));
+        assert_eq!(run.totals.unquotable, 2, "both sampled shapes failed to quote");
+        assert!(run.totals.rounds >= 1);
+    }
+
+    #[tokio::test]
+    async fn a_failed_replay_is_counted_and_leaves_no_measurement() {
+        let script = vec![(None, Some(10_000)), (None, Some(9_950)), (Some(9_900), Some(9_950))];
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(2, pool.len());
+
+        run_session(&solver, &config(1, 2, Some(2)), &pool, &mut run).await;
+
+        // Offset 1's replay failed; offset 2's succeeded.
+        assert_eq!(run.totals.simulation_failed, 1);
+        assert_eq!(
+            run.summary
+                .stats()
+                .iter()
+                .map(|s| s.offset)
+                .collect::<Vec<_>>(),
+            vec![2]
+        );
+        // The record still exists — a missing measurement stays attributable.
+        assert_eq!(run.totals.records, 2);
+    }
+
+    #[tokio::test]
+    async fn quoting_draws_from_the_sample_pool() {
+        let mut script = vec![(None, Some(10_000))];
+        script.extend((1..=2).map(|_| (Some(9_900), Some(9_950))));
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(8);
+        let mut run = state(2, pool.len());
+
+        run_session(&solver, &config(3, 2, Some(2)), &pool, &mut run).await;
+
+        let solved = solver.solved.lock().expect("lock");
+        // 3 quotes at block 0, then 3 fresh solves at each of 2 offsets.
+        assert_eq!(solved.len(), 9);
+        let quoted_amounts: Vec<U256> = solved[..3]
+            .iter()
+            .map(|(_, amount)| *amount)
+            .collect();
+        assert!(
+            quoted_amounts.iter().all(|amount| pool
+                .iter()
+                .any(|s| s.amount_in == *amount)),
+            "every quote must come from the pool"
+        );
+        // The same three trades are re-solved at each offset, so the market-movement reference is
+        // for the trade it is compared against.
+        assert_eq!(
+            solved[3..6]
+                .iter()
+                .map(|(t, _)| *t)
+                .collect::<Vec<_>>(),
+            solved[..3]
+                .iter()
+                .map(|(t, _)| *t)
+                .collect::<Vec<_>>()
+        );
+    }
+}

--- a/tools/hindsight/src/decay/mod.rs
+++ b/tools/hindsight/src/decay/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     },
     resolve::{
         jsonl::RotatingWriter,
-        session::{self, Session, SolverArgs},
+        session::{self, LagGuard, RpcHead, Session, SolverArgs},
         step::{Encoding, StepAdapter},
         Outcome, SteppingSolver,
     },
@@ -97,17 +97,30 @@ enum SessionEnd {
 /// Counters that survive feed rebuilds, so `--max-blocks` and the final tally span the whole run.
 #[derive(Default)]
 struct Totals {
-    /// Blocks whose measurement work completed, the unit `--max-blocks` counts.
+    /// Blocks whose work is accounted for — every offset measured or skipped, and every block
+    /// burned by an all-unquotable round — the unit `--max-blocks` counts. Not counted: the very
+    /// first bootstrap block (there is nothing to measure before a baseline exists) and the one
+    /// block a round's quote lands on between rounds. Both carry no measurement of their own, so
+    /// `--max-blocks` bounds measurement work exactly, even though the chain advances a little
+    /// further than the count alone suggests.
     blocks: u64,
     rounds: u64,
     /// Rounds abandoned because the feed died before their last offset.
     abandoned_rounds: u64,
+    /// Offsets skipped because the measured block did not land on `quote_block + offset` — a feed
+    /// gap or reorg moved the state further than that offset's worth. See [`measure_round`].
+    gapped_offsets: u64,
     records: u64,
     /// Sampled shapes the solver could not quote at all, so they never entered a round.
     unquotable: u64,
     pool_gone: u64,
     simulation_failed: u64,
     no_market_reference: u64,
+    zero_amount: u64,
+    /// Records whose `execution_slippage_bps` was clamped from a positive raw value to zero — the
+    /// fresh solve failing to reproduce a route it had itself found a few blocks earlier. The
+    /// solver-inconsistency rate; see [`record::DecayBps::execution_slippage_clamped`].
+    execution_slippage_clamped: u64,
 }
 
 impl Totals {
@@ -116,6 +129,7 @@ impl Totals {
             ReplayFailure::PoolGone => self.pool_gone += 1,
             ReplayFailure::SimulationFailed => self.simulation_failed += 1,
             ReplayFailure::NoMarketReference => self.no_market_reference += 1,
+            ReplayFailure::ZeroAmount => self.zero_amount += 1,
         }
     }
 }
@@ -134,14 +148,21 @@ pub(crate) async fn run(cfg: DecayArgs) -> anyhow::Result<()> {
         offsets: cfg.offsets,
         max_blocks: cfg.solver.max_blocks,
     };
+    // A separate provider from the one the solver builds internally: decay has no decoder of its
+    // own to hang a lag check off, unlike `monitor`, so it polls chain head directly.
+    let head_provider = crate::provider_from(&cfg.solver.chain.rpc_url)?;
+    let max_lag_blocks = cfg.solver.max_lag_blocks;
     let session = Session::prepare(cfg.solver).await?;
-    let block_budget = session::block_time(session.chain()).mul_f64(PACING_WARN_FRACTION);
+    let chain = session.chain();
+    let lag_guard = LagGuard::new(RpcHead::new(head_provider), chain, max_lag_blocks);
+    let block_budget = session::block_time(chain).mul_f64(PACING_WARN_FRACTION);
     info!(
         sample_size = cfg.sample_size,
         offsets = cfg.offsets,
         pool = shapes.len(),
         seed = cfg.seed,
         block_budget_ms = block_budget.as_millis(),
+        max_lag_blocks = max_lag_blocks.unwrap_or_else(|| session::default_lag_blocks(chain)),
         "measuring route decay in rounds"
     );
 
@@ -191,7 +212,7 @@ pub(crate) async fn run(cfg: DecayArgs) -> anyhow::Result<()> {
                 info!("received Ctrl-C; shutting down");
                 break;
             }
-            end = run_session(&adapter, &rounds, &shapes, &mut state) => match end {
+            end = run_session(&adapter, &rounds, &shapes, &mut state, Some(&lag_guard)) => match end {
                 SessionEnd::Complete => break,
                 SessionEnd::Unhealthy(reason) => reason,
             },
@@ -231,11 +252,15 @@ struct RunState {
 
 /// Drive one solver session: draw a sample, quote it, measure it across the configured offsets, and
 /// repeat until the run completes or the feed dies.
+///
+/// `lag_guard` is `None` in tests, which drive a mock with no chain head to poll against; the live
+/// run always passes one.
 async fn run_session<S: SteppingSolver + ?Sized>(
     adapter: &S,
     cfg: &RoundConfig,
     shapes: &[TradeShape],
     state: &mut RunState,
+    lag_guard: Option<&LagGuard>,
 ) -> SessionEnd {
     // A quote needs an applied state to be quoted against.
     if adapter.current_block().await.is_none() {
@@ -254,12 +279,24 @@ async fn run_session<S: SteppingSolver + ?Sized>(
             continue;
         };
 
-        let quoted = quote_round(adapter, cfg, shapes, state, quote_block).await;
+        if let Some(guard) = lag_guard {
+            if let Some((head, lag)) = guard.exceeded(quote_block).await {
+                return SessionEnd::Unhealthy(format!(
+                    "decay is {lag} blocks behind head {head}; presuming an unhealthy session"
+                ));
+            }
+        }
+
         state.totals.rounds += 1;
         let round_id = state.totals.rounds;
+        let quote_started = Instant::now();
+        let quoted = quote_round(adapter, cfg, shapes, state, quote_block).await;
+        warn_if_over_budget(state, quote_started.elapsed(), round_id, None, quoted.len());
+
         if quoted.is_empty() {
             // Nothing to replay, but the offsets must still elapse — otherwise the next round would
-            // quote against the very state this one did.
+            // quote against the very state this one did. Counted toward --max-blocks too: an
+            // unquotable sample pool would otherwise never terminate the run.
             warn!(
                 block = quote_block,
                 round_id, "no sampled trade could be quoted; skipping the round"
@@ -269,48 +306,7 @@ async fn run_session<S: SteppingSolver + ?Sized>(
                     return SessionEnd::Unhealthy(e.to_string());
                 }
             }
-            continue;
-        }
-
-        for offset in 1..=cfg.offsets {
-            if let Err(e) = adapter.advance().await {
-                // The round dies with the session: its remaining offsets would be measured against
-                // a rebuilt solver's states, which are not continuous with this
-                // round's quote.
-                state.totals.abandoned_rounds += 1;
-                return SessionEnd::Unhealthy(e.to_string());
-            }
-            let started = Instant::now();
-            let Some(measured_block) = adapter.current_block().await else {
-                warn!(round_id, offset, "no applied block after advancing; abandoning the round");
-                state.totals.abandoned_rounds += 1;
-                break;
-            };
-            let at = RoundAt { round_id, quote_block, measured_block, offset };
-            measure_offset(adapter, state, &quoted, at).await;
-
-            let elapsed = started.elapsed();
-            telemetry::record_block_seconds(elapsed.as_secs_f64());
-            if elapsed > state.block_budget {
-                warn!(
-                    round_id,
-                    offset,
-                    elapsed_ms = elapsed.as_millis(),
-                    budget_ms = state.block_budget.as_millis(),
-                    trades = quoted.len(),
-                    "measurement exceeded its per-block budget; lower --sample-size"
-                );
-            }
-
-            state.totals.blocks += 1;
-            info!(
-                block = measured_block,
-                round_id,
-                offset,
-                trades = quoted.len(),
-                elapsed_s = elapsed.as_secs_f64(),
-                "measured offset"
-            );
+            state.totals.blocks += u64::from(cfg.offsets);
             if cfg
                 .max_blocks
                 .is_some_and(|max| state.totals.blocks >= max)
@@ -318,7 +314,127 @@ async fn run_session<S: SteppingSolver + ?Sized>(
                 info!(blocks = state.totals.blocks, "reached --max-blocks");
                 return SessionEnd::Complete;
             }
+            continue;
         }
+
+        match measure_round(adapter, cfg, state, &quoted, round_id, quote_block).await {
+            RoundOutcome::End(end) => return end,
+            // Rare: advancing succeeded but the solver reported no block right after. Nothing to
+            // do but retry from the top; the next `current_block()` read decides what's next.
+            RoundOutcome::Abandoned => {}
+            // Advance once more so the next round's quote lands on a block none of this round's
+            // offsets measured — otherwise it would double up on the last offset's block (see the
+            // module doc: rounds must not overlap).
+            RoundOutcome::Measured => {
+                if let Err(e) = adapter.advance().await {
+                    return SessionEnd::Unhealthy(e.to_string());
+                }
+            }
+        }
+    }
+}
+
+/// How a round's offset-measuring loop in [`measure_round`] ended.
+enum RoundOutcome {
+    /// Every offset was measured or skipped for a gap; safe to advance once more before the next
+    /// round's quote.
+    Measured,
+    /// Abandoned partway through — the solver reported no block right after a successful
+    /// `advance()`. Rare, and not a feed death, so the outer loop just retries.
+    Abandoned,
+    /// The session should end now, either because the feed died or `--max-blocks` was reached.
+    End(SessionEnd),
+}
+
+/// Measure every offset of one round: advance a block, check it lands where expected, and measure
+/// it — or skip it and note the gap. Split out of [`run_session`] because the round-boundary
+/// bookkeeping (lag, quoting, `--max-blocks` on an empty round) and the offset-by-offset
+/// measurement are two different concerns.
+async fn measure_round<S: SteppingSolver + ?Sized>(
+    adapter: &S,
+    cfg: &RoundConfig,
+    state: &mut RunState,
+    quoted: &[QuotedTrade],
+    round_id: u64,
+    quote_block: u64,
+) -> RoundOutcome {
+    for offset in 1..=cfg.offsets {
+        if let Err(e) = adapter.advance().await {
+            // The round dies with the session: its remaining offsets would be measured against a
+            // rebuilt solver's states, which are not continuous with this round's quote.
+            state.totals.abandoned_rounds += 1;
+            return RoundOutcome::End(SessionEnd::Unhealthy(e.to_string()));
+        }
+        let Some(measured_block) = adapter.current_block().await else {
+            warn!(round_id, offset, "no applied block after advancing; abandoning the round");
+            state.totals.abandoned_rounds += 1;
+            return RoundOutcome::Abandoned;
+        };
+
+        // `advance()` only guarantees a strictly newer block, not the very next one: a feed gap or
+        // reorg can move the state further than one offset's worth. Once that happens the block
+        // number can only stay ahead (it never goes backward), so every later offset in this round
+        // would also land past its target — skip the measurement rather than file a longer move
+        // under a shorter offset. Mirrors the same check monitor.rs makes for its own back-of-block
+        // pairing.
+        let expected_block = quote_block + u64::from(offset);
+        if measured_block == expected_block {
+            let started = Instant::now();
+            let at = RoundAt { round_id, quote_block, measured_block, offset };
+            measure_offset(adapter, state, quoted, at).await;
+            warn_if_over_budget(state, started.elapsed(), round_id, Some(offset), quoted.len());
+            info!(
+                block = measured_block,
+                round_id,
+                offset,
+                trades = quoted.len(),
+                "measured offset"
+            );
+        } else {
+            warn!(
+                round_id,
+                offset,
+                quote_block,
+                expected_block,
+                measured_block,
+                "measured block does not match the expected offset (gap or reorg); skipping the \
+                 measurement"
+            );
+            state.totals.gapped_offsets += 1;
+        }
+
+        state.totals.blocks += 1;
+        if cfg
+            .max_blocks
+            .is_some_and(|max| state.totals.blocks >= max)
+        {
+            info!(blocks = state.totals.blocks, "reached --max-blocks");
+            return RoundOutcome::End(SessionEnd::Complete);
+        }
+    }
+    RoundOutcome::Measured
+}
+
+/// Record `elapsed`'s cost to telemetry and warn when it exceeded the run's per-block budget.
+/// Shared between the quote round (`offset: None`) and each offset's measurement, since both are
+/// one block's worth of solver work and either can be the one that runs hot.
+fn warn_if_over_budget(
+    state: &RunState,
+    elapsed: Duration,
+    round_id: u64,
+    offset: Option<u32>,
+    trades: usize,
+) {
+    telemetry::record_block_seconds(elapsed.as_secs_f64());
+    if elapsed > state.block_budget {
+        warn!(
+            round_id,
+            ?offset,
+            elapsed_ms = elapsed.as_millis(),
+            budget_ms = state.block_budget.as_millis(),
+            trades,
+            "block work exceeded its per-block budget; lower --sample-size"
+        );
     }
 }
 
@@ -386,12 +502,13 @@ async fn measure_offset<S: SteppingSolver + ?Sized>(
             }
         };
         // The fresh solve is the market-movement reference: what any router would have got at this
-        // state, so whatever the replay lost beyond it is down to the route being stale.
+        // state, so whatever the replay lost beyond it is down to the route being stale. Kept
+        // whole (not just its amount) so its route can be recorded alongside the amount.
         let fresh = match adapter
             .solve(trade.shape.token_in, trade.shape.token_out, trade.shape.amount_in)
             .await
         {
-            Outcome::Solved(quote) => Some(quote.amount_out),
+            Outcome::Solved(quote) => Some(quote),
             Outcome::Partial(_) | Outcome::Unsolvable(_) => None,
         };
         let record = DecayRecord::build(
@@ -409,6 +526,9 @@ async fn measure_offset<S: SteppingSolver + ?Sized>(
             state.totals.count_failure(failure);
         }
         if let Some(bps) = record.bps {
+            if bps.execution_slippage_clamped {
+                state.totals.execution_slippage_clamped += 1;
+            }
             state.summary.record(at.offset, bps);
         }
         records.push(record);
@@ -448,10 +568,13 @@ fn report(state: &RunState) {
         blocks = totals.blocks,
         records = totals.records,
         abandoned_rounds = totals.abandoned_rounds,
+        gapped_offsets = totals.gapped_offsets,
         unquotable_samples = totals.unquotable,
         pool_gone = totals.pool_gone,
         simulation_failed = totals.simulation_failed,
         no_market_reference = totals.no_market_reference,
+        zero_amount = totals.zero_amount,
+        execution_slippage_clamped = totals.execution_slippage_clamped,
         "decay run finished"
     );
     let stats = state.summary.stats();
@@ -492,9 +615,10 @@ mod tests {
 
     use alloy::primitives::{Address, U256};
     use async_trait::async_trait;
+    use tycho_simulation::tycho_common::models::Chain;
 
     use super::*;
-    use crate::resolve::SolvedAmount;
+    use crate::resolve::{session::HeadSource, SolvedAmount};
 
     /// A stepping mock that walks a scripted list of per-block outputs.
     ///
@@ -504,6 +628,11 @@ mod tests {
     struct ScriptedSolver {
         /// `(replayed, fresh)` per block, indexed by how many times `advance` has run.
         script: Vec<(Option<u64>, Option<u64>)>,
+        /// Block number reported at each step, indexed the same as `script`. Ordinarily
+        /// `1_000 + step`, but a gap test can override it via `with_blocks` to jump a step's block
+        /// number by more than one, without `advance` itself pretending to move more than one
+        /// block.
+        blocks: Vec<u64>,
         block: AtomicUsize,
         /// Every `(token_in, amount_in)` handed to `solve`, so a test can see what was quoted.
         solved: Mutex<Vec<(Address, U256)>>,
@@ -511,7 +640,17 @@ mod tests {
 
     impl ScriptedSolver {
         fn new(script: Vec<(Option<u64>, Option<u64>)>) -> Self {
-            Self { script, block: AtomicUsize::new(0), solved: Mutex::new(Vec::new()) }
+            let blocks = (0..script.len())
+                .map(|i| 1_000 + u64::try_from(i).unwrap_or(0))
+                .collect();
+            Self::with_blocks(script, blocks)
+        }
+
+        /// Like [`Self::new`], but `blocks[i]` is the block number reported at step `i` — letting a
+        /// test simulate a feed gap.
+        fn with_blocks(script: Vec<(Option<u64>, Option<u64>)>, blocks: Vec<u64>) -> Self {
+            assert_eq!(script.len(), blocks.len(), "one block number per scripted step");
+            Self { script, blocks, block: AtomicUsize::new(0), solved: Mutex::new(Vec::new()) }
         }
 
         fn step(&self) -> usize {
@@ -539,7 +678,7 @@ mod tests {
     #[async_trait]
     impl SteppingSolver for ScriptedSolver {
         async fn current_block(&self) -> Option<u64> {
-            Some(1_000 + u64::try_from(self.step()).unwrap_or(0))
+            self.blocks.get(self.step()).copied()
         }
 
         async fn solve(&self, token_in: Address, _: Address, amount_in: U256) -> Outcome {
@@ -606,7 +745,7 @@ mod tests {
         let mut run = state(5, pool.len());
 
         // --max-blocks equals the offsets, so the run stops exactly at the round's end.
-        let end = run_session(&solver, &config(1, 5, Some(5)), &pool, &mut run).await;
+        let end = run_session(&solver, &config(1, 5, Some(5)), &pool, &mut run, None).await;
         assert!(matches!(end, SessionEnd::Complete));
 
         let stats = run.summary.stats();
@@ -633,7 +772,7 @@ mod tests {
         let pool = shapes(1);
         let mut run = state(3, pool.len());
 
-        run_session(&solver, &config(1, 3, Some(3)), &pool, &mut run).await;
+        run_session(&solver, &config(1, 3, Some(3)), &pool, &mut run, None).await;
 
         for offset in run.summary.stats() {
             // -100 bps at every offset, all of it execution slippage (the fresh solve never moved).
@@ -655,7 +794,7 @@ mod tests {
         let pool = shapes(1);
         let mut run = state(3, pool.len());
 
-        run_session(&solver, &config(1, 3, Some(3)), &pool, &mut run).await;
+        run_session(&solver, &config(1, 3, Some(3)), &pool, &mut run, None).await;
 
         // The scripted solver reports block 1000+step, so a quote at 1000 must be measured at
         // 1001..1003 — a stuck measured_block would mean the loop reads the state before advancing.
@@ -671,7 +810,7 @@ mod tests {
         let pool = shapes(1);
         let mut run = state(5, pool.len());
 
-        let end = run_session(&solver, &config(1, 5, None), &pool, &mut run).await;
+        let end = run_session(&solver, &config(1, 5, None), &pool, &mut run, None).await;
         assert!(matches!(end, SessionEnd::Unhealthy(_)), "a dead feed must end the session");
         assert_eq!(run.totals.abandoned_rounds, 1);
         // Only the offsets that completed before the feed died are recorded.
@@ -694,7 +833,7 @@ mod tests {
         let pool = shapes(2);
         let mut run = state(2, pool.len());
 
-        let end = run_session(&solver, &config(2, 2, None), &pool, &mut run).await;
+        let end = run_session(&solver, &config(2, 2, None), &pool, &mut run, None).await;
         // The round is skipped, then the next round quotes fine and runs until the script ends.
         assert!(matches!(end, SessionEnd::Unhealthy(_)));
         assert_eq!(run.totals.unquotable, 2, "both sampled shapes failed to quote");
@@ -708,7 +847,7 @@ mod tests {
         let pool = shapes(1);
         let mut run = state(2, pool.len());
 
-        run_session(&solver, &config(1, 2, Some(2)), &pool, &mut run).await;
+        run_session(&solver, &config(1, 2, Some(2)), &pool, &mut run, None).await;
 
         // Offset 1's replay failed; offset 2's succeeded.
         assert_eq!(run.totals.simulation_failed, 1);
@@ -732,7 +871,7 @@ mod tests {
         let pool = shapes(8);
         let mut run = state(2, pool.len());
 
-        run_session(&solver, &config(3, 2, Some(2)), &pool, &mut run).await;
+        run_session(&solver, &config(3, 2, Some(2)), &pool, &mut run, None).await;
 
         let solved = solver.solved.lock().expect("lock");
         // 3 quotes at block 0, then 3 fresh solves at each of 2 offsets.
@@ -759,5 +898,85 @@ mod tests {
                 .map(|(t, _)| *t)
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[tokio::test]
+    async fn a_block_gap_skips_every_offset_it_contaminates() {
+        // Quote at block 1000 (step 0). The feed then skips straight to 1002 at step 1 — a
+        // two-block gap — so offset 1 (expected 1001) is contaminated, and offset 2 inherits the
+        // same gap since block numbers only move forward, never back.
+        let script =
+            vec![(None, Some(10_000)), (Some(9_900), Some(9_950)), (Some(9_800), Some(9_900))];
+        let blocks = vec![1_000, 1_002, 1_003];
+        let solver = ScriptedSolver::with_blocks(script, blocks);
+        let pool = shapes(1);
+        let mut run = state(2, pool.len());
+
+        let end = run_session(&solver, &config(1, 2, Some(2)), &pool, &mut run, None).await;
+        assert!(matches!(end, SessionEnd::Complete));
+        assert_eq!(
+            run.totals.gapped_offsets, 2,
+            "both offsets are contaminated by the earlier gap"
+        );
+        assert!(run.summary.stats().is_empty(), "a gapped round must not contaminate the summary");
+        // Both blocks still count toward --max-blocks even though neither produced a measurement.
+        assert_eq!(run.totals.blocks, 2);
+    }
+
+    #[tokio::test]
+    async fn an_unquotable_run_still_terminates_at_max_blocks() {
+        // Every round is unquotable (fresh is always None), so nothing is ever measured — but
+        // --max-blocks must still bound the run, or it would spin forever.
+        let script: Vec<(Option<u64>, Option<u64>)> = (0..=10).map(|_| (None, None)).collect();
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(3, pool.len());
+
+        let end = run_session(&solver, &config(1, 3, Some(3)), &pool, &mut run, None).await;
+        assert!(matches!(end, SessionEnd::Complete), "an unquotable run must still terminate");
+        assert_eq!(run.totals.blocks, 3);
+        assert_eq!(run.totals.records, 0);
+    }
+
+    #[tokio::test]
+    async fn a_clamped_execution_slippage_is_still_counted() {
+        // The held route (replayed 9_950) beats the fresh solve (9_900) at the same state —
+        // solver noise, clamped to zero rather than recorded as a gain — but the run must still be
+        // able to report how often that happened.
+        let script = vec![(None, Some(10_000)), (Some(9_950), Some(9_900))];
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(1, pool.len());
+
+        run_session(&solver, &config(1, 1, Some(1)), &pool, &mut run, None).await;
+
+        assert_eq!(run.totals.execution_slippage_clamped, 1);
+        assert_eq!(run.summary.stats()[0].count, 1);
+    }
+
+    struct FixedHead(u64);
+
+    #[async_trait]
+    impl HeadSource for FixedHead {
+        async fn head(&self) -> Option<u64> {
+            Some(self.0)
+        }
+    }
+
+    #[tokio::test]
+    async fn a_lagging_head_ends_the_session_as_unhealthy() {
+        let mut script = vec![(None, Some(10_000))];
+        script.extend((1..=5).map(|_| (Some(9_900), Some(9_950))));
+        let solver = ScriptedSolver::new(script);
+        let pool = shapes(1);
+        let mut run = state(5, pool.len());
+        // The mock reports block 1000 at step 0; a head of 10_100 is hopelessly far ahead of a
+        // 10-block budget.
+        let guard = LagGuard::new(FixedHead(10_100), Chain::Ethereum, Some(10));
+
+        let end = run_session(&solver, &config(1, 5, None), &pool, &mut run, Some(&guard)).await;
+        assert!(matches!(end, SessionEnd::Unhealthy(_)));
+        // The lag check runs before quoting, so no round should have started.
+        assert_eq!(run.totals.rounds, 0);
     }
 }

--- a/tools/hindsight/src/decay/record.rs
+++ b/tools/hindsight/src/decay/record.rs
@@ -1,0 +1,335 @@
+//! One measurement of a quoted route replayed `offset` blocks later, and its JSONL projection.
+
+use alloy::primitives::{Address, U256};
+use fynd_tools_common::bps::raw_bps_diff;
+use num_bigint::BigUint;
+use serde::Serialize;
+
+use crate::{decay::sample::TradeShape, resolve::SolvedAmount};
+
+/// Why a replay produced no measurement. Kept apart from a plain error string because a pool
+/// leaving the feed is a distinct, meaningful outcome — the route became unexecutable, which is
+/// itself the revert signal we are looking for — rather than noise to be lumped in with a
+/// simulation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReplayFailure {
+    /// A pool in the route no longer has simulation state: it was removed by the feed or filtered
+    /// out since the quote. The route could not have executed at this block.
+    PoolGone,
+    /// The route replayed but a pool's simulation failed, or the replay returned nothing usable.
+    SimulationFailed,
+    /// The fresh solve at this block found no route, so market movement has no reference and the
+    /// decomposition cannot be computed.
+    NoMarketReference,
+}
+
+impl ReplayFailure {
+    /// Classify a `reexecute` failure string. `fynd_core::ReplayError::MissingState` renders as
+    /// "no simulation state for component …", which is the one case we separate out.
+    pub(crate) fn classify(reason: &str) -> Self {
+        if reason.contains("no simulation state for component") {
+            Self::PoolGone
+        } else {
+            Self::SimulationFailed
+        }
+    }
+}
+
+/// The three bps figures for one (trade, offset) measurement.
+///
+/// Sign convention follows hindsight's [`crate::resolve::Slippage`]: **positive means surplus** —
+/// the later state produced more output than the original quote. PR #297 reported the opposite
+/// (positive = decay), so flip these before comparing against its Ethereum numbers.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[expect(
+    clippy::struct_field_names,
+    reason = "the _bps suffix is the unit, and dropping it from a struct of three bare f64s is \
+              exactly how a bps figure gets mistaken for a ratio"
+)]
+pub(crate) struct DecayBps {
+    /// The quoted route replayed at the later state, against its own original quote. The total
+    /// move: market drift plus whatever the route lost by being stale.
+    pub route_slippage_bps: f64,
+    /// A freshly solved quote at the later state, against the original quote. The part of the move
+    /// that any router would have suffered — unavoidable market drift.
+    pub market_movement_bps: f64,
+    /// `route_slippage_bps - market_movement_bps`: the part specific to holding a stale route,
+    /// which better routing or faster submission could recover. Negative means the stale route
+    /// underperformed a fresh solve.
+    pub execution_slippage_bps: f64,
+}
+
+impl DecayBps {
+    /// Build the decomposition from three amounts in the output token's units.
+    ///
+    /// Returns `None` when the original quote is zero, which leaves every ratio undefined.
+    pub(crate) fn new(quoted: U256, replayed: U256, fresh: U256) -> Option<Self> {
+        let route_slippage_bps = bps_against(quoted, replayed)?;
+        let market_movement_bps = bps_against(quoted, fresh)?;
+        Some(Self {
+            route_slippage_bps,
+            market_movement_bps,
+            execution_slippage_bps: route_slippage_bps - market_movement_bps,
+        })
+    }
+}
+
+/// `later` versus `quoted`, in bps, positive when `later` is larger.
+///
+/// `raw_bps_diff(baseline, other)` computes `(baseline - other) / other`, so passing the later
+/// amount as the baseline and the original quote as `other` yields "how much more the later state
+/// produced", matching [`crate::resolve::compare::slippage`]'s convention.
+fn bps_against(quoted: U256, later: U256) -> Option<f64> {
+    raw_bps_diff(&to_biguint(later), &to_biguint(quoted))
+}
+
+/// Convert an alloy `U256` to `BigUint` big-endian, without a decimal string round-trip.
+fn to_biguint(amount: U256) -> BigUint {
+    BigUint::from_bytes_be(&amount.to_be_bytes::<32>())
+}
+
+/// One measurement: a trade quoted at `quote_block`, replayed at `measured_block`.
+///
+/// Every record carries either `bps` (a complete measurement) or `failure` (why there is none), so
+/// a missing measurement is always attributable rather than silently absent from the output.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DecayRecord {
+    /// Groups the offsets measured from one quote, and one sample, together.
+    pub round_id: u64,
+    /// How many blocks after the quote this measurement was taken, `1..=offsets`.
+    pub offset: u32,
+    /// The block whose state the route was quoted against.
+    pub quote_block: u64,
+    /// The block whose state the route was replayed against.
+    pub measured_block: u64,
+    pub token_in: Address,
+    pub token_out: Address,
+    /// Decimal string: an exact `U256` does not survive JSON's number type.
+    pub amount_in: String,
+    /// The original quote's output at `quote_block`.
+    pub quoted_amount_out: String,
+    /// The same route's output replayed at `measured_block`. Absent when the replay failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replayed_amount_out: Option<String>,
+    /// A fresh solve's output at `measured_block`, the market-movement reference. Absent when the
+    /// fresh solve found no route.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fresh_amount_out: Option<String>,
+    /// The decomposition. Absent when either leg is missing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bps: Option<DecayBps>,
+    /// Why this measurement has no `bps`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure: Option<ReplayFailure>,
+    /// The algorithm that produced the original quote.
+    pub algorithm: String,
+}
+
+/// Everything a round holds about one quoted trade, so each of its offsets can be measured against
+/// the same original quote.
+///
+/// `quote` is kept whole because [`crate::resolve::SteppingSolver::reexecute`] replays
+/// `quote.solved_route` — the round holds the route itself for its whole lifetime, which is what
+/// makes "the same route, later" measurable at all.
+pub(crate) struct QuotedTrade {
+    pub shape: TradeShape,
+    pub quote: SolvedAmount,
+}
+
+impl QuotedTrade {
+    /// The output this route was quoted at, the baseline every offset is measured against.
+    pub(crate) fn quoted_amount_out(&self) -> U256 {
+        self.quote.amount_out
+    }
+}
+
+/// Where a measurement is built from: the quoted trade plus this offset's two outputs.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Measurement {
+    pub round_id: u64,
+    pub offset: u32,
+    pub quote_block: u64,
+    pub measured_block: u64,
+    /// The replayed output, or why the replay produced none.
+    pub replayed: Result<U256, ReplayFailure>,
+    /// The fresh solve's output, or `None` when it found no route.
+    pub fresh: Option<U256>,
+}
+
+impl DecayRecord {
+    /// Project a measurement into a record, computing the decomposition when both legs are present.
+    pub(crate) fn build(trade: &QuotedTrade, measurement: Measurement) -> Self {
+        let replayed = measurement.replayed.ok();
+        // A failed replay is the more specific diagnosis, so it wins over a missing fresh solve.
+        let failure = match (measurement.replayed, measurement.fresh) {
+            (Err(failure), _) => Some(failure),
+            (Ok(_), None) => Some(ReplayFailure::NoMarketReference),
+            (Ok(_), Some(_)) => None,
+        };
+        let bps = match (replayed, measurement.fresh) {
+            (Some(replayed), Some(fresh)) => {
+                DecayBps::new(trade.quoted_amount_out(), replayed, fresh)
+            }
+            _ => None,
+        };
+        Self {
+            round_id: measurement.round_id,
+            offset: measurement.offset,
+            quote_block: measurement.quote_block,
+            measured_block: measurement.measured_block,
+            token_in: trade.shape.token_in,
+            token_out: trade.shape.token_out,
+            amount_in: trade.shape.amount_in.to_string(),
+            quoted_amount_out: trade.quoted_amount_out().to_string(),
+            replayed_amount_out: replayed.map(|a| a.to_string()),
+            fresh_amount_out: measurement.fresh.map(|a| a.to_string()),
+            bps,
+            failure,
+            algorithm: trade.quote.algorithm.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shape() -> TradeShape {
+        TradeShape {
+            token_in: Address::repeat_byte(0x11),
+            token_out: Address::repeat_byte(0x22),
+            amount_in: U256::from(1_000),
+        }
+    }
+
+    fn trade(quoted: u64) -> QuotedTrade {
+        QuotedTrade {
+            shape: shape(),
+            quote: SolvedAmount {
+                amount_out: U256::from(quoted),
+                amount_out_net_gas: U256::from(quoted),
+                gas_estimate: U256::from(21_000),
+                algorithm: "bellman_ford".to_string(),
+                quote_json: None,
+                solved_route: None,
+            },
+        }
+    }
+
+    fn measurement(replayed: Result<U256, ReplayFailure>, fresh: Option<U256>) -> Measurement {
+        Measurement {
+            round_id: 3,
+            offset: 2,
+            quote_block: 100,
+            measured_block: 102,
+            replayed,
+            fresh,
+        }
+    }
+
+    #[test]
+    fn decomposition_identity_holds() {
+        // Whatever the inputs, the two parts must sum back to the total.
+        let bps = DecayBps::new(U256::from(10_000), U256::from(9_900), U256::from(9_950))
+            .expect("decomposable");
+        assert!(
+            (bps.route_slippage_bps - (bps.market_movement_bps + bps.execution_slippage_bps)).abs() <
+                1e-9
+        );
+    }
+
+    #[test]
+    fn positive_means_surplus() {
+        // Replayed above the quote is a surplus, matching resolve::compare::slippage's convention.
+        let up = DecayBps::new(U256::from(10_000), U256::from(10_050), U256::from(10_000))
+            .expect("decomposable");
+        assert!((up.route_slippage_bps - 50.0).abs() < 0.01, "got {}", up.route_slippage_bps);
+
+        let down = DecayBps::new(U256::from(10_000), U256::from(9_900), U256::from(10_000))
+            .expect("decomposable");
+        assert!((down.route_slippage_bps + 100.0).abs() < 0.01, "got {}", down.route_slippage_bps);
+    }
+
+    #[test]
+    fn market_movement_absorbs_a_drift_both_legs_saw() {
+        // The whole move was market drift: a fresh solve at the later block fell just as far, so
+        // nothing is attributable to the route being stale.
+        let bps = DecayBps::new(U256::from(10_000), U256::from(9_900), U256::from(9_900))
+            .expect("decomposable");
+        assert!((bps.market_movement_bps + 100.0).abs() < 0.01);
+        assert!(bps.execution_slippage_bps.abs() < 1e-9, "drift must not count as execution loss");
+    }
+
+    #[test]
+    fn execution_slippage_isolates_the_stale_route() {
+        // The market did not move (fresh == quoted) but the held route lost 100 bps: all of it is
+        // execution slippage.
+        let bps = DecayBps::new(U256::from(10_000), U256::from(9_900), U256::from(10_000))
+            .expect("decomposable");
+        assert!(bps.market_movement_bps.abs() < 1e-9);
+        assert!((bps.execution_slippage_bps + 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn zero_quote_is_not_decomposable() {
+        assert_eq!(DecayBps::new(U256::ZERO, U256::from(10), U256::from(10)), None);
+    }
+
+    #[test]
+    fn missing_state_classifies_as_pool_gone() {
+        // The exact wording fynd_core::ReplayError::MissingState renders.
+        assert_eq!(
+            ReplayFailure::classify("re-execution failed: no simulation state for component 0xabc"),
+            ReplayFailure::PoolGone
+        );
+        assert_eq!(
+            ReplayFailure::classify("re-execution failed: simulation failed on component 0xabc"),
+            ReplayFailure::SimulationFailed
+        );
+    }
+
+    #[test]
+    fn record_carries_bps_when_both_legs_are_present() {
+        let record = DecayRecord::build(
+            &trade(10_000),
+            measurement(Ok(U256::from(9_900)), Some(U256::from(9_950))),
+        );
+        assert!(record.bps.is_some());
+        assert_eq!(record.failure, None);
+        assert_eq!(record.offset, 2);
+        assert_eq!(record.measured_block, 102);
+        assert_eq!(record.replayed_amount_out.as_deref(), Some("9900"));
+        assert_eq!(record.fresh_amount_out.as_deref(), Some("9950"));
+    }
+
+    #[test]
+    fn record_reports_the_replay_failure_over_a_missing_reference() {
+        // Both legs missing: the replay failure is the more specific diagnosis.
+        let record =
+            DecayRecord::build(&trade(10_000), measurement(Err(ReplayFailure::PoolGone), None));
+        assert_eq!(record.failure, Some(ReplayFailure::PoolGone));
+        assert_eq!(record.bps, None);
+        assert_eq!(record.replayed_amount_out, None);
+    }
+
+    #[test]
+    fn record_reports_a_missing_market_reference() {
+        let record = DecayRecord::build(&trade(10_000), measurement(Ok(U256::from(9_900)), None));
+        assert_eq!(record.failure, Some(ReplayFailure::NoMarketReference));
+        assert_eq!(record.bps, None);
+        // The replayed amount is still recorded — only the decomposition is missing.
+        assert_eq!(record.replayed_amount_out.as_deref(), Some("9900"));
+    }
+
+    #[test]
+    fn json_omits_absent_fields_and_keeps_amounts_as_strings() {
+        let record =
+            DecayRecord::build(&trade(10_000), measurement(Err(ReplayFailure::PoolGone), None));
+        let json = serde_json::to_string(&record).expect("serializable");
+        assert!(json.contains(r#""failure":"pool_gone""#), "{json}");
+        assert!(json.contains(r#""amount_in":"1000""#), "{json}");
+        assert!(!json.contains("replayed_amount_out"), "absent legs must be omitted: {json}");
+        assert!(!json.contains(r#""bps""#), "{json}");
+    }
+}

--- a/tools/hindsight/src/decay/record.rs
+++ b/tools/hindsight/src/decay/record.rs
@@ -5,7 +5,10 @@ use fynd_tools_common::bps::raw_bps_diff;
 use num_bigint::BigUint;
 use serde::Serialize;
 
-use crate::{decay::sample::TradeShape, resolve::SolvedAmount};
+use crate::{
+    decay::sample::TradeShape,
+    resolve::{render_route, SolvedAmount},
+};
 
 /// Why a replay produced no measurement. Kept apart from a plain error string because a pool
 /// leaving the feed is a distinct, meaningful outcome — the route became unexecutable, which is
@@ -22,6 +25,11 @@ pub(crate) enum ReplayFailure {
     /// The fresh solve at this block found no route, so market movement has no reference and the
     /// decomposition cannot be computed.
     NoMarketReference,
+    /// The replay and the fresh solve both succeeded, but the quoted, replayed, or fresh amount
+    /// was zero, so [`DecayBps::new`] could not form a ratio. A zero replayed amount is itself the
+    /// extreme decay case — the held route became worthless — so this is marked as a failure
+    /// rather than silently dropped, which would make the reported tail optimistic.
+    ZeroAmount,
 }
 
 impl ReplayFailure {
@@ -42,11 +50,6 @@ impl ReplayFailure {
 /// the later state produced more output than the original quote. PR #297 reported the opposite
 /// (positive = decay), so flip these before comparing against its Ethereum numbers.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize)]
-#[expect(
-    clippy::struct_field_names,
-    reason = "the _bps suffix is the unit, and dropping it from a struct of three bare f64s is \
-              exactly how a bps figure gets mistaken for a ratio"
-)]
 pub(crate) struct DecayBps {
     /// The quoted route replayed at the later state, against its own original quote. The total
     /// move: market drift plus whatever the route lost by being stale.
@@ -54,23 +57,38 @@ pub(crate) struct DecayBps {
     /// A freshly solved quote at the later state, against the original quote. The part of the move
     /// that any router would have suffered — unavoidable market drift.
     pub market_movement_bps: f64,
-    /// `route_slippage_bps - market_movement_bps`: the part specific to holding a stale route,
-    /// which better routing or faster submission could recover. Negative means the stale route
-    /// underperformed a fresh solve.
+    /// `route_slippage_bps - market_movement_bps`, clamped at zero: the part specific to holding
+    /// a stale route, which better routing or faster submission could recover. Negative means the
+    /// stale route underperformed a fresh solve. Never positive — see
+    /// [`Self::execution_slippage_clamped`].
     pub execution_slippage_bps: f64,
+    /// Whether the raw `route_slippage_bps - market_movement_bps` was positive — the held route
+    /// beating a fresh solve at the same state — before it was clamped to zero. A real in-block
+    /// solver holds the original route and takes the better of the two, so its outcome is
+    /// `max(replayed, fresh)`; a fresh solve that comes back worse than the route it already found
+    /// a few blocks earlier is the solver failing to reproduce its own result, not a genuine
+    /// opportunity the route missed. Left uncancelled, these wrong-sign cases average against the
+    /// real losses and understate the reported decay. Kept on the record (rather than dropped) so
+    /// the solver-inconsistency rate stays visible and offline analysis can still see the raw
+    /// signal.
+    pub execution_slippage_clamped: bool,
 }
 
 impl DecayBps {
     /// Build the decomposition from three amounts in the output token's units.
     ///
-    /// Returns `None` when the original quote is zero, which leaves every ratio undefined.
+    /// Returns `None` when the quoted, replayed, or fresh amount is zero: `raw_bps_diff` treats a
+    /// zero on either side of a ratio as undefined, and every one of the three amounts appears as
+    /// one side of the two ratios below.
     pub(crate) fn new(quoted: U256, replayed: U256, fresh: U256) -> Option<Self> {
         let route_slippage_bps = bps_against(quoted, replayed)?;
         let market_movement_bps = bps_against(quoted, fresh)?;
+        let raw_execution_slippage_bps = route_slippage_bps - market_movement_bps;
         Some(Self {
             route_slippage_bps,
             market_movement_bps,
-            execution_slippage_bps: route_slippage_bps - market_movement_bps,
+            execution_slippage_bps: raw_execution_slippage_bps.min(0.0),
+            execution_slippage_clamped: raw_execution_slippage_bps > 0.0,
         })
     }
 }
@@ -79,7 +97,7 @@ impl DecayBps {
 ///
 /// `raw_bps_diff(baseline, other)` computes `(baseline - other) / other`, so passing the later
 /// amount as the baseline and the original quote as `other` yields "how much more the later state
-/// produced", matching [`crate::resolve::compare::slippage`]'s convention.
+/// produced", matching `resolve::compare::slippage`'s convention.
 fn bps_against(quoted: U256, later: U256) -> Option<f64> {
     raw_bps_diff(&to_biguint(later), &to_biguint(quoted))
 }
@@ -122,8 +140,18 @@ pub(crate) struct DecayRecord {
     /// Why this measurement has no `bps`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub failure: Option<ReplayFailure>,
-    /// The algorithm that produced the original quote.
-    pub algorithm: String,
+    /// The algorithm that produced the quote whose route is being tested for staleness — the same
+    /// value carried on every offset of a round, since every offset replays the same quote.
+    pub quote_algorithm: String,
+    /// The fresh solve's route at `measured_block`, rendered as a readable path (see
+    /// [`crate::resolve::render_route`]). Absent when the fresh solve found no route.
+    ///
+    /// Recorded so two situations that `execution_slippage_bps` alone cannot tell apart become
+    /// distinguishable: the fresh solve finding a genuinely different, better route (a real,
+    /// measurable gain) versus returning the same route with a different number (solver
+    /// inconsistency — see [`DecayBps::execution_slippage_clamped`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fresh_route: Option<String>,
 }
 
 /// Everything a round holds about one quoted trade, so each of its offsets can be measured against
@@ -144,8 +172,8 @@ impl QuotedTrade {
     }
 }
 
-/// Where a measurement is built from: the quoted trade plus this offset's two outputs.
-#[derive(Debug, Clone, Copy)]
+/// Where a measurement is built from: the quoted trade plus this offset's two outcomes.
+#[derive(Debug, Clone)]
 pub(crate) struct Measurement {
     pub round_id: u64,
     pub offset: u32,
@@ -153,40 +181,53 @@ pub(crate) struct Measurement {
     pub measured_block: u64,
     /// The replayed output, or why the replay produced none.
     pub replayed: Result<U256, ReplayFailure>,
-    /// The fresh solve's output, or `None` when it found no route.
-    pub fresh: Option<U256>,
+    /// The fresh solve's full outcome, kept whole (not just its `amount_out`) so its route can be
+    /// recorded alongside its amount. `None` when it found no route.
+    pub fresh: Option<SolvedAmount>,
 }
 
 impl DecayRecord {
-    /// Project a measurement into a record, computing the decomposition when both legs are present.
+    /// Project a measurement into a record, computing the decomposition when both legs are present
+    /// and non-zero.
     pub(crate) fn build(trade: &QuotedTrade, measurement: Measurement) -> Self {
-        let replayed = measurement.replayed.ok();
-        // A failed replay is the more specific diagnosis, so it wins over a missing fresh solve.
-        let failure = match (measurement.replayed, measurement.fresh) {
-            (Err(failure), _) => Some(failure),
-            (Ok(_), None) => Some(ReplayFailure::NoMarketReference),
-            (Ok(_), Some(_)) => None,
-        };
-        let bps = match (replayed, measurement.fresh) {
+        let Measurement { round_id, offset, quote_block, measured_block, replayed, fresh } =
+            measurement;
+        let replayed_amount = replayed.ok();
+        let fresh_amount = fresh.as_ref().map(|f| f.amount_out);
+        let bps = match (replayed_amount, fresh_amount) {
             (Some(replayed), Some(fresh)) => {
                 DecayBps::new(trade.quoted_amount_out(), replayed, fresh)
             }
             _ => None,
         };
+        // A failed replay is the more specific diagnosis, so it wins over a missing fresh solve,
+        // which in turn wins over a decomposition that silently rejected a zero amount — every
+        // record ends up with exactly one of `bps` or `failure`.
+        let failure = match (&replayed, &fresh) {
+            (Err(failure), _) => Some(*failure),
+            (Ok(_), None) => Some(ReplayFailure::NoMarketReference),
+            (Ok(_), Some(_)) if bps.is_none() => Some(ReplayFailure::ZeroAmount),
+            (Ok(_), Some(_)) => None,
+        };
+        let fresh_route = fresh
+            .as_ref()
+            .and_then(|f| f.solved_route.as_deref())
+            .map(render_route);
         Self {
-            round_id: measurement.round_id,
-            offset: measurement.offset,
-            quote_block: measurement.quote_block,
-            measured_block: measurement.measured_block,
+            round_id,
+            offset,
+            quote_block,
+            measured_block,
             token_in: trade.shape.token_in,
             token_out: trade.shape.token_out,
             amount_in: trade.shape.amount_in.to_string(),
             quoted_amount_out: trade.quoted_amount_out().to_string(),
-            replayed_amount_out: replayed.map(|a| a.to_string()),
-            fresh_amount_out: measurement.fresh.map(|a| a.to_string()),
+            replayed_amount_out: replayed_amount.map(|a| a.to_string()),
+            fresh_amount_out: fresh_amount.map(|a| a.to_string()),
             bps,
             failure,
-            algorithm: trade.quote.algorithm.clone(),
+            quote_algorithm: trade.quote.algorithm.clone(),
+            fresh_route,
         }
     }
 }
@@ -217,7 +258,10 @@ mod tests {
         }
     }
 
-    fn measurement(replayed: Result<U256, ReplayFailure>, fresh: Option<U256>) -> Measurement {
+    fn measurement(
+        replayed: Result<U256, ReplayFailure>,
+        fresh: Option<SolvedAmount>,
+    ) -> Measurement {
         Measurement {
             round_id: 3,
             offset: 2,
@@ -228,11 +272,28 @@ mod tests {
         }
     }
 
+    /// A fresh solve's outcome carrying just an amount and no route — the common case for tests
+    /// exercising the decomposition rather than the route projection (see
+    /// `fresh_route_is_rendered_from_the_fresh_solves_route`).
+    fn fresh_solve(amount_out: u64) -> SolvedAmount {
+        SolvedAmount {
+            amount_out: U256::from(amount_out),
+            amount_out_net_gas: U256::from(amount_out),
+            gas_estimate: U256::from(21_000),
+            algorithm: "most_liquid".to_string(),
+            quote_json: None,
+            solved_route: None,
+        }
+    }
+
     #[test]
-    fn decomposition_identity_holds() {
-        // Whatever the inputs, the two parts must sum back to the total.
+    fn decomposition_identity_holds_when_not_clamped() {
+        // Whatever the inputs, the two parts must sum back to the total — as long as the raw
+        // execution slippage is not positive (see execution_slippage_is_clamped_at_zero_when_...
+        // below for the clamped case, where the identity does not hold by design).
         let bps = DecayBps::new(U256::from(10_000), U256::from(9_900), U256::from(9_950))
             .expect("decomposable");
+        assert!(!bps.execution_slippage_clamped);
         assert!(
             (bps.route_slippage_bps - (bps.market_movement_bps + bps.execution_slippage_bps)).abs() <
                 1e-9
@@ -277,6 +338,21 @@ mod tests {
     }
 
     #[test]
+    fn execution_slippage_is_clamped_at_zero_when_the_stale_route_beats_a_fresh_solve() {
+        // The held route (replayed 9_950) outperforms a fresh solve (9_900) at the same state.
+        // That is solver noise, not a real opportunity: a real in-block solver already holds the
+        // better of the two, so the physical outcome is never worse than the held route.
+        let bps = DecayBps::new(U256::from(10_000), U256::from(9_950), U256::from(9_900))
+            .expect("decomposable");
+        assert!(bps.execution_slippage_clamped);
+        assert!(
+            bps.execution_slippage_bps.abs() < 1e-9,
+            "must clamp to zero, got {}",
+            bps.execution_slippage_bps
+        );
+    }
+
+    #[test]
     fn missing_state_classifies_as_pool_gone() {
         // The exact wording fynd_core::ReplayError::MissingState renders.
         assert_eq!(
@@ -290,10 +366,20 @@ mod tests {
     }
 
     #[test]
+    fn missing_state_error_renders_to_the_string_classify_matches_on() {
+        // Guards the wording `classify` depends on against the real `fynd_core` error rather than
+        // a hand-written copy: if `ReplayError::MissingState`'s `#[error(...)]` attribute is ever
+        // reworded, this test — not just the one above — must catch it.
+        let error = fynd_core::ReplayError::MissingState("0xabc".to_string());
+        let rendered = format!("re-execution failed: {error}");
+        assert_eq!(ReplayFailure::classify(&rendered), ReplayFailure::PoolGone);
+    }
+
+    #[test]
     fn record_carries_bps_when_both_legs_are_present() {
         let record = DecayRecord::build(
             &trade(10_000),
-            measurement(Ok(U256::from(9_900)), Some(U256::from(9_950))),
+            measurement(Ok(U256::from(9_900)), Some(fresh_solve(9_950))),
         );
         assert!(record.bps.is_some());
         assert_eq!(record.failure, None);
@@ -320,6 +406,45 @@ mod tests {
         assert_eq!(record.bps, None);
         // The replayed amount is still recorded — only the decomposition is missing.
         assert_eq!(record.replayed_amount_out.as_deref(), Some("9900"));
+    }
+
+    #[test]
+    fn a_zero_replayed_amount_is_reported_as_a_failure_not_silently_dropped() {
+        // A replayed amount of zero is the extreme decay case — the held route became worthless —
+        // and DecayBps::new rejects the zero, so without this classification the record would
+        // carry neither `bps` nor `failure`, contradicting DecayRecord's own invariant and
+        // silently dropping the worst observations from the tail statistics.
+        let record = DecayRecord::build(
+            &trade(10_000),
+            measurement(Ok(U256::ZERO), Some(fresh_solve(9_950))),
+        );
+        assert_eq!(record.failure, Some(ReplayFailure::ZeroAmount));
+        assert_eq!(record.bps, None);
+        // The zero is still recorded — only the decomposition is missing.
+        assert_eq!(record.replayed_amount_out.as_deref(), Some("0"));
+    }
+
+    #[test]
+    fn fresh_route_is_rendered_from_the_fresh_solves_route() {
+        let fresh = SolvedAmount {
+            solved_route: Some(Box::new(crate::resolve::test_support::route(&[(
+                "uniswap_v2",
+                "USDT",
+                "DAI",
+            )]))),
+            ..fresh_solve(9_950)
+        };
+        let record =
+            DecayRecord::build(&trade(10_000), measurement(Ok(U256::from(9_900)), Some(fresh)));
+        assert_eq!(record.fresh_route.as_deref(), Some("USDT -[uniswap_v2]-> DAI"));
+        // The quote's own algorithm is still carried, distinctly named from the fresh route.
+        assert_eq!(record.quote_algorithm, "bellman_ford");
+    }
+
+    #[test]
+    fn fresh_route_is_absent_when_the_fresh_solve_found_none() {
+        let record = DecayRecord::build(&trade(10_000), measurement(Ok(U256::from(9_900)), None));
+        assert_eq!(record.fresh_route, None);
     }
 
     #[test]

--- a/tools/hindsight/src/decay/sample.rs
+++ b/tools/hindsight/src/decay/sample.rs
@@ -1,0 +1,354 @@
+//! Trade shapes drawn from a `monitor` run's comparison JSONL.
+//!
+//! Only the **shape** of a settled trade is taken — its token pair and input amount. Nothing about
+//! how it settled is read: not the settled amounts, not the `top`/`back` outcomes, and above all
+//! not the existing `slippage` field, which measures a route replayed into the very block its own
+//! trade settled in and is therefore contaminated by that trade's own price impact.
+//!
+//! Sampled shapes are re-quoted at live blocks unrelated to any settlement, so nothing the sampled
+//! trade did on-chain can move the pools we measure against.
+
+use std::{
+    io::{BufRead, BufReader},
+    path::Path,
+};
+
+use alloy::primitives::{Address, U256};
+use anyhow::Context;
+use serde::Deserialize;
+use tracing::info;
+
+/// The venue whose flow is sampled. Compared case-insensitively against a record's `venue`.
+pub(crate) const RELAY_VENUE: &str = "relay";
+
+/// A trade's routing-essential shape: what to ask the solver for, and nothing else.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TradeShape {
+    pub token_in: Address,
+    pub token_out: Address,
+    pub amount_in: U256,
+}
+
+/// The fields of a comparison record this module reads. Everything else in the record is ignored by
+/// omission, so no settled-outcome field can leak into the sample.
+///
+/// All three trade fields are optional because `monitor` also records **reverted** transactions
+/// (`"status": "reverted"`), where they are explicitly `null` — a revert settles no amounts, so
+/// there is nothing to decode. Those rows are well-formed and expected, not corrupt, so they must
+/// parse and then be dropped for having no shape rather than counted as malformed.
+#[derive(Deserialize)]
+struct ComparisonRow {
+    venue: Option<String>,
+    token_in: Option<String>,
+    token_out: Option<String>,
+    amount_in: Option<String>,
+}
+
+impl ComparisonRow {
+    /// The row's trade shape, or `None` when it is not a usable sample: a different venue, a
+    /// reverted trade with no amounts to read, an unparseable address or amount, or a zero input
+    /// (nothing to quote).
+    fn shape(&self, venue: &str) -> Option<TradeShape> {
+        if !self
+            .venue
+            .as_deref()?
+            .eq_ignore_ascii_case(venue)
+        {
+            return None;
+        }
+        let amount_in = U256::from_str_radix(self.amount_in.as_deref()?, 10).ok()?;
+        if amount_in.is_zero() {
+            return None;
+        }
+        Some(TradeShape {
+            token_in: self.token_in.as_deref()?.parse().ok()?,
+            token_out: self
+                .token_out
+                .as_deref()?
+                .parse()
+                .ok()?,
+            amount_in,
+        })
+    }
+}
+
+/// Whether `name` is one of the daily comparison files `monitor` writes.
+fn is_comparisons_file(name: &str) -> bool {
+    let prefixed = name
+        .strip_prefix(crate::resolve::jsonl::COMPARISONS_PREFIX)
+        .is_some_and(|rest| rest.starts_with('-'));
+    prefixed &&
+        Path::new(name)
+            .extension()
+            .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+}
+
+/// Load every `venue`-matching trade shape from the `comparisons-*.jsonl` files in `dir`.
+///
+/// Shapes are kept **per record, with duplicates**, so a pair that trades often is proportionally
+/// represented and the sample reflects real demand rather than a flat list of distinct pairs.
+/// Malformed lines are counted and skipped: these files are appended by a long-running process, so
+/// the last line of a live file is routinely a partial write.
+pub(crate) fn load_shapes(dir: &Path, venue: &str) -> anyhow::Result<Vec<TradeShape>> {
+    let entries = std::fs::read_dir(dir)
+        .with_context(|| format!("failed to read comparisons directory {}", dir.display()))?;
+    let mut paths = Vec::new();
+    for entry in entries {
+        let path = entry
+            .with_context(|| format!("failed to list {}", dir.display()))?
+            .path();
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(is_comparisons_file)
+        {
+            paths.push(path);
+        }
+    }
+    // Deterministic order, so a given directory always yields the same pool and `--seed` alone
+    // decides the draw.
+    paths.sort();
+    anyhow::ensure!(
+        !paths.is_empty(),
+        "no comparisons-*.jsonl files in {} — point --comparisons-dir at a monitor run's output",
+        dir.display()
+    );
+
+    let mut shapes = Vec::new();
+    let mut skipped = 0_u64;
+    for path in &paths {
+        let file = std::fs::File::open(path)
+            .with_context(|| format!("failed to open {}", path.display()))?;
+        for line in BufReader::new(file).lines() {
+            let Ok(line) = line else {
+                skipped += 1;
+                continue;
+            };
+            // A row that parses but does not match the venue is the common case, not a defect, so
+            // only a parse failure counts as skipped.
+            match serde_json::from_str::<ComparisonRow>(&line) {
+                Ok(row) => shapes.extend(row.shape(venue)),
+                Err(_) => skipped += 1,
+            }
+        }
+    }
+    info!(
+        files = paths.len(),
+        shapes = shapes.len(),
+        skipped_lines = skipped,
+        venue,
+        "loaded trade shapes"
+    );
+    anyhow::ensure!(
+        !shapes.is_empty(),
+        "no usable {venue} trade shapes found in {} ({skipped} unparseable lines)",
+        dir.display()
+    );
+    Ok(shapes)
+}
+
+/// A seeded sampler over a fixed pool of trade shapes.
+///
+/// Deliberately does not use the `rand` crate: `rand` does not guarantee that a given seed produces
+/// the same values across releases, which would silently invalidate `--seed` reproducibility on a
+/// dependency bump. `SplitMix64` is pinned here instead, so a seed reproduces its draw for as long
+/// as this file does — and it costs no dependency.
+pub(crate) struct Sampler {
+    state: u64,
+    /// A permutation buffer over the pool's indices, partially shuffled on each draw.
+    indices: Vec<usize>,
+}
+
+impl Sampler {
+    pub(crate) fn new(seed: u64, pool_len: usize) -> Self {
+        Self { state: seed, indices: (0..pool_len).collect() }
+    }
+
+    /// `SplitMix64`, the reference generator: one multiply-xor-shift finalizer over a
+    /// golden-ratio-incremented counter. Good enough for choosing which trades to quote, and small
+    /// enough to be obviously stable.
+    fn next_u64(&mut self) -> u64 {
+        self.state = self
+            .state
+            .wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// A uniform index below `bound`, via Lemire's multiply-shift. Biased by at most 2^-64 per
+    /// draw, which no sample of trades can notice.
+    fn index_below(&mut self, bound: usize) -> usize {
+        let product = u128::from(self.next_u64()) * bound as u128;
+        // The high 64 bits are strictly below `bound`, so they always fit a usize; the fallback
+        // only exists because `try_from` must return something.
+        usize::try_from(product >> 64).unwrap_or(0)
+    }
+
+    /// Draw `count` distinct pool indices, uniformly and without replacement within the draw.
+    ///
+    /// Partial Fisher-Yates over the persistent permutation buffer: each call reshuffles only the
+    /// first `count` slots, so a draw costs `count` swaps regardless of pool size. Successive calls
+    /// keep permuting the same buffer, so each round gets a fresh sample. `count` above the pool
+    /// size yields the whole pool.
+    pub(crate) fn draw(&mut self, count: usize) -> Vec<usize> {
+        let len = self.indices.len();
+        let count = count.min(len);
+        for slot in 0..count {
+            let pick = slot + self.index_below(len - slot);
+            self.indices.swap(slot, pick);
+        }
+        self.indices[..count].to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(venue: &str, amount: &str) -> String {
+        format!(
+            r#"{{"venue":"{venue}","token_in":"0x{a}","token_out":"0x{b}","amount_in":"{amount}","settled_amount_out":"5","slippage":{{"bps":-3.0,"usd":0.0}}}}"#,
+            a = "11".repeat(20),
+            b = "22".repeat(20)
+        )
+    }
+
+    fn write_dir(lines: &[String]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path()
+                .join("comparisons-2026-08-03.jsonl"),
+            lines.join("\n"),
+        )
+        .expect("write");
+        dir
+    }
+
+    #[test]
+    fn keeps_only_the_requested_venue() {
+        let dir = write_dir(&[
+            row("relay", "1000"),
+            row("uniswap", "2000"),
+            row("Relay", "3000"),
+            row("kyberswap", "4000"),
+        ]);
+        let shapes = load_shapes(dir.path(), RELAY_VENUE).expect("load");
+        // Venue match is case-insensitive, so "Relay" counts too.
+        assert_eq!(shapes.len(), 2);
+        let amounts: Vec<U256> = shapes
+            .iter()
+            .map(|s| s.amount_in)
+            .collect();
+        assert_eq!(amounts, vec![U256::from(1000), U256::from(3000)]);
+    }
+
+    #[test]
+    fn keeps_duplicates_so_frequent_pairs_stay_weighted() {
+        let dir = write_dir(&[row("relay", "1000"), row("relay", "1000"), row("relay", "1000")]);
+        assert_eq!(
+            load_shapes(dir.path(), RELAY_VENUE)
+                .expect("load")
+                .len(),
+            3
+        );
+    }
+
+    #[test]
+    fn reverted_records_are_dropped_without_counting_as_malformed() {
+        // A revert settles no amounts, so `monitor` writes nulls. Real Base data carries ~8k of
+        // these per few days; counting them as unparseable would bury a genuinely corrupt file.
+        let reverted = r#"{"block":49396056,"status":"reverted","cause":"out_of_gas","venue":"relay","solver":"0x","decoder":"reverted","token_in":null,"token_out":null,"amount_in":null,"settled_amount_out":null}"#;
+        let dir = write_dir(&[reverted.to_string(), row("relay", "1000")]);
+        let shapes = load_shapes(dir.path(), RELAY_VENUE).expect("load");
+        assert_eq!(shapes.len(), 1, "only the settled trade has a shape");
+        assert_eq!(shapes[0].amount_in, U256::from(1000));
+    }
+
+    #[test]
+    fn skips_zero_amounts_and_malformed_lines() {
+        let dir = write_dir(&[
+            row("relay", "1000"),
+            row("relay", "0"),
+            "not json at all".to_string(),
+            // A partial write, which a live file's last line routinely is.
+            r#"{"venue":"relay","token_in":"0x11"#.to_string(),
+        ]);
+        let shapes = load_shapes(dir.path(), RELAY_VENUE).expect("load");
+        assert_eq!(shapes.len(), 1);
+        assert_eq!(shapes[0].amount_in, U256::from(1000));
+    }
+
+    #[test]
+    fn native_leg_shapes_survive_the_round_trip() {
+        // ~55% of Base Relay records carry the zero address as a native-ETH leg; it must reach the
+        // solver unchanged rather than being filtered as a bad address.
+        let dir = write_dir(&[format!(
+            r#"{{"venue":"relay","token_in":"0x{}","token_out":"0x{}","amount_in":"7"}}"#,
+            "33".repeat(20),
+            "0".repeat(40)
+        )]);
+        let shapes = load_shapes(dir.path(), RELAY_VENUE).expect("load");
+        assert_eq!(shapes[0].token_out, Address::ZERO);
+        assert_eq!(shapes[0].amount_in, U256::from(7));
+    }
+
+    #[test]
+    fn errors_when_the_directory_has_no_comparison_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("report.html"), "<html/>").expect("write");
+        assert!(load_shapes(dir.path(), RELAY_VENUE).is_err());
+    }
+
+    #[test]
+    fn errors_when_no_record_matches_the_venue() {
+        let dir = write_dir(&[row("uniswap", "1000")]);
+        assert!(load_shapes(dir.path(), RELAY_VENUE).is_err());
+    }
+
+    #[test]
+    fn draw_is_reproducible_for_a_seed_and_differs_across_seeds() {
+        let first = Sampler::new(42, 100).draw(10);
+        assert_eq!(first, Sampler::new(42, 100).draw(10), "same seed must replay the same draw");
+        assert_ne!(first, Sampler::new(43, 100).draw(10), "a different seed must differ");
+    }
+
+    #[test]
+    fn draw_yields_distinct_in_range_indices() {
+        let mut sampler = Sampler::new(7, 50);
+        let drawn = sampler.draw(20);
+        assert_eq!(drawn.len(), 20);
+        assert!(drawn.iter().all(|&i| i < 50));
+        let unique: std::collections::HashSet<usize> = drawn.iter().copied().collect();
+        assert_eq!(unique.len(), 20, "a draw must not repeat an index");
+    }
+
+    #[test]
+    fn successive_draws_differ() {
+        let mut sampler = Sampler::new(7, 500);
+        // Each round re-quotes a fresh sample; identical consecutive draws would mean the
+        // permutation buffer is not advancing.
+        assert_ne!(sampler.draw(20), sampler.draw(20));
+    }
+
+    #[test]
+    fn draw_larger_than_the_pool_yields_the_whole_pool() {
+        let mut sampler = Sampler::new(1, 3);
+        let drawn = sampler.draw(10);
+        assert_eq!(drawn.len(), 3);
+        let unique: std::collections::HashSet<usize> = drawn.iter().copied().collect();
+        assert_eq!(unique, [0, 1, 2].into_iter().collect());
+    }
+
+    #[test]
+    fn draw_covers_the_pool_roughly_uniformly() {
+        // A biased index_below would concentrate draws; over many rounds every index should appear.
+        let mut sampler = Sampler::new(99, 20);
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..200 {
+            seen.extend(sampler.draw(5));
+        }
+        assert_eq!(seen.len(), 20, "every pool index should be drawn eventually");
+    }
+}

--- a/tools/hindsight/src/decay/sample.rs
+++ b/tools/hindsight/src/decay/sample.rs
@@ -32,10 +32,10 @@ pub(crate) struct TradeShape {
 /// The fields of a comparison record this module reads. Everything else in the record is ignored by
 /// omission, so no settled-outcome field can leak into the sample.
 ///
-/// All three trade fields are optional because `monitor` also records **reverted** transactions
-/// (`"status": "reverted"`), where they are explicitly `null` — a revert settles no amounts, so
-/// there is nothing to decode. Those rows are well-formed and expected, not corrupt, so they must
-/// parse and then be dropped for having no shape rather than counted as malformed.
+/// All three trade fields are optional so that a row with no shape to extract — whichever
+/// producer wrote it, and whatever the reason — still parses cleanly. Such a row is well-formed
+/// and expected, not corrupt, so it must parse and then be dropped for having no shape rather than
+/// counted as malformed.
 #[derive(Deserialize)]
 struct ComparisonRow {
     venue: Option<String>,
@@ -256,13 +256,13 @@ mod tests {
     }
 
     #[test]
-    fn reverted_records_are_dropped_without_counting_as_malformed() {
-        // A revert settles no amounts, so `monitor` writes nulls. Real Base data carries ~8k of
-        // these per few days; counting them as unparseable would bury a genuinely corrupt file.
-        let reverted = r#"{"block":49396056,"status":"reverted","cause":"out_of_gas","venue":"relay","solver":"0x","decoder":"reverted","token_in":null,"token_out":null,"amount_in":null,"settled_amount_out":null}"#;
-        let dir = write_dir(&[reverted.to_string(), row("relay", "1000")]);
+    fn null_trade_fields_are_dropped_without_counting_as_malformed() {
+        // A record with no shape to extract is well-formed, not corrupt: it must parse and then
+        // be dropped for lacking a shape, rather than counted among the skipped/malformed lines.
+        let no_shape = r#"{"venue":"relay","token_in":null,"token_out":null,"amount_in":null}"#;
+        let dir = write_dir(&[no_shape.to_string(), row("relay", "1000")]);
         let shapes = load_shapes(dir.path(), RELAY_VENUE).expect("load");
-        assert_eq!(shapes.len(), 1, "only the settled trade has a shape");
+        assert_eq!(shapes.len(), 1, "only the row with a shape survives");
         assert_eq!(shapes[0].amount_in, U256::from(1000));
     }
 

--- a/tools/hindsight/src/decay/summary.rs
+++ b/tools/hindsight/src/decay/summary.rs
@@ -1,7 +1,12 @@
 //! Per-offset aggregation of a decay run's measurements.
 //!
 //! Accumulates every measurement in memory, which a run of any realistic length affords: at the
-//! default sample size a day of Base produces ~1.1M measurements, or ~1.7 MB of `f64` per offset.
+//! default sample size a day of Base produces ~1.1M measurements. Each pushes three `f64`s (route,
+//! market, execution) into one of the 5 default offset buckets, so that day is ~26 MB across all
+//! offsets and vectors, ~550 MB over three weeks — all of it live, since `stats()` needs the full
+//! sorted slice for percentiles. Fine for the runs this tool is built for; a streaming quantile
+//! sketch (t-digest / P²) or a periodic flush-and-reset would remove the ceiling if a run needs to
+//! go unattended for longer.
 
 use serde::Serialize;
 
@@ -221,6 +226,7 @@ mod tests {
             route_slippage_bps: route,
             market_movement_bps: market,
             execution_slippage_bps: route - market,
+            execution_slippage_clamped: false,
         }
     }
 

--- a/tools/hindsight/src/decay/summary.rs
+++ b/tools/hindsight/src/decay/summary.rs
@@ -1,0 +1,324 @@
+//! Per-offset aggregation of a decay run's measurements.
+//!
+//! Accumulates every measurement in memory, which a run of any realistic length affords: at the
+//! default sample size a day of Base produces ~1.1M measurements, or ~1.7 MB of `f64` per offset.
+
+use serde::Serialize;
+
+use crate::decay::record::DecayBps;
+
+/// Degradation past this many bps is counted as tail risk — PR #297's threshold, kept so the Base
+/// numbers line up with its Ethereum run.
+const TAIL_BPS: f64 = 20.0;
+
+/// Percentile denominator, so quantiles are expressed as exact integer percents and no float ever
+/// has to be turned into a slice index.
+const PERCENT: usize = 100;
+
+/// Winsorizing percentile: the most extreme 1% at each end is clamped to the 1st/99th percentile
+/// before the winsorized mean. Route decay is heavy-tailed enough that a handful of thousand-bps
+/// observations otherwise decide the raw mean.
+const WINSOR_PERCENT: usize = 1;
+
+/// Every measurement taken at one offset.
+#[derive(Default)]
+struct OffsetSamples {
+    /// The total move per measurement: the quoted route replayed this many blocks later.
+    route: Vec<f64>,
+    /// Unavoidable market drift per measurement.
+    market: Vec<f64>,
+    /// The part specific to holding a stale route.
+    execution: Vec<f64>,
+}
+
+impl OffsetSamples {
+    fn push(&mut self, bps: DecayBps) {
+        self.route.push(bps.route_slippage_bps);
+        self.market
+            .push(bps.market_movement_bps);
+        self.execution
+            .push(bps.execution_slippage_bps);
+    }
+}
+
+/// One offset's aggregated statistics.
+///
+/// Every bps figure keeps hindsight's sign convention: **positive means surplus**, so degradation
+/// is negative. `degraded_share` and `tail_share` are therefore counted on the negative side.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub(crate) struct OffsetStats {
+    pub offset: u32,
+    /// Measurements with a complete decomposition at this offset.
+    pub count: usize,
+    pub mean_bps: f64,
+    /// Mean after clamping the outer 1% at each end — the number to read when comparing runs,
+    /// since the raw mean is dominated by a few extreme observations.
+    pub winsorized_mean_bps: f64,
+    pub p50_bps: f64,
+    /// The 5th percentile: the bad tail, since negative is degradation.
+    pub p05_bps: f64,
+    pub p01_bps: f64,
+    /// Fraction of measurements where the route produced less than quoted.
+    pub degraded_share: f64,
+    /// Fraction that degraded by more than [`TAIL_BPS`].
+    pub tail_share: f64,
+    /// Mean absolute market drift, and mean absolute stale-route loss.
+    pub mean_abs_market_bps: f64,
+    pub mean_abs_execution_bps: f64,
+    /// Market drift's share of the total absolute move, and the stale route's. These sum to 1 and
+    /// are the split PR #297 reported as "41% market movement / 59% execution slippage".
+    pub market_share: f64,
+    pub execution_share: f64,
+}
+
+/// Accumulates measurements and renders the run's per-offset summary.
+pub(crate) struct Summary {
+    offsets: Vec<OffsetSamples>,
+}
+
+impl Summary {
+    /// Room for offsets `1..=offsets`.
+    pub(crate) fn new(offsets: u32) -> Self {
+        Self {
+            offsets: (0..offsets)
+                .map(|_| OffsetSamples::default())
+                .collect(),
+        }
+    }
+
+    /// Record one complete measurement. Offsets outside `1..=offsets` are ignored rather than
+    /// panicking: a summary is a report, and must never take a run down.
+    pub(crate) fn record(&mut self, offset: u32, bps: DecayBps) {
+        let Some(slot) = offset
+            .checked_sub(1)
+            .and_then(|i| self.offsets.get_mut(i as usize))
+        else {
+            return;
+        };
+        slot.push(bps);
+    }
+
+    /// Statistics for every offset that saw at least one measurement, in offset order.
+    pub(crate) fn stats(&self) -> Vec<OffsetStats> {
+        let mut stats = Vec::new();
+        for (index, samples) in self.offsets.iter().enumerate() {
+            if samples.route.is_empty() {
+                continue;
+            }
+            let offset = u32::try_from(index + 1).unwrap_or(u32::MAX);
+            stats.push(offset_stats(offset, samples));
+        }
+        stats
+    }
+}
+
+fn offset_stats(offset: u32, samples: &OffsetSamples) -> OffsetStats {
+    let mut sorted = samples.route.clone();
+    // Total order over floats: measurements are finite by construction (a non-finite bps value
+    // cannot come out of `raw_bps_diff`, which rejects non-positive amounts).
+    sorted.sort_by(f64::total_cmp);
+    let count = sorted.len();
+    let mean_abs_market = mean_abs(&samples.market);
+    let mean_abs_execution = mean_abs(&samples.execution);
+    let abs_total = mean_abs_market + mean_abs_execution;
+    // A run where nothing moved at all leaves the split undefined; report it as an even split
+    // rather than a NaN that would poison the JSON summary.
+    let (market_share, execution_share) = if abs_total > 0.0 {
+        (mean_abs_market / abs_total, mean_abs_execution / abs_total)
+    } else {
+        (0.5, 0.5)
+    };
+    OffsetStats {
+        offset,
+        count,
+        mean_bps: mean(&sorted),
+        winsorized_mean_bps: winsorized_mean(&sorted),
+        p50_bps: percentile(&sorted, 50),
+        p05_bps: percentile(&sorted, 5),
+        p01_bps: percentile(&sorted, 1),
+        degraded_share: share(&sorted, |v| v < 0.0),
+        tail_share: share(&sorted, |v| v < -TAIL_BPS),
+        mean_abs_market_bps: mean_abs_market,
+        mean_abs_execution_bps: mean_abs_execution,
+        market_share,
+        execution_share,
+    }
+}
+
+/// A sample count as an `f64` divisor. Counts are bounded by how many measurements a run can take,
+/// so they never reach the 2^53 where an `f64` stops representing integers exactly.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "a measurement count cannot reach 2^53, where f64 stops being exact for integers"
+)]
+fn count_as_f64(count: usize) -> f64 {
+    count as f64
+}
+
+fn mean(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    values.iter().sum::<f64>() / count_as_f64(values.len())
+}
+
+fn mean_abs(values: &[f64]) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let total: f64 = values.iter().map(|v| v.abs()).sum();
+    total / count_as_f64(values.len())
+}
+
+/// The `percent`th percentile of an ascending slice, by nearest rank. Empty input yields `0.0`.
+///
+/// The rank is integer arithmetic rather than `percent / 100 * len` in floating point, so no float
+/// is ever cast to an index — the cast that would silently truncate or lose a sign.
+fn percentile(sorted: &[f64], percent: usize) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let rank = sorted
+        .len()
+        .saturating_mul(percent.min(PERCENT)) /
+        PERCENT;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+/// Mean of an ascending slice with the outer [`WINSOR_PERCENT`] at each end clamped to that
+/// percentile's value, rather than dropped — so the count stays the same and the mean stays
+/// comparable across runs of different length.
+fn winsorized_mean(sorted: &[f64]) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let low = percentile(sorted, WINSOR_PERCENT);
+    let high = percentile(sorted, PERCENT - WINSOR_PERCENT);
+    let clamped: f64 = sorted
+        .iter()
+        .map(|v| v.clamp(low, high))
+        .sum();
+    clamped / count_as_f64(sorted.len())
+}
+
+fn share(values: &[f64], predicate: impl Fn(f64) -> bool) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    let matched = values
+        .iter()
+        .filter(|&&v| predicate(v))
+        .count();
+    count_as_f64(matched) / count_as_f64(values.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bps(route: f64, market: f64) -> DecayBps {
+        DecayBps {
+            route_slippage_bps: route,
+            market_movement_bps: market,
+            execution_slippage_bps: route - market,
+        }
+    }
+
+    #[test]
+    fn stats_are_reported_per_offset_in_order() {
+        let mut summary = Summary::new(3);
+        summary.record(3, bps(-3.0, -1.0));
+        summary.record(1, bps(-1.0, -1.0));
+        summary.record(1, bps(-1.0, -1.0));
+        let stats = summary.stats();
+        // Offset 2 saw nothing, so it is absent rather than reported as an empty row.
+        assert_eq!(
+            stats
+                .iter()
+                .map(|s| s.offset)
+                .collect::<Vec<_>>(),
+            vec![1, 3]
+        );
+        assert_eq!(stats[0].count, 2);
+        assert_eq!(stats[1].count, 1);
+    }
+
+    #[test]
+    fn out_of_range_offsets_are_ignored() {
+        let mut summary = Summary::new(2);
+        summary.record(0, bps(-1.0, 0.0));
+        summary.record(9, bps(-1.0, 0.0));
+        assert!(summary.stats().is_empty(), "no in-range offset saw a measurement");
+    }
+
+    #[test]
+    fn degraded_and_tail_shares_count_the_negative_side() {
+        let mut summary = Summary::new(1);
+        // Two degrade (one past the 20 bps tail), one improves, one is flat.
+        for route in [-30.0, -5.0, 4.0, 0.0] {
+            summary.record(1, bps(route, 0.0));
+        }
+        let stats = &summary.stats()[0];
+        assert!((stats.degraded_share - 0.5).abs() < 1e-9);
+        assert!((stats.tail_share - 0.25).abs() < 1e-9);
+    }
+
+    #[test]
+    fn winsorizing_pulls_in_an_extreme_outlier() {
+        let mut summary = Summary::new(1);
+        for _ in 0..99 {
+            summary.record(1, bps(-1.0, 0.0));
+        }
+        // One 7405 bps observation, the magnitude seen in real Base Relay data.
+        summary.record(1, bps(-7405.0, 0.0));
+        let stats = &summary.stats()[0];
+        assert!(stats.mean_bps < -70.0, "raw mean must feel the outlier: {}", stats.mean_bps);
+        assert!(
+            (stats.winsorized_mean_bps + 1.0).abs() < 0.5,
+            "winsorized mean must not: {}",
+            stats.winsorized_mean_bps
+        );
+    }
+
+    #[test]
+    fn split_shares_sum_to_one_and_attribute_correctly() {
+        let mut summary = Summary::new(1);
+        // Total -10, of which -4 was market drift: 40/60, the shape PR #297 reported.
+        summary.record(1, bps(-10.0, -4.0));
+        let stats = &summary.stats()[0];
+        assert!((stats.market_share - 0.4).abs() < 1e-9, "got {}", stats.market_share);
+        assert!((stats.execution_share - 0.6).abs() < 1e-9);
+        assert!((stats.market_share + stats.execution_share - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn a_flat_market_reports_an_even_split_not_a_nan() {
+        let mut summary = Summary::new(1);
+        summary.record(1, bps(0.0, 0.0));
+        let stats = &summary.stats()[0];
+        assert!(stats.market_share.is_finite() && stats.execution_share.is_finite());
+        assert!((stats.market_share - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn percentiles_track_the_distribution() {
+        let mut summary = Summary::new(1);
+        // -100..-1, so the bad tail is the most negative.
+        for i in 1..=100 {
+            summary.record(1, bps(-f64::from(i), 0.0));
+        }
+        let stats = &summary.stats()[0];
+        assert!((stats.p50_bps + 50.0).abs() <= 1.0, "p50 {}", stats.p50_bps);
+        assert!((stats.p05_bps + 95.0).abs() <= 1.0, "p05 {}", stats.p05_bps);
+        assert!((stats.p01_bps + 99.0).abs() <= 1.0, "p01 {}", stats.p01_bps);
+    }
+
+    #[test]
+    fn percentile_and_mean_helpers_tolerate_empty_input() {
+        assert!(percentile(&[], 50).abs() < f64::EPSILON);
+        assert!(winsorized_mean(&[]).abs() < f64::EPSILON);
+        assert!(mean(&[]).abs() < f64::EPSILON);
+        assert!(mean_abs(&[]).abs() < f64::EPSILON);
+        assert!(share(&[], |_| true).abs() < f64::EPSILON);
+    }
+}

--- a/tools/hindsight/src/main.rs
+++ b/tools/hindsight/src/main.rs
@@ -1,3 +1,4 @@
+mod decay;
 mod decoder;
 mod report;
 mod resolve;
@@ -16,6 +17,7 @@ use tracing_subscriber::EnvFilter;
 use tycho_simulation::tycho_common::models::Chain;
 
 use crate::{
+    decay::DecayArgs,
     decoder::{DecodedTrade, Decoder, Registry},
     report::ReportArgs,
     resolve::monitor::MonitorArgs,
@@ -38,6 +40,9 @@ enum Command {
     /// Live monitor: drive an in-process solver block-by-block, re-solving each block's settled
     /// trades at top-of-block (N-1) and back-of-block (N).
     Monitor(MonitorArgs),
+    /// Measure route decay: quote a sample of trade shapes, then replay those routes at each of
+    /// the next few blocks, splitting the move into market drift and stale-route loss.
+    Decay(DecayArgs),
     /// Render an offline HTML report from a monitor run's comparison JSONL.
     Report(ReportArgs),
 }
@@ -159,6 +164,7 @@ async fn main() -> anyhow::Result<()> {
         Command::Decode(args) => run_decode(args).await,
         Command::Verify(args) => run_verify(args).await,
         Command::Monitor(args) => resolve::monitor::run(args).await,
+        Command::Decay(args) => decay::run(args).await,
         Command::Report(args) => report::run(args),
     };
 

--- a/tools/hindsight/src/resolve/jsonl.rs
+++ b/tools/hindsight/src/resolve/jsonl.rs
@@ -20,29 +20,39 @@ use crate::{
     usd::Prices,
 };
 
-/// Append-only comparisons writer that rotates to a new file at each UTC day boundary —
-/// `comparisons-YYYY-MM-DD.jsonl` inside its directory — so an external sync job (e.g. an S3
+/// The filename prefix `monitor` writes its per-trade comparisons under. Also what
+/// [`crate::decay::sample`] globs for when it loads trade shapes, so nothing else may use it.
+pub(crate) const COMPARISONS_PREFIX: &str = "comparisons";
+
+/// Append-only JSONL writer that rotates to a new file at each UTC day boundary —
+/// `<prefix>-YYYY-MM-DD.jsonl` inside its directory — so an external sync job (e.g. an S3
 /// upload `CronJob`) ships closed daily files instead of re-shipping one ever-growing one.
+///
+/// The prefix is explicit because the two record kinds must never share one: the decay sampler
+/// reads `comparisons-*.jsonl` as its input, so writing anything else under that name would feed a
+/// run its own output.
 pub(crate) struct RotatingWriter {
     dir: PathBuf,
+    prefix: &'static str,
     date: String,
     writer: BufWriter<std::fs::File>,
 }
 
 impl RotatingWriter {
-    /// Open today's file inside `dir` for appending, creating the directory if needed.
-    pub(crate) fn open(dir: impl Into<PathBuf>) -> anyhow::Result<Self> {
+    /// Open today's `<prefix>-<date>.jsonl` inside `dir` for appending, creating the directory if
+    /// needed.
+    pub(crate) fn open(dir: impl Into<PathBuf>, prefix: &'static str) -> anyhow::Result<Self> {
         let dir = dir.into();
         std::fs::create_dir_all(&dir)
-            .with_context(|| format!("failed to create comparisons directory {}", dir.display()))?;
+            .with_context(|| format!("failed to create output directory {}", dir.display()))?;
         let date = utc_date();
-        let writer = open_dated(&dir, &date)?;
-        Ok(Self { dir, date, writer })
+        let writer = open_dated(&dir, prefix, &date)?;
+        Ok(Self { dir, prefix, date, writer })
     }
 
     /// The path of the file currently being written.
     pub(crate) fn current_path(&self) -> PathBuf {
-        dated_path(&self.dir, &self.date)
+        dated_path(&self.dir, self.prefix, &self.date)
     }
 
     /// The current file's writer, rotated first when the UTC day has changed.
@@ -59,32 +69,35 @@ impl RotatingWriter {
             return;
         }
         if let Err(e) = self.writer.flush() {
-            warn!(error = %e, "failed to flush comparisons file before rotation");
+            warn!(error = %e, "failed to flush jsonl file before rotation");
         }
-        match open_dated(&self.dir, &date) {
+        match open_dated(&self.dir, self.prefix, &date) {
             Ok(writer) => {
-                info!(path = %dated_path(&self.dir, &date).display(), "rotated comparisons file");
+                info!(
+                    path = %dated_path(&self.dir, self.prefix, &date).display(),
+                    "rotated jsonl file"
+                );
                 self.writer = writer;
                 self.date = date;
             }
             Err(e) => {
-                warn!(error = %e, "failed to rotate comparisons file; keeping the previous day's");
+                warn!(error = %e, "failed to rotate jsonl file; keeping the previous day's");
             }
         }
     }
 }
 
-fn dated_path(dir: &Path, date: &str) -> PathBuf {
-    dir.join(format!("comparisons-{date}.jsonl"))
+fn dated_path(dir: &Path, prefix: &str, date: &str) -> PathBuf {
+    dir.join(format!("{prefix}-{date}.jsonl"))
 }
 
-fn open_dated(dir: &Path, date: &str) -> anyhow::Result<BufWriter<std::fs::File>> {
-    let path = dated_path(dir, date);
+fn open_dated(dir: &Path, prefix: &str, date: &str) -> anyhow::Result<BufWriter<std::fs::File>> {
+    let path = dated_path(dir, prefix, date);
     let file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(&path)
-        .with_context(|| format!("failed to open comparisons jsonl {}", path.display()))?;
+        .with_context(|| format!("failed to open jsonl {}", path.display()))?;
     Ok(BufWriter::new(file))
 }
 
@@ -304,7 +317,7 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("hindsight-rotate-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
 
-        let mut rotating = RotatingWriter::open(&dir).unwrap();
+        let mut rotating = RotatingWriter::open(&dir, COMPARISONS_PREFIX).unwrap();
         let today = rotating.current_path();
         writeln!(rotating.writer(), "{{\"day\":1}}").unwrap();
 

--- a/tools/hindsight/src/resolve/mod.rs
+++ b/tools/hindsight/src/resolve/mod.rs
@@ -11,6 +11,8 @@
 mod compare;
 pub(crate) mod jsonl;
 pub(crate) mod monitor;
+pub(crate) mod session;
+pub(crate) mod step;
 
 use std::collections::HashMap;
 
@@ -272,6 +274,10 @@ pub(crate) trait SteppingSolver {
     /// Re-execute `top`'s route at the solver's current block state — same pools, splits, and
     /// input amount against the pools as the block left them.
     async fn reexecute(&self, top: &SolvedAmount) -> Outcome;
+    /// The block number of the currently-applied state, or `None` before the first block lands.
+    /// On the trait rather than the live adapter so a measurement loop that reads which block it is
+    /// on stays testable against a mock.
+    async fn current_block(&self) -> Option<u64>;
 }
 
 /// Build a `RangeComparison` from a trade's three outcomes: the top-of-block solve, the fresh
@@ -428,6 +434,15 @@ mod tests {
 
     #[async_trait]
     impl SteppingSolver for MockStepping {
+        /// One block before `advance()`, the next after — enough for the two-state pipeline, which
+        /// never reads the number itself.
+        async fn current_block(&self) -> Option<u64> {
+            Some(u64::from(
+                self.advanced
+                    .load(std::sync::atomic::Ordering::Relaxed),
+            ))
+        }
+
         async fn solve(&self, _: Address, _: Address, _: U256) -> Outcome {
             if self
                 .advanced

--- a/tools/hindsight/src/resolve/monitor.rs
+++ b/tools/hindsight/src/resolve/monitor.rs
@@ -9,47 +9,25 @@
 //! parent module via a mock `SteppingSolver`; this live driver is exercised by the gated
 //! integration test in `tests/` (requires `TYCHO_URL` + `RPC_URL`).
 
-use std::{
-    future::Future,
-    pin::Pin,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 
-use alloy::{
-    primitives::{Address, U256},
-    providers::Provider,
-};
-use async_trait::async_trait;
-use fynd_core::{
-    types::{
-        EncodingOptions, Order, OrderQuote, OrderSide, QuoteOptions, QuoteRequest, QuoteStatus,
-    },
-    BlockStepController, FyndBuilder, Solver,
-};
-use num_bigint::BigUint;
+use alloy::{primitives::Address, providers::Provider};
+use fynd_core::Solver;
 use tracing::{debug, info, warn};
 use tycho_simulation::tycho_common::models::{Address as CoreAddress, Chain};
 
 use crate::{
     decoder::{DecodedTrade, Decoder, Registry},
     provider_from,
-    resolve::{resolve_block_range, Outcome, SolvedAmount, SteppingSolver},
+    resolve::{
+        resolve_block_range,
+        session::{self, Session, SolverArgs},
+        step::{Encoding, StepAdapter},
+        SteppingSolver,
+    },
     telemetry,
     usd::Prices,
 };
-
-/// How often to warn while the solver has not applied the next block.
-const STALL_WARN_INTERVAL: Duration = Duration::from_mins(5);
-/// No block for this long means the feed is dead, not slow. The observed failure mode: one
-/// server-side subscription goes silent, tycho-client's block synchronizer stops emitting while
-/// it waits for it, and ~35 minutes later backpressure kills the remaining subscriptions
-/// ("Buffer full, unsubscribing!"). Nothing resubscribes, so the stream never recovers — the
-/// monitor rebuilds the solver instead of waiting.
-const FEED_DEAD_TIMEOUT: Duration = Duration::from_mins(15);
-/// Pause between solver rebuild attempts after a feed death, so a struggling Tycho server is not
-/// hammered in a tight loop.
-const REBUILD_BACKOFF: Duration = Duration::from_secs(30);
-const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// How far the receipts RPC may trail the Tycho stream before the monitor decodes the target block
 /// anyway. In blocks, not seconds, because an RPC node trails by blocks.
@@ -58,62 +36,12 @@ const DECODE_RPC_LAG_BUDGET_BLOCKS: u32 = 3;
 /// monitor only idles until the block lands, and `eth_blockNumber` is cheap.
 const DECODE_RPC_LAG_POLL: Duration = Duration::from_millis(250);
 
-/// Wall-clock budget behind chain head that `default_lag_blocks` converts into a block count.
-const LAG_BUDGET_SECS: u64 = 20 * 60;
-
 /// Inputs for the live monitor — the `monitor` subcommand's CLI arguments, used directly as its
 /// configuration.
 #[derive(clap::Args)]
 pub(crate) struct MonitorArgs {
     #[command(flatten)]
-    pub chain: crate::ChainArgs,
-
-    /// Tycho WebSocket URL feeding the in-process solver
-    #[arg(long, env = "TYCHO_URL")]
-    pub tycho_url: String,
-
-    /// Protocols to index, comma-separated. Defaults to every native on-chain protocol; use
-    /// `all_onchain` to include VM-simulated ones too (see `fynd serve --protocols`)
-    #[arg(long, value_delimiter = ',', default_value = "native_onchain")]
-    pub protocols: Vec<String>,
-
-    /// Minimum pool TVL filter for the solver
-    #[arg(long, default_value_t = 100.0)]
-    pub min_tvl: f64,
-
-    /// Tycho API key (if the endpoint requires one)
-    #[arg(long, env = "TYCHO_API_KEY")]
-    pub tycho_api_key: Option<String>,
-
-    /// Worker-pools TOML config (algorithm/hops/workers); the default path falls back to Fynd's
-    /// built-in default pools when absent, like `fynd serve`. Custom paths that don't exist fail
-    /// fast
-    #[arg(long, env = "WORKER_POOLS_CONFIG", default_value = "worker_pools.toml")]
-    pub worker_pools_config: std::path::PathBuf,
-
-    /// Per-quote timeout in milliseconds. Defaults to the budget `fynd serve` gives a real quote,
-    /// because the comparison only means "what would Fynd have returned" if Fynd is given the same
-    /// time it would have had in production. A request-level timeout overrides the router's
-    /// default outright (see `WorkerPoolRouter::effective_timeout`), so a generous value here
-    /// silently hands the re-solve more time than any production quote gets — overstating
-    /// savings — and, on a sub-second chain, lets one solve outlast several blocks.
-    #[arg(long, default_value_t = fynd_rpc::config::defaults::WORKER_ROUTER_TIMEOUT_MS)]
-    pub timeout_ms: u64,
-
-    /// Serve Prometheus metrics on this port
-    #[arg(long)]
-    pub metrics_port: Option<u16>,
-
-    /// Stop after this many blocks (runs until interrupted if omitted)
-    #[arg(long)]
-    pub max_blocks: Option<u64>,
-
-    /// Chain-head lag (in blocks) beyond which the session is considered unhealthy and the solver
-    /// is rebuilt — seen live: a worker died, every solve crawled, and the monitor slid hours
-    /// behind while the feed-dead watchdog never fired (blocks still trickled through). When
-    /// omitted, defaults to roughly 20 minutes' worth of blocks for the chain's block time
-    #[arg(long)]
-    pub max_lag_blocks: Option<u64>,
+    pub solver: SolverArgs,
 
     /// Write one JSON line per re-solved trade (every comparison — wins, losses, and unsolvable
     /// coverage gaps) into this directory as `comparisons-YYYY-MM-DD.jsonl`, rotated at each UTC
@@ -122,171 +50,6 @@ pub(crate) struct MonitorArgs {
     /// reason; filter downstream for the improvement or coverage view
     #[arg(long)]
     pub comparisons_dir: Option<std::path::PathBuf>,
-}
-
-/// Drives the in-process solver, stepping the chain one block per `SteppingSolver::advance`.
-struct StepAdapter<'a> {
-    solver: &'a Solver,
-    controller: &'a BlockStepController,
-    timeout_ms: u64,
-}
-
-impl StepAdapter<'_> {
-    /// The block number of the solver's currently-applied market state, if any.
-    async fn current_block(&self) -> Option<u64> {
-        self.solver
-            .market_data()
-            .read()
-            .await
-            .last_updated()
-            .map(fynd_core::BlockInfo::number)
-    }
-}
-
-#[async_trait]
-impl SteppingSolver for StepAdapter<'_> {
-    async fn solve(&self, token_in: Address, token_out: Address, amount_in: U256) -> Outcome {
-        let Ok(amount) = amount_in.to_string().parse::<BigUint>() else {
-            return Outcome::Unsolvable("unparseable amount_in".to_string());
-        };
-        // Placeholder receiver: routing/amounts are receiver-independent; it only fills the encoded
-        // calldata's recipient. Encoding is requested so each quote carries its on-chain
-        // transaction (note: this refines gas estimates and a failed encode yields
-        // Unsolvable).
-        let order = Order::new(
-            CoreAddress::from(token_in.into_array()),
-            CoreAddress::from(token_out.into_array()),
-            amount,
-            OrderSide::Sell,
-            CoreAddress::from([0x11u8; 20]),
-        );
-        let request = QuoteRequest::new(
-            vec![order],
-            QuoteOptions::default()
-                .with_timeout_ms(self.timeout_ms)
-                .with_encoding_options(EncodingOptions::new(0.005)),
-        );
-
-        let quote = match self.solver.quote(request).await {
-            Ok(quote) => quote,
-            Err(e) => return Outcome::Unsolvable(format!("solve error: {e}")),
-        };
-        let Some(order) = quote.orders().first() else {
-            return Outcome::Unsolvable("solver returned no order quote".to_string());
-        };
-        order_quote_to_outcome(order)
-    }
-
-    async fn reexecute(&self, top: &SolvedAmount) -> Outcome {
-        let Some(route) = top.solved_route.as_ref() else {
-            return Outcome::Unsolvable("top-of-block quote carried no route".to_string());
-        };
-        let market = self.solver.market_data();
-        let view = market.read().await;
-        match fynd_core::replay_route(route, view.base_market_state()) {
-            Ok(replay) => {
-                let amount_out = biguint_to_u256(&replay.amount_out);
-                // Same route ⇒ same gas: reuse the top quote's gas deduction (in token_out
-                // units) and its encoding-refined gas estimate instead of re-deriving gas
-                // prices at the new block state.
-                let gas_deduction = top
-                    .amount_out
-                    .saturating_sub(top.amount_out_net_gas);
-                Outcome::Solved(SolvedAmount {
-                    amount_out,
-                    amount_out_net_gas: amount_out.saturating_sub(gas_deduction),
-                    gas_estimate: top.gas_estimate,
-                    // Same route re-executed: attribution carries over from the top quote. The
-                    // route itself does not — nothing serializes a re-executed outcome's route
-                    // (it only feeds the slippage numbers via its amounts).
-                    algorithm: top.algorithm.clone(),
-                    quote_json: top.quote_json.clone(),
-                    solved_route: None,
-                })
-            }
-            Err(e) => Outcome::Unsolvable(format!("re-execution failed: {e}")),
-        }
-    }
-
-    async fn advance(&self) -> anyhow::Result<()> {
-        let before = self.current_block().await;
-        self.controller
-            .trigger_next_block()
-            .map_err(|_| anyhow::anyhow!("tycho stream ended (trigger channel closed)"))?;
-
-        // Deterministic barrier: wait until the solver applies a block strictly newer than
-        // `before`. An error here means the feed died — either its stream ended (peek returns
-        // None once the gating task exits) or it jammed without ending (no block within
-        // FEED_DEAD_TIMEOUT). The caller rebuilds the solver on any error.
-        let stall_started = Instant::now();
-        let mut next_warn = stall_started + STALL_WARN_INTERVAL;
-        loop {
-            if let Some(now) = self.current_block().await {
-                if before.is_none_or(|b| now > b) {
-                    return Ok(());
-                }
-            }
-            if stall_started.elapsed() >= FEED_DEAD_TIMEOUT {
-                anyhow::bail!(
-                    "no block applied in {}s; tycho feed presumed dead",
-                    stall_started.elapsed().as_secs()
-                );
-            }
-            if Instant::now() >= next_warn {
-                warn!(
-                    waited_s = stall_started.elapsed().as_secs(),
-                    last_applied_block = ?before,
-                    "tycho stream stalled; waiting for the next block"
-                );
-                next_warn += STALL_WARN_INTERVAL;
-            }
-            tokio::select! {
-                () = tokio::time::sleep(POLL_INTERVAL) => {}
-                peeked = self.controller.peek_next_block() => {
-                    if peeked.is_none() {
-                        anyhow::bail!("tycho stream ended while waiting for the next block");
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn order_quote_to_outcome(quote: &OrderQuote) -> Outcome {
-    if quote.status() != QuoteStatus::Success {
-        return Outcome::Unsolvable(format!("{:?}", quote.status()));
-    }
-    // Project the quote to a slim route + calldata, built directly from the quote object. We must
-    // NOT serialize the whole `OrderQuote`: it embeds each hop's `protocol_state`, which both
-    // dominates size and fails to serialize for vm pools (e.g. Curve) — dropping the entire route
-    // for exactly the deep-liquidity stable trades we care about.
-    let quote_json = serde_json::to_string(&super::jsonl::slim_quote(quote)).ok();
-    Outcome::Solved(SolvedAmount {
-        amount_out: biguint_to_u256(quote.amount_out()),
-        amount_out_net_gas: biguint_to_u256(quote.amount_out_net_gas()),
-        gas_estimate: biguint_to_u256(quote.gas_estimate()),
-        // Which algorithm won the quote — the winning quote is the one the `WorkerPoolRouter`
-        // ranked first across every configured pool, so this is the pool that beat the others on
-        // this order. The readable path is derived from `solved_route` at serialization time
-        // (see `resolve::render_route`), not stored here.
-        algorithm: quote.algorithm().to_string(),
-        quote_json,
-        // Kept in memory so the route can be re-executed at back-of-block.
-        solved_route: quote.route().cloned().map(Box::new),
-    })
-}
-
-fn biguint_to_u256(value: &BigUint) -> U256 {
-    // Convert via big-endian bytes: avoids a decimal string round-trip and catches overflow
-    // without relying on parse. U256 fits in 32 bytes; a larger value is a solver bug.
-    let bytes = value.to_bytes_be();
-    if bytes.len() > 32 {
-        warn!(bits = value.bits(), "solver quote amount overflows U256; treating as zero");
-        return U256::ZERO;
-    }
-    let mut buf = [0u8; 32];
-    buf[32 - bytes.len()..].copy_from_slice(&bytes);
-    U256::from_be_bytes(buf)
 }
 
 /// Decode `block`, first waiting out any RPC lag. The HTTP RPC used for receipts can trail the
@@ -350,56 +113,6 @@ struct Totals {
     skipped_blocks: u64,
 }
 
-/// Build the in-process solver and its block-step controller.
-async fn build_solver(
-    cfg: &MonitorArgs,
-    chain: Chain,
-    protocols: &[String],
-    pools_config: &fynd_rpc::config::WorkerPoolsConfig,
-) -> anyhow::Result<(Solver, BlockStepController)> {
-    info!(
-        chain = cfg.chain.name,
-        protocols = protocols.len(),
-        "building in-process solver (loading tokens may take minutes)…"
-    );
-    let mut builder = FyndBuilder::new(
-        chain,
-        &cfg.tycho_url,
-        &cfg.chain.rpc_url,
-        protocols.to_vec(),
-        cfg.min_tvl,
-    );
-    if let Some(key) = cfg.tycho_api_key.as_deref() {
-        builder = builder.tycho_api_key(key);
-    }
-    for (name, pool) in pools_config.pools() {
-        builder = builder
-            .add_pool(name, pool)
-            .map_err(|e| anyhow::anyhow!("failed to add worker pool {name}: {e}"))?;
-    }
-    builder
-        .build_with_step_controller()
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to build solver: {e}"))
-}
-
-/// The chain's block time, which every pacing budget in the monitor is expressed against. A custom
-/// chain with no registered block time falls back to 12-second blocks.
-fn block_time(chain: Chain) -> Duration {
-    let secs = chain
-        .try_block_time_secs()
-        .unwrap_or(12)
-        .max(1);
-    Duration::from_secs(secs)
-}
-
-/// The default `--max-lag-blocks`: a ~20-minute wall-clock budget for how far behind chain head the
-/// monitor may fall before rebuilding, expressed as a block count at the chain's block time so the
-/// budget stays about the same wall-clock length on every chain.
-fn default_lag_blocks(chain: Chain) -> u64 {
-    (LAG_BUDGET_SECS / block_time(chain).as_secs()).max(1)
-}
-
 /// The pacing budgets one session runs against, both scaled to the chain's block time.
 struct Pacing {
     /// Chain-head lag beyond which the session is unhealthy and the solver is rebuilt.
@@ -411,44 +124,8 @@ struct Pacing {
 impl Pacing {
     fn for_chain(chain: Chain, max_lag_blocks: Option<u64>) -> Self {
         Self {
-            max_lag_blocks: max_lag_blocks.unwrap_or_else(|| default_lag_blocks(chain)),
-            rpc_lag_budget: block_time(chain) * DECODE_RPC_LAG_BUDGET_BLOCKS,
-        }
-    }
-}
-
-/// Resolves when the process receives Ctrl-C (SIGINT), the signal the monitor treats as "stop".
-/// If the handler cannot be installed the future never resolves, so a failed registration disables
-/// graceful shutdown rather than tearing the run down immediately.
-async fn shutdown_signal() {
-    if let Err(e) = tokio::signal::ctrl_c().await {
-        warn!(error = %e, "failed to install Ctrl-C handler; graceful shutdown disabled");
-        std::future::pending::<()>().await;
-    }
-}
-
-/// Rebuild the solver after a feed death, retrying with backoff until it succeeds. Returns `None`
-/// when `shutdown` resolves first (Ctrl-C during the retry loop or a build), so the caller stops
-/// instead of rebuilding.
-async fn rebuild_after_feed_death<S: Future<Output = ()>>(
-    cfg: &MonitorArgs,
-    chain: Chain,
-    protocols: &[String],
-    pools_config: &fynd_rpc::config::WorkerPoolsConfig,
-    mut shutdown: Pin<&mut S>,
-) -> Option<(Solver, BlockStepController)> {
-    loop {
-        let rebuilt = tokio::select! {
-            biased;
-            () = shutdown.as_mut() => return None,
-            result = async {
-                tokio::time::sleep(REBUILD_BACKOFF).await;
-                build_solver(cfg, chain, protocols, pools_config).await
-            } => result,
-        };
-        match rebuilt {
-            Ok(built) => return Some(built),
-            Err(e) => warn!(error = %e, "solver rebuild failed; retrying"),
+            max_lag_blocks: max_lag_blocks.unwrap_or_else(|| session::default_lag_blocks(chain)),
+            rpc_lag_budget: session::block_time(chain) * DECODE_RPC_LAG_BUDGET_BLOCKS,
         }
     }
 }
@@ -460,47 +137,23 @@ async fn rebuild_after_feed_death<S: Future<Output = ()>>(
 /// Ctrl-C stops the run cleanly at any await point, tearing the current solver down before
 /// returning.
 pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
-    let chain = cfg.chain.chain()?;
+    let comparisons_dir = cfg.comparisons_dir;
+    let session = Session::prepare(cfg.solver).await?;
+    let chain = session.chain();
 
-    // Expand protocol tokens (e.g. `native_onchain`/`all_onchain`) against Tycho, like serve/scale.
-    let protocols = fynd_rpc::protocols::resolve_protocols(
-        &cfg.tycho_url,
-        cfg.tycho_api_key.as_deref(),
-        true,
-        chain,
-        &cfg.protocols,
-    )
-    .await
-    .map_err(|e| anyhow::anyhow!("failed to resolve protocols: {e}"))?;
+    let mut decoder = Decoder::new(
+        provider_from(&session.args().chain.rpc_url)?,
+        session.args().chain.load_registry()?,
+    );
 
-    // Load worker pools like `fynd serve`: the default path falls back to the built-in default
-    // pools when absent; custom paths that don't exist fail fast.
-    let default_path = std::path::Path::new("worker_pools.toml");
-    let pools_config =
-        if cfg.worker_pools_config.as_path() == default_path && !default_path.exists() {
-            info!("worker_pools.toml not found; using Fynd's built-in default pools");
-            fynd_rpc::config::WorkerPoolsConfig::builtin_default()
-        } else {
-            fynd_rpc::config::WorkerPoolsConfig::load_from_file(&cfg.worker_pools_config).map_err(
-                |e| {
-                    anyhow::anyhow!(
-                        "failed to load worker pools config {}: {e}",
-                        cfg.worker_pools_config.display()
-                    )
-                },
-            )?
-        };
-
-    let mut decoder = Decoder::new(provider_from(&cfg.chain.rpc_url)?, cfg.chain.load_registry()?);
-
-    if let Some(port) = cfg.metrics_port {
+    if let Some(port) = session.args().metrics_port {
         telemetry::install_exporter(port)?;
         info!(port, "serving Prometheus metrics at /metrics");
     }
 
-    let mut comparisons = match cfg.comparisons_dir.as_ref() {
+    let mut comparisons = match comparisons_dir.as_ref() {
         Some(dir) => {
-            let writer = super::jsonl::RotatingWriter::open(dir)?;
+            let writer = super::jsonl::RotatingWriter::open(dir, super::jsonl::COMPARISONS_PREFIX)?;
             info!(path = %writer.current_path().display(), "appending comparisons to JSONL");
             Some(writer)
         }
@@ -508,7 +161,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
     };
 
     let mut totals = Totals::default();
-    let pacing = Pacing::for_chain(chain, cfg.max_lag_blocks);
+    let pacing = Pacing::for_chain(chain, session.args().max_lag_blocks);
     info!(
         max_lag_blocks = pacing.max_lag_blocks,
         rpc_lag_budget_ms = pacing.rpc_lag_budget.as_millis(),
@@ -518,7 +171,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
     // Resolves on Ctrl-C, so a long run stops cleanly at any await below — including the
     // multi-minute solver builds. On shutdown the in-flight block is abandoned, the solver's
     // workers and background tasks are torn down, and `comparisons` flushes as it drops.
-    let shutdown = shutdown_signal();
+    let shutdown = session::shutdown_signal();
     tokio::pin!(shutdown);
 
     // The first build fails fast — an error here is a configuration problem. Rebuilds after a
@@ -526,11 +179,12 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
     let (mut solver, mut controller) = tokio::select! {
         biased;
         () = &mut shutdown => return Ok(()),
-        built = build_solver(&cfg, chain, &protocols, &pools_config) => built?,
+        built = session.build() => built?,
     };
     loop {
+        // Encoding on: each comparison record carries the quote's on-chain transaction.
         let adapter =
-            StepAdapter { solver: &solver, controller: &controller, timeout_ms: cfg.timeout_ms };
+            StepAdapter::new(&solver, &controller, session.args().timeout_ms, Encoding::Requested);
         let reason = tokio::select! {
             biased;
             () = &mut shutdown => {
@@ -538,7 +192,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
                 break;
             }
             end = run_session(
-                &cfg,
+                &session,
                 &pacing,
                 &adapter,
                 &mut decoder,
@@ -552,10 +206,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
         warn!(reason, "session unhealthy; rebuilding the solver to resubscribe");
         telemetry::record_feed_rebuild();
         solver.shutdown();
-        let Some(built) =
-            rebuild_after_feed_death(&cfg, chain, &protocols, &pools_config, shutdown.as_mut())
-                .await
-        else {
+        let Some(built) = session.rebuild(shutdown.as_mut()).await else {
             info!("received Ctrl-C during rebuild; shutting down");
             return Ok(());
         };
@@ -568,7 +219,7 @@ pub(crate) async fn run(cfg: MonitorArgs) -> anyhow::Result<()> {
 /// Drive one solver session: step blocks and re-solve each block's settled trades until the run
 /// completes or the feed dies.
 async fn run_session<P: Provider>(
-    cfg: &MonitorArgs,
+    session: &Session,
     pacing: &Pacing,
     adapter: &StepAdapter<'_>,
     decoder: &mut Decoder<P>,
@@ -585,7 +236,7 @@ async fn run_session<P: Provider>(
 
     loop {
         if adapter
-            .controller
+            .controller()
             .peek_next_block()
             .await
             .is_none()
@@ -638,14 +289,14 @@ async fn run_session<P: Provider>(
         let start = Instant::now();
         // Snapshot token prices at top-of-block (N-1) for the headline metric and the top-of-block
         // USD valuation.
-        let prices_top = snapshot_prices(adapter.solver, decoder.registry()).await;
+        let prices_top = snapshot_prices(adapter.solver(), decoder.registry()).await;
         let ranges = match resolve_block_range(adapter, &trades, &prices_top).await {
             Ok(ranges) => ranges,
             Err(e) => return SessionEnd::Unhealthy(e.to_string()),
         };
         // resolve_block_range advanced the solver to back-of-block (N); snapshot again so the
         // back-of-block improvement is valued against the state it was solved at.
-        let prices_back = snapshot_prices(adapter.solver, decoder.registry()).await;
+        let prices_back = snapshot_prices(adapter.solver(), decoder.registry()).await;
         // The back-of-block solve should land on `target`. On a reorg/gap/resync the stream can
         // apply a different block, silently pairing the back state with another block's trades.
         // The top-of-block (N-1) headline is unaffected; warn so the mispaired back state is
@@ -661,7 +312,7 @@ async fn run_session<P: Provider>(
         for range in &ranges {
             telemetry::record_range(
                 range,
-                &cfg.chain.name,
+                &session.args().chain.name,
                 &prices_top,
                 &prices_back,
                 decoder.registry(),
@@ -676,7 +327,8 @@ async fn run_session<P: Provider>(
         info!(block = target, trades = ranges.len(), elapsed_s, "re-solved block (top/back)");
 
         totals.processed += 1;
-        if cfg
+        if session
+            .args()
             .max_blocks
             .is_some_and(|max| totals.processed >= max)
         {
@@ -728,13 +380,6 @@ fn core_to_alloy(address: &CoreAddress) -> Option<Address> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_default_lag_blocks_scales_with_block_time() {
-        assert_eq!(default_lag_blocks(Chain::Ethereum), 100); // 12s blocks
-        assert_eq!(default_lag_blocks(Chain::Base), 600); // 2s blocks
-        assert_eq!(default_lag_blocks(Chain::Unichain), 1200); // 1s blocks
-    }
 
     #[test]
     fn test_pacing_scales_both_budgets_with_block_time() {
@@ -805,17 +450,19 @@ mod tests {
         let tycho_url = std::env::var("TYCHO_URL").expect("set TYCHO_URL");
         let api_key = std::env::var("TYCHO_API_KEY").ok();
         run(MonitorArgs {
-            chain: crate::ChainArgs { name: "ethereum".to_string(), rpc_url, registry: None },
-            tycho_url,
-            protocols: vec!["uniswap_v2".to_string(), "uniswap_v3".to_string()],
-            // High TVL floor → fewer pools → faster load for a smoke test.
-            min_tvl: 10_000.0,
-            tycho_api_key: api_key,
-            worker_pools_config: std::path::PathBuf::from("worker_pools.toml"),
-            timeout_ms: fynd_rpc::config::defaults::WORKER_ROUTER_TIMEOUT_MS,
-            metrics_port: None,
-            max_blocks: Some(1),
-            max_lag_blocks: Some(100),
+            solver: SolverArgs {
+                chain: crate::ChainArgs { name: "ethereum".to_string(), rpc_url, registry: None },
+                tycho_url,
+                protocols: vec!["uniswap_v2".to_string(), "uniswap_v3".to_string()],
+                // High TVL floor → fewer pools → faster load for a smoke test.
+                min_tvl: 10_000.0,
+                tycho_api_key: api_key,
+                worker_pools_config: std::path::PathBuf::from("worker_pools.toml"),
+                timeout_ms: fynd_rpc::config::defaults::WORKER_ROUTER_TIMEOUT_MS,
+                metrics_port: None,
+                max_blocks: Some(1),
+                max_lag_blocks: Some(100),
+            },
             comparisons_dir: None,
         })
         .await

--- a/tools/hindsight/src/resolve/session.rs
+++ b/tools/hindsight/src/resolve/session.rs
@@ -1,0 +1,232 @@
+//! Building and rebuilding the in-process stepped solver that both live commands drive.
+//!
+//! `monitor` and `decay` need the same thing: an in-process `fynd-core` solver whose block stream
+//! is gated by a [`BlockStepController`], rebuilt in place when the Tycho feed dies so a long
+//! unattended run survives feed failures. That construction — protocol expansion, worker-pool
+//! loading, build, rebuild-with-backoff — lives here so neither command owns a private copy.
+
+use std::{future::Future, path::Path, pin::Pin, time::Duration};
+
+use fynd_core::{BlockStepController, FyndBuilder, Solver};
+use tracing::{info, warn};
+use tycho_simulation::tycho_common::models::Chain;
+
+/// Pause between solver rebuild attempts after a feed death, so a struggling Tycho server is not
+/// hammered in a tight loop.
+const REBUILD_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Wall-clock budget behind chain head that [`default_lag_blocks`] converts into a block count.
+const LAG_BUDGET_SECS: u64 = 20 * 60;
+
+/// Block time assumed for a custom chain with no registered one.
+const FALLBACK_BLOCK_TIME_SECS: u64 = 12;
+
+/// Everything needed to build the in-process stepped solver, shared by the commands that drive one.
+///
+/// Flattened into each command's own args, so `monitor` and `decay` expose an identical solver
+/// surface and a run of one can be reproduced by the other with the same flags.
+#[derive(clap::Args)]
+pub(crate) struct SolverArgs {
+    #[command(flatten)]
+    pub chain: crate::ChainArgs,
+
+    /// Tycho WebSocket URL feeding the in-process solver
+    #[arg(long, env = "TYCHO_URL")]
+    pub tycho_url: String,
+
+    /// Protocols to index, comma-separated. Defaults to every native on-chain protocol; use
+    /// `all_onchain` to include VM-simulated ones too (see `fynd serve --protocols`)
+    #[arg(long, value_delimiter = ',', default_value = "native_onchain")]
+    pub protocols: Vec<String>,
+
+    /// Minimum pool TVL filter for the solver
+    #[arg(long, default_value_t = 100.0)]
+    pub min_tvl: f64,
+
+    /// Tycho API key (if the endpoint requires one)
+    #[arg(long, env = "TYCHO_API_KEY")]
+    pub tycho_api_key: Option<String>,
+
+    /// Worker-pools TOML config (algorithm/hops/workers); the default path falls back to Fynd's
+    /// built-in default pools when absent, like `fynd serve`. Custom paths that don't exist fail
+    /// fast
+    #[arg(long, env = "WORKER_POOLS_CONFIG", default_value = "worker_pools.toml")]
+    pub worker_pools_config: std::path::PathBuf,
+
+    /// Per-quote timeout in milliseconds. Defaults to the budget `fynd serve` gives a real quote,
+    /// because a measurement only means "what would Fynd have returned" if Fynd is given the same
+    /// time it would have had in production. A request-level timeout overrides the router's
+    /// default outright (see `WorkerPoolRouter::effective_timeout`), so a generous value here
+    /// silently hands the solve more time than any production quote gets — and, on a sub-second
+    /// chain, lets one solve outlast several blocks.
+    #[arg(long, default_value_t = fynd_rpc::config::defaults::WORKER_ROUTER_TIMEOUT_MS)]
+    pub timeout_ms: u64,
+
+    /// Serve Prometheus metrics on this port
+    #[arg(long)]
+    pub metrics_port: Option<u16>,
+
+    /// Stop after this many blocks (runs until interrupted if omitted)
+    #[arg(long)]
+    pub max_blocks: Option<u64>,
+
+    /// Chain-head lag (in blocks) beyond which the session is considered unhealthy and the solver
+    /// is rebuilt — seen live: a worker died, every solve crawled, and the run slid hours behind
+    /// while the feed-dead watchdog never fired (blocks still trickled through). When omitted,
+    /// defaults to roughly 20 minutes' worth of blocks for the chain's block time
+    #[arg(long)]
+    pub max_lag_blocks: Option<u64>,
+}
+
+/// The chain's block time, which every pacing budget is expressed against. A custom chain with no
+/// registered block time falls back to 12-second blocks.
+pub(crate) fn block_time(chain: Chain) -> Duration {
+    let secs = chain
+        .try_block_time_secs()
+        .unwrap_or(FALLBACK_BLOCK_TIME_SECS)
+        .max(1);
+    Duration::from_secs(secs)
+}
+
+/// The default `--max-lag-blocks`: a ~20-minute wall-clock budget for how far behind chain head a
+/// run may fall before rebuilding, expressed as a block count at the chain's block time so the
+/// budget stays about the same wall-clock length on every chain.
+pub(crate) fn default_lag_blocks(chain: Chain) -> u64 {
+    (LAG_BUDGET_SECS / block_time(chain).as_secs()).max(1)
+}
+
+/// Resolves when the process receives Ctrl-C (SIGINT), the signal a live run treats as "stop".
+/// If the handler cannot be installed the future never resolves, so a failed registration disables
+/// graceful shutdown rather than tearing the run down immediately.
+pub(crate) async fn shutdown_signal() {
+    if let Err(e) = tokio::signal::ctrl_c().await {
+        warn!(error = %e, "failed to install Ctrl-C handler; graceful shutdown disabled");
+        std::future::pending::<()>().await;
+    }
+}
+
+/// A prepared solver factory: protocols expanded against Tycho and the worker-pool config loaded
+/// once, so every build and rebuild in a run uses identical inputs.
+pub(crate) struct Session {
+    args: SolverArgs,
+    chain: Chain,
+    protocols: Vec<String>,
+    pools_config: fynd_rpc::config::WorkerPoolsConfig,
+}
+
+impl Session {
+    /// Expand the protocol list against Tycho and load the worker-pool config, like `fynd serve`.
+    pub(crate) async fn prepare(args: SolverArgs) -> anyhow::Result<Self> {
+        let chain = args.chain.chain()?;
+
+        // Expand protocol tokens (e.g. `native_onchain`/`all_onchain`) against Tycho, like
+        // serve/scale.
+        let protocols = fynd_rpc::protocols::resolve_protocols(
+            &args.tycho_url,
+            args.tycho_api_key.as_deref(),
+            true,
+            chain,
+            &args.protocols,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to resolve protocols: {e}"))?;
+
+        let pools_config = load_pools_config(&args.worker_pools_config)?;
+        Ok(Self { args, chain, protocols, pools_config })
+    }
+
+    pub(crate) fn args(&self) -> &SolverArgs {
+        &self.args
+    }
+
+    pub(crate) fn chain(&self) -> Chain {
+        self.chain
+    }
+
+    /// Build the in-process solver and its block-step controller.
+    pub(crate) async fn build(&self) -> anyhow::Result<(Solver, BlockStepController)> {
+        info!(
+            chain = self.args.chain.name,
+            protocols = self.protocols.len(),
+            "building in-process solver (loading tokens may take minutes)…"
+        );
+        let mut builder = FyndBuilder::new(
+            self.chain,
+            &self.args.tycho_url,
+            &self.args.chain.rpc_url,
+            self.protocols.clone(),
+            self.args.min_tvl,
+        );
+        if let Some(key) = self.args.tycho_api_key.as_deref() {
+            builder = builder.tycho_api_key(key);
+        }
+        for (name, pool) in self.pools_config.pools() {
+            builder = builder
+                .add_pool(name, pool)
+                .map_err(|e| anyhow::anyhow!("failed to add worker pool {name}: {e}"))?;
+        }
+        builder
+            .build_with_step_controller()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to build solver: {e}"))
+    }
+
+    /// Rebuild the solver after a feed death, retrying with backoff until it succeeds. Returns
+    /// `None` when `shutdown` resolves first (Ctrl-C during the retry loop or a build), so the
+    /// caller stops instead of rebuilding.
+    pub(crate) async fn rebuild<S: Future<Output = ()>>(
+        &self,
+        mut shutdown: Pin<&mut S>,
+    ) -> Option<(Solver, BlockStepController)> {
+        loop {
+            let rebuilt = tokio::select! {
+                biased;
+                () = shutdown.as_mut() => return None,
+                result = async {
+                    tokio::time::sleep(REBUILD_BACKOFF).await;
+                    self.build().await
+                } => result,
+            };
+            match rebuilt {
+                Ok(built) => return Some(built),
+                Err(e) => warn!(error = %e, "solver rebuild failed; retrying"),
+            }
+        }
+    }
+}
+
+/// Load worker pools like `fynd serve`: the default path falls back to the built-in default pools
+/// when absent; a custom path that does not exist fails fast.
+fn load_pools_config(path: &Path) -> anyhow::Result<fynd_rpc::config::WorkerPoolsConfig> {
+    let default_path = Path::new("worker_pools.toml");
+    if path == default_path && !default_path.exists() {
+        info!("worker_pools.toml not found; using Fynd's built-in default pools");
+        return Ok(fynd_rpc::config::WorkerPoolsConfig::builtin_default());
+    }
+    fynd_rpc::config::WorkerPoolsConfig::load_from_file(path)
+        .map_err(|e| anyhow::anyhow!("failed to load worker pools config {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_lag_blocks_scales_with_block_time() {
+        assert_eq!(default_lag_blocks(Chain::Ethereum), 100); // 12s blocks
+        assert_eq!(default_lag_blocks(Chain::Base), 600); // 2s blocks
+        assert_eq!(default_lag_blocks(Chain::Unichain), 1200); // 1s blocks
+    }
+
+    #[test]
+    fn test_block_time_per_chain() {
+        assert_eq!(block_time(Chain::Ethereum), Duration::from_secs(12));
+        assert_eq!(block_time(Chain::Base), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn test_missing_default_pools_config_falls_back_to_builtin() {
+        // A non-default path that does not exist must fail fast rather than silently defaulting.
+        assert!(load_pools_config(Path::new("definitely-not-here.toml")).is_err());
+    }
+}

--- a/tools/hindsight/src/resolve/session.rs
+++ b/tools/hindsight/src/resolve/session.rs
@@ -7,6 +7,8 @@
 
 use std::{future::Future, path::Path, pin::Pin, time::Duration};
 
+use alloy::providers::Provider;
+use async_trait::async_trait;
 use fynd_core::{BlockStepController, FyndBuilder, Solver};
 use tracing::{info, warn};
 use tycho_simulation::tycho_common::models::Chain;
@@ -195,6 +197,66 @@ impl Session {
     }
 }
 
+/// A source of the current chain head, abstracted so a lag check stays testable without a live
+/// RPC connection.
+#[async_trait]
+pub(crate) trait HeadSource: Send + Sync {
+    /// The chain's current head block, or `None` when it could not be determined — treated as
+    /// "skip this check" rather than as a lag, since a flaky RPC call is not evidence the session
+    /// fell behind.
+    async fn head(&self) -> Option<u64>;
+}
+
+/// Reads the chain head from a live JSON-RPC provider.
+pub(crate) struct RpcHead<P>(P);
+
+impl<P> RpcHead<P> {
+    pub(crate) fn new(provider: P) -> Self {
+        Self(provider)
+    }
+}
+
+#[async_trait]
+impl<P: Provider + Send + Sync> HeadSource for RpcHead<P> {
+    async fn head(&self) -> Option<u64> {
+        self.0.get_block_number().await.ok()
+    }
+}
+
+/// Chain-head lag guard: how far behind head a session may fall before it is considered unhealthy
+/// and its solver rebuilt. `monitor` has its own inline version of this check, folded into its
+/// per-block `Pacing`; this one is `decay`'s (see `decay::run_session`), kept here so neither
+/// reinvents the head-polling and telemetry plumbing.
+pub(crate) struct LagGuard {
+    source: Box<dyn HeadSource>,
+    budget: u64,
+}
+
+impl LagGuard {
+    /// `max_lag_blocks`, or the chain's ~20-minute default when omitted.
+    pub(crate) fn new(
+        source: impl HeadSource + 'static,
+        chain: Chain,
+        max_lag_blocks: Option<u64>,
+    ) -> Self {
+        Self {
+            source: Box::new(source),
+            budget: max_lag_blocks.unwrap_or_else(|| default_lag_blocks(chain)),
+        }
+    }
+
+    /// `target`'s lag behind the current chain head, recorded to telemetry regardless of whether
+    /// it trips the budget. `Some((head, lag))` only when the lag exceeds the budget — the
+    /// trigger to consider the session unhealthy. `None` on a transient head-lookup failure too:
+    /// a confirmed lag is worth a solver rebuild, a flaky lookup is not.
+    pub(crate) async fn exceeded(&self, target: u64) -> Option<(u64, u64)> {
+        let head = self.source.head().await?;
+        let lag = head.saturating_sub(target);
+        crate::telemetry::record_head_lag_blocks(lag);
+        (lag > self.budget).then_some((head, lag))
+    }
+}
+
 /// Load worker pools like `fynd serve`: the default path falls back to the built-in default pools
 /// when absent; a custom path that does not exist fails fast.
 fn load_pools_config(path: &Path) -> anyhow::Result<fynd_rpc::config::WorkerPoolsConfig> {
@@ -228,5 +290,44 @@ mod tests {
     fn test_missing_default_pools_config_falls_back_to_builtin() {
         // A non-default path that does not exist must fail fast rather than silently defaulting.
         assert!(load_pools_config(Path::new("definitely-not-here.toml")).is_err());
+    }
+
+    struct FixedHead(Option<u64>);
+
+    #[async_trait]
+    impl HeadSource for FixedHead {
+        async fn head(&self) -> Option<u64> {
+            self.0
+        }
+    }
+
+    #[tokio::test]
+    async fn test_lag_guard_is_quiet_within_budget() {
+        let guard = LagGuard::new(FixedHead(Some(105)), Chain::Ethereum, Some(10));
+        assert_eq!(guard.exceeded(100).await, None);
+    }
+
+    #[tokio::test]
+    async fn test_lag_guard_trips_past_budget() {
+        let guard = LagGuard::new(FixedHead(Some(120)), Chain::Ethereum, Some(10));
+        assert_eq!(guard.exceeded(100).await, Some((120, 20)));
+    }
+
+    #[tokio::test]
+    async fn test_lag_guard_defaults_to_the_chain_budget_when_unset() {
+        // Ethereum's default is 100 blocks (~20 minutes at 12s blocks): 90 blocks behind is
+        // within it, 110 is not.
+        let guard = LagGuard::new(FixedHead(Some(1_090)), Chain::Ethereum, None);
+        assert_eq!(guard.exceeded(1_000).await, None);
+        let guard = LagGuard::new(FixedHead(Some(1_110)), Chain::Ethereum, None);
+        assert_eq!(guard.exceeded(1_000).await, Some((1_110, 110)));
+    }
+
+    #[tokio::test]
+    async fn test_lag_guard_treats_an_unknown_head_as_not_exceeded() {
+        // A transient head-lookup failure is not evidence of a lag — only a confirmed one is
+        // worth the cost of a solver rebuild.
+        let guard = LagGuard::new(FixedHead(None), Chain::Ethereum, Some(0));
+        assert_eq!(guard.exceeded(100).await, None);
     }
 }

--- a/tools/hindsight/src/resolve/step.rs
+++ b/tools/hindsight/src/resolve/step.rs
@@ -1,0 +1,238 @@
+//! The live [`SteppingSolver`]: drives an in-process `fynd-core` solver, releasing the chain one
+//! block at a time so a route quoted at one block state can be replayed against a later one.
+//!
+//! Shared by both measurement commands. `monitor` uses it for the two-state (N-1 → N) comparison
+//! against settled trades; `decay` uses it to replay one quote across several following blocks.
+//! The block barrier is deterministic: after releasing a block via
+//! [`BlockStepController::trigger_next_block`], [`StepAdapter::advance`] waits until the solver's
+//! `MarketData` reports a strictly newer applied block.
+
+use std::time::{Duration, Instant};
+
+use alloy::primitives::{Address, U256};
+use async_trait::async_trait;
+use fynd_core::{
+    types::{
+        EncodingOptions, Order, OrderQuote, OrderSide, QuoteOptions, QuoteRequest, QuoteStatus,
+    },
+    BlockStepController, Solver,
+};
+use num_bigint::BigUint;
+use tracing::warn;
+use tycho_simulation::tycho_common::models::Address as CoreAddress;
+
+use crate::resolve::{Outcome, SolvedAmount, SteppingSolver};
+
+/// How often to warn while the solver has not applied the next block.
+const STALL_WARN_INTERVAL: Duration = Duration::from_mins(5);
+/// No block for this long means the feed is dead, not slow. The observed failure mode: one
+/// server-side subscription goes silent, tycho-client's block synchronizer stops emitting while
+/// it waits for it, and ~35 minutes later backpressure kills the remaining subscriptions
+/// ("Buffer full, unsubscribing!"). Nothing resubscribes, so the stream never recovers — the
+/// caller rebuilds the solver instead of waiting.
+pub(crate) const FEED_DEAD_TIMEOUT: Duration = Duration::from_mins(15);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Slippage tolerance used when a quote is encoded. Only shapes the calldata's `minAmountOut`; it
+/// does not affect routing or the quoted amounts.
+const ENCODING_SLIPPAGE: f64 = 0.005;
+
+/// Whether a solve also encodes its quote into an on-chain transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Encoding {
+    /// Encode: the quote carries its calldata and an encoding-refined gas estimate. Costs extra
+    /// work per solve, and a failed encode turns an otherwise good route into
+    /// [`Outcome::Unsolvable`].
+    Requested,
+    /// Skip encoding: routing and amounts are unaffected, so a measurement that reads only
+    /// `amount_out` pays nothing for calldata it never uses and keeps routes an encoder would
+    /// have rejected.
+    Skipped,
+}
+
+/// Drives the in-process solver, stepping the chain one block per [`SteppingSolver::advance`].
+pub(crate) struct StepAdapter<'a> {
+    solver: &'a Solver,
+    controller: &'a BlockStepController,
+    timeout_ms: u64,
+    encoding: Encoding,
+}
+
+impl<'a> StepAdapter<'a> {
+    pub(crate) fn new(
+        solver: &'a Solver,
+        controller: &'a BlockStepController,
+        timeout_ms: u64,
+        encoding: Encoding,
+    ) -> Self {
+        Self { solver, controller, timeout_ms, encoding }
+    }
+
+    /// The solver being driven, for callers that read its market or derived data directly.
+    pub(crate) fn solver(&self) -> &Solver {
+        self.solver
+    }
+
+    /// The block-step controller, for callers that need to peek at the pending block.
+    pub(crate) fn controller(&self) -> &BlockStepController {
+        self.controller
+    }
+}
+
+#[async_trait]
+impl SteppingSolver for StepAdapter<'_> {
+    async fn current_block(&self) -> Option<u64> {
+        self.solver
+            .market_data()
+            .read()
+            .await
+            .last_updated()
+            .map(fynd_core::BlockInfo::number)
+    }
+
+    async fn solve(&self, token_in: Address, token_out: Address, amount_in: U256) -> Outcome {
+        let Ok(amount) = amount_in.to_string().parse::<BigUint>() else {
+            return Outcome::Unsolvable("unparseable amount_in".to_string());
+        };
+        // Placeholder receiver: routing/amounts are receiver-independent; it only fills the encoded
+        // calldata's recipient.
+        let order = Order::new(
+            CoreAddress::from(token_in.into_array()),
+            CoreAddress::from(token_out.into_array()),
+            amount,
+            OrderSide::Sell,
+            CoreAddress::from([0x11u8; 20]),
+        );
+        let options = QuoteOptions::default().with_timeout_ms(self.timeout_ms);
+        let options = match self.encoding {
+            Encoding::Requested => {
+                options.with_encoding_options(EncodingOptions::new(ENCODING_SLIPPAGE))
+            }
+            Encoding::Skipped => options,
+        };
+
+        let quote = match self
+            .solver
+            .quote(QuoteRequest::new(vec![order], options))
+            .await
+        {
+            Ok(quote) => quote,
+            Err(e) => return Outcome::Unsolvable(format!("solve error: {e}")),
+        };
+        let Some(order) = quote.orders().first() else {
+            return Outcome::Unsolvable("solver returned no order quote".to_string());
+        };
+        order_quote_to_outcome(order)
+    }
+
+    async fn reexecute(&self, top: &SolvedAmount) -> Outcome {
+        let Some(route) = top.solved_route.as_ref() else {
+            return Outcome::Unsolvable("quote carried no route".to_string());
+        };
+        let market = self.solver.market_data();
+        let view = market.read().await;
+        match fynd_core::replay_route(route, view.base_market_state()) {
+            Ok(replay) => {
+                let amount_out = biguint_to_u256(&replay.amount_out);
+                // Same route ⇒ same gas: reuse the original quote's gas deduction (in token_out
+                // units) and its gas estimate instead of re-deriving gas prices at the new block
+                // state.
+                let gas_deduction = top
+                    .amount_out
+                    .saturating_sub(top.amount_out_net_gas);
+                Outcome::Solved(SolvedAmount {
+                    amount_out,
+                    amount_out_net_gas: amount_out.saturating_sub(gas_deduction),
+                    gas_estimate: top.gas_estimate,
+                    // Same route re-executed: attribution carries over from the original quote. The
+                    // route itself does not — nothing serializes a re-executed outcome's route
+                    // (it only feeds the slippage numbers via its amounts).
+                    algorithm: top.algorithm.clone(),
+                    quote_json: top.quote_json.clone(),
+                    solved_route: None,
+                })
+            }
+            Err(e) => Outcome::Unsolvable(format!("re-execution failed: {e}")),
+        }
+    }
+
+    async fn advance(&self) -> anyhow::Result<()> {
+        let before = self.current_block().await;
+        self.controller
+            .trigger_next_block()
+            .map_err(|_| anyhow::anyhow!("tycho stream ended (trigger channel closed)"))?;
+
+        // Deterministic barrier: wait until the solver applies a block strictly newer than
+        // `before`. An error here means the feed died — either its stream ended (peek returns
+        // None once the gating task exits) or it jammed without ending (no block within
+        // FEED_DEAD_TIMEOUT). The caller rebuilds the solver on any error.
+        let stall_started = Instant::now();
+        let mut next_warn = stall_started + STALL_WARN_INTERVAL;
+        loop {
+            if let Some(now) = self.current_block().await {
+                if before.is_none_or(|b| now > b) {
+                    return Ok(());
+                }
+            }
+            if stall_started.elapsed() >= FEED_DEAD_TIMEOUT {
+                anyhow::bail!(
+                    "no block applied in {}s; tycho feed presumed dead",
+                    stall_started.elapsed().as_secs()
+                );
+            }
+            if Instant::now() >= next_warn {
+                warn!(
+                    waited_s = stall_started.elapsed().as_secs(),
+                    last_applied_block = ?before,
+                    "tycho stream stalled; waiting for the next block"
+                );
+                next_warn += STALL_WARN_INTERVAL;
+            }
+            tokio::select! {
+                () = tokio::time::sleep(POLL_INTERVAL) => {}
+                peeked = self.controller.peek_next_block() => {
+                    if peeked.is_none() {
+                        anyhow::bail!("tycho stream ended while waiting for the next block");
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn order_quote_to_outcome(quote: &OrderQuote) -> Outcome {
+    if quote.status() != QuoteStatus::Success {
+        return Outcome::Unsolvable(format!("{:?}", quote.status()));
+    }
+    // Project the quote to a slim route + calldata, built directly from the quote object. We must
+    // NOT serialize the whole `OrderQuote`: it embeds each hop's `protocol_state`, which both
+    // dominates size and fails to serialize for vm pools (e.g. Curve) — dropping the entire route
+    // for exactly the deep-liquidity stable trades we care about.
+    let quote_json = serde_json::to_string(&crate::resolve::jsonl::slim_quote(quote)).ok();
+    Outcome::Solved(SolvedAmount {
+        amount_out: biguint_to_u256(quote.amount_out()),
+        amount_out_net_gas: biguint_to_u256(quote.amount_out_net_gas()),
+        gas_estimate: biguint_to_u256(quote.gas_estimate()),
+        // Which algorithm won the quote — the winning quote is the one the `WorkerPoolRouter`
+        // ranked first across every configured pool, so this is the pool that beat the others on
+        // this order. The readable path is derived from `solved_route` at serialization time
+        // (see `resolve::render_route`), not stored here.
+        algorithm: quote.algorithm().to_string(),
+        quote_json,
+        // Kept in memory so the route can be replayed at a later block state.
+        solved_route: quote.route().cloned().map(Box::new),
+    })
+}
+
+pub(crate) fn biguint_to_u256(value: &BigUint) -> U256 {
+    // Convert via big-endian bytes: avoids a decimal string round-trip and catches overflow
+    // without relying on parse. U256 fits in 32 bytes; a larger value is a solver bug.
+    let bytes = value.to_bytes_be();
+    if bytes.len() > 32 {
+        warn!(bits = value.bits(), "solver quote amount overflows U256; treating as zero");
+        return U256::ZERO;
+    }
+    let mut buf = [0u8; 32];
+    buf[32 - bytes.len()..].copy_from_slice(&bytes);
+    U256::from_be_bytes(buf)
+}


### PR DESCRIPTION
Adds a `decay` subcommand that quotes a sample of trade shapes at one block, then replays those
exact routes at each of the next `--offsets` blocks (default 5). Each offset records the total
move, the market drift a fresh solve at the same state also saw, and the difference — what holding
a stale route cost.

## Why a separate measurement

`monitor`'s existing `slippage` field solves a settled trade at N-1 and replays it at N. That state
already contains the trade's own price impact, so the number measures the route eating its own
shadow. The trades `decay` samples never execute: shapes are drawn from a `monitor` run's
comparison JSONL (pair and input amount only) and re-quoted at unrelated live blocks, which removes
that contamination.

## Cost

Rounds do not overlap, so per-block work is `--sample-size` replays plus `--sample-size` solves
regardless of offset depth. A run warns when a block's work exceeds half the chain's block time.

## Refactors carried along

- `SteppingSolver` moves to `resolve/step.rs` and the solver build/rebuild scaffolding to
  `resolve/session.rs`; both are now shared with `monitor`.
- `StepAdapter` gains an encoding opt-out. `decay` reads only `amount_out`, and requesting calldata
  would both cost work and drop routes an encoder rejects.
- `RotatingWriter` takes an explicit filename prefix, so decay output cannot be re-read as sampler
  input.
- The sampler tolerates reverted-transaction records, which carry null amounts by design, without
  counting them as malformed.

## Note on the open hindsight stack

This branch sits directly on `main`, independent of the open decoding stack (#388 → #371 → #391).
Those PRs also touch `resolve/jsonl.rs` and `resolve/monitor.rs`, so whichever merges second will
need a rebase; there is no functional overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)