### PR TITLE
ci: install a current cargo-semver-checks

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -59,9 +59,13 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@71b48393496777ee11188c07a34d48b048a985cd  # v2
+        # The version is explicit because cargo-semver-checks reads the rustdoc JSON built below,
+        # and each Rust release can change that file format. Without a version the action installs
+        # whatever its own pinned commit knows about, which fell behind current Rust and could not
+        # read the file. 0.50.0 reads what stable and nightly Rust write today.
+        uses: taiki-e/install-action@a2a5f6e99e1a31540baa0468acfa302cff0f359f  # v2.86.4
         with:
-          tool: cargo-semver-checks
+          tool: cargo-semver-checks@0.50.0
 
       - name: Build baseline rustdoc from full workspace
         # cargo semver-checks --baseline-rev builds each package in an isolated placeholder


### PR DESCRIPTION
## What broke

The `API Semver Check` job compares this branch's public Rust API against main's, so a breaking change cannot land without the PR title declaring it. It works in two steps: Rust writes a machine-readable description of each crate's API, then `cargo-semver-checks` reads main's description and this branch's and diffs them.

Rust changes the layout of that description file every few releases, and each `cargo-semver-checks` version only reads the layouts it knows. Since about 17:16Z on 2026-08-20 the tool the job installs cannot read the file at all, so the job fails before it compares anything:

```
unsupported rustdoc format v60 for file: target/doc/fynd_core.json
(supported formats are v55, v56, v57)
```

No branch is at fault. Every open PR fails the same way, the release PR included.

## Why now

The install step asks for `cargo-semver-checks` with no version. That does not mean newest: the install action serves the newest version its own pinned commit knows about, and our pin is from February. So the job has been running 0.46.0, from January, all along. Rust 1.98 landed on 2026-08-18 with a new file layout, and a seven-month-old tool cannot read it. `cargo-semver-checks` added support for this layout in 0.49.0, in July.

## The fix

Ask for 0.50.0 by name, and move the install action pin forward so it can serve that version. Rust stays on `stable`.

Two alternatives I did not take:

- **Pin Rust to 1.97.1.** Green immediately, but it keeps a January tool and freezes the check on an old compiler. It hides the stale install instead of correcting it. This is what the first version of this PR did.
- **Leave the version unnamed.** The same failure returns at the next layout change, on a day nobody picks.

A named version fails loudly on a line that is easy to find, and updating it is one edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
