### PR TITLE
feat: report exclusive surplus in gas-token units

### DIFF
--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -141,6 +141,12 @@ beats the committed amount and records the difference as `SurplusInfo`
 (`OrderQuote::surplus_amount()`, `committed_amount_out()`, `Swap::committed_amount_out()`). All are
 `#[serde(skip)]` — internal, not on the wire.
 
+Two gauges report what the overlay is worth, in whole gas tokens: `exclusive_fee_amount` (LP fee
+capture) and `exclusive_user_savings_amount` (user improvement over the public reference).
+`to_gas_token_amount` converts without a price lookup — the quote states its gas cost both in wei
+(`gas_estimate * gas_price`) and in output-token units (`amount_out - amount_out_net_gas`), so that
+pair is the rate. An unpriced output token increments `exclusive_unpriced_output_total` instead.
+
 Enable by setting the scope per pool via `PoolConfig::with_liquidity_scope()` or
 `liquidity_scope = "include_exclusive"` in `worker_pools.toml`. A deployment where every pool sets it
 fails the build (`SolverBuildError::NoPublicPool`) — there would be no pool left to establish the

--- a/fynd-core/src/worker_pool_router/mod.rs
+++ b/fynd-core/src/worker_pool_router/mod.rs
@@ -37,7 +37,7 @@ use config::WorkerPoolRouterConfig;
 use futures::stream::{FuturesUnordered, StreamExt};
 use metrics::{counter, gauge, histogram};
 use num_bigint::BigUint;
-use num_traits::ToPrimitive;
+use num_traits::{CheckedSub, ToPrimitive};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, warn};
@@ -64,6 +64,9 @@ const DEFAULT_USER_IMPROVEMENT_SHARE_BPS: u32 = 1_000;
 
 /// Basis-point denominator: `10_000` bps is the whole improvement.
 const BPS_DENOMINATOR: u32 = 10_000;
+
+/// Wei per whole gas token. The exclusive metrics report whole gas tokens, not wei.
+const WEI_PER_GAS_TOKEN: f64 = 1e18;
 
 /// The configured user share, parsed from [`ENV_USER_IMPROVEMENT_SHARE_BPS`].
 static USER_IMPROVEMENT_SHARE_BPS: LazyLock<u32> = LazyLock::new(user_improvement_share_bps_env);
@@ -840,13 +843,45 @@ fn combine_with_surplus(
     // no public amount_out to diff against.
     if let Some(public_reference) = public_reference {
         let user_savings = &committed_amount_out - public_reference.amount_out();
-        gauge!("exclusive_user_savings_amount").increment(user_savings.to_f64().unwrap_or(0.0));
+        record_gas_token_amount(
+            "exclusive_user_savings_amount",
+            exclusive_candidate,
+            &user_savings,
+        );
     }
 
     let mut result = Vec::with_capacity(public_ranked.len() + 1);
     result.push(pin_commitment(exclusive_candidate, committed_amount_out));
     result.extend(public_ranked);
     result
+}
+
+/// Restates an output-token `amount` of `quote` in wei.
+///
+/// The quote states its gas cost in both units, so that pair is the rate. `None` when either side
+/// is zero, which is how an unpriced output token shows up.
+fn to_gas_token_amount(quote: &OrderQuote, amount: &BigUint) -> Option<BigUint> {
+    let gas_cost_out = quote
+        .amount_out()
+        .checked_sub(quote.amount_out_net_gas())?;
+    let gas_cost_wei = quote.gas_estimate() * quote.gas_price()?;
+    if gas_cost_out == BigUint::ZERO || gas_cost_wei == BigUint::ZERO {
+        return None;
+    }
+    Some(amount * gas_cost_wei / gas_cost_out)
+}
+
+/// Records an output-token `amount` under `metric`, in whole gas tokens.
+///
+/// Output-token base units are not summable across tokens, so a total over them means nothing. An
+/// amount with no rate increments `exclusive_unpriced_output_total`; a zero would read as "captured
+/// nothing".
+fn record_gas_token_amount(metric: &'static str, quote: &OrderQuote, amount: &BigUint) {
+    let Some(gas_token_amount) = to_gas_token_amount(quote, amount) else {
+        counter!("exclusive_unpriced_output_total").increment(1);
+        return;
+    };
+    gauge!(metric).increment(gas_token_amount.to_f64().unwrap_or(0.0) / WEI_PER_GAS_TOKEN);
 }
 
 /// Whether a quote is eligible to be ranked against the others for this request.
@@ -957,7 +992,7 @@ fn pin_commitment(exclusive_candidate: &OrderQuote, committed_amount_out: BigUin
     let exclusive_gas_cost = exclusive_route_amount_out - exclusive_candidate.amount_out_net_gas();
     let surplus_amount = exclusive_route_amount_out - &committed_amount_out;
 
-    gauge!("exclusive_fee_amount").increment(surplus_amount.to_f64().unwrap_or(0.0));
+    record_gas_token_amount("exclusive_fee_amount", exclusive_candidate, &surplus_amount);
 
     let mut surplus_quote = exclusive_candidate.clone();
 
@@ -2831,5 +2866,73 @@ mod tests {
         ]);
 
         assert!(!has_valid_exclusive_route(&quote, SimChain::Ethereum));
+    }
+
+    /// A quote stating its gas cost twice, in output-token units and in wei.
+    fn make_rate_quote(amount_out: u64, amount_out_net_gas: u64, gas_estimate: u64) -> OrderQuote {
+        OrderQuote::new(
+            "rate-order".to_string(),
+            QuoteStatus::Success,
+            BigUint::from(1_000u64),
+            BigUint::from(amount_out),
+            BigUint::from(gas_estimate),
+            BigUint::from(amount_out_net_gas),
+            BlockInfo::new(1, "0x123".to_string(), 1000),
+            "test".to_string(),
+            Bytes::from(make_address(0xAA).as_ref()),
+            Bytes::from(make_address(0xAA).as_ref()),
+            "1".to_string(),
+        )
+    }
+
+    /// 300k gas at 5 gwei is 0.0015 ETH, charged as 3 USDC: 2000 USDC per ETH.
+    fn usdc_quote() -> OrderQuote {
+        make_rate_quote(100_000_000, 97_000_000, 300_000)
+            .with_gas_price(BigUint::from(5_000_000_000u64))
+    }
+
+    #[test]
+    fn test_to_gas_token_amount() {
+        // 100 USDC at 2000 USDC per ETH is 0.05 ETH.
+        let wei = to_gas_token_amount(&usdc_quote(), &BigUint::from(100_000_000u64));
+
+        assert_eq!(wei, Some(BigUint::from(50_000_000_000_000_000u64)));
+    }
+
+    #[test]
+    fn test_to_gas_token_amount_of_zero() {
+        assert_eq!(to_gas_token_amount(&usdc_quote(), &BigUint::ZERO), Some(BigUint::ZERO));
+    }
+
+    #[test]
+    fn test_to_gas_token_amount_unpriced_output() {
+        // Derived data has not priced the output token, so the algorithm netted no gas off it.
+        let quote = make_rate_quote(100_000_000, 100_000_000, 300_000)
+            .with_gas_price(BigUint::from(5_000_000_000u64));
+
+        assert_eq!(to_gas_token_amount(&quote, &BigUint::from(100_000_000u64)), None);
+    }
+
+    #[test]
+    fn test_to_gas_token_amount_without_gas_price() {
+        let quote = make_rate_quote(100_000_000, 97_000_000, 300_000);
+
+        assert_eq!(to_gas_token_amount(&quote, &BigUint::from(100_000_000u64)), None);
+    }
+
+    #[test]
+    fn test_to_gas_token_amount_without_gas_estimate() {
+        let quote = make_rate_quote(100_000_000, 97_000_000, 0).with_gas_price(BigUint::from(5u64));
+
+        assert_eq!(to_gas_token_amount(&quote, &BigUint::from(100_000_000u64)), None);
+    }
+
+    #[test]
+    fn test_to_gas_token_amount_net_gas_above_output() {
+        // Gas refinement can overwrite the net output. Subtracting it must not panic.
+        let quote = make_rate_quote(97_000_000, 100_000_000, 300_000)
+            .with_gas_price(BigUint::from(5_000_000_000u64));
+
+        assert_eq!(to_gas_token_amount(&quote, &BigUint::from(100_000_000u64)), None);
     }
 }


### PR DESCRIPTION
## What changed

The two exclusive gauges recorded raw output-token base units. A WETH amount (18 decimals) and a
USDC amount (6 decimals) summed into a number with no unit — the prod dashboard read 11.3e18 for
"total LP earnings". Both gauges now report whole gas tokens.

Metric names are unchanged: `exclusive_fee_amount` and `exclusive_user_savings_amount`. Only the
unit changes. A deploy restarts the pods, so the cumulative gauge resets and `increase()` reads the
step as a reset.

## How

The rate is already on the quote, stated twice:

```
gas cost in wei               = gas_estimate * gas_price
gas cost in output-token units = amount_out - amount_out_net_gas
```

The second is the first converted with the output token's derived price, because that is how the
algorithm nets gas off the output. So `to_gas_token_amount` divides one by the other and needs no
price lookup of its own. `OrderQuote` and the worker are untouched.

A quote carrying no rate — a zero gas cost in either unit, which is what an output token derived
data has not priced looks like — records nothing and increments `exclusive_unpriced_output_total`.
Recording zero would read as "captured nothing".

## Follow-up

The Grafana panels in `terraform-infrastructure` keep working as-is. They need the unit and the
panel descriptions updated after this deploys, since the numbers are now gas tokens.

## Tests

`cargo nextest run --workspace --all-features --lib --bins --tests`: 1405 pass. Excluded are the
11 tests that load the Git LFS market fixture; git-lfs is not installed locally, so they fail with
`Unknown frame descriptor` on `main` too.

Six new tests cover the conversion: a realistic USDC/ETH rate, a zero amount, an unpriced output
token, a missing gas price, a zero gas estimate, and a net output above `amount_out` (which would
underflow the subtraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)