### PR TITLE
fix(hindsight): veto fee-on-transfer trades

### DIFF
--- a/tools/hindsight/CLAUDE.md
+++ b/tools/hindsight/CLAUDE.md
@@ -62,7 +62,7 @@ Match → trace → decode → veto → record.
 | `decode.rs` | The `TradeDecoder` trait, the matched entity → decoders mapping, `DecodeContext`, `TraderFlow` |
 | `netting_decoders.rs` | Netting toolkit (`sender_flow`, `venue_flow`) plus the `SenderNetting` decoder |
 | `transfer_ledger.rs` | Builds a transfer ledger from logs and native ETH flows |
-| `veto.rs` | The shared `Veto` type, plus post-decode vetoes of non-comparable shapes (NFT purchases, mis-paired wrap trades) |
+| `veto.rs` | The shared `Veto` type, plus post-decode vetoes of non-comparable shapes (NFT purchases, mis-paired wrap trades, fee-on-transfer skims) |
 | `registry.rs` | Per-chain address book, loaded from TOML (see below) |
 | `sandwich.rs` | Flags trades bracketed by a front/back attacker pair (see the design spec) |
 | `venues/` | Per-venue `TradeDecoder` impls (Relay, MetaMask, Rabby), listed in `venues::decoders_for` |

--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -269,7 +269,7 @@ impl<P: Provider> Decoder<P> {
             return None;
         };
 
-        if let Some(veto) = veto::check(&flow, logs, registry) {
+        if let Some(veto) = veto::check(&flow, &transfer_ledger, logs, registry) {
             debug!(
                 tx = %receipt.transaction_hash,
                 venue = %registry.label(entry_point),

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -293,7 +293,8 @@ impl Registry {
 
     /// Whether the address is a registered fee collector: a venue section's collector or a
     /// fee-identified venue wallet. Fees paid to these are venue fees — backed out by the venue
-    /// decoders and `venue_attribution` — not token-level skims (see `veto::Veto::FeeOnTransfer`).
+    /// decoders and `venue_attribution` — not token-level transfer fees (see
+    /// `veto::Veto::FeeOnTransfer`).
     pub(crate) fn is_fee_collector(&self, address: Address) -> bool {
         self.venue_fees.contains_key(&address) ||
             self.venues

--- a/tools/hindsight/src/decoder/registry.rs
+++ b/tools/hindsight/src/decoder/registry.rs
@@ -291,6 +291,16 @@ impl Registry {
         self.infrastructure.contains(&address) || address == self.wrapped_native
     }
 
+    /// Whether the address is a registered fee collector: a venue section's collector or a
+    /// fee-identified venue wallet. Fees paid to these are venue fees — backed out by the venue
+    /// decoders and `venue_attribution` — not token-level skims (see `veto::Veto::FeeOnTransfer`).
+    pub(crate) fn is_fee_collector(&self, address: Address) -> bool {
+        self.venue_fees.contains_key(&address) ||
+            self.venues
+                .values()
+                .any(|venue| venue.fee_collectors.contains(&address))
+    }
+
     /// The chain's `(stablecoin, decimals)` anchors for USD valuation.
     pub(crate) fn stablecoin_anchors(&self) -> &[(Address, u32)] {
         &self.usd_stablecoins
@@ -545,6 +555,16 @@ mod tests {
         );
         assert_eq!(registry.venue_name(collector), None);
         assert!(registry.venue("kyberswap").is_none());
+    }
+
+    #[test]
+    fn test_is_fee_collector() {
+        let registry = Registry::ethereum();
+        let relay_collector = address!("0xf70da97812cb96acdf810712aa562db8dfa3dbef");
+        let phantom_wallet = address!("0x2cffed5d56eb6a17662756ca0fdf350e732c9818");
+        assert!(registry.is_fee_collector(relay_collector));
+        assert!(registry.is_fee_collector(phantom_wallet));
+        assert!(!registry.is_fee_collector(addr(123)));
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/transfer_ledger.rs
+++ b/tools/hindsight/src/decoder/transfer_ledger.rs
@@ -26,7 +26,9 @@
 //! - **One swap per address per transaction.** Two swaps by the same address net into one combined
 //!   flow; if they share sides they merge, otherwise they decline as multi-token.
 //! - **Rebasing/fee-on-transfer tokens** can leave residue that fails the one-in/one-out rule; such
-//!   trades decline rather than record skewed amounts.
+//!   trades decline rather than record skewed amounts. An input-side transfer tax nets cleanly (the
+//!   tax is part of the trader's outflow), so it is caught after decoding instead — see
+//!   `veto::Veto::FeeOnTransfer`.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 
@@ -214,6 +216,25 @@ impl TransferLedger {
             .into_iter()
             .filter(|(_, total)| !total.is_zero())
             .map(|((recipient, token), total)| (recipient, token, total))
+            .collect()
+    }
+
+    /// Totals of `token` that `from` sent directly to pure sinks — addresses that received value
+    /// in the transaction but never sent any — as `(recipient, total)`.
+    pub(crate) fn sink_payments_from(&self, from: Address, token: Address) -> Vec<(Address, U256)> {
+        let mut senders: HashSet<Address> = HashSet::new();
+        for &(_, sender, _, _) in &self.transfers {
+            senders.insert(sender);
+        }
+        let mut payments: HashMap<Address, U256> = HashMap::new();
+        for &(transferred, sender, to, value) in &self.transfers {
+            if transferred == token && sender == from && !senders.contains(&to) {
+                *payments.entry(to).or_default() += value;
+            }
+        }
+        payments
+            .into_iter()
+            .filter(|(_, total)| !total.is_zero())
             .collect()
     }
 
@@ -720,6 +741,34 @@ mod tests {
             transfer_ledger.group_net_received(&group),
             HashMap::from([(addr(11), U256::from(200))])
         );
+    }
+
+    #[test]
+    fn test_sink_payments_from() {
+        // The pool forwards value (not a sink); the tax wallet only accumulates. Only the
+        // trader's own payments count — the pool's payout to the trader is not a sink payment
+        // because the trader sent value too.
+        let trader = addr(1);
+        let pool = addr(50);
+        let tax_wallet = addr(60);
+        let token_a = addr(10);
+        let token_b = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_a, trader, pool, U256::from(950)),
+            make_transfer_log(token_a, trader, tax_wallet, U256::from(30)),
+            make_transfer_log(token_a, trader, tax_wallet, U256::from(20)),
+            make_transfer_log(token_b, pool, trader, U256::from(1000)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+
+        assert_eq!(
+            transfer_ledger.sink_payments_from(trader, token_a),
+            vec![(tax_wallet, U256::from(50))]
+        );
+        assert!(transfer_ledger
+            .sink_payments_from(pool, token_b)
+            .is_empty());
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/transfer_ledger.rs
+++ b/tools/hindsight/src/decoder/transfer_ledger.rs
@@ -26,8 +26,8 @@
 //! - **One swap per address per transaction.** Two swaps by the same address net into one combined
 //!   flow; if they share sides they merge, otherwise they decline as multi-token.
 //! - **Rebasing/fee-on-transfer tokens** can leave residue that fails the one-in/one-out rule; such
-//!   trades decline rather than record skewed amounts. An input-side transfer tax nets cleanly (the
-//!   tax is part of the trader's outflow), so it is caught after decoding instead — see
+//!   trades decline rather than record skewed amounts. An input-side transfer fee nets cleanly (the
+//!   fee is part of the trader's outflow), so it is caught after decoding instead — see
 //!   `veto::Veto::FeeOnTransfer`.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -219,20 +219,26 @@ impl TransferLedger {
             .collect()
     }
 
-    /// Totals of `token` that `from` sent directly to pure sinks — addresses that received value
-    /// in the transaction but never sent any — as `(recipient, total)`.
-    pub(crate) fn sink_payments_from(&self, from: Address, token: Address) -> Vec<(Address, U256)> {
+    /// Totals of `token` paid to pure sinks — addresses that received value in the transaction
+    /// but never sent any — by senders that never received the token themselves: a trader
+    /// spending it or a pool paying out a swap, never a router forwarding what it was paid.
+    /// Returned as `(recipient, total)`.
+    pub(crate) fn sink_payments(&self, token: Address) -> Vec<(Address, U256)> {
         let mut senders: HashSet<Address> = HashSet::new();
-        for &(_, sender, _, _) in &self.transfers {
-            senders.insert(sender);
-        }
-        let mut payments: HashMap<Address, U256> = HashMap::new();
-        for &(transferred, sender, to, value) in &self.transfers {
-            if transferred == token && sender == from && !senders.contains(&to) {
-                *payments.entry(to).or_default() += value;
+        let mut token_receivers: HashSet<Address> = HashSet::new();
+        for &(transferred, from, to, _) in &self.transfers {
+            senders.insert(from);
+            if transferred == token {
+                token_receivers.insert(to);
             }
         }
-        payments
+        let mut totals: HashMap<Address, U256> = HashMap::new();
+        for &(transferred, from, to, value) in &self.transfers {
+            if transferred == token && !token_receivers.contains(&from) && !senders.contains(&to) {
+                *totals.entry(to).or_default() += value;
+            }
+        }
+        totals
             .into_iter()
             .filter(|(_, total)| !total.is_zero())
             .collect()
@@ -744,31 +750,31 @@ mod tests {
     }
 
     #[test]
-    fn test_sink_payments_from() {
-        // The pool forwards value (not a sink); the tax wallet only accumulates. Only the
-        // trader's own payments count — the pool's payout to the trader is not a sink payment
-        // because the trader sent value too.
+    fn test_sink_payments() {
+        // The trader pays token_a to the pool (a sender, so never a sink) and, split by the
+        // token contract, to a wallet that only accumulates. On the token_b side the pool is
+        // the source of the fee wallet's leg, while the router only forwards what it received.
         let trader = addr(1);
         let pool = addr(50);
-        let tax_wallet = addr(60);
+        let router = addr(2);
+        let in_fee_wallet = addr(60);
+        let out_fee_wallet = addr(61);
         let token_a = addr(10);
         let token_b = addr(11);
 
         let logs = vec![
             make_transfer_log(token_a, trader, pool, U256::from(950)),
-            make_transfer_log(token_a, trader, tax_wallet, U256::from(30)),
-            make_transfer_log(token_a, trader, tax_wallet, U256::from(20)),
-            make_transfer_log(token_b, pool, trader, U256::from(1000)),
+            make_transfer_log(token_a, trader, in_fee_wallet, U256::from(30)),
+            make_transfer_log(token_a, trader, in_fee_wallet, U256::from(20)),
+            make_transfer_log(token_b, pool, trader, U256::from(1900)),
+            make_transfer_log(token_b, pool, out_fee_wallet, U256::from(100)),
+            make_transfer_log(token_b, pool, router, U256::from(500)),
+            make_transfer_log(token_b, router, out_fee_wallet, U256::from(500)),
         ];
         let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
 
-        assert_eq!(
-            transfer_ledger.sink_payments_from(trader, token_a),
-            vec![(tax_wallet, U256::from(50))]
-        );
-        assert!(transfer_ledger
-            .sink_payments_from(pool, token_b)
-            .is_empty());
+        assert_eq!(transfer_ledger.sink_payments(token_a), vec![(in_fee_wallet, U256::from(50))]);
+        assert_eq!(transfer_ledger.sink_payments(token_b), vec![(out_fee_wallet, U256::from(100))]);
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/veto.rs
+++ b/tools/hindsight/src/decoder/veto.rs
@@ -19,7 +19,7 @@ use alloy::{
 use crate::decoder::{
     decode::TraderFlow,
     registry::Registry,
-    transfer_ledger::{NetSwap, Transfer},
+    transfer_ledger::{NetSwap, Transfer, TransferLedger, RESIDUE_GROSS_RATIO},
 };
 
 /// A transaction rejected as not a comparable trade, by the shape that disqualified it.
@@ -37,17 +37,55 @@ pub(crate) enum Veto {
     /// destination chain, so there is no same-chain swap to record. Placed at match time by
     /// `solvers::solver_veto`, never by `check`.
     BridgeOrder,
+    /// Part of the trader's input never reached routing: the trader's own transfer of the input
+    /// token split a significant share off to an address that only accumulates — a
+    /// fee-on-transfer token's tax wallet, or an unregistered input-side fee. The skim nets into
+    /// `amount_in`, and the re-solve cannot model it, so every comparison would credit Fynd with
+    /// value no routing can recover.
+    FeeOnTransfer,
 }
 
 /// Check a decoded flow against every post-decode veto, returning the first.
-pub(crate) fn check(flow: &TraderFlow, logs: &[Log], registry: &Registry) -> Option<Veto> {
+pub(crate) fn check(
+    flow: &TraderFlow,
+    transfer_ledger: &TransferLedger,
+    logs: &[Log],
+    registry: &Registry,
+) -> Option<Veto> {
     if received_nft(logs, flow.tracked) {
         return Some(Veto::NftPurchase);
     }
     if wrap_pair_mispaired(&flow.swap, registry.wrapped_native()) {
         return Some(Veto::MispairedWrapPair);
     }
+    if input_skimmed(flow, transfer_ledger, registry) {
+        return Some(Veto::FeeOnTransfer);
+    }
     None
+}
+
+/// Whether a significant share of the trader's input-token outflow went to a pure sink that is
+/// not a registered fee collector.
+///
+/// A fee-on-transfer token's tax is invisible to netting: the token contract splits the trader's
+/// own transfer, so the full outflow nets as `amount_in` while only the untaxed part reached the
+/// route (ZRP on Polygon taxes 5%, and every settled trade read as a constant ~525 bps win). The
+/// tax leg's fingerprint is that it comes straight from the trader and lands on an address that
+/// sends nothing all transaction — a pool or router always sends something onward. Registered fee
+/// collectors share the shape but carry venue fees, which the venue decoders and
+/// `venue_attribution` back out — so they are exempt. A leg under the residue line (1% of the
+/// input, `RESIDUE_GROSS_RATIO`) is dust, not a skim.
+fn input_skimmed(flow: &TraderFlow, transfer_ledger: &TransferLedger, registry: &Registry) -> bool {
+    for (recipient, amount) in transfer_ledger.sink_payments_from(flow.tracked, flow.swap.token_in)
+    {
+        if registry.is_fee_collector(recipient) || registry.is_infrastructure(recipient) {
+            continue;
+        }
+        if amount.saturating_mul(U256::from(RESIDUE_GROSS_RATIO)) >= flow.swap.amount_in {
+            return true;
+        }
+    }
+    false
 }
 
 sol! {
@@ -181,6 +219,128 @@ mod tests {
         assert!(!wrap_pair_mispaired(&swap(weth, 1000, Address::ZERO, 1000), weth));
         // An unwrap with a fee taken stays within the 2x band.
         assert!(!wrap_pair_mispaired(&swap(weth, 1000, Address::ZERO, 900), weth));
+    }
+
+    fn flow(tracked: Address, net: NetSwap) -> TraderFlow {
+        TraderFlow::without_fees(tracked, net)
+    }
+
+    #[test]
+    fn test_fee_on_transfer_input_tax() {
+        // The transfer-tax shape (ZRP on Polygon): the token contract splits the trader's own
+        // transfer, 95% to the pool and 5% to a tax wallet that sends nothing, while netting
+        // reads the full outflow as amount_in.
+        let trader = addr(1);
+        let pool = addr(50);
+        let tax_wallet = addr(60);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, trader, pool, U256::from(950)),
+            make_transfer_log(token_in, trader, tax_wallet, U256::from(50)),
+            make_transfer_log(token_out, pool, trader, U256::from(2000)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+        let taxed = flow(trader, swap(token_in, 1000, token_out, 2000));
+
+        assert_eq!(
+            check(&taxed, &transfer_ledger, &logs, &Registry::ethereum()),
+            Some(Veto::FeeOnTransfer)
+        );
+    }
+
+    #[test]
+    fn test_fee_collector_sink_is_not_a_skim() {
+        // The same split, but the sink is a registered venue fee collector: a venue fee the
+        // decoders back out, not a token tax.
+        let registry = Registry::ethereum();
+        let collector = *registry
+            .venue("metamask")
+            .unwrap()
+            .fee_collectors
+            .iter()
+            .next()
+            .unwrap();
+        let trader = addr(1);
+        let pool = addr(50);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, trader, pool, U256::from(950)),
+            make_transfer_log(token_in, trader, collector, U256::from(50)),
+            make_transfer_log(token_out, pool, trader, U256::from(2000)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+        let fee_paying = flow(trader, swap(token_in, 1000, token_out, 2000));
+
+        assert_eq!(check(&fee_paying, &transfer_ledger, &logs, &registry), None);
+    }
+
+    #[test]
+    fn test_router_paid_fee_is_not_a_skim() {
+        // The partner-fee shape (ParaSwap): the router skims the output to a fee wallet. The
+        // sink leg comes from the router, not the trader, so it is a solver fee — part of the
+        // settled price by policy, never a fee-on-transfer veto.
+        let trader = addr(1);
+        let pool = addr(50);
+        let router = addr(2);
+        let fee_wallet = addr(60);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, trader, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, router, U256::from(2000)),
+            make_transfer_log(token_out, router, fee_wallet, U256::from(30)),
+            make_transfer_log(token_out, router, trader, U256::from(1970)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+        let partner_fee = flow(trader, swap(token_in, 1000, token_out, 1970));
+
+        assert_eq!(check(&partner_fee, &transfer_ledger, &logs, &Registry::ethereum()), None);
+    }
+
+    #[test]
+    fn test_split_route_pools_are_not_sinks() {
+        // A split route pays two pools; both send output onward, so neither is a sink.
+        let trader = addr(1);
+        let pool_a = addr(50);
+        let pool_b = addr(51);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, trader, pool_a, U256::from(600)),
+            make_transfer_log(token_in, trader, pool_b, U256::from(400)),
+            make_transfer_log(token_out, pool_a, trader, U256::from(1200)),
+            make_transfer_log(token_out, pool_b, trader, U256::from(800)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+        let split = flow(trader, swap(token_in, 1000, token_out, 2000));
+
+        assert_eq!(check(&split, &transfer_ledger, &logs, &Registry::ethereum()), None);
+    }
+
+    #[test]
+    fn test_dust_sink_leg_is_not_a_skim() {
+        // A sink leg under the 1% residue line is rounding dust, not a tax.
+        let trader = addr(1);
+        let pool = addr(50);
+        let sink = addr(60);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, trader, pool, U256::from(9950)),
+            make_transfer_log(token_in, trader, sink, U256::from(50)),
+            make_transfer_log(token_out, pool, trader, U256::from(20_000)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+        let dusty = flow(trader, swap(token_in, 10_000, token_out, 20_000));
+
+        assert_eq!(check(&dusty, &transfer_ledger, &logs, &Registry::ethereum()), None);
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/veto.rs
+++ b/tools/hindsight/src/decoder/veto.rs
@@ -37,11 +37,13 @@ pub(crate) enum Veto {
     /// destination chain, so there is no same-chain swap to record. Placed at match time by
     /// `solvers::solver_veto`, never by `check`.
     BridgeOrder,
-    /// Part of the trader's input never reached routing: the trader's own transfer of the input
-    /// token split a significant share off to an address that only accumulates — a
-    /// fee-on-transfer token's tax wallet, or an unregistered input-side fee. The skim nets into
-    /// `amount_in`, and the re-solve cannot model it, so every comparison would credit Fynd with
-    /// value no routing can recover.
+    /// Part of the trade's value was taken by a fee on transfer: the token contract (or an
+    /// unregistered fee) split a transfer, landing a significant share on an address that only
+    /// accumulates — its fee wallet. Selling such a token, the fee nets into `amount_in`;
+    /// buying it, the trader's receipt is already net of the fee the pool paid gross.
+    /// Fee-on-transfer tokens are not supported by the Tycho simulation (the re-solve quotes as
+    /// if the full amounts moved fee-free), so every comparison would credit Fynd with the
+    /// token's own fee.
     FeeOnTransfer,
 }
 
@@ -58,31 +60,33 @@ pub(crate) fn check(
     if wrap_pair_mispaired(&flow.swap, registry.wrapped_native()) {
         return Some(Veto::MispairedWrapPair);
     }
-    if input_skimmed(flow, transfer_ledger, registry) {
+    if fee_on_transfer(flow, transfer_ledger, registry) {
         return Some(Veto::FeeOnTransfer);
     }
     None
 }
 
-/// Whether a significant share of the trader's input-token outflow went to a pure sink that is
-/// not a registered fee collector.
+/// Whether a fee on transfer took a significant share of either side of the trade.
 ///
-/// A fee-on-transfer token's tax is invisible to netting: the token contract splits the trader's
-/// own transfer, so the full outflow nets as `amount_in` while only the untaxed part reached the
-/// route (ZRP on Polygon taxes 5%, and every settled trade read as a constant ~525 bps win). The
-/// tax leg's fingerprint is that it comes straight from the trader and lands on an address that
-/// sends nothing all transaction — a pool or router always sends something onward. Registered fee
-/// collectors share the shape but carry venue fees, which the venue decoders and
-/// `venue_attribution` back out — so they are exempt. A leg under the residue line (1% of the
-/// input, `RESIDUE_GROSS_RATIO`) is dust, not a skim.
-fn input_skimmed(flow: &TraderFlow, transfer_ledger: &TransferLedger, registry: &Registry) -> bool {
-    for (recipient, amount) in transfer_ledger.sink_payments_from(flow.tracked, flow.swap.token_in)
-    {
-        if registry.is_fee_collector(recipient) || registry.is_infrastructure(recipient) {
-            continue;
-        }
-        if amount.saturating_mul(U256::from(RESIDUE_GROSS_RATIO)) >= flow.swap.amount_in {
-            return true;
+/// Catches any fee-on-transfer token that Tycho mislabels and does not support: the re-solve
+/// quotes fee-free amounts, so the comparison would credit Fynd with the token's own fee.
+/// Registered venue fee collectors are exempt — their fees are backed out downstream. A leg
+/// under the residue line (1% of the trade amount, `RESIDUE_GROSS_RATIO`) is dust, not a fee.
+fn fee_on_transfer(
+    flow: &TraderFlow,
+    transfer_ledger: &TransferLedger,
+    registry: &Registry,
+) -> bool {
+    let sides =
+        [(flow.swap.token_in, flow.swap.amount_in), (flow.swap.token_out, flow.swap.amount_out)];
+    for (token, trade_amount) in sides {
+        for (recipient, total) in transfer_ledger.sink_payments(token) {
+            if registry.is_fee_collector(recipient) || registry.is_infrastructure(recipient) {
+                continue;
+            }
+            if total.saturating_mul(U256::from(RESIDUE_GROSS_RATIO)) >= trade_amount {
+                return true;
+            }
         }
     }
     false
@@ -251,7 +255,32 @@ mod tests {
     }
 
     #[test]
-    fn test_fee_collector_sink_is_not_a_skim() {
+    fn test_fee_on_transfer_output_tax() {
+        // The buy-side mirror: the pool pays the gross output and the token contract splits it —
+        // 95% to the trader, 5% to the fee wallet. The pool never received the output token, so
+        // it is the token's source, unlike a router that forwards what it was paid.
+        let trader = addr(1);
+        let pool = addr(50);
+        let tax_wallet = addr(60);
+        let token_in = addr(10);
+        let token_out = addr(11);
+
+        let logs = vec![
+            make_transfer_log(token_in, trader, pool, U256::from(1000)),
+            make_transfer_log(token_out, pool, trader, U256::from(1900)),
+            make_transfer_log(token_out, pool, tax_wallet, U256::from(100)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+        let taxed = flow(trader, swap(token_in, 1000, token_out, 1900));
+
+        assert_eq!(
+            check(&taxed, &transfer_ledger, &logs, &Registry::ethereum()),
+            Some(Veto::FeeOnTransfer)
+        );
+    }
+
+    #[test]
+    fn test_fee_collector_sink_is_not_a_transfer_fee() {
         // The same split, but the sink is a registered venue fee collector: a venue fee the
         // decoders back out, not a token tax.
         let registry = Registry::ethereum();
@@ -279,10 +308,10 @@ mod tests {
     }
 
     #[test]
-    fn test_router_paid_fee_is_not_a_skim() {
-        // The partner-fee shape (ParaSwap): the router skims the output to a fee wallet. The
-        // sink leg comes from the router, not the trader, so it is a solver fee — part of the
-        // settled price by policy, never a fee-on-transfer veto.
+    fn test_router_paid_fee_is_not_a_transfer_fee() {
+        // The partner-fee shape (ParaSwap): the router pays a cut of the output to a fee wallet.
+        // The sink leg comes from the router, not the trader, so it is a solver fee — part
+        // of the settled price by policy, never a fee-on-transfer veto.
         let trader = addr(1);
         let pool = addr(50);
         let router = addr(2);
@@ -324,7 +353,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dust_sink_leg_is_not_a_skim() {
+    fn test_dust_sink_leg_is_not_a_transfer_fee() {
         // A sink leg under the 1% residue line is rounding dust, not a tax.
         let trader = addr(1);
         let pool = addr(50);


### PR DESCRIPTION
A fee-on-transfer token's contract splits transfers, sending the fee to its own wallet. Netting cannot see this: the fee lands inside the settled amounts, and Tycho's simulation does not support fee-on-transfer tokens, so the re-solve quotes as if the full amounts moved fee-free and every such trade records a fake win. On Polygon, a token with a 5% transfer fee read as a constant ~525 bps improvement on all of its trades. Tycho scores that token `quality: 100, tax: 0`, so the solver's `min_token_quality` filter cannot catch it upstream.

Such trades are now vetoed, on both the sell and the buy side. Registered venue fee collectors stay exempt (their fees are backed out downstream), and router-paid partner fees never match the shape — the settled price keeps the solver's own fee, per policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)