### PR TITLE
feat: count exclusive candidates dropped for invalid route shape

### DIFF
--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -1076,6 +1076,7 @@ fn has_valid_exclusive_route(quote: &OrderQuote, chain: Chain) -> bool {
                         is_native_wrap(next, chain)
                 });
         if !reaches_output {
+            counter!("exclusive_route_invalid_shape_total").increment(1);
             return false;
         }
         exclusive_count += 1;


### PR DESCRIPTION
An exclusive leg that does not reach the route's output token makes the candidate unusable, so no commitment is made and the order falls back to public liquidity. That happened silently.

`exclusive_route_invalid_shape_total` counts it:

```rust
if !reaches_output {
    counter!("exclusive_route_invalid_shape_total").increment(1);
    return false;
}
```

It counts only the wrong-position case, not routes that carry no exclusive leg at all — those are pools routing around the exclusive components, not rejections, and they would swamp the series.

The counter fires per exclusive-scope candidate, not per order. An order served by several exclusive-scope pools contributes several increments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)