### PR TITLE
docs: fix exclusive-liquidity docs to match the actual code

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -139,31 +139,33 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 ## Exclusive Liquidity (restricted)
 
 A limited, opt-in service offered to specific deployments — **not** part of the normal routing path.
-Ordinary deployments configure no exclusivity policy, every pool stays `LiquidityScope::PublicOnly`,
+Ordinary deployments set no pool's `liquidity_scope`, every pool stays `LiquidityScope::PublicOnly`,
 and nothing below applies. Treat it as out of scope unless a task names it.
 
 Worker pools are partitioned by `LiquidityScope` (`fynd-core/src/worker_pool_router/`):
 
 - `PublicOnly` (default) — public liquidity only. Its best candidate is the **committed amount out**,
   the reference output a quote must at least deliver
-- `All` — also routes through components an `ExclusivityPolicy`
-  (`fynd-core/src/feed/exclusivity.rs`, a caller-supplied `ProtocolComponent` predicate) classifies
-  as exclusive. Its candidates may beat the public reference; the difference is **surplus**, tracked
-  in `SurplusInfo` / `OrderQuote::surplus_amount()` and never serialized on the wire
+- `IncludeExclusive` — no filtering: routes through whatever the stream delivers, exclusive
+  components included. A component is classified exclusive by `is_exclusive`
+  (`fynd-core/src/feed/exclusivity.rs`), a fixed check for the `is_exclusive` static attribute on the
+  component's Tycho data — not a per-deployment predicate. Its candidates may beat the public
+  reference; the difference is **surplus**, tracked in `SurplusInfo` / `OrderQuote::surplus_amount()`
+  and never serialized on the wire
 
 Exclusive components only reach `MarketState` if the protocol's stream filter admits them. That is
 opt-in per protocol via the `exclusive:` prefix on a `--protocols` entry (e.g.
 `--protocols all_onchain,exclusive:ekubo_v3`), handled in
 `fynd-core/src/feed/protocol_registry.rs`; `EXCLUSIVE_CAPABLE_PROTOCOLS` lists the protocols that
 have such a variant (`ekubo_v3` only) and the prefix is rejected for any other. Stream admission is
-independent of the routing policy below — opting in without an `ExclusivityPolicy` leaves those
-pools indistinguishable from public liquidity.
+independent of the routing scope below — opting in without any pool set to `IncludeExclusive` leaves
+those pools indistinguishable from public liquidity everywhere.
 
-Enabled per pool via `liquidity_scope = "all"` in `worker_pools.toml`; a pool that sets it without a
-configured policy fails the build (`SolverBuildError::LiquidityScopeWithoutPolicy`). Encoding a leg
-that carries a committed amount is protocol-specific and lives in
-`fynd-core/src/encoding/exclusive_swap.rs`, which needs `EXCLUSIVE_SWAP_CONTROLLER_KEY`. See
-`fynd-core/CLAUDE.md` for the crate-level detail.
+Enabled per pool via `liquidity_scope = "include_exclusive"` in `worker_pools.toml`; a deployment
+where every pool sets it fails the build (`SolverBuildError::NoPublicPool`) since no pool would be
+left to establish the committed reference output. Encoding a leg that carries a committed amount is
+protocol-specific and lives in `fynd-core/src/encoding/exclusive_swap.rs`, which needs
+`EXCLUSIVE_SWAP_CONTROLLER_KEY`. See `fynd-core/CLAUDE.md` for the crate-level detail.
 
 ## Related Repositories
 

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -99,7 +99,7 @@ recorded with `tools/record-market`. See `tests/integration/README.md`.
 ## Exclusive Liquidity (restricted)
 
 A limited, opt-in service for specific deployments — **not** part of the normal routing path. With no
-`ExclusivityPolicy` configured (the default) every pool is `LiquidityScope::PublicOnly`, none of this
+pool's `liquidity_scope` set (the default) every pool is `LiquidityScope::PublicOnly`, none of this
 code runs, and the flows above are complete. Skip this section unless a task names it.
 
 Exclusive components must first be admitted to the stream. `feed/protocol_registry.rs` parses each
@@ -123,22 +123,26 @@ Pools are partitioned by `LiquidityScope` (`worker_pool_router/`, re-exported at
 
 - `PublicOnly` (default) — public liquidity only. Its best candidate is the **committed amount out**,
   the reference output the quote must at least deliver.
-- `All` — also routes through components the configured `ExclusivityPolicy`
-  (`feed/exclusivity.rs`) classifies as exclusive.
+- `IncludeExclusive` — no filtering: routes through whatever the stream delivers, exclusive
+  components included if the deployment opted them into the stream.
 
-Isolation is per worker, not per state: `MarketState` is never duplicated. `PublicOnly` workers hold
-`Some(policy)` and filter exclusive components out of their local graph topology and incoming
-`MarketEvent`s; `All` workers hold `None` and ingest everything.
+A component is classified exclusive by `is_exclusive` (`feed/exclusivity.rs`) — a fixed check for the
+`is_exclusive` static attribute on the component's Tycho data, applied generically to every ingested
+component. There is no per-deployment policy to configure.
 
-After public ranking, `combine_with_surplus` overlays any `All`-scope candidate that beats the
-committed amount and records the difference as `SurplusInfo` (`OrderQuote::surplus_amount()`,
-`committed_amount_out()`, `Swap::committed_amount_out()`). All are `#[serde(skip)]` — internal, not
-on the wire.
+Isolation is per worker, not per state: `MarketState` is never duplicated. `PublicOnly` workers filter
+exclusive components out of their local graph topology and incoming `MarketEvent`s (via
+`remove_exclusive_components`/`scope_event`); `IncludeExclusive` workers ingest everything.
 
-Enable with `FyndBuilder::exclusivity_policy(predicate)` (`Fn(&ProtocolComponent) -> bool`), then set
-the scope per pool via `PoolConfig::with_liquidity_scope()` or `liquidity_scope = "all"` in
-`worker_pools.toml`. A pool with a scope but no policy fails the build
-(`SolverBuildError::LiquidityScopeWithoutPolicy`).
+After public ranking, `combine_with_surplus` overlays any `IncludeExclusive`-scope candidate that
+beats the committed amount and records the difference as `SurplusInfo`
+(`OrderQuote::surplus_amount()`, `committed_amount_out()`, `Swap::committed_amount_out()`). All are
+`#[serde(skip)]` — internal, not on the wire.
+
+Enable by setting the scope per pool via `PoolConfig::with_liquidity_scope()` or
+`liquidity_scope = "include_exclusive"` in `worker_pools.toml`. A deployment where every pool sets it
+fails the build (`SolverBuildError::NoPublicPool`) — there would be no pool left to establish the
+committed reference output.
 
 Encoding a committed leg is protocol-specific: `encoding/exclusive_swap.rs` is Ekubo-only. It signs
 an EIP-712 authorization with `EXCLUSIVE_SWAP_CONTROLLER_KEY` and packs it, plus a derived Q32 fee,


### PR DESCRIPTION
## Summary

`fynd-core/CLAUDE.md` and `.claude/CODEBASE.md` describe an `ExclusivityPolicy` /
`FyndBuilder::exclusivity_policy(predicate)` / `SolverBuildError::LiquidityScopeWithoutPolicy` /
`LiquidityScope::All` design. None of those identifiers exist in `fynd-core/src` -- classification
is the fixed `is_exclusive` static-attribute check in `feed/exclusivity.rs`, the scope variant is
`LiquidityScope::IncludeExclusive`, the `worker_pools.toml` value is `"include_exclusive"` (not
`"all"`), and the only build-time guard is `SolverBuildError::NoPublicPool` (every pool set to
`IncludeExclusive` leaves no pool to establish the committed reference output).

Found while writing a helm-configuration PR to enable exclusive Ekubo V3 liquidity on hosted Fynd
and cross-checking the docs against the actual source.