### PR TITLE
feat: add configurable calldata watermark

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -107,6 +107,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 | `WORKER_POOLS_CONFIG` | Worker pools config file (default: `worker_pools.toml`) |
 | `BLOCKLIST_CONFIG` | Blocklist config file |
 | `EXCLUSIVE_SWAP_CONTROLLER_KEY` | Restricted exclusive-liquidity deployments only — see [Exclusive liquidity](#exclusive-liquidity-restricted). Unset in ordinary deployments |
+| `CALLDATA_WATERMARK` | Watermark bytes appended to every encoded transaction's calldata (also `--calldata-watermark`). Ignored by the EVM; attributes router calls to this deployment. Unset by default |
 | `RUST_LOG` | Tracing filter (e.g. `info,fynd=debug`) |
 | `METRICS_PORT` | Prometheus metrics server port (default: `9898`, requires `metrics` feature) |
 | `FYND_HOSTED_SWAGGER_URL` | Server URL advertised by the hosted OpenAPI spec. When unset, the hosted Swagger UI (`/docs/hosted/`) is not served — only the self-hosted `/docs/` |

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -16,7 +16,7 @@ applications.
 | `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
 | `price_guard/`        | Price guard: external price validation for quotes. Sub-modules: `guard` (validation logic), `binance_ws` (Binance WebSocket price provider), `hyperliquid` (Hyperliquid oracle provider), `provider_registry`, `config`, `utils` |
 | `replay.rs`           | `replay_route(&Route, &MarketState)` — re-execute an already-built route against a (possibly newer) market state, honoring split fractions and shared-pool depletion. Used by `hindsight` to measure quote-to-execution slippage |
-| `encoding/`           | `Encoder` wraps `tycho-execution` to produce ABI-encoded calldata (singleSwap, sequentialSwap, Permit2 variants). Computes `FeeBreakdown` mirroring on-chain `FeeCalculator` logic. `RouterFees`/`SharedRouterFees` hold default + per-client fee rates; `RouterFeeFetcher` refreshes them from the FeeCalculator contract every 5 min |
+| `encoding/`           | `Encoder` wraps `tycho-execution` to produce ABI-encoded calldata (singleSwap, sequentialSwap, Permit2 variants). Optional calldata watermark (`with_calldata_watermark`) appends attribution bytes the EVM ignores. Computes `FeeBreakdown` mirroring on-chain `FeeCalculator` logic. `RouterFees`/`SharedRouterFees` hold default + per-client fee rates; `RouterFeeFetcher` refreshes them from the FeeCalculator contract every 5 min |
 | `types/`              | Core types: `Order`, `Route`, `Swap`, `Quote`, `QuoteRequest`, `BlockInfo`, `EncodingOptions`, `FeeBreakdown`, error types                                                         |
 
 ## Key Traits

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -54,6 +54,10 @@ pub struct Encoder {
     router_fees: SharedRouterFees,
     /// Signs exclusive legs. `None` disables signing (no controller key configured).
     exclusive_swap_signer: Option<ExclusiveSwapSigner>,
+    /// Bytes appended to every encoded transaction's calldata to tag its origin. Trailing
+    /// calldata beyond the ABI-encoded arguments is ignored by the EVM, so the tag is free of
+    /// on-chain effect. `None` (the default) appends nothing.
+    calldata_watermark: Option<Vec<u8>>,
 }
 
 /// Maps a successful quote onto an encodable solution, leaving `min_amount_out` equal to the
@@ -174,7 +178,17 @@ impl Encoder {
             router_address,
             router_fees: SharedRouterFees::default(),
             exclusive_swap_signer,
+            calldata_watermark: None,
         })
+    }
+
+    /// Sets a watermark appended to every encoded transaction's calldata (e.g. `"fynd"`), so
+    /// on-chain observers can attribute router calls to this deployment. The EVM ignores
+    /// calldata past the ABI-encoded arguments, so the watermark does not change execution.
+    #[must_use]
+    pub fn with_calldata_watermark(mut self, watermark: impl Into<Vec<u8>>) -> Self {
+        self.calldata_watermark = Some(watermark.into());
+        self
     }
 
     /// Overrides the exclusive-swap signer, replacing whatever was read from the environment.
@@ -521,8 +535,11 @@ impl Encoder {
             )));
         };
 
-        let contract_interaction =
+        let mut contract_interaction =
             Self::encode_input(encoded_solution.function_signature(), method_calldata);
+        if let Some(watermark) = &self.calldata_watermark {
+            contract_interaction.extend_from_slice(watermark);
+        }
 
         let value =
             if token_in == router_eth { solution.amount_in().clone() } else { BigUint::ZERO };
@@ -794,6 +811,7 @@ mod tests {
             router_address: Some(Bytes::from([0u8; 20].as_ref())),
             router_fees,
             exclusive_swap_signer: None,
+            calldata_watermark: None,
         }
     }
 
@@ -1195,6 +1213,99 @@ mod tests {
         let mut calldata = tx.data().to_vec();
         calldata[offset..offset + 65].copy_from_slice(&real_sig);
         assert_eq!(&calldata[offset..offset + 65], &real_sig[..]);
+    }
+
+    // ==================== Calldata Watermark Tests ====================
+
+    #[tokio::test]
+    async fn test_encode_appends_calldata_watermark() {
+        let encoder = real_encoder().with_calldata_watermark("fynd");
+        let quote = make_order_quote(990)
+            .with_route(make_route_with_tokens(&[(make_address(0x01), make_address(0x02))]));
+
+        let result = encoder
+            .encode(vec![quote], EncodingOptions::new(0.01))
+            .await
+            .unwrap();
+
+        let tx = result[0].transaction().unwrap();
+        assert!(
+            tx.data().ends_with(b"fynd"),
+            "calldata must end with the watermark bytes, got suffix {:?}",
+            &tx.data()[tx.data().len().saturating_sub(4)..]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_encode_without_watermark_leaves_calldata_unchanged() {
+        let make_quote = || {
+            make_order_quote(990)
+                .with_route(make_route_with_tokens(&[(make_address(0x01), make_address(0x02))]))
+        };
+
+        let plain = real_encoder()
+            .encode(vec![make_quote()], EncodingOptions::new(0.01))
+            .await
+            .unwrap();
+        let watermarked = real_encoder()
+            .with_calldata_watermark("fynd")
+            .encode(vec![make_quote()], EncodingOptions::new(0.01))
+            .await
+            .unwrap();
+
+        let plain_data = plain[0].transaction().unwrap().data();
+        let watermarked_data = watermarked[0]
+            .transaction()
+            .unwrap()
+            .data();
+        // The watermark is a pure suffix: stripping it yields the unwatermarked calldata.
+        assert_eq!(*plain_data, watermarked_data[..watermarked_data.len() - 4]);
+    }
+
+    #[tokio::test]
+    async fn test_watermarked_calldata_still_decodes() {
+        let encoder = real_encoder().with_calldata_watermark("fynd");
+        let quote = make_order_quote(1_000_000_000)
+            .with_route(make_route_with_tokens(&[(make_address(0x01), make_address(0x02))]));
+        let amount_in = quote.amount_in().clone();
+        let opts = EncodingOptions::new(0.01).with_client_fee_params(make_client_fee(100));
+
+        let result = encoder
+            .encode(vec![quote], opts)
+            .await
+            .unwrap();
+
+        let tx = result[0].transaction().unwrap();
+        // Solidity's ABI decoder ignores trailing calldata, so decoding the args without the
+        // 4-byte watermark suffix must still work.
+        let (encoded_amount_in, _, _, _, _, _, _, _) =
+            <SingleSwapCalldata as SolValue>::abi_decode_params(&tx.data()[4..tx.data().len() - 4])
+                .unwrap();
+        assert_eq!(encoded_amount_in, biguint_to_u256(&amount_in));
+    }
+
+    #[tokio::test]
+    async fn test_signature_offset_unaffected_by_watermark() {
+        let encoder = real_encoder().with_calldata_watermark("fynd");
+        let real_sig = vec![0xFF; 65];
+        let quote = make_order_quote(990)
+            .with_route(make_route_with_tokens(&[(make_address(0x01), make_address(0x02))]));
+        let opts = EncodingOptions::new(0.01).with_client_fee_params(make_client_fee(100));
+
+        let result = encoder
+            .encode(vec![quote], opts)
+            .await
+            .unwrap();
+
+        let tx = result[0].transaction().unwrap();
+        let offset = tx
+            .client_fee_signature_offset()
+            .unwrap();
+
+        let mut calldata = tx.data().to_vec();
+        calldata[offset..offset + 65].copy_from_slice(&real_sig);
+        assert_eq!(&calldata[offset..offset + 65], &real_sig[..]);
+        assert!(calldata.ends_with(b"fynd"));
     }
 
     // ==================== Fee Breakdown Tests ====================

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -427,6 +427,7 @@ pub struct FyndBuilder {
     router_timeout: Duration,
     router_min_responses: usize,
     encoder: Option<Encoder>,
+    calldata_watermark: Option<Vec<u8>>,
     pools: Vec<PoolEntry>,
     price_guard_enabled: bool,
     price_providers: Vec<Box<dyn PriceProvider>>,
@@ -460,6 +461,7 @@ impl FyndBuilder {
             router_timeout: DEFAULT_ROUTER_TIMEOUT,
             router_min_responses: defaults::ROUTER_MIN_RESPONSES,
             encoder: None,
+            calldata_watermark: None,
             pools: Vec::new(),
             price_guard_enabled: false,
             price_providers: Vec::new(),
@@ -552,6 +554,14 @@ impl FyndBuilder {
     /// Overrides the default encoder.
     pub fn encoder(mut self, encoder: Encoder) -> Self {
         self.encoder = Some(encoder);
+        self
+    }
+
+    /// Sets a watermark appended to every encoded transaction's calldata (e.g. `"fynd"`), so
+    /// on-chain observers can attribute router calls to this deployment. Applied to the encoder
+    /// at build time, whether default or overridden. Default: no watermark.
+    pub fn calldata_watermark(mut self, watermark: impl Into<Vec<u8>>) -> Self {
+        self.calldata_watermark = Some(watermark.into());
         self
     }
 
@@ -832,6 +842,10 @@ impl FyndBuilder {
                 Encoder::new(self.chain, registry)
                     .map_err(|e| SolverBuildError::Encoder(e.to_string()))?
             }
+        };
+        let encoder = match self.calldata_watermark {
+            Some(watermark) => encoder.with_calldata_watermark(watermark),
+            None => encoder,
         };
 
         let chain = self.chain;

--- a/fynd-rpc/src/builder.rs
+++ b/fynd-rpc/src/builder.rs
@@ -185,6 +185,15 @@ impl FyndRPCBuilder {
         self
     }
 
+    /// Sets a watermark appended to every encoded transaction's calldata (e.g. `"fynd"`), so
+    /// on-chain observers can attribute router calls to this deployment. Default: no watermark.
+    pub fn calldata_watermark(mut self, watermark: impl Into<Vec<u8>>) -> Self {
+        self.fynd_builder = self
+            .fynd_builder
+            .calldata_watermark(watermark);
+        self
+    }
+
     /// Sets the gas price staleness threshold. Health returns 503 when exceeded.
     pub fn gas_price_stale_threshold(mut self, threshold: Option<Duration>) -> Self {
         self.gas_price_stale_threshold = threshold;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,6 +138,13 @@ pub struct ServeArgs {
     #[arg(long)]
     pub enable_price_guard: bool,
 
+    /// Watermark appended to every encoded transaction's calldata (e.g. "fynd"), so on-chain
+    /// observers can attribute router calls to this deployment. The EVM ignores calldata past
+    /// the ABI-encoded arguments, so the watermark does not change execution. Disabled by
+    /// default.
+    #[arg(long, env)]
+    pub calldata_watermark: Option<String>,
+
     /// URL of the hosted gateway fronting this instance. When set, a second Swagger UI is served
     /// at /docs/hosted/, describing the gateway's per-chain paths and API-key auth. When unset,
     /// only the self-hosted /docs/ is served.
@@ -253,6 +260,19 @@ mod cli_tests {
     fn test_openapi_subcommand() {
         let cli = Cli::try_parse_from(vec!["fynd", "openapi"]).expect("parse errored");
         assert_eq!(cli.command, Commands::Openapi);
+    }
+
+    #[test]
+    fn test_parses_calldata_watermark() {
+        std::env::remove_var("CALLDATA_WATERMARK");
+        let cli = Cli::try_parse_from(vec!["fynd", "serve", "--calldata-watermark", "fynd"])
+            .expect("parse errored");
+        let Commands::Serve(args) = cli.command else { panic!("expected serve") };
+        assert_eq!(args.calldata_watermark, Some("fynd".to_string()));
+
+        let cli = Cli::try_parse_from(vec!["fynd", "serve"]).expect("parse errored");
+        let Commands::Serve(args) = cli.command else { panic!("expected serve") };
+        assert_eq!(args.calldata_watermark, None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -345,6 +345,9 @@ async fn setup_solver(args: &cli::ServeArgs) -> Result<fynd_rpc::builder::FyndRP
     builder = builder.blocklist(blocklist);
     builder = builder.partial_blocks(args.partial_blocks);
     builder = builder.price_guard_enabled(args.enable_price_guard);
+    if let Some(watermark) = &args.calldata_watermark {
+        builder = builder.calldata_watermark(watermark.as_bytes());
+    }
 
     // Build and start solver
     let solver = builder


### PR DESCRIPTION
## What

Adds an optional watermark appended to every encoded transaction's calldata, so on-chain observers can attribute Tycho router calls to a Fynd deployment (e.g. the ASCII bytes `fynd`).

The EVM ignores calldata past the ABI-encoded arguments, so the watermark has no execution effect. The client-fee signature patch offset is unaffected since the watermark is a pure suffix.

## Configuration

- `--calldata-watermark fynd` or `CALLDATA_WATERMARK=fynd` on `serve`
- Library users: `Encoder::with_calldata_watermark`, `FyndBuilder::calldata_watermark`, `FyndRPCBuilder::calldata_watermark`
- Disabled by default — no watermark is appended unless configured

## Tests

- Watermark is appended as a suffix; stripping it yields the unwatermarked calldata
- Watermarked calldata still ABI-decodes
- Client-fee signature offset patching still works with the watermark present
- CLI flag parsing (set and default-off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)