### PR TITLE
chore: bump tycho crates to 0.356.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7906,9 +7906,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.354.0"
+version = "0.356.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418ae2ea3fbf0376cddf77b43421ac7e08bde342e7753fa9cb7fc79a2ebde206"
+checksum = "201efd6fbee8d147b8618d8172d95a10ece41849fb0dc83da4fe33dc1321a021"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7936,9 +7936,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.354.0"
+version = "0.356.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c519ddd22ea7a8e5277e3be5faa72942ff28f36916751aeb471dc1e381442f1"
+checksum = "84a79decf01f50919f440055f5eff3be35a9a39ca9fe19f2929370ee54a8b447"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7965,9 +7965,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.354.0"
+version = "0.356.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f561027877004ef4f6794be51c8f5890b04bec0373ff3765416053faa19e72"
+checksum = "8d62dbcece72e1aca907b4fcee6d794621b35a2e495a0dfc565f3ecbd6d4a584"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7987,9 +7987,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.354.0"
+version = "0.356.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39c8c20fcf2825f5a589745b16200aa013c69d76f6626c4c244979450fee00b"
+checksum = "5d8f223a1cf8c3efac6d2428a0e9fbc84d9d61735867f40fac81d27ad36eead1"
 dependencies = [
  "alloy",
  "chrono",
@@ -8009,9 +8009,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.354.0"
+version = "0.356.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2d6dd42e10a0c48a14df8b4ab5fccf5acb332926d93fece8bd42eb30d5efb2"
+checksum = "b8ae288e2bc78ad1266103e9be9f413b26b345c5ddeb9858703fc9e271649db2"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-tycho-execution = ">=0.354.0"
-tycho-simulation = ">=0.354.0"
+tycho-execution = ">=0.356.0"
+tycho-simulation = ">=0.356.0"
 typetag = "0.2"
 
 # Compression


### PR DESCRIPTION
Bumps `tycho-execution` and `tycho-simulation` from 0.354.0 to 0.356.0.

0.356.0 points `ekubo_v3` at the redeployed executor (tycho#1291).

🤖 Generated with [Claude Code](https://claude.com/claude-code)