### PR TITLE
feat: accept exclusive legs anywhere in the route

### DIFF
--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -141,6 +141,14 @@ beats the committed amount and records the difference as `SurplusInfo`
 (`OrderQuote::surplus_amount()`, `committed_amount_out()`, `Swap::committed_amount_out()`). All are
 `#[serde(skip)]` — internal, not on the wire.
 
+A route can carry a commitment when it has exactly one exclusive leg and replays against the states
+its swaps were quoted at. Where the leg sits does not matter.
+`worker_pool_router/exclusive_capture.rs` solves how much the leg withholds: for a leg that ends the
+route the answer is the surplus itself, and for a leg with swaps after it the answer is what those
+swaps turn into the surplus, found by bisecting replays of the route. The router reads token
+decimals for those replays from `MarketData` (`WorkerPoolRouter::with_market_data`); without it no
+commitment is made and orders answer from public liquidity.
+
 Enable by setting the scope per pool via `PoolConfig::with_liquidity_scope()` or
 `liquidity_scope = "include_exclusive"` in `worker_pools.toml`. A deployment where every pool sets it
 fails the build (`SolverBuildError::NoPublicPool`) — there would be no pool left to establish the

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -862,7 +862,8 @@ impl FyndBuilder {
         let router_config = WorkerPoolRouterConfig::default()
             .with_timeout(self.router_timeout)
             .with_min_responses(self.router_min_responses);
-        let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
+        let mut router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder)
+            .with_market_data(market_data.clone());
 
         if self.price_guard_enabled {
             let mut registry = PriceProviderRegistry::new();
@@ -1328,7 +1329,8 @@ impl Solver {
         let router_config = WorkerPoolRouterConfig::default()
             .with_timeout(Duration::from_millis(max_timeout_ms.max(5000)))
             .with_min_responses(defaults::ROUTER_MIN_RESPONSES);
-        let router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder);
+        let router = WorkerPoolRouter::new(solver_pool_handles, router_config, encoder)
+            .with_market_data(market_data.clone());
 
         // Trigger derived data computation
         let market_read = market_data.read().await;

--- a/fynd-core/src/worker_pool_router/exclusive_capture.rs
+++ b/fynd-core/src/worker_pool_router/exclusive_capture.rs
@@ -1,0 +1,400 @@
+//! Solves how much an exclusive leg must withhold for a route to land on its committed amount.
+//!
+//! An exclusive leg captures surplus by emitting less than it could. When the leg is the last hop
+//! of its path, withholding one unit costs the user exactly one unit, so the amount to withhold is
+//! the surplus itself. When swaps sit between the leg and the route's output token, the withheld
+//! amount passes through those pools first: withholding `d` at the leg lowers the route output by
+//! `g(x) - g(x - d)`, where `g` is the composition of the downstream pools. Capturing a surplus `s`
+//! means solving `g(x) - g(x - d) = s` for `d`.
+//!
+//! There is no closed form for `g` across mixed protocols, so this module inverts it numerically.
+//! Every swap carries the pool state it was quoted against ([`Swap::protocol_state`]), so a
+//! candidate route can be re-simulated without reading the market again.
+//!
+//! `g` is non-decreasing for every protocol we route through, which is what makes the search
+//! sound: the route output falls monotonically as the leg withholds more. The search keeps the
+//! best withholding that still leaves the user at or above the target, so stopping early costs the
+//! protocol capture and never costs the user output.
+
+use num_bigint::BigUint;
+use num_traits::{CheckedSub, Zero};
+use rustc_hash::FxHashMap;
+use tycho_simulation::tycho_common::{
+    models::{token::Token, Address},
+    simulation::protocol_sim::ProtocolSim,
+};
+
+use crate::{algorithm::sim_guard::GuardedProtocolSim, types::quote::Swap};
+
+/// Bisection steps taken when narrowing the withheld amount.
+///
+/// Each step is one replay of the route. 24 steps put the answer within `leg_output / 2^24` of
+/// exact — below a wei for any realistic leg — and cap the simulation work per quote.
+const MAX_BISECTION_STEPS: u32 = 24;
+
+/// Decimals and address for every token a candidate route touches, taken from the market before
+/// solving. Pool simulations need the full token, not just its address.
+pub(super) type TokenLookup = FxHashMap<Address, Token>;
+
+/// Why a route's withheld amount could not be solved.
+///
+/// A candidate that cannot be solved cannot carry a commitment, so `best_exclusive_candidate`
+/// drops it rather than guessing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum CaptureError {
+    /// A token on the route was absent from the lookup built for it.
+    MissingToken(Address),
+    /// A pool simulation failed or panicked while replaying the route.
+    Simulation(String),
+    /// Replaying the route at full leg output produced nothing for the output token, so there is
+    /// no baseline to reduce.
+    EmptyBaseline,
+}
+
+/// Returns how much the leg at `leg_index` must withhold, in its own output token, for the route
+/// to deliver `surplus` less than it otherwise would.
+///
+/// `swaps` is the route in emitted order (topological). `input_token` and `output_token` are the
+/// route's ends.
+///
+/// The returned amount never exceeds the leg's own output, and never withholds so much that the
+/// route falls below `baseline - surplus`. When the surplus is at least the whole baseline the leg
+/// gives up its entire output; the caller's commitment gates keep that from being reachable in
+/// practice.
+///
+/// # Errors
+///
+/// Returns [`CaptureError`] when the route cannot be replayed against the states its swaps carry.
+pub(super) fn solve_withheld_amount(
+    swaps: &[Swap],
+    input_token: &Address,
+    output_token: &Address,
+    leg_index: usize,
+    surplus: &BigUint,
+    tokens: &TokenLookup,
+) -> Result<BigUint, CaptureError> {
+    let leg_output = swaps
+        .get(leg_index)
+        .map(Swap::amount_out)
+        .cloned()
+        .unwrap_or_default();
+
+    let replay = |withheld: &BigUint| {
+        simulate_with_withholding(swaps, input_token, output_token, leg_index, withheld, tokens)
+    };
+
+    let baseline = replay(&BigUint::ZERO)?;
+    if baseline.is_zero() {
+        return Err(CaptureError::EmptyBaseline);
+    }
+    let Some(target) = baseline.checked_sub(surplus) else {
+        return Ok(leg_output);
+    };
+
+    // Largest withheld amount whose replay still clears `target`. `low` is always feasible and
+    // `high` always the first amount past the answer, so an early stop returns a feasible amount.
+    let mut low = BigUint::ZERO;
+    let mut high = leg_output.clone() + 1u32;
+
+    // The leg's own price is a lower bound on the answer whenever the downstream pools have
+    // diminishing returns, which is the ordinary case. Seeding with it skips most of the search.
+    // It is checked rather than trusted, so a pool that does not behave that way just costs steps.
+    let seed = surplus * &leg_output / &baseline;
+    if seed > BigUint::ZERO && seed <= leg_output && replay(&seed)? >= target {
+        low = seed;
+    }
+
+    for _ in 0..MAX_BISECTION_STEPS {
+        if &high - &low <= BigUint::from(1u32) {
+            break;
+        }
+        let mid = (&low + &high) / 2u32;
+        if replay(&mid)? >= target {
+            low = mid;
+        } else {
+            high = mid;
+        }
+    }
+
+    Ok(low)
+}
+
+/// Replays `swaps` against the states they carry, with the leg at `leg_index` emitting `withheld`
+/// less than it did, and returns what reaches `output_token`.
+///
+/// Balances are threaded exactly as [`crate::replay::replay_route`] threads them: swaps run in the
+/// route's topological order, a positive `split` takes that fraction of the balance its token had
+/// when the branch opened, the final swap of a group takes the remainder, and a pool used twice
+/// sees its own post-swap state the second time.
+///
+/// Unlike `replay_route` this reads no market. Each swap's own quote-time state is the point: the
+/// question is what the route would have produced at the state it was quoted against, not what it
+/// would produce now.
+fn simulate_with_withholding(
+    swaps: &[Swap],
+    input_token: &Address,
+    output_token: &Address,
+    leg_index: usize,
+    withheld: &BigUint,
+    tokens: &TokenLookup,
+) -> Result<BigUint, CaptureError> {
+    let total_in: BigUint = swaps
+        .iter()
+        .filter(|swap| swap.token_in() == input_token)
+        .map(Swap::amount_in)
+        .sum();
+
+    let mut available: FxHashMap<Address, BigUint> = FxHashMap::default();
+    available.insert(input_token.clone(), total_in);
+    let mut branch_totals: FxHashMap<Address, BigUint> = FxHashMap::default();
+    let mut post_swap: FxHashMap<String, Box<dyn ProtocolSim>> = FxHashMap::default();
+
+    for (index, swap) in swaps.iter().enumerate() {
+        let token_in = lookup(tokens, swap.token_in())?;
+        let token_out = lookup(tokens, swap.token_out())?;
+
+        let branch_total = branch_totals
+            .entry(swap.token_in().clone())
+            .or_insert_with(|| {
+                available
+                    .get(swap.token_in())
+                    .cloned()
+                    .unwrap_or_default()
+            })
+            .clone();
+        let remaining = available
+            .entry(swap.token_in().clone())
+            .or_default();
+        let amount_in = if *swap.split() > 0.0 {
+            let (part, _) =
+                crate::algorithm::split_primitives::split_amount(&branch_total, *swap.split());
+            part.min(remaining.clone())
+        } else {
+            remaining.clone()
+        };
+        *remaining -= &amount_in;
+
+        let sim = post_swap
+            .get(swap.component_id())
+            .map(|state| state.as_ref())
+            .unwrap_or_else(|| swap.protocol_state());
+        let result = sim
+            .get_amount_out_guarded(amount_in, token_in, token_out)
+            .map_err(|e| CaptureError::Simulation(e.to_string()))?;
+
+        let amount_out = if index == leg_index {
+            result
+                .amount
+                .checked_sub(withheld)
+                .unwrap_or_default()
+        } else {
+            result.amount.clone()
+        };
+
+        *available
+            .entry(swap.token_out().clone())
+            .or_default() += amount_out;
+        post_swap.insert(swap.component_id().to_string(), result.new_state);
+    }
+
+    Ok(available
+        .remove(output_token)
+        .unwrap_or_default())
+}
+
+/// Resolves a route token to the full token the pool simulations need.
+fn lookup<'a>(tokens: &'a TokenLookup, address: &Address) -> Result<&'a Token, CaptureError> {
+    tokens
+        .get(address)
+        .ok_or_else(|| CaptureError::MissingToken(address.clone()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algorithm::test_utils::{component, token, ConstantProductSim};
+
+    /// A constant-product pool holding `reserve_in` of the token it takes and `reserve_out` of the
+    /// one it gives.
+    fn pool(
+        token_in: &Token,
+        token_out: &Token,
+        reserve_in: u64,
+        reserve_out: u64,
+    ) -> Box<dyn ProtocolSim> {
+        let (reserve_0, reserve_1) = if token_in.address < token_out.address {
+            (reserve_in, reserve_out)
+        } else {
+            (reserve_out, reserve_in)
+        };
+        Box::new(ConstantProductSim {
+            reserve_0: BigUint::from(reserve_0),
+            reserve_1: BigUint::from(reserve_1),
+            gas: 0,
+        })
+    }
+
+    /// Builds a chain of legs, simulating each hop so every leg carries the amounts a solver
+    /// would really have quoted it with.
+    fn chain(hops: Vec<(&str, &Token, &Token, Box<dyn ProtocolSim>)>, amount_in: u64) -> Vec<Swap> {
+        let mut amount = BigUint::from(amount_in);
+        let mut swaps = Vec::new();
+        for (id, token_in, token_out, sim) in hops {
+            let amount_out = sim
+                .get_amount_out(amount.clone(), token_in, token_out)
+                .expect("test pool must quote")
+                .amount;
+            swaps.push(Swap::new(
+                id.to_string(),
+                "uniswap_v2".to_string(),
+                token_in.address.clone(),
+                token_out.address.clone(),
+                amount.clone(),
+                amount_out.clone(),
+                BigUint::ZERO,
+                component(id, &[token_in.clone(), token_out.clone()]),
+                sim,
+            ));
+            amount = amount_out;
+        }
+        swaps
+    }
+
+    fn lookup_for(tokens: &[&Token]) -> TokenLookup {
+        tokens
+            .iter()
+            .map(|t| (t.address.clone(), (*t).clone()))
+            .collect()
+    }
+
+    /// The route output with nothing withheld. Asserts the replay agrees with the amounts the
+    /// legs carry, so a broken fixture fails here rather than somewhere subtler.
+    fn baseline_of(
+        swaps: &[Swap],
+        input: &Address,
+        output: &Address,
+        tokens: &TokenLookup,
+    ) -> BigUint {
+        let replayed =
+            simulate_with_withholding(swaps, input, output, usize::MAX, &BigUint::ZERO, tokens)
+                .expect("route must replay");
+        assert_eq!(
+            replayed,
+            *swaps
+                .last()
+                .expect("non-empty route")
+                .amount_out(),
+            "replay must reproduce the amounts the route carries",
+        );
+        replayed
+    }
+
+    #[test]
+    fn test_terminal_leg_withholds_the_surplus_itself() {
+        let (a, b) = (token(0x01, "A"), token(0x02, "B"));
+        let tokens = lookup_for(&[&a, &b]);
+        let swaps = chain(vec![("exclusive", &a, &b, pool(&a, &b, 1_000_000, 1_000_000))], 1_000);
+        let out = baseline_of(&swaps, &a.address, &b.address, &tokens);
+
+        let surplus = BigUint::from(50u32);
+        let withheld =
+            solve_withheld_amount(&swaps, &a.address, &b.address, 0, &surplus, &tokens).unwrap();
+
+        assert_eq!(withheld, surplus, "a leg that ends the route withholds the surplus itself");
+        assert!(out > surplus);
+    }
+
+    #[test]
+    fn test_mid_path_leg_lands_the_route_on_the_target() {
+        let (a, b, c) = (token(0x01, "A"), token(0x02, "B"), token(0x03, "C"));
+        let tokens = lookup_for(&[&a, &b, &c]);
+        let swaps = chain(
+            vec![
+                ("exclusive", &a, &b, pool(&a, &b, 1_000_000, 1_000_000)),
+                ("downstream", &b, &c, pool(&b, &c, 500_000, 1_000_000)),
+            ],
+            1_000,
+        );
+        let baseline = baseline_of(&swaps, &a.address, &c.address, &tokens);
+
+        let surplus = BigUint::from(100u32);
+        let withheld =
+            solve_withheld_amount(&swaps, &a.address, &c.address, 0, &surplus, &tokens).unwrap();
+        let target = &baseline - &surplus;
+
+        let landed =
+            simulate_with_withholding(&swaps, &a.address, &c.address, 0, &withheld, &tokens)
+                .unwrap();
+        let overshoot = simulate_with_withholding(
+            &swaps,
+            &a.address,
+            &c.address,
+            0,
+            &(&withheld + 1u32),
+            &tokens,
+        )
+        .unwrap();
+
+        assert!(landed >= target, "the user keeps at least the committed amount");
+        assert!(overshoot < target, "withholding one more would take the user below it");
+        assert!(withheld > BigUint::ZERO);
+    }
+
+    #[test]
+    fn test_solved_amount_exceeds_the_average_price_estimate() {
+        let (a, b, c) = (token(0x01, "A"), token(0x02, "B"), token(0x03, "C"));
+        let tokens = lookup_for(&[&a, &b, &c]);
+        // A thin downstream pool: the marginal price is well below the average price, which is
+        // exactly where scaling the surplus by the average price under-captures.
+        let swaps = chain(
+            vec![
+                ("exclusive", &a, &b, pool(&a, &b, 1_000_000, 1_000_000)),
+                ("downstream", &b, &c, pool(&b, &c, 200_000, 200_000)),
+            ],
+            100_000,
+        );
+        let baseline = baseline_of(&swaps, &a.address, &c.address, &tokens);
+
+        let surplus = BigUint::from(2_000u32);
+        let withheld =
+            solve_withheld_amount(&swaps, &a.address, &c.address, 0, &surplus, &tokens).unwrap();
+        let average_price_estimate = &surplus * swaps[0].amount_out() / &baseline;
+
+        assert!(
+            withheld > average_price_estimate,
+            "solved {withheld} must exceed the average-price estimate {average_price_estimate}",
+        );
+    }
+
+    #[test]
+    fn test_surplus_above_the_baseline_takes_the_whole_leg() {
+        let (a, b, c) = (token(0x01, "A"), token(0x02, "B"), token(0x03, "C"));
+        let tokens = lookup_for(&[&a, &b, &c]);
+        let swaps = chain(
+            vec![
+                ("exclusive", &a, &b, pool(&a, &b, 1_000_000, 1_000_000)),
+                ("downstream", &b, &c, pool(&b, &c, 500_000, 1_000_000)),
+            ],
+            1_000,
+        );
+        let baseline = baseline_of(&swaps, &a.address, &c.address, &tokens);
+
+        let withheld =
+            solve_withheld_amount(&swaps, &a.address, &c.address, 0, &(&baseline + 1u32), &tokens)
+                .unwrap();
+
+        assert_eq!(withheld, *swaps[0].amount_out());
+    }
+
+    #[test]
+    fn test_missing_token_is_an_error() {
+        let (a, b) = (token(0x01, "A"), token(0x02, "B"));
+        let swaps = chain(vec![("exclusive", &a, &b, pool(&a, &b, 1_000_000, 1_000_000))], 1_000);
+        let tokens = lookup_for(&[&a]);
+
+        let solved =
+            solve_withheld_amount(&swaps, &a.address, &b.address, 0, &BigUint::from(1u32), &tokens);
+
+        assert_eq!(solved, Err(CaptureError::MissingToken(b.address.clone())));
+    }
+}

--- a/fynd-core/src/worker_pool_router/exclusive_capture.rs
+++ b/fynd-core/src/worker_pool_router/exclusive_capture.rs
@@ -28,8 +28,10 @@ use crate::{algorithm::sim_guard::GuardedProtocolSim, types::quote::Swap};
 
 /// Bisection steps taken when narrowing the withheld amount.
 ///
-/// Each step is one replay of the route. 24 steps put the answer within `leg_output / 2^24` of
-/// exact — below a wei for any realistic leg — and cap the simulation work per quote.
+/// Each step is one replay of the route, so this is the simulation work one candidate costs. The
+/// search stops early once the interval closes; where it does not, it leaves up to
+/// `leg_output / 2^24` of the surplus unwithheld. That residue stays with the user, so spending
+/// fewer steps costs the protocol capture rather than correctness.
 const MAX_BISECTION_STEPS: u32 = 24;
 
 /// Decimals and address for every token a candidate route touches, taken from the market before
@@ -46,9 +48,29 @@ pub(super) enum CaptureError {
     MissingToken(Address),
     /// A pool simulation failed or panicked while replaying the route.
     Simulation(String),
-    /// Replaying the route at full leg output produced nothing for the output token, so there is
-    /// no baseline to reduce.
+    /// The route produced nothing for its output token, so there is no baseline to reduce.
     EmptyBaseline,
+}
+
+/// Returns what the route delivers when nothing is withheld.
+///
+/// This is the cheap half of the module: one replay, enough to tell whether a candidate can be
+/// solved at all. `solve_withheld_amount` does the search.
+///
+/// # Errors
+///
+/// Returns [`CaptureError`] when the route cannot be replayed against the states its swaps carry.
+pub(super) fn replay_baseline(
+    swaps: &[Swap],
+    input_token: &Address,
+    output_token: &Address,
+    tokens: &TokenLookup,
+) -> Result<BigUint, CaptureError> {
+    let baseline = simulate_with_withholding(swaps, input_token, output_token, None, tokens)?;
+    if baseline.is_zero() {
+        return Err(CaptureError::EmptyBaseline);
+    }
+    Ok(baseline)
 }
 
 /// Returns how much the leg at `leg_index` must withhold, in its own output token, for the route
@@ -57,10 +79,9 @@ pub(super) enum CaptureError {
 /// `swaps` is the route in emitted order (topological). `input_token` and `output_token` are the
 /// route's ends.
 ///
-/// The returned amount never exceeds the leg's own output, and never withholds so much that the
-/// route falls below `baseline - surplus`. When the surplus is at least the whole baseline the leg
-/// gives up its entire output; the caller's commitment gates keep that from being reachable in
-/// practice.
+/// The answer never exceeds the leg's own output, and never withholds so much that the route falls
+/// below `baseline - surplus`. A surplus at or above the baseline takes the leg's whole output; the
+/// caller's commitment gates keep that out of reach in practice.
 ///
 /// # Errors
 ///
@@ -80,29 +101,24 @@ pub(super) fn solve_withheld_amount(
         .unwrap_or_default();
 
     let replay = |withheld: &BigUint| {
-        simulate_with_withholding(swaps, input_token, output_token, leg_index, withheld, tokens)
+        simulate_with_withholding(
+            swaps,
+            input_token,
+            output_token,
+            Some((leg_index, withheld)),
+            tokens,
+        )
     };
 
-    let baseline = replay(&BigUint::ZERO)?;
-    if baseline.is_zero() {
-        return Err(CaptureError::EmptyBaseline);
-    }
+    let baseline = replay_baseline(swaps, input_token, output_token, tokens)?;
     let Some(target) = baseline.checked_sub(surplus) else {
         return Ok(leg_output);
     };
 
-    // Largest withheld amount whose replay still clears `target`. `low` is always feasible and
-    // `high` always the first amount past the answer, so an early stop returns a feasible amount.
+    // `low` is always an amount whose replay clears `target` and `high` always the first amount
+    // past it, so the answer is `low` whenever the loop stops, however early that is.
     let mut low = BigUint::ZERO;
-    let mut high = leg_output.clone() + 1u32;
-
-    // The leg's own price is a lower bound on the answer whenever the downstream pools have
-    // diminishing returns, which is the ordinary case. Seeding with it skips most of the search.
-    // It is checked rather than trusted, so a pool that does not behave that way just costs steps.
-    let seed = surplus * &leg_output / &baseline;
-    if seed > BigUint::ZERO && seed <= leg_output && replay(&seed)? >= target {
-        low = seed;
-    }
+    let mut high = leg_output + 1u32;
 
     for _ in 0..MAX_BISECTION_STEPS {
         if &high - &low <= BigUint::from(1u32) {
@@ -119,8 +135,10 @@ pub(super) fn solve_withheld_amount(
     Ok(low)
 }
 
-/// Replays `swaps` against the states they carry, with the leg at `leg_index` emitting `withheld`
-/// less than it did, and returns what reaches `output_token`.
+/// Replays `swaps` against the states they carry and returns what reaches `output_token`.
+///
+/// `withholding` names a leg and how much less than its simulated output it emits. `None` replays
+/// the route untouched.
 ///
 /// Balances are threaded exactly as [`crate::replay::replay_route`] threads them: swaps run in the
 /// route's topological order, a positive `split` takes that fraction of the balance its token had
@@ -134,8 +152,7 @@ fn simulate_with_withholding(
     swaps: &[Swap],
     input_token: &Address,
     output_token: &Address,
-    leg_index: usize,
-    withheld: &BigUint,
+    withholding: Option<(usize, &BigUint)>,
     tokens: &TokenLookup,
 ) -> Result<BigUint, CaptureError> {
     let total_in: BigUint = swaps
@@ -182,13 +199,12 @@ fn simulate_with_withholding(
             .get_amount_out_guarded(amount_in, token_in, token_out)
             .map_err(|e| CaptureError::Simulation(e.to_string()))?;
 
-        let amount_out = if index == leg_index {
-            result
+        let amount_out = match withholding {
+            Some((leg_index, withheld)) if index == leg_index => result
                 .amount
                 .checked_sub(withheld)
-                .unwrap_or_default()
-        } else {
-            result.amount.clone()
+                .unwrap_or_default(),
+            _ => result.amount.clone(),
         };
 
         *available
@@ -275,9 +291,8 @@ mod tests {
         output: &Address,
         tokens: &TokenLookup,
     ) -> BigUint {
-        let replayed =
-            simulate_with_withholding(swaps, input, output, usize::MAX, &BigUint::ZERO, tokens)
-                .expect("route must replay");
+        let replayed = simulate_with_withholding(swaps, input, output, None, tokens)
+            .expect("route must replay");
         assert_eq!(
             replayed,
             *swaps
@@ -322,15 +337,20 @@ mod tests {
             solve_withheld_amount(&swaps, &a.address, &c.address, 0, &surplus, &tokens).unwrap();
         let target = &baseline - &surplus;
 
-        let landed =
-            simulate_with_withholding(&swaps, &a.address, &c.address, 0, &withheld, &tokens)
-                .unwrap();
+        let landed = simulate_with_withholding(
+            &swaps,
+            &a.address,
+            &c.address,
+            Some((0, &withheld)),
+            &tokens,
+        )
+        .unwrap();
+        let one_more = &withheld + 1u32;
         let overshoot = simulate_with_withholding(
             &swaps,
             &a.address,
             &c.address,
-            0,
-            &(&withheld + 1u32),
+            Some((0, &one_more)),
             &tokens,
         )
         .unwrap();

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -24,6 +24,7 @@
 mod allocation;
 mod comparison_log;
 pub mod config;
+mod exclusive_capture;
 
 use std::{
     sync::LazyLock,
@@ -34,6 +35,7 @@ pub use allocation::ExclusiveAccess;
 use allocation::{allocate, Allocation, OrderClass};
 use comparison_log::{log_quote_comparison, solver_error_label};
 use config::WorkerPoolRouterConfig;
+use exclusive_capture::{solve_withheld_amount, TokenLookup};
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, gauge, histogram};
 use num_bigint::BigUint;
@@ -45,13 +47,15 @@ use tycho_execution::encoding::{
     evm::gas_estimator::estimate_gas_usage,
     models::{Solution, Strategy},
 };
-use tycho_simulation::tycho_common::{models::Chain, Bytes};
+use tycho_simulation::tycho_common::{models::Address, Bytes};
 
 use crate::{
-    encoding::encoder::Encoder, feed::exclusivity::is_exclusive, price_guard::guard::PriceGuard,
-    worker_pool::task_queue::TaskQueueHandle, BlockInfo, EncodingOptions, Order, OrderQuote,
-    OrderSide, Quote, QuoteOptions, QuoteRequest, QuoteStatus, SolveError, SolveParams,
-    SurplusInfo, Swap,
+    encoding::encoder::Encoder,
+    feed::{exclusivity::is_exclusive, market_data::MarketData},
+    price_guard::guard::PriceGuard,
+    worker_pool::task_queue::TaskQueueHandle,
+    BlockInfo, EncodingOptions, Order, OrderQuote, OrderSide, Quote, QuoteOptions, QuoteRequest,
+    QuoteStatus, SolveError, SolveParams, SurplusInfo,
 };
 
 /// Environment variable overriding [`DEFAULT_USER_IMPROVEMENT_SHARE_BPS`]. Read once, on the
@@ -243,6 +247,10 @@ pub struct WorkerPoolRouter {
     /// Validates solution outputs against external price sources.
     /// Present when the server has price guard enabled; `None` when disabled.
     price_guard: Option<PriceGuard>,
+    /// Source of the token decimals that replaying an exclusive candidate needs. `None` leaves
+    /// exclusive candidates unsolvable, so no commitment is made and orders answer from public
+    /// liquidity.
+    market_data: Option<MarketData>,
 }
 
 impl WorkerPoolRouter {
@@ -252,7 +260,45 @@ impl WorkerPoolRouter {
         config: WorkerPoolRouterConfig,
         encoder: Encoder,
     ) -> Self {
-        Self { solver_pools, config, encoder, price_guard: None }
+        Self { solver_pools, config, encoder, price_guard: None, market_data: None }
+    }
+
+    /// Gives the router the market it reads token decimals from.
+    ///
+    /// Only exclusive routing needs this: replaying a candidate to solve its withheld amount calls
+    /// the pool simulations, which take full tokens rather than addresses.
+    pub fn with_market_data(mut self, market_data: MarketData) -> Self {
+        self.market_data = Some(market_data);
+        self
+    }
+
+    /// Collects the tokens every candidate route touches, in one read of the market.
+    ///
+    /// Solving runs inside a synchronous ranking pass, so the tokens are gathered up front rather
+    /// than looked up per swap.
+    async fn route_tokens(&self, responses: &[OrderResponses]) -> TokenLookup {
+        let Some(market_data) = self.market_data.as_ref() else {
+            return TokenLookup::default();
+        };
+        let addresses: FxHashSet<Address> = responses
+            .iter()
+            .flat_map(|response| response.quotes.iter())
+            .filter_map(|wq| wq.quote.route())
+            .flat_map(|route| route.swaps())
+            .flat_map(|swap| [swap.token_in().clone(), swap.token_out().clone()])
+            .collect();
+        if addresses.is_empty() {
+            return TokenLookup::default();
+        }
+
+        let market = market_data.read().await;
+        addresses
+            .into_iter()
+            .filter_map(|address| {
+                let token = market.get_token(&address)?.clone();
+                Some((address, token))
+            })
+            .collect()
     }
 
     /// Makes price guard validation available for this router.
@@ -350,6 +396,16 @@ impl WorkerPoolRouter {
             refine_gas_estimates(&mut order_responses, encoding_options)?;
         }
 
+        let exclusive_tokens = if allocations
+            .iter()
+            .any(Allocation::exclusive_routing_active)
+        {
+            self.route_tokens(&order_responses)
+                .await
+        } else {
+            TokenLookup::default()
+        };
+
         // Rank quotes for each order (sorted by refined amount_out_net_gas descending).
         // `rank_quotes` produces the public ranking — the committed reference AND the price-guard
         // fallback chain. When the allocation holds an exclusive-scope worker pool, the winning
@@ -372,7 +428,7 @@ impl WorkerPoolRouter {
                         request.options(),
                         public_ranked,
                         *USER_IMPROVEMENT_SHARE_BPS,
-                        self.encoder.chain(),
+                        &exclusive_tokens,
                     )
                 } else {
                     self.rank_quotes(responses, request.options())
@@ -813,10 +869,10 @@ fn combine_with_surplus(
     options: &QuoteOptions,
     public_ranked: Vec<OrderQuote>,
     user_share_bps: u32,
-    chain: Chain,
+    tokens: &TokenLookup,
 ) -> Vec<OrderQuote> {
     let Some(exclusive_candidate) =
-        best_exclusive_candidate(responses, pool_scopes, options, chain)
+        best_exclusive_candidate(responses, pool_scopes, options, tokens)
     else {
         return public_ranked;
     };
@@ -843,8 +899,12 @@ fn combine_with_surplus(
         gauge!("exclusive_user_savings_amount").increment(user_savings.to_f64().unwrap_or(0.0));
     }
 
+    let Some(pinned) = pin_commitment(exclusive_candidate, committed_amount_out, tokens) else {
+        return public_ranked;
+    };
+
     let mut result = Vec::with_capacity(public_ranked.len() + 1);
-    result.push(pin_commitment(exclusive_candidate, committed_amount_out));
+    result.push(pinned);
     result.extend(public_ranked);
     result
 }
@@ -859,12 +919,12 @@ fn is_rankable(quote: &OrderQuote, options: &QuoteOptions) -> bool {
 }
 
 /// Returns the exclusive-access candidate with the highest output net of gas. The candidate must
-/// obey the request `max_gas` and the route shape rules of `has_valid_exclusive_route`.
+/// obey the request `max_gas` and the rules of `has_valid_exclusive_route`.
 fn best_exclusive_candidate<'a>(
     responses: &'a OrderResponses,
     pool_scopes: &FxHashMap<String, LiquidityScope>,
     options: &QuoteOptions,
-    chain: Chain,
+    tokens: &TokenLookup,
 ) -> Option<&'a OrderQuote> {
     responses
         .quotes
@@ -877,7 +937,7 @@ fn best_exclusive_candidate<'a>(
                 .map(|max| wq.quote.gas_estimate() <= max)
                 .unwrap_or(true)
         })
-        .filter(|wq| has_valid_exclusive_route(&wq.quote, chain))
+        .filter(|wq| has_valid_exclusive_route(&wq.quote, tokens))
         .max_by(|a, b| {
             a.quote
                 .amount_out_net_gas()
@@ -948,11 +1008,22 @@ fn default_fee_commitment(exclusive_candidate: &OrderQuote) -> Option<BigUint> {
     Some(committed_amount_out)
 }
 
-/// Sets `exclusive_candidate` to `committed_amount_out`. This sets the committed amount on each
-/// leg, sets `amount_out` and `amount_out_net_gas`, and attaches the `SurplusInfo`.
+/// Sets `exclusive_candidate` to `committed_amount_out`. This sets the committed amount on the
+/// exclusive leg, sets `amount_out` and `amount_out_net_gas`, and attaches the `SurplusInfo`.
 ///
-/// The exclusive components capture all output above the commitment.
-fn pin_commitment(exclusive_candidate: &OrderQuote, committed_amount_out: BigUint) -> OrderQuote {
+/// The exclusive component captures all output above the commitment. How much the leg withholds to
+/// do that is solved by [`solve_withheld_amount`], which replays the route against the states its
+/// swaps were quoted at. A leg that ends its path withholds the surplus itself; a leg with swaps
+/// after it withholds whatever those swaps turn into the surplus.
+///
+/// Returns `None` when the route cannot be replayed, since the withheld amount is then unknown.
+/// `best_exclusive_candidate` has already replayed the candidate, so this is not reachable for a
+/// candidate it returned.
+fn pin_commitment(
+    exclusive_candidate: &OrderQuote,
+    committed_amount_out: BigUint,
+    tokens: &TokenLookup,
+) -> Option<OrderQuote> {
     let exclusive_route_amount_out = exclusive_candidate.amount_out();
     let exclusive_gas_cost = exclusive_route_amount_out - exclusive_candidate.amount_out_net_gas();
     let surplus_amount = exclusive_route_amount_out - &committed_amount_out;
@@ -960,58 +1031,12 @@ fn pin_commitment(exclusive_candidate: &OrderQuote, committed_amount_out: BigUin
     gauge!("exclusive_fee_amount").increment(surplus_amount.to_f64().unwrap_or(0.0));
 
     let mut surplus_quote = exclusive_candidate.clone();
-
-    // Final output of each swap's path, walked backwards (a path's terminal output propagates
-    // to its chained predecessors). Converting captured surplus into a leg's token needs the
-    // realized downstream price `path_final_out / leg_out`; for terminal legs the ratio is 1.
-    let path_final_outs: Vec<BigUint> = surplus_quote
-        .route()
-        .map(|route| {
-            let swaps = route.swaps();
-            let mut finals = vec![BigUint::ZERO; swaps.len()];
-            let mut current_final = BigUint::ZERO;
-            for i in (0..swaps.len()).rev() {
-                let is_terminal =
-                    i == swaps.len() - 1 || swaps[i + 1].token_in() != swaps[i].token_out();
-                if is_terminal {
-                    current_final = swaps[i].amount_out().clone();
-                }
-                finals[i] = current_final.clone();
-            }
-            finals
-        })
-        .unwrap_or_default();
+    let withheld = withheld_leg_amount(&surplus_quote, &surplus_amount, tokens)?;
 
     if let Some(route) = surplus_quote.route_mut() {
-        // Capture the route's surplus at the exclusive legs.
-        // Each leg absorbs up to its path's capacity; any remainder is left with the user.
-        let mut surplus = exclusive_route_amount_out - &committed_amount_out;
-        for (i, swap) in route.swaps_mut().iter_mut().enumerate() {
+        for swap in route.swaps_mut().iter_mut() {
             if is_exclusive(swap.protocol_component()) {
-                let Some(path_final_out) = path_final_outs.get(i) else {
-                    continue;
-                };
-                let captured = surplus
-                    .clone()
-                    .min(path_final_out.clone());
-                // Convert into the leg's own token, rounding down so any error is taken
-                // from the protocol, not the user. Today the leg is always the last hop of
-                // its path (validator), so path_final_out equals the leg's output and this
-                // divides by itself — a plain subtraction. Once mid-path legs are allowed,
-                // the "user gets at least the committed amount" guarantee also requires the
-                // components after the leg to have diminishing returns.
-                let captured_leg = if *path_final_out == BigUint::ZERO {
-                    BigUint::ZERO
-                } else {
-                    &captured * swap.amount_out() / path_final_out
-                };
-                debug_assert!(
-                    captured_leg <= *swap.amount_out(),
-                    "captured amount ({captured_leg}) must not exceed the leg's output ({})",
-                    swap.amount_out(),
-                );
-                let committed_leg = swap.amount_out() - &captured_leg;
-                surplus -= captured;
+                let committed_leg = swap.amount_out() - &withheld;
                 swap.set_committed_amount_out(committed_leg);
             }
         }
@@ -1025,79 +1050,73 @@ fn pin_commitment(exclusive_candidate: &OrderQuote, committed_amount_out: BigUin
     surplus_quote.set_amount_out_net_gas(&committed_amount_out - &exclusive_gas_cost);
 
     let surplus_info = SurplusInfo::new(surplus_amount, committed_amount_out);
-    surplus_quote.with_surplus(surplus_info)
+    Some(surplus_quote.with_surplus(surplus_info))
 }
 
-/// Returns `true` only for routes carrying exactly one exclusive leg that produces the route's
-/// output token, either itself or through a single native wrap leg.
+/// Returns how much the route's exclusive leg withholds so the route delivers `surplus` less.
+///
+/// Returns `None` if the route is missing, has no exclusive leg, or cannot be replayed.
+fn withheld_leg_amount(
+    quote: &OrderQuote,
+    surplus: &BigUint,
+    tokens: &TokenLookup,
+) -> Option<BigUint> {
+    let route = quote.route()?;
+    let (input_token, output_token) = (route.input_token()?, route.output_token()?);
+    let swaps = route.swaps();
+    let leg_index = swaps
+        .iter()
+        .position(|swap| is_exclusive(swap.protocol_component()))?;
+
+    match solve_withheld_amount(swaps, &input_token, &output_token, leg_index, surplus, tokens) {
+        Ok(withheld) => Some(withheld),
+        Err(error) => {
+            warn!(?error, "exclusive candidate could not be replayed; dropping the commitment");
+            counter!("exclusive_capture_failures_total").increment(1);
+            None
+        }
+    }
+}
+
+/// Returns `true` for routes carrying exactly one exclusive leg whose withheld amount can be
+/// solved.
 ///
 /// Returns `false` for routes with no exclusive leg, more than one exclusive leg, an empty route,
-/// no route at all, or an exclusive leg whose output reaches the route's output token any other
-/// way.
+/// no route at all, or a route that cannot be replayed against the states its swaps carry.
 ///
-/// The single-leg constraint is a v1 restriction that keeps per-leg surplus attribution
-/// unambiguous: multiple exclusive legs make the per-component attribution non-unique.
+/// The single-leg constraint stays: with two exclusive legs the split of the surplus between them
+/// is not determined by the route, so there is no one answer to solve for.
 ///
-/// A trailing wrap leg is allowed because it converts 1:1, so it needs no inverse simulation.
-/// `pin_commitment` converts captured surplus into a leg's token with the ratio
-/// `path_final_out / leg_out`, which a wrap leaves at exactly 1 — the same arithmetic a terminal
-/// leg gets. Without this a pool quoting the native token could never serve a request for the
-/// wrapped token, even though tycho streams the wrap as an ordinary component.
-fn has_valid_exclusive_route(quote: &OrderQuote, chain: Chain) -> bool {
+/// Where the leg sits in the route no longer matters. A leg that ends its path withholds the
+/// surplus itself; a leg with swaps after it withholds the amount those swaps turn into the
+/// surplus, which [`solve_withheld_amount`] finds by replaying the route. Replaying it here as
+/// well as in `pin_commitment` costs one extra pass and keeps an unsolvable candidate from being
+/// ranked as if it could carry a commitment.
+fn has_valid_exclusive_route(quote: &OrderQuote, tokens: &TokenLookup) -> bool {
     let Some(route) = quote.route() else {
         return false;
     };
-
     let swaps = route.swaps();
-    if swaps.is_empty() {
-        return false;
-    }
-
-    let Some(output_token) = route.output_token() else {
-        return false;
-    };
-
-    let mut exclusive_count = 0;
-
-    for (index, swap) in swaps.iter().enumerate() {
-        if !is_exclusive(swap.protocol_component()) {
-            continue;
-        }
-
-        // Only the immediately following leg is considered: a wrap run that ends at the output
-        // token is always a single leg, and requiring adjacency keeps this validator in step with
-        // the chaining rule `pin_commitment` uses to find a path's final output.
-        let reaches_output = *swap.token_out() == output_token ||
-            swaps
-                .get(index + 1)
-                .is_some_and(|next| {
-                    next.token_in() == swap.token_out() &&
-                        next.token_out() == &output_token &&
-                        is_native_wrap(next, chain)
-                });
-        if !reaches_output {
-            return false;
-        }
-        exclusive_count += 1;
-    }
-
-    exclusive_count == 1
-}
-
-/// Returns `true` when the leg converts between the native token and its wrapped form, which tycho
-/// streams as a 1:1 component.
-///
-/// An unregistered custom chain resolves no wrap pair, so no leg qualifies and the exclusive leg
-/// must be terminal.
-fn is_native_wrap(swap: &Swap, chain: Chain) -> bool {
-    let (Ok(native), Ok(wrapped)) = (chain.try_native_token(), chain.try_wrapped_native_token())
+    let (Some(input_token), Some(output_token)) = (route.input_token(), route.output_token())
     else {
         return false;
     };
 
-    let (token_in, token_out) = (swap.token_in(), swap.token_out());
-    (*token_in == native.address && *token_out == wrapped.address) ||
-        (*token_in == wrapped.address && *token_out == native.address)
+    let mut exclusive_legs = swaps
+        .iter()
+        .enumerate()
+        .filter(|(_, swap)| is_exclusive(swap.protocol_component()));
+    let Some((leg_index, _)) = exclusive_legs.next() else {
+        return false;
+    };
+    if exclusive_legs.next().is_some() {
+        return false;
+    }
+
+    // A zero surplus solves trivially, so probe with the leg's whole output: that is the largest
+    // surplus any commitment can ask for, and it exercises the same replay path.
+    let probe = swaps[leg_index].amount_out().clone();
+    solve_withheld_amount(swaps, &input_token, &output_token, leg_index, &probe, tokens).is_ok()
 }
 
 /// Shared-graph facts beat path-specific reasons (most specific first:
@@ -1573,7 +1592,8 @@ mod tests {
             .with_timeout(Duration::from_millis(2000))
             .with_min_responses(min_responses);
         let worker_router =
-            WorkerPoolRouter::new(vec![public_pool, exclusive_pool], config, default_encoder());
+            WorkerPoolRouter::new(vec![public_pool, exclusive_pool], config, default_encoder())
+                .with_market_data(exclusive_fixture_market().await);
         let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
 
         let start = Instant::now();
@@ -1617,7 +1637,8 @@ mod tests {
             vec![public_pool, exclusive_pool],
             WorkerPoolRouterConfig::default().with_timeout(Duration::from_millis(2000)),
             default_encoder(),
-        );
+        )
+        .with_market_data(exclusive_fixture_market().await);
         let request = QuoteRequest::new(vec![make_order()], QuoteOptions::default());
 
         let result = worker_router
@@ -2015,6 +2036,48 @@ mod tests {
         assert_eq!(*result[1].amount_out_net_gas(), BigUint::from(800u64));
     }
 
+    /// Every token a quote's route touches, at 18 decimals — the lookup the router builds from
+    /// the market before solving an exclusive candidate.
+    fn tokens_of(quote: &OrderQuote) -> TokenLookup {
+        quote
+            .route()
+            .map(|route| {
+                route
+                    .swaps()
+                    .iter()
+                    .flat_map(|swap| [swap.token_in().clone(), swap.token_out().clone()])
+                    .map(|address| {
+                        let token = Token {
+                            address: address.clone(),
+                            symbol: "T".to_string(),
+                            decimals: 18,
+                            tax: Default::default(),
+                            gas: vec![],
+                            chain: SimChain::Ethereum,
+                            quality: 100,
+                        };
+                        (address, token)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// The lookup for the fixtures below, whose routes only ever touch tokens 0x01 and 0x02.
+    fn exclusive_fixture_tokens() -> TokenLookup {
+        tokens_of(make_exclusive_quote(1_000).order())
+    }
+
+    /// A market holding those same tokens, for the router tests that quote end to end.
+    async fn exclusive_fixture_market() -> MarketData {
+        let market_data = MarketData::new_shared();
+        market_data
+            .write()
+            .await
+            .upsert_tokens(exclusive_fixture_tokens().into_values());
+        market_data
+    }
+
     /// Like `make_single_quote` but the swap uses an exclusive protocol component. The swap's own
     /// output is `leg_amount_out`, letting tests exercise per-leg attribution where the leg
     /// differs from the route total
@@ -2106,7 +2169,10 @@ mod tests {
                 &[tin_token.clone(), tout_token.clone()],
             ),
             Box::new(MockProtocolSim::default()),
-        );
+        )
+        // Half the input each. Without the fraction the branches are not replayable: the first
+        // swap of a token's group takes everything the split-0.0 rule leaves it.
+        .with_split(0.5);
         let mut exclusive_comp = component(
             "0x0000000000000000000000000000000000000002",
             &[tin_token.clone(), tout_token.clone()],
@@ -2273,7 +2339,7 @@ mod tests {
             &QuoteOptions::default(),
             public_ranked,
             user_share_bps,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         let expected_surplus = expected_surplus.map(BigUint::from);
@@ -2328,7 +2394,7 @@ mod tests {
             &options,
             public_ranked,
             1_000,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         assert_eq!(combined.len(), 1);
@@ -2381,7 +2447,7 @@ mod tests {
             &QuoteOptions::default(),
             vec![no_route_quote()],
             1_000,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         assert_eq!(combined.len(), 2);
@@ -2422,7 +2488,7 @@ mod tests {
             &QuoteOptions::default(),
             vec![no_route_quote()],
             1_000,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         assert_eq!(*combined[0].amount_out(), BigUint::from(1_099_750u64));
@@ -2461,7 +2527,7 @@ mod tests {
             &QuoteOptions::default(),
             vec![no_route_quote()],
             1_000,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         assert_eq!(combined.len(), 1);
@@ -2480,7 +2546,7 @@ mod tests {
             &QuoteOptions::default(),
             public_ranked,
             1_000,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         let surplus_quote = &combined[0];
@@ -2529,7 +2595,7 @@ mod tests {
             &QuoteOptions::default(),
             public_ranked,
             1_000,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         let route = combined[0]
@@ -2587,7 +2653,7 @@ mod tests {
             &QuoteOptions::default(),
             public_ranked,
             1_000,
-            SimChain::Ethereum,
+            &exclusive_fixture_tokens(),
         );
 
         assert_eq!(*combined[0].amount_out(), BigUint::from(1010u64));
@@ -2706,26 +2772,25 @@ mod tests {
         .with_route(Route::new(swaps, tokens).expect("non-empty route"))
     }
 
-    /// Route-shape validation: exactly one exclusive leg, terminal in its path.
+    /// Route validation: exactly one exclusive leg, wherever in the route it sits.
     #[rstest]
     #[case::terminal_exclusive_leg(
         &[("uniswap_v2", 0x01, 0x02), ("vm:exclusive", 0x02, 0x03)], true)]
+    // The leg the old shape rule turned away. Its output now reaches the route's output token
+    // through the swap after it, and `solve_withheld_amount` prices that hop.
     #[case::mid_route_exclusive_leg(
-        &[("vm:exclusive", 0x01, 0x02), ("uniswap_v2", 0x02, 0x03)], false)]
-    // Split route in sequential representation: path 1 is a single exclusive hop 0x01→0x02;
-    // path 2 is 0x01→0x03→0x02. The exclusive leg is terminal for its path because the next
-    // swap starts over from 0x01.
+        &[("vm:exclusive", 0x01, 0x02), ("uniswap_v2", 0x02, 0x03)], true)]
     #[case::exclusive_leg_ending_its_path(
         &[("vm:exclusive", 0x01, 0x02), ("uniswap_v2", 0x01, 0x03), ("uniswap_v2", 0x03, 0x02)],
         true)]
     #[case::no_exclusive_leg(
         &[("uniswap_v2", 0x01, 0x02), ("uniswap_v2", 0x02, 0x03)], false)]
-    // Two exclusive legs: out of scope for v1 (ambiguous per-component attribution).
+    // Two exclusive legs: still out of scope. The route does not say how the surplus divides
+    // between them, so there is no single withheld amount to solve for.
     #[case::two_exclusive_legs(
         &[("vm:exclusive", 0x01, 0x02), ("vm:exclusive", 0x01, 0x02)], false)]
     // Diamond split: 0x01 splits into 0x01->0x02 (exclusive) and 0x01->0x03, both merging into
-    // 0x02->0x04 and 0x03->0x04. The exclusive leg feeds the merge point, not the route's output
-    // (0x04), so it's mid-path even though the next serialized swap starts a sibling branch.
+    // 0x02->0x04 and 0x03->0x04. The exclusive leg feeds the merge point rather than the output.
     #[case::exclusive_leg_feeding_diamond_merge(
         &[
             ("vm:exclusive", 0x01, 0x02),
@@ -2733,21 +2798,7 @@ mod tests {
             ("uniswap_v2", 0x02, 0x04),
             ("uniswap_v2", 0x03, 0x04),
         ],
-        false)]
-    // Same diamond shape, reordered so the exclusive leg's real continuation is adjacent to it —
-    // regression case for a prior bug where terminal-ness was inferred from adjacency alone.
-    #[case::exclusive_leg_feeding_diamond_merge_reordered(
-        &[
-            ("vm:exclusive", 0x01, 0x02),
-            ("uniswap_v2", 0x02, 0x04),
-            ("uniswap_v2", 0x01, 0x03),
-            ("uniswap_v2", 0x03, 0x04),
-        ],
-        false)]
-    // Sibling branches sharing a prefix: 0x01->0x02->0x03->0x04 alongside
-    // 0x01->0x02->0x05->0x04(exclusive). The exclusive leg is the terminal hop of its own branch
-    // and produces the route's output token, so it's valid despite sharing 0x01->0x02 with the
-    // other branch.
+        true)]
     #[case::exclusive_leg_on_sibling_branch(
         &[
             ("uniswap_v2", 0x01, 0x02),
@@ -2759,76 +2810,32 @@ mod tests {
         true)]
     fn test_exclusive_route_validation(#[case] legs: &[(&str, u8, u8)], #[case] expected: bool) {
         let quote = make_route_quote(legs);
-        assert_eq!(has_valid_exclusive_route(&quote, SimChain::Ethereum), expected);
+        let tokens = tokens_of(&quote);
+        assert_eq!(has_valid_exclusive_route(&quote, &tokens), expected);
     }
 
-    /// Native token, its wrapped form, and an unrelated token. Read from the same chain config the
-    /// validator uses, so the pair cannot drift from tycho's.
-    fn wrap_tokens() -> (Address, Address, Address) {
-        (
-            SimChain::Ethereum
-                .native_token()
-                .address,
-            SimChain::Ethereum
-                .wrapped_native_token()
-                .address,
-            make_address(0x07),
-        )
+    #[test]
+    fn test_route_missing_a_token_is_rejected() {
+        let quote = make_route_quote(&[("vm:exclusive", 0x01, 0x02)]);
+        assert!(!has_valid_exclusive_route(&quote, &TokenLookup::default()));
     }
 
+    /// A leg that wraps into the output token needs no special case any more: the wrap is an
+    /// ordinary downstream swap, and the replay prices it like any other.
     #[test]
     fn test_exclusive_leg_wrapped_into_output() {
-        let (native, wrapped, other) = wrap_tokens();
+        let native = SimChain::Ethereum
+            .native_token()
+            .address;
+        let wrapped = SimChain::Ethereum
+            .wrapped_native_token()
+            .address;
         let quote = make_route_quote_for_tokens(&[
-            ("vm:exclusive", other, native.clone()),
+            ("vm:exclusive", make_address(0x07), native.clone()),
             ("uniswap_v2", native, wrapped),
         ]);
+        let tokens = tokens_of(&quote);
 
-        assert!(has_valid_exclusive_route(&quote, SimChain::Ethereum));
-    }
-
-    #[test]
-    fn test_exclusive_leg_unwrapped_into_output() {
-        let (native, wrapped, other) = wrap_tokens();
-        let quote = make_route_quote_for_tokens(&[
-            ("vm:exclusive", other, wrapped.clone()),
-            ("uniswap_v2", wrapped, native),
-        ]);
-
-        assert!(has_valid_exclusive_route(&quote, SimChain::Ethereum));
-    }
-
-    #[test]
-    fn test_exclusive_leg_followed_by_non_wrap() {
-        let (native, _, other) = wrap_tokens();
-        let quote = make_route_quote_for_tokens(&[
-            ("vm:exclusive", other, native.clone()),
-            ("uniswap_v2", native, make_address(0x08)),
-        ]);
-
-        assert!(!has_valid_exclusive_route(&quote, SimChain::Ethereum));
-    }
-
-    #[test]
-    fn test_exclusive_leg_wrap_not_producing_output() {
-        let (native, wrapped, other) = wrap_tokens();
-        let quote = make_route_quote_for_tokens(&[
-            ("vm:exclusive", other, native.clone()),
-            ("uniswap_v2", native, wrapped.clone()),
-            ("uniswap_v2", wrapped, make_address(0x08)),
-        ]);
-
-        assert!(!has_valid_exclusive_route(&quote, SimChain::Ethereum));
-    }
-
-    #[test]
-    fn test_exclusive_leg_wrap_of_another_path() {
-        let (native, wrapped, other) = wrap_tokens();
-        let quote = make_route_quote_for_tokens(&[
-            ("vm:exclusive", other, make_address(0x08)),
-            ("uniswap_v2", native, wrapped),
-        ]);
-
-        assert!(!has_valid_exclusive_route(&quote, SimChain::Ethereum));
+        assert!(has_valid_exclusive_route(&quote, &tokens));
     }
 }

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -35,7 +35,7 @@ pub use allocation::ExclusiveAccess;
 use allocation::{allocate, Allocation, OrderClass};
 use comparison_log::{log_quote_comparison, solver_error_label};
 use config::WorkerPoolRouterConfig;
-use exclusive_capture::{solve_withheld_amount, TokenLookup};
+use exclusive_capture::{replay_baseline, solve_withheld_amount, TokenLookup};
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, gauge, histogram};
 use num_bigint::BigUint;
@@ -55,7 +55,7 @@ use crate::{
     price_guard::guard::PriceGuard,
     worker_pool::task_queue::TaskQueueHandle,
     BlockInfo, EncodingOptions, Order, OrderQuote, OrderSide, Quote, QuoteOptions, QuoteRequest,
-    QuoteStatus, SolveError, SolveParams, SurplusInfo,
+    QuoteStatus, Route, SolveError, SolveParams, SurplusInfo,
 };
 
 /// Environment variable overriding [`DEFAULT_USER_IMPROVEMENT_SHARE_BPS`]. Read once, on the
@@ -284,6 +284,12 @@ impl WorkerPoolRouter {
             .iter()
             .flat_map(|response| response.quotes.iter())
             .filter_map(|wq| wq.quote.route())
+            .filter(|route| {
+                route
+                    .swaps()
+                    .iter()
+                    .any(|swap| is_exclusive(swap.protocol_component()))
+            })
             .flat_map(|route| route.swaps())
             .flat_map(|swap| [swap.token_in().clone(), swap.token_out().clone()])
             .collect();
@@ -1031,16 +1037,16 @@ fn pin_commitment(
     gauge!("exclusive_fee_amount").increment(surplus_amount.to_f64().unwrap_or(0.0));
 
     let mut surplus_quote = exclusive_candidate.clone();
-    let withheld = withheld_leg_amount(&surplus_quote, &surplus_amount, tokens)?;
+    let leg_index = exclusive_leg_index(surplus_quote.route()?)?;
+    let withheld = withheld_leg_amount(surplus_quote.route()?, leg_index, &surplus_amount, tokens)?;
 
-    if let Some(route) = surplus_quote.route_mut() {
-        for swap in route.swaps_mut().iter_mut() {
-            if is_exclusive(swap.protocol_component()) {
-                let committed_leg = swap.amount_out() - &withheld;
-                swap.set_committed_amount_out(committed_leg);
-            }
-        }
-    }
+    surplus_quote
+        .route_mut()?
+        .swaps_mut()
+        .get_mut(leg_index)?
+        .set_committed_amount_out(
+            exclusive_candidate.route()?.swaps()[leg_index].amount_out() - &withheld,
+        );
 
     surplus_quote.set_amount_out(committed_amount_out.clone());
 
@@ -1053,22 +1059,39 @@ fn pin_commitment(
     Some(surplus_quote.with_surplus(surplus_info))
 }
 
-/// Returns how much the route's exclusive leg withholds so the route delivers `surplus` less.
+/// Returns the index of the route's only exclusive leg.
 ///
-/// Returns `None` if the route is missing, has no exclusive leg, or cannot be replayed.
+/// `None` when the route has no exclusive leg, or more than one. Two exclusive legs stay out of
+/// scope: the route does not say how the surplus divides between them, so there is no single
+/// withheld amount to solve for.
+fn exclusive_leg_index(route: &Route) -> Option<usize> {
+    let mut legs = route
+        .swaps()
+        .iter()
+        .enumerate()
+        .filter(|(_, swap)| is_exclusive(swap.protocol_component()));
+    let (index, _) = legs.next()?;
+    legs.next().is_none().then_some(index)
+}
+
+/// Returns how much the leg at `leg_index` withholds so the route delivers `surplus` less.
+///
+/// `None` when the route cannot be replayed, since the withheld amount is then unknown.
 fn withheld_leg_amount(
-    quote: &OrderQuote,
+    route: &Route,
+    leg_index: usize,
     surplus: &BigUint,
     tokens: &TokenLookup,
 ) -> Option<BigUint> {
-    let route = quote.route()?;
     let (input_token, output_token) = (route.input_token()?, route.output_token()?);
-    let swaps = route.swaps();
-    let leg_index = swaps
-        .iter()
-        .position(|swap| is_exclusive(swap.protocol_component()))?;
-
-    match solve_withheld_amount(swaps, &input_token, &output_token, leg_index, surplus, tokens) {
+    match solve_withheld_amount(
+        route.swaps(),
+        &input_token,
+        &output_token,
+        leg_index,
+        surplus,
+        tokens,
+    ) {
         Ok(withheld) => Some(withheld),
         Err(error) => {
             warn!(?error, "exclusive candidate could not be replayed; dropping the commitment");
@@ -1081,42 +1104,26 @@ fn withheld_leg_amount(
 /// Returns `true` for routes carrying exactly one exclusive leg whose withheld amount can be
 /// solved.
 ///
-/// Returns `false` for routes with no exclusive leg, more than one exclusive leg, an empty route,
-/// no route at all, or a route that cannot be replayed against the states its swaps carry.
+/// Returns `false` for routes with no exclusive leg, more than one exclusive leg, no route at all,
+/// or a route that cannot be replayed against the states its swaps carry.
 ///
-/// The single-leg constraint stays: with two exclusive legs the split of the surplus between them
-/// is not determined by the route, so there is no one answer to solve for.
-///
-/// Where the leg sits in the route no longer matters. A leg that ends its path withholds the
-/// surplus itself; a leg with swaps after it withholds the amount those swaps turn into the
-/// surplus, which [`solve_withheld_amount`] finds by replaying the route. Replaying it here as
-/// well as in `pin_commitment` costs one extra pass and keeps an unsolvable candidate from being
-/// ranked as if it could carry a commitment.
+/// Where the leg sits in the route does not matter. A leg that ends its path withholds the surplus
+/// itself; a leg with swaps after it withholds the amount those swaps turn into the surplus, which
+/// [`solve_withheld_amount`] finds by replaying the route. Solvability is the whole check here, and
+/// one replay settles it — the search itself runs once, on the winner, in `pin_commitment`.
 fn has_valid_exclusive_route(quote: &OrderQuote, tokens: &TokenLookup) -> bool {
     let Some(route) = quote.route() else {
         return false;
     };
-    let swaps = route.swaps();
+    if exclusive_leg_index(route).is_none() {
+        return false;
+    }
     let (Some(input_token), Some(output_token)) = (route.input_token(), route.output_token())
     else {
         return false;
     };
 
-    let mut exclusive_legs = swaps
-        .iter()
-        .enumerate()
-        .filter(|(_, swap)| is_exclusive(swap.protocol_component()));
-    let Some((leg_index, _)) = exclusive_legs.next() else {
-        return false;
-    };
-    if exclusive_legs.next().is_some() {
-        return false;
-    }
-
-    // A zero surplus solves trivially, so probe with the leg's whole output: that is the largest
-    // surplus any commitment can ask for, and it exercises the same replay path.
-    let probe = swaps[leg_index].amount_out().clone();
-    solve_withheld_amount(swaps, &input_token, &output_token, leg_index, &probe, tokens).is_ok()
+    replay_baseline(route.swaps(), &input_token, &output_token, tokens).is_ok()
 }
 
 /// Shared-graph facts beat path-specific reasons (most specific first:


### PR DESCRIPTION
Sketch: what it takes to drop the rule that an exclusive leg must produce the route's output token.

## The rule and why it was there

A candidate was dropped unless its exclusive leg produced the output token, itself or through a trailing native wrap. The surplus is denominated in the output token, and a mid-route leg withholds a different token, so there was no way to say how much the leg should hold back.

## How the conversion works

`fynd-core/src/worker_pool_router/exclusive_capture.rs` replays the route against the states its swaps were quoted at. Every `Swap` already carries its own `protocol_state`, so asking what the route would have produced had the leg emitted less needs no market read and no new data.

```
baseline = replay(withheld = 0)
target   = baseline - surplus
withheld = largest d where replay(d) >= target        // bisection, 24 steps
```

Route output falls monotonically as the leg withholds more, which is what makes the search sound. The search keeps the largest withheld amount that still clears the target, so stopping early leaves output with the user and costs the protocol capture.

## What this also fixes

The terminal case used `surplus * leg_out / path_final_out` — the average price. Average price overstates what the next unit is worth, so it under-captured whenever the downstream pool was thin. `test_solved_amount_exceeds_the_average_price_estimate` pins that difference.

`is_native_wrap` is gone. A wrap is now an ordinary downstream swap that the replay prices like any other, so the special case has nothing left to do.

## What stays rejected

Two exclusive legs. The route does not say how the surplus divides between them, so there is no single amount to solve for.

## Cost

Solving runs twice per exclusive candidate — once to validate, once to pin — at up to 25 route replays each. That is cheap for native pools and not cheap for VM pools, where a replay is a revm call. Worth a latency read before this goes anywhere near production.

The router now needs token decimals, which the pool simulations take instead of addresses. `WorkerPoolRouter::with_market_data` supplies them and `FyndBuilder` wires it; a router built without it makes no commitment and orders answer from public liquidity.

## Open

The committed amount reaches the chain as a Q32 fee rate on the leg (`derive_fee_q32`), applied to whatever the leg produces at execution time. For a terminal leg a fraction of leg output is the same fraction of user output at any market state. For a mid-route leg the fraction maps to the final output through pools whose state has moved since the quote, so the realized capture drifts from the solved one. Sizing that drift is the next question, and it is a property of the on-chain encoding rather than of this solver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)