### PR TITLE
feat: add exclusive-pool-pnl tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3185,6 +3185,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "exclusive-pool-pnl"
+version = "0.99.12"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "chrono",
+ "clap",
+ "futures 0.3.32",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.23",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ members = [
     "tools/benchmark",
     "tools/common",
     "tools/erc20-overrides",
+    "tools/exclusive-pool-pnl",
     "tools/fynd-swap-cli",
     "tools/fynd-gas-audit",
     "tools/hindsight",

--- a/tools/CLAUDE.md
+++ b/tools/CLAUDE.md
@@ -4,10 +4,43 @@ Developer and operational tooling for the Fynd solver.
 
 | Tool | Crate | Description |
 |---|---|---|
+| [exclusive-pool-pnl](#exclusive-pool-pnl) | `tools/exclusive-pool-pnl/` | LP fee revenue and markout for the exclusive Ekubo pool |
 | [fynd-benchmark](#fynd-benchmark) | `tools/benchmark/` | Load testing, solver comparison, trade dataset download |
 | [fynd-swap-cli](#fynd-swap-cli) | `tools/fynd-swap-cli/` | Quote and execute token swaps (ERC-20 or Permit2) |
 | [hindsight](#hindsight) | `tools/hindsight/` | Decode solver swaps from on-chain data and live-monitor re-solve quality |
 | [record-market](#record-market) | `tools/record-market/` | Record Tycho market state and expected outputs for integration tests |
+
+---
+
+## exclusive-pool-pnl
+
+One-shot report on the Fynd exclusive Ekubo V3 pool, hardcoded in `src/pool.rs`. Run with
+`cargo run -p exclusive-pool-pnl --release --` and an `RPC_URL` pointing at an archive node.
+
+### Module Map
+
+| File | Purpose |
+|---|---|
+| `pool.rs` | Pool identity: id, extension, Ekubo core, event topics, token decimals |
+| `chain.rs` | Chunked `eth_getLogs` scan, retries, and the swap / fee / signed-fee decoders |
+| `prices.rs` | Binance one-minute klines used as the markout reference |
+| `pnl.rs` | Fee attribution across Ekubo's one-interaction lag, plus markout math |
+| `report.rs` | Per-swap table, totals block, JSON artifact |
+
+### Key Behaviors
+
+- **Discovery starts at the extension**, which indexes the pool id as topic1. Ekubo core emits its
+  swap event with `log0` and cannot be filtered server-side, so swaps are decoded from the receipts
+  of the transactions the extension points at. Position updates share the extension's topic and are
+  separated by whether that receipt holds a core swap log.
+- **Fees are measured from `FeesAccumulated`**, not recomputed from the signed rate. Ekubo credits
+  an accrued fee on the next pool interaction, so `pnl::attribute_fees` shifts each credit back one
+  interaction. A swap whose fee never reached the pool reports zero LP revenue.
+- **Markout, not LVR**: no arbitrageur can trade a signature-gated pool, so the report measures
+  adverse selection on Fynd's routed flow against Binance ETHUSDC.
+- `price_guard` providers are deliberately unused — they are live-only and keep no history.
+
+See [`tools/exclusive-pool-pnl/README.md`](exclusive-pool-pnl/README.md) for flags and caveats.
 
 ---
 

--- a/tools/exclusive-pool-pnl/Cargo.toml
+++ b/tools/exclusive-pool-pnl/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "exclusive-pool-pnl"
+version.workspace = true
+edition = "2021"
+description = "LP fee revenue and markout for the Fynd exclusive Ekubo pool"
+license = "MIT"
+
+[dependencies]
+alloy = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/tools/exclusive-pool-pnl/README.md
+++ b/tools/exclusive-pool-pnl/README.md
@@ -1,0 +1,84 @@
+# exclusive-pool-pnl
+
+Reports LP fee revenue and markout for the Fynd exclusive Ekubo V3 pool on Ethereum mainnet.
+
+**PnL** is profit and loss: what the pool's liquidity providers gained or lost. This tool states it
+in USDC, per swap and in total. A negative PnL means the LPs ended a swap worse off than if they
+had held their tokens and traded at the reference price instead.
+
+The pool is hardcoded in `src/pool.rs`: ETH/USDC behind the `SignedExclusiveSwap` extension at
+`0x55b703eed01b35641963da2fb2e14885993605a3`. Its `PoolKey` sets `fee = 0`, so every unit of LP
+revenue comes from the extension's per-swap fee.
+
+## Usage
+
+```bash
+export RPC_URL=<archive node>
+cargo run --release -p exclusive-pool-pnl
+```
+
+Useful flags:
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `--from-block` | extension deploy block | First block to scan |
+| `--to-block` | chain head | Last block to scan |
+| `--chunk` | `1000` | Block span per `eth_getLogs`; most nodes cap here |
+| `--concurrency` | `8` | Maximum in-flight RPC requests |
+| `--retries` | `5` | Attempts per request; managed nodes throttle under concurrency |
+| `--markout-secs` | `0,300,3600` | Markout horizons, comma separated |
+| `--no-prices` | off | Skip the price download and report fees only |
+| `--json <path>` | none | Write every swap and total as JSON |
+
+A full scan is around 160 `eth_getLogs` calls and finishes in well under a minute.
+
+## What it measures
+
+For one swap, with `p` the reference price in USDC per ETH:
+
+```
+adverse_selection = delta0·p + delta1        the raw curve trade, valued at p
+fee_revenue       = lp_fee0·p + lp_fee1      what the pool kept for its LPs
+lp_pnl            = adverse_selection + fee_revenue   the LPs' profit and loss
+```
+
+`delta0` and `delta1` are the pool-side deltas from Ekubo's swap event, so `adverse_selection` is
+zero when the curve trades exactly at the reference price and negative when the pool traded worse
+than the market.
+
+### This is markout, not LVR
+
+LVR is the loss an LP takes to traders who swap *because* the pool is mispriced. Nobody can
+arbitrage this pool — every swap carries a controller signature — so classical LVR is close to
+zero here by construction. What the report measures instead is markout on the flow Fynd routes in,
+which answers the question that does apply: is that flow benign, or is Fynd picking off its own
+LPs?
+
+### Fees are measured, not modelled
+
+Fee amounts come from Ekubo's `FeesAccumulated` events rather than from recomputing the signed
+rate. Ekubo credits an accrued fee on the *next* interaction with the pool, so `pnl::attribute_fees`
+shifts each credit back onto the swap that earned it. Two consequences show up in the output:
+
+- The newest swap's fee is marked pending until something else touches the pool.
+- A swap whose fee never reached the pool reports zero LP revenue even though the taker paid it.
+  Early swaps on this pool behave that way.
+
+The `fee bps` column is separate: it is the rate the controller signed into `user_data`, decoded
+from calldata, and shows what the taker was charged whether or not LPs received it.
+
+### Reference prices
+
+`fynd-core`'s `price_guard` providers are not used. They stream or poll the current price to
+validate a live quote and keep no history, whereas a markout needs the price at a past timestamp.
+This tool pulls one-minute klines from Binance's public REST endpoint instead. No API key needed.
+
+A horizon that has not elapsed yet for every swap prices less than the full volume; those swaps
+drop out of that row rather than reusing a stale price, and the totals block says so.
+
+## Caveats
+
+- Volume on this pool is small. Treat single-horizon numbers as anecdote, not as a measured edge.
+- Binance ETHUSDC carries its own basis against on-chain ETH/USDC. Differences below roughly 30 bps
+  are inside that noise.
+- Long horizons on a one-directional day mostly measure inventory drift, not adverse selection.

--- a/tools/exclusive-pool-pnl/src/chain.rs
+++ b/tools/exclusive-pool-pnl/src/chain.rs
@@ -1,0 +1,433 @@
+//! Reads the pool's history from an Ethereum archive node.
+//!
+//! Discovery starts at the extension rather than at Ekubo core: the extension indexes the pool id
+//! as topic1, so one `eth_getLogs` filter returns every interaction with this pool and nothing
+//! else. Ekubo core emits its swap event with `log0` (no topics at all), which cannot be filtered
+//! server-side, so it is decoded from the receipts of the transactions the extension points at.
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    time::Duration,
+};
+
+use alloy::{
+    consensus::Transaction as _,
+    eips::BlockNumberOrTag,
+    network::Ethereum,
+    primitives::TxHash,
+    providers::{Provider, RootProvider},
+    rpc::types::Filter,
+};
+use anyhow::{anyhow, Context, Result};
+use futures::stream::{StreamExt as _, TryStreamExt as _};
+use tracing::{debug, warn};
+
+use crate::pool::{EKUBO_CORE, EXTENSION, FEES_ACCUMULATED_TOPIC, INTERACTION_TOPIC, POOL_ID};
+
+/// Lowest plausible signed-swap deadline, used to reject false calldata matches.
+const MIN_PLAUSIBLE_DEADLINE: u32 = 1_600_000_000;
+
+/// Delay before the first retry; doubles on each further attempt.
+const RETRY_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Tuning for one scan of the pool's history.
+#[derive(Debug, Clone, Copy)]
+pub struct ScanConfig {
+    /// First block to scan, inclusive.
+    pub from_block: u64,
+    /// Last block to scan, inclusive.
+    pub to_block: u64,
+    /// Block span of a single `eth_getLogs` call.
+    pub chunk: u64,
+    /// Maximum in-flight requests.
+    pub concurrency: usize,
+    /// Attempts per request before giving up. Managed nodes throttle under concurrency.
+    pub retries: u32,
+}
+
+/// Runs `op` until it succeeds or `attempts` are exhausted, backing off between tries.
+async fn with_retry<T, F, Fut>(attempts: u32, mut op: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    let mut delay = RETRY_BACKOFF;
+    let mut last: Option<anyhow::Error> = None;
+    for attempt in 0..attempts.max(1) {
+        if attempt > 0 {
+            tokio::time::sleep(delay).await;
+            delay *= 2;
+        }
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                debug!("rpc attempt {} failed: {error:#}", attempt + 1);
+                last = Some(error);
+            }
+        }
+    }
+    Err(last.unwrap_or_else(|| anyhow!("retry loop ran no attempts")))
+}
+
+/// The trade the pool's curve executed, from the pool's point of view.
+///
+/// A negative delta means the pool paid that token out. The deltas are gross: the extension's fee
+/// is carved out of the output *after* the curve runs, so it is not reflected here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CurveTrade {
+    /// Pool-side token0 delta.
+    pub delta0: i128,
+    /// Pool-side token1 delta.
+    pub delta1: i128,
+}
+
+/// The fee the Fynd controller signed into `user_data` for one swap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SignedFee {
+    /// Fee rate as 0.32 fixed point, charged on the swap's output token.
+    pub fee_q32: u32,
+    /// Unix second the signature expires at.
+    pub deadline: u32,
+}
+
+/// One transaction that touched the pool: a swap, or a position update.
+#[derive(Debug, Clone)]
+pub struct Interaction {
+    pub block: u64,
+    pub timestamp: u64,
+    pub tx: TxHash,
+    /// `None` for position updates, which emit the same extension topic as swaps.
+    pub trade: Option<CurveTrade>,
+    /// Rate signed for this swap, absent when the calldata carries no recognisable signed hop.
+    pub signed_fee: Option<SignedFee>,
+    /// token0 fees credited to LPs in this transaction.
+    pub fees_credited0: u128,
+    /// token1 fees credited to LPs in this transaction.
+    pub fees_credited1: u128,
+}
+
+impl Interaction {
+    /// Whether this interaction actually moved the curve.
+    pub fn is_swap(&self) -> bool {
+        self.trade.is_some()
+    }
+}
+
+/// Reads `n` big-endian bytes at `offset` as a signed 128-bit integer.
+fn read_i128(data: &[u8], offset: usize) -> i128 {
+    let mut buf = [0u8; 16];
+    buf.copy_from_slice(&data[offset..offset + 16]);
+    i128::from_be_bytes(buf)
+}
+
+/// Reads a 32-byte big-endian word at `offset`, saturating into `u128`.
+fn read_u128_word(data: &[u8], offset: usize) -> u128 {
+    let mut buf = [0u8; 16];
+    buf.copy_from_slice(&data[offset + 16..offset + 32]);
+    u128::from_be_bytes(buf)
+}
+
+/// Decodes Ekubo core's untopiced swap event for this pool.
+///
+/// Wire layout: `extension(20) | poolId(32) | delta0(16) | delta1(16) | sqrtRatioAfter(16) |
+/// liquidityAfter(16)`. Returns `None` for any other pool or event.
+pub fn decode_core_swap(data: &[u8]) -> Option<CurveTrade> {
+    if data.len() < 116 || data[..20] != EXTENSION[..] || data[20..52] != POOL_ID[..] {
+        return None;
+    }
+    Some(CurveTrade { delta0: read_i128(data, 52), delta1: read_i128(data, 68) })
+}
+
+/// Decodes Ekubo core's `FeesAccumulated` payload for this pool.
+///
+/// Wire layout: `poolId(32) | amount0(32) | amount1(32)`. Returns `None` for any other pool.
+pub fn decode_fees_accumulated(data: &[u8]) -> Option<(u128, u128)> {
+    if data.len() < 96 || data[..32] != POOL_ID[..] {
+        return None;
+    }
+    Some((read_u128_word(data, 32), read_u128_word(data, 64)))
+}
+
+/// Extracts every signed-swap fee the calldata carries for this pool's extension, in wire order.
+///
+/// `EkuboV3SwapEncoder` lays each hop out as `extension(20) | fee(8) | pool_type_config(4) |
+/// meta(32) | …`, and packs the controller's rate into `meta[4..8]`. The extension address is
+/// matched as a byte pattern, so a match is confirmed by requiring the meta's leading deadline to
+/// be a plausible Unix second; random calldata almost never satisfies that.
+pub fn decode_signed_fees(calldata: &[u8]) -> Vec<SignedFee> {
+    let mut found = Vec::new();
+    let mut i = 0usize;
+    while i + 64 <= calldata.len() {
+        if calldata[i..i + 20] != EXTENSION[..] {
+            i += 1;
+            continue;
+        }
+        let meta = &calldata[i + 32..i + 64];
+        let deadline = u32::from_be_bytes([meta[0], meta[1], meta[2], meta[3]]);
+        if deadline >= MIN_PLAUSIBLE_DEADLINE {
+            let fee_q32 = u32::from_be_bytes([meta[4], meta[5], meta[6], meta[7]]);
+            found.push(SignedFee { fee_q32, deadline });
+        }
+        i += 20;
+    }
+    found
+}
+
+/// Fetches every interaction with the pool in `config`'s block range, in chain order.
+///
+/// Public and managed nodes commonly cap `eth_getLogs` at 1 000 blocks per call and throttle
+/// under concurrency, so the scan is chunked and every request is retried.
+pub async fn fetch_interactions(
+    provider: &RootProvider<Ethereum>,
+    config: ScanConfig,
+) -> Result<Vec<Interaction>> {
+    let ScanConfig { from_block, to_block, chunk, concurrency, retries } = config;
+    let ranges: Vec<(u64, u64)> = (from_block..=to_block)
+        .step_by(chunk as usize)
+        .map(|start| (start, (start + chunk - 1).min(to_block)))
+        .collect();
+    debug!("scanning {} block ranges of up to {chunk} blocks", ranges.len());
+
+    let logs = futures::stream::iter(
+        ranges
+            .into_iter()
+            .map(|(start, end)| async move {
+                with_retry(retries, || async move {
+                    let filter = Filter::new()
+                        .address(EXTENSION)
+                        .event_signature(INTERACTION_TOPIC)
+                        .topic1(POOL_ID)
+                        .from_block(BlockNumberOrTag::Number(start))
+                        .to_block(BlockNumberOrTag::Number(end));
+                    provider
+                        .get_logs(&filter)
+                        .await
+                        .map_err(anyhow::Error::from)
+                })
+                .await
+                .with_context(|| format!("eth_getLogs failed for blocks {start}..={end}"))
+            }),
+    )
+    .buffer_unordered(concurrency)
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    let mut refs: Vec<(u64, u64, TxHash, Option<u64>)> = logs
+        .into_iter()
+        .flatten()
+        .filter_map(|log| {
+            Some((log.block_number?, log.log_index?, log.transaction_hash?, log.block_timestamp))
+        })
+        .collect();
+    refs.sort_unstable_by_key(|(block, index, _, _)| (*block, *index));
+
+    let timestamps = resolve_timestamps(provider, &refs, config).await?;
+    let hashes: Vec<(u64, TxHash)> = refs
+        .into_iter()
+        .map(|(block, _, tx, _)| (block, tx))
+        .collect();
+
+    futures::stream::iter(hashes.into_iter().map(|(block, tx)| {
+        let timestamp = timestamps
+            .get(&block)
+            .copied()
+            .unwrap_or_default();
+        async move { load_interaction(provider, block, timestamp, tx, retries).await }
+    }))
+    .buffered(concurrency)
+    .try_collect()
+    .await
+}
+
+/// Fills in block timestamps the node omitted from its log payloads.
+async fn resolve_timestamps(
+    provider: &RootProvider<Ethereum>,
+    refs: &[(u64, u64, TxHash, Option<u64>)],
+    config: ScanConfig,
+) -> Result<BTreeMap<u64, u64>> {
+    let mut known = BTreeMap::new();
+    let mut missing = HashSet::new();
+    for (block, _, _, timestamp) in refs {
+        match timestamp {
+            Some(t) => {
+                known.insert(*block, *t);
+            }
+            None => {
+                missing.insert(*block);
+            }
+        }
+    }
+    if missing.is_empty() {
+        return Ok(known);
+    }
+    let fetched = futures::stream::iter(
+        missing
+            .into_iter()
+            .map(|block| async move {
+                with_retry(config.retries, || async move {
+                    let header = provider
+                        .get_block_by_number(BlockNumberOrTag::Number(block))
+                        .await?
+                        .with_context(|| format!("block {block} not found"))?;
+                    anyhow::Ok((block, header.header.timestamp))
+                })
+                .await
+            }),
+    )
+    .buffered(config.concurrency)
+    .try_collect::<Vec<_>>()
+    .await?;
+    known.extend(fetched);
+    Ok(known)
+}
+
+/// Builds one [`Interaction`] from its receipt and calldata.
+async fn load_interaction(
+    provider: &RootProvider<Ethereum>,
+    block: u64,
+    timestamp: u64,
+    tx: TxHash,
+    retries: u32,
+) -> Result<Interaction> {
+    let receipt = with_retry(retries, || async move {
+        provider
+            .get_transaction_receipt(tx)
+            .await?
+            .with_context(|| format!("receipt missing for {tx}"))
+    })
+    .await?;
+
+    let mut trades = Vec::new();
+    let mut fees_credited0 = 0u128;
+    let mut fees_credited1 = 0u128;
+    for log in receipt.inner.logs() {
+        if log.address() != EKUBO_CORE {
+            continue;
+        }
+        let data = log.data().data.as_ref();
+        match log.topics().first() {
+            None => trades.extend(decode_core_swap(data)),
+            Some(&topic) if topic == FEES_ACCUMULATED_TOPIC => {
+                if let Some((fee0, fee1)) = decode_fees_accumulated(data) {
+                    fees_credited0 += fee0;
+                    fees_credited1 += fee1;
+                }
+            }
+            Some(_) => {}
+        }
+    }
+    if trades.len() > 1 {
+        warn!(%tx, "transaction holds {} swaps on the pool; reporting the first", trades.len());
+    }
+
+    let transaction = with_retry(retries, || async move {
+        provider
+            .get_transaction_by_hash(tx)
+            .await?
+            .with_context(|| format!("transaction {tx} not found"))
+    })
+    .await?;
+    let signed_fee = decode_signed_fees(transaction.input())
+        .into_iter()
+        .next();
+
+    Ok(Interaction {
+        block,
+        timestamp,
+        tx,
+        trade: trades.into_iter().next(),
+        signed_fee,
+        fees_credited0,
+        fees_credited1,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ekubo core swap log from tx 0x162dff8f…98a46b (1 522.185 USDC in, 0.651354 ETH out).
+    const SWAP_LOG: &str = concat!(
+        "55b703eed01b35641963da2fb2e14885993605a3",
+        "9efd723a29a4e7f40c955f7b968144a5e2a7261a4a0f1573fbb0e2653600e4a4",
+        "fffffffffffffffff6f5ecf4a82780ed",
+        "0000000000000000000000005abab328",
+        "4000cb44275e839ff9427e9cfed0d0f3",
+        "000000000000000000167d314653bf35",
+    );
+
+    /// The signed Ekubo hop from the same transaction's calldata.
+    const SIGNED_HOP: &str = concat!(
+        "55b703eed01b35641963da2fb2e14885993605a3", // extension
+        "0000000000000000",                         // pool config fee
+        "80000400",                                 // pool_type_config
+        "6a88a3010742c560000000006a88915900000000000000000000000000000000", // meta
+    );
+
+    fn bytes(hex: &str) -> Vec<u8> {
+        (0..hex.len())
+            .step_by(2)
+            .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).expect("valid hex"))
+            .collect()
+    }
+
+    #[test]
+    fn decodes_curve_deltas_from_a_real_swap_log() {
+        let trade = decode_core_swap(&bytes(SWAP_LOG)).expect("pool swap");
+        assert_eq!(trade.delta1, 1_522_185_000);
+        assert_eq!(trade.delta0, -651_354_035_547_832_083);
+    }
+
+    #[test]
+    fn rejects_a_swap_log_from_another_pool() {
+        let mut data = bytes(SWAP_LOG);
+        data[20] ^= 0xff;
+        assert_eq!(decode_core_swap(&data), None);
+    }
+
+    #[test]
+    fn rejects_a_truncated_swap_log() {
+        let data = bytes(SWAP_LOG);
+        assert_eq!(decode_core_swap(&data[..115]), None);
+    }
+
+    #[test]
+    fn decodes_fees_accumulated_for_this_pool() {
+        let mut data = bytes(&POOL_ID.to_string()[2..]);
+        data.extend(std::iter::repeat_n(0, 16));
+        data.extend(23_667_994_721_360u128.to_be_bytes());
+        data.extend(std::iter::repeat_n(0, 32));
+        assert_eq!(decode_fees_accumulated(&data), Some((23_667_994_721_360, 0)));
+    }
+
+    #[test]
+    fn ignores_fees_accumulated_for_another_pool() {
+        let data = vec![0u8; 96];
+        assert_eq!(decode_fees_accumulated(&data), None);
+    }
+
+    #[test]
+    fn extracts_the_signed_fee_from_a_real_hop() {
+        let fees = decode_signed_fees(&bytes(SIGNED_HOP));
+        assert_eq!(fees, vec![SignedFee { fee_q32: 0x0742_c560, deadline: 0x6a88_a301 }]);
+    }
+
+    #[test]
+    fn extracts_one_entry_per_hop() {
+        let calldata = bytes(&format!("{SIGNED_HOP}{SIGNED_HOP}"));
+        assert_eq!(decode_signed_fees(&calldata).len(), 2);
+    }
+
+    #[test]
+    fn skips_an_extension_match_without_a_plausible_deadline() {
+        let mut data = bytes(SIGNED_HOP);
+        data[32..36].copy_from_slice(&0u32.to_be_bytes());
+        assert!(decode_signed_fees(&data).is_empty());
+    }
+
+    #[test]
+    fn ignores_an_extension_match_too_close_to_the_end() {
+        let data = bytes("55b703eed01b35641963da2fb2e14885993605a3");
+        assert!(decode_signed_fees(&data).is_empty());
+    }
+}

--- a/tools/exclusive-pool-pnl/src/main.rs
+++ b/tools/exclusive-pool-pnl/src/main.rs
@@ -1,0 +1,174 @@
+//! exclusive-pool-pnl — LP fee revenue and markout for the Fynd exclusive Ekubo pool.
+//!
+//! The pool is hardcoded in [`pool`]. See `README.md` for usage and for what the numbers mean.
+
+mod chain;
+mod pnl;
+mod pool;
+mod prices;
+mod report;
+
+use std::path::PathBuf;
+
+use alloy::{
+    network::Ethereum,
+    providers::{Provider as _, ProviderBuilder, RootProvider},
+};
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+/// Seconds of reference prices fetched beyond the last swap, so the longest markout resolves.
+const PRICE_TAIL_SECS: u64 = 3_600;
+
+/// Seconds of reference prices fetched before the first swap, so its own minute is covered.
+const PRICE_LEAD_SECS: u64 = 600;
+
+#[derive(Parser)]
+#[command(name = "exclusive-pool-pnl")]
+#[command(about = "LP fee revenue and markout for the Fynd exclusive Ekubo pool")]
+struct Cli {
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: String,
+
+    /// First block to scan. Defaults to the extension's deployment block.
+    #[arg(long, default_value_t = pool::DEPLOY_BLOCK)]
+    from_block: u64,
+
+    /// Last block to scan. Defaults to the chain head.
+    #[arg(long)]
+    to_block: Option<u64>,
+
+    /// Block span of a single `eth_getLogs` call. Most nodes cap this at 1 000.
+    #[arg(long, default_value_t = 1_000)]
+    chunk: u64,
+
+    /// Maximum in-flight RPC requests.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+
+    /// Attempts per RPC request before giving up.
+    #[arg(long, default_value_t = 5)]
+    retries: u32,
+
+    /// Markout horizons in seconds, applied to every swap.
+    #[arg(long, value_delimiter = ',', default_values_t = [0u64, 300, 3_600])]
+    markout_secs: Vec<u64>,
+
+    /// Skip the reference-price download and report fees only.
+    #[arg(long)]
+    no_prices: bool,
+
+    /// Write the full result set here as JSON.
+    #[arg(long)]
+    json: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()))
+        .init();
+
+    let cli = Cli::parse();
+    if cli.chunk == 0 || cli.concurrency == 0 {
+        bail!("--chunk and --concurrency must be greater than zero");
+    }
+    if cli.markout_secs.is_empty() {
+        bail!("--markout-secs needs at least one horizon");
+    }
+
+    let provider: RootProvider<Ethereum> = ProviderBuilder::default().connect_http(
+        cli.rpc_url
+            .parse()
+            .with_context(|| format!("invalid RPC URL: {}", cli.rpc_url))?,
+    );
+    let to_block = match cli.to_block {
+        Some(block) => block,
+        None => provider
+            .get_block_number()
+            .await
+            .context("could not read the chain head")?,
+    };
+    if cli.from_block > to_block {
+        bail!("--from-block {} is past --to-block {to_block}", cli.from_block);
+    }
+
+    info!("scanning blocks {}..={to_block} for pool {}", cli.from_block, pool::POOL_ID);
+    let scan = chain::ScanConfig {
+        from_block: cli.from_block,
+        to_block,
+        chunk: cli.chunk,
+        concurrency: cli.concurrency,
+        retries: cli.retries,
+    };
+    let interactions = chain::fetch_interactions(&provider, scan).await?;
+    let swap_count = interactions
+        .iter()
+        .filter(|interaction| interaction.is_swap())
+        .count();
+    info!("found {} pool interactions, {swap_count} of them swaps", interactions.len());
+    if swap_count == 0 {
+        println!("no swaps on the pool in blocks {}..={to_block}", cli.from_block);
+        return Ok(());
+    }
+
+    let prices = if cli.no_prices {
+        prices::PriceSeries::default()
+    } else {
+        fetch_prices(&interactions, &cli.markout_secs).await?
+    };
+    if !cli.no_prices {
+        info!("loaded {} reference candles", prices.len());
+    }
+
+    let swaps = pnl::build(&interactions, &prices, &cli.markout_secs);
+    let primary = cli
+        .markout_secs
+        .iter()
+        .copied()
+        .min()
+        .unwrap_or_default();
+    report::print_swaps(&swaps, primary);
+    report::print_totals(&swaps, &cli.markout_secs);
+    if let Some(path) = &cli.json {
+        report::write_json(&swaps, &cli.markout_secs, path)?;
+        info!("wrote {}", path.display());
+    }
+    Ok(())
+}
+
+/// Downloads reference prices covering every swap and every requested horizon.
+async fn fetch_prices(
+    interactions: &[chain::Interaction],
+    horizons: &[u64],
+) -> Result<prices::PriceSeries> {
+    let stamps: Vec<u64> = interactions
+        .iter()
+        .filter(|interaction| interaction.is_swap())
+        .map(|interaction| interaction.timestamp)
+        .collect();
+    let first = stamps
+        .iter()
+        .min()
+        .copied()
+        .unwrap_or_default();
+    let last = stamps
+        .iter()
+        .max()
+        .copied()
+        .unwrap_or_default();
+    let tail = horizons
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(PRICE_TAIL_SECS)
+        .max(PRICE_TAIL_SECS);
+    prices::PriceSeries::fetch(
+        pool::REFERENCE_SYMBOL,
+        first.saturating_sub(PRICE_LEAD_SECS),
+        last + tail,
+    )
+    .await
+}

--- a/tools/exclusive-pool-pnl/src/pnl.rs
+++ b/tools/exclusive-pool-pnl/src/pnl.rs
@@ -1,0 +1,320 @@
+//! Turns decoded pool interactions into LP revenue and markout.
+//!
+//! # What the numbers mean
+//!
+//! `pnl` is profit and loss: what the pool's liquidity providers gained or lost, stated in token1.
+//! A negative value means the LPs ended a swap worse off than holding and trading at the reference
+//! price instead.
+//!
+//! For one swap, with `p` the reference price in token1 per token0:
+//!
+//! ```text
+//! adverse_selection = delta0·p + delta1        (the raw curve trade, valued at p)
+//! fee_revenue       = lp_fee0·p + lp_fee1      (what the pool kept for its LPs)
+//! lp_pnl            = adverse_selection + fee_revenue   (the LPs' profit and loss)
+//! ```
+//!
+//! `adverse_selection` is zero when the curve trades exactly at `p` and negative when the pool
+//! traded at a worse price than the market. Classical LVR measures that loss against arbitrageurs
+//! who trade *because* the pool is mispriced. No arbitrageur can trade this pool — every swap
+//! needs a controller signature — so what this reports is markout on Fynd's routed flow, which is
+//! the closest measurable analogue, not LVR itself.
+//!
+//! Fee amounts are measured from Ekubo's `FeesAccumulated` events rather than recomputed from the
+//! signed rate. Ekubo credits an accrued fee on the *next* interaction with the pool, so
+//! [`attribute_fees`] shifts each credit back onto the swap that earned it. A swap whose fee has
+//! not been flushed yet is reported as pending, and a swap whose fee never reached the pool shows
+//! zero LP revenue even though the taker was charged.
+
+use crate::{
+    chain::Interaction,
+    pool::{token0_units, token1_units},
+    prices::PriceSeries,
+};
+
+/// Fees credited to LPs for one swap, resolved across Ekubo's one-interaction lag.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AttributedFee {
+    /// token0 fees credited to the pool for this swap.
+    pub amount0: u128,
+    /// token1 fees credited to the pool for this swap.
+    pub amount1: u128,
+    /// Set when no later interaction has flushed this swap's fee yet.
+    pub pending: bool,
+}
+
+/// LP outcome for one swap, valued at one markout horizon.
+#[derive(Debug, Clone, Copy)]
+pub struct Markout {
+    /// Seconds after the swap that the reference price was taken at.
+    pub horizon_secs: u64,
+    /// Reference price used, in token1 per token0.
+    pub reference_price: f64,
+    /// Value the curve trade gave up against the reference, in token1 units.
+    pub adverse_selection: f64,
+    /// Value the pool kept as fees, in token1 units.
+    pub fee_revenue: f64,
+    /// Net LP outcome, in token1 units.
+    pub lp_pnl: f64,
+}
+
+/// One swap, with its fee attribution and markouts.
+#[derive(Debug, Clone)]
+pub struct SwapPnl {
+    pub block: u64,
+    pub timestamp: u64,
+    pub tx: String,
+    /// Pool-side token0 delta, in whole units.
+    pub delta0: f64,
+    /// Pool-side token1 delta, in whole units.
+    pub delta1: f64,
+    /// Price the curve traded at, in token1 per token0.
+    pub pool_price: f64,
+    /// Rate the controller signed, in basis points of the output token.
+    pub signed_fee_bps: Option<f64>,
+    pub fee: AttributedFee,
+    pub markouts: Vec<Markout>,
+}
+
+impl SwapPnl {
+    /// Trade size in token1 units, always positive.
+    pub fn size(&self) -> f64 {
+        self.delta1.abs()
+    }
+
+    /// Whether the pool bought token0 (the taker sold it).
+    pub fn pool_bought_token0(&self) -> bool {
+        self.delta0 > 0.0
+    }
+}
+
+/// Assigns each `FeesAccumulated` credit back to the swap that earned it.
+///
+/// Walks interactions in chain order holding the most recent swap that has not been credited yet.
+/// That swap is settled by the next interaction which either credits fees, or is itself a swap and
+/// therefore takes over the accrual — settling at zero means the fee never reached the pool. An
+/// interaction that does neither leaves the swap pending, so a position update that turns out not
+/// to flush cannot misattribute a later credit. The returned vector is aligned with the swaps in
+/// `interactions`, in the same order.
+pub fn attribute_fees(interactions: &[Interaction]) -> Vec<AttributedFee> {
+    let mut fees: Vec<AttributedFee> = Vec::new();
+    let mut awaiting: Option<usize> = None;
+    for interaction in interactions {
+        let credited = interaction.fees_credited0 > 0 || interaction.fees_credited1 > 0;
+        if credited || interaction.is_swap() {
+            if let Some(index) = awaiting.take() {
+                fees[index] = AttributedFee {
+                    amount0: interaction.fees_credited0,
+                    amount1: interaction.fees_credited1,
+                    pending: false,
+                };
+            }
+        }
+        if interaction.is_swap() {
+            awaiting = Some(fees.len());
+            fees.push(AttributedFee { pending: true, ..AttributedFee::default() });
+        }
+    }
+    fees
+}
+
+/// Builds the per-swap report from decoded interactions and a reference price series.
+pub fn build(interactions: &[Interaction], prices: &PriceSeries, horizons: &[u64]) -> Vec<SwapPnl> {
+    let fees = attribute_fees(interactions);
+    interactions
+        .iter()
+        .filter(|interaction| interaction.is_swap())
+        .zip(fees)
+        .map(|(interaction, fee)| {
+            let trade = interaction
+                .trade
+                .expect("filtered to swaps");
+            let delta0 = token0_units(trade.delta0);
+            let delta1 = token1_units(trade.delta1);
+            let markouts = horizons
+                .iter()
+                .filter_map(|horizon| {
+                    markout(*horizon, interaction.timestamp, delta0, delta1, &fee, prices)
+                })
+                .collect();
+            SwapPnl {
+                block: interaction.block,
+                timestamp: interaction.timestamp,
+                tx: interaction.tx.to_string(),
+                delta0,
+                delta1,
+                pool_price: if delta0 == 0.0 { f64::NAN } else { -delta1 / delta0 },
+                signed_fee_bps: interaction
+                    .signed_fee
+                    .map(|signed| f64::from(signed.fee_q32) / 2f64.powi(32) * 10_000.0),
+                fee,
+                markouts,
+            }
+        })
+        .collect()
+}
+
+/// Values one swap against the reference price `horizon` seconds after it settled.
+fn markout(
+    horizon: u64,
+    timestamp: u64,
+    delta0: f64,
+    delta1: f64,
+    fee: &AttributedFee,
+    prices: &PriceSeries,
+) -> Option<Markout> {
+    let reference_price = prices.at(timestamp + horizon)?;
+    let adverse_selection = delta0 * reference_price + delta1;
+    let fee_revenue =
+        token0_units(fee.amount0 as i128) * reference_price + token1_units(fee.amount1 as i128);
+    Some(Markout {
+        horizon_secs: horizon,
+        reference_price,
+        adverse_selection,
+        fee_revenue,
+        lp_pnl: adverse_selection + fee_revenue,
+    })
+}
+
+/// Totals across every swap, for one markout horizon.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Totals {
+    pub horizon_secs: u64,
+    pub volume: f64,
+    pub adverse_selection: f64,
+    pub fee_revenue: f64,
+    pub lp_pnl: f64,
+}
+
+impl Totals {
+    /// Net LP outcome as basis points of traded volume, or zero when nothing traded.
+    pub fn lp_bps(&self) -> f64 {
+        if self.volume == 0.0 {
+            return 0.0;
+        }
+        self.lp_pnl / self.volume * 10_000.0
+    }
+
+    /// Fee revenue as basis points of traded volume, or zero when nothing traded.
+    pub fn fee_bps(&self) -> f64 {
+        if self.volume == 0.0 {
+            return 0.0;
+        }
+        self.fee_revenue / self.volume * 10_000.0
+    }
+}
+
+/// Sums per-swap results for one horizon. Swaps missing that horizon are skipped.
+pub fn totals(swaps: &[SwapPnl], horizon: u64) -> Totals {
+    let mut out = Totals { horizon_secs: horizon, ..Totals::default() };
+    for swap in swaps {
+        let Some(markout) = swap
+            .markouts
+            .iter()
+            .find(|m| m.horizon_secs == horizon)
+        else {
+            continue;
+        };
+        out.volume += swap.size();
+        out.adverse_selection += markout.adverse_selection;
+        out.fee_revenue += markout.fee_revenue;
+        out.lp_pnl += markout.lp_pnl;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::TxHash;
+
+    use super::*;
+    use crate::chain::CurveTrade;
+
+    fn interaction(block: u64, trade: Option<CurveTrade>, credited0: u128) -> Interaction {
+        Interaction {
+            block,
+            timestamp: block * 12,
+            tx: TxHash::with_last_byte(block as u8),
+            trade,
+            signed_fee: None,
+            fees_credited0: credited0,
+            fees_credited1: 0,
+        }
+    }
+
+    fn swap(block: u64, credited0: u128) -> Interaction {
+        interaction(block, Some(CurveTrade { delta0: -1, delta1: 1 }), credited0)
+    }
+
+    #[test]
+    fn credits_a_fee_to_the_swap_one_interaction_earlier() {
+        let fees = attribute_fees(&[swap(1, 0), swap(2, 500)]);
+        assert_eq!(fees[0], AttributedFee { amount0: 500, amount1: 0, pending: false });
+    }
+
+    #[test]
+    fn marks_the_last_swap_pending_until_it_is_flushed() {
+        let fees = attribute_fees(&[swap(1, 0), swap(2, 500)]);
+        assert!(fees[1].pending);
+        assert_eq!(fees[1].amount0, 0);
+    }
+
+    #[test]
+    fn lets_a_position_update_flush_a_swap_fee() {
+        let fees = attribute_fees(&[swap(1, 0), interaction(2, None, 700)]);
+        assert_eq!(fees.len(), 1);
+        assert_eq!(fees[0], AttributedFee { amount0: 700, amount1: 0, pending: false });
+    }
+
+    #[test]
+    fn reports_zero_when_a_swap_fee_never_reaches_the_pool() {
+        // Three swaps, and only the third credits anything: swap 1's fee was never flushed.
+        let fees = attribute_fees(&[swap(1, 0), swap(2, 0), swap(3, 900)]);
+        assert_eq!(fees[0], AttributedFee::default());
+        assert_eq!(fees[1].amount0, 900);
+    }
+
+    #[test]
+    fn ignores_position_updates_when_listing_swaps() {
+        let fees = attribute_fees(&[interaction(1, None, 0), swap(2, 0), interaction(3, None, 0)]);
+        assert_eq!(fees.len(), 1);
+    }
+
+    #[test]
+    fn markout_is_zero_when_the_curve_trades_at_the_reference() {
+        let prices = PriceSeries::from_candles(vec![(60, 2_000.0)]);
+        // Pool pays out 1 token0 and receives 2 000 token1 — exactly the reference price.
+        let result = markout(0, 60, -1.0, 2_000.0, &AttributedFee::default(), &prices)
+            .expect("price available");
+        assert!(result.adverse_selection.abs() < 1e-9);
+        assert!(result.lp_pnl.abs() < 1e-9);
+    }
+
+    #[test]
+    fn markout_is_negative_when_the_pool_sells_below_the_reference() {
+        let prices = PriceSeries::from_candles(vec![(60, 2_100.0)]);
+        let result = markout(0, 60, -1.0, 2_000.0, &AttributedFee::default(), &prices)
+            .expect("price available");
+        assert!((result.adverse_selection - -100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fee_revenue_offsets_the_curve_loss() {
+        let prices = PriceSeries::from_candles(vec![(60, 2_100.0)]);
+        let fee = AttributedFee { amount0: 10u128.pow(17), amount1: 0, pending: false };
+        let result = markout(0, 60, -1.0, 2_000.0, &fee, &prices).expect("price available");
+        assert!((result.fee_revenue - 210.0).abs() < 1e-9);
+        assert!((result.lp_pnl - 110.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn markout_is_skipped_when_the_horizon_predates_the_price_series() {
+        let prices = PriceSeries::from_candles(vec![(1_000, 2_000.0)]);
+        assert!(markout(0, 60, -1.0, 2_000.0, &AttributedFee::default(), &prices).is_none());
+    }
+
+    #[test]
+    fn totals_are_zero_bps_without_volume() {
+        assert_eq!(totals(&[], 0).lp_bps(), 0.0);
+    }
+}

--- a/tools/exclusive-pool-pnl/src/pool.rs
+++ b/tools/exclusive-pool-pnl/src/pool.rs
@@ -1,0 +1,49 @@
+//! Hardcoded identity of the Fynd exclusive Ekubo V3 pool on Ethereum mainnet.
+//!
+//! The pool is ETH/USDC behind the `SignedExclusiveSwap` extension: only quotes signed by the
+//! Fynd controller key can trade it. Its `PoolKey` carries `fee = 0`, so every unit of LP revenue
+//! comes from the extension's per-swap fee rather than from a configured swap fee.
+
+use alloy::primitives::{address, b256, Address, B256};
+
+/// `keccak256(token0 ‖ token1 ‖ poolConfig)` for the pool this tool reports on.
+pub const POOL_ID: B256 = b256!("9efd723a29a4e7f40c955f7b968144a5e2a7261a4a0f1573fbb0e2653600e4a4");
+
+/// The `SignedExclusiveSwap` extension that gates and prices every swap on the pool.
+pub const EXTENSION: Address = address!("55b703eed01b35641963da2fb2e14885993605a3");
+
+/// Ekubo V3 core, which holds the pool's reserves and emits its swap and fee events.
+pub const EKUBO_CORE: Address = address!("00000000000014aa86c5d3c41765bb24e11bd701");
+
+/// Topic0 the extension emits on every pool interaction, with the pool id as topic1.
+///
+/// Position updates carry this topic too, so a log match alone does not mean a swap happened.
+/// [`crate::chain`] confirms a swap by finding Ekubo core's swap log in the same receipt.
+pub const INTERACTION_TOPIC: B256 =
+    b256!("d59d72ec6d1bba1eef52ec72bd29117451b6c411faada758fdea78bf56a87648");
+
+/// Topic0 of Ekubo core's `FeesAccumulated`, which credits fees to the pool's LPs.
+pub const FEES_ACCUMULATED_TOPIC: B256 =
+    b256!("f7e050d866774820d81a86ca676f3afe7bc72603ee893f82e99c08fbde39af6c");
+
+/// Block the extension was deployed in — no pool interaction can predate it.
+pub const DEPLOY_BLOCK: u64 = 25_648_587;
+
+/// token0 is native ETH.
+pub const TOKEN0_DECIMALS: u32 = 18;
+
+/// token1 is USDC.
+pub const TOKEN1_DECIMALS: u32 = 6;
+
+/// Binance symbol used as the markout reference price, quoted in token1 per token0.
+pub const REFERENCE_SYMBOL: &str = "ETHUSDC";
+
+/// Converts a token0 amount to a float in whole units.
+pub fn token0_units(raw: i128) -> f64 {
+    raw as f64 / 10f64.powi(TOKEN0_DECIMALS as i32)
+}
+
+/// Converts a token1 amount to a float in whole units.
+pub fn token1_units(raw: i128) -> f64 {
+    raw as f64 / 10f64.powi(TOKEN1_DECIMALS as i32)
+}

--- a/tools/exclusive-pool-pnl/src/prices.rs
+++ b/tools/exclusive-pool-pnl/src/prices.rs
@@ -1,0 +1,138 @@
+//! Historical reference prices for the markout benchmark.
+//!
+//! `fynd-core`'s `price_guard` providers are deliberately not used here: they stream or poll the
+//! *current* price to validate a live quote, and keep no history. A markout needs the price at a
+//! past timestamp, so this module pulls one-minute klines from Binance's public REST endpoint
+//! instead. No API key is required.
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use tracing::debug;
+
+/// Binance returns at most this many klines per request.
+const MAX_KLINES_PER_REQUEST: u64 = 1_000;
+
+const SECONDS_PER_MINUTE: u64 = 60;
+
+/// One-minute closing prices, ordered by time, quoted in token1 per token0.
+#[derive(Debug, Clone, Default)]
+pub struct PriceSeries {
+    /// `(minute open time in seconds, close price)`, ascending.
+    candles: Vec<(u64, f64)>,
+}
+
+impl PriceSeries {
+    /// Downloads one-minute closes covering `[from, to]` inclusive, in Unix seconds.
+    pub async fn fetch(symbol: &str, from: u64, to: u64) -> Result<Self> {
+        let client = reqwest::Client::new();
+        let mut candles: Vec<(u64, f64)> = Vec::new();
+        let mut cursor = from;
+        while cursor <= to {
+            let url = format!(
+                "https://api.binance.com/api/v3/klines?symbol={symbol}&interval=1m\
+                 &startTime={}&limit={MAX_KLINES_PER_REQUEST}",
+                cursor * 1_000
+            );
+            let batch: Vec<Value> = client
+                .get(&url)
+                .send()
+                .await
+                .context("binance klines request failed")?
+                .error_for_status()
+                .context("binance klines returned an error status")?
+                .json()
+                .await
+                .context("binance klines response was not JSON")?;
+            if batch.is_empty() {
+                break;
+            }
+            for row in &batch {
+                let open_ms = row[0]
+                    .as_u64()
+                    .context("kline open time was not a number")?;
+                let close = row[4]
+                    .as_str()
+                    .context("kline close was not a string")?
+                    .parse::<f64>()
+                    .context("kline close was not a number")?;
+                candles.push((open_ms / 1_000, close));
+            }
+            let last_open = candles
+                .last()
+                .map(|(open, _)| *open)
+                .unwrap_or(cursor);
+            cursor = last_open + SECONDS_PER_MINUTE;
+        }
+        candles.sort_unstable_by_key(|(open, _)| *open);
+        candles.dedup_by_key(|(open, _)| *open);
+        debug!("fetched {} reference candles for {symbol}", candles.len());
+        Ok(Self { candles })
+    }
+
+    /// Returns the close of the minute containing `timestamp`.
+    ///
+    /// Returns `None` when `timestamp` falls outside the downloaded window on either side. Running
+    /// off the end matters most: a markout horizon that has not elapsed yet must drop out of the
+    /// report rather than silently reuse the newest price.
+    pub fn at(&self, timestamp: u64) -> Option<f64> {
+        let index = self
+            .candles
+            .partition_point(|(open, _)| *open <= timestamp);
+        if index == 0 {
+            return None;
+        }
+        let (open, close) = self.candles[index - 1];
+        (timestamp < open + SECONDS_PER_MINUTE).then_some(close)
+    }
+
+    /// Number of candles held.
+    pub fn len(&self) -> usize {
+        self.candles.len()
+    }
+
+    /// Builds a series directly from `(minute open, close)` pairs. Test helper.
+    #[cfg(test)]
+    pub fn from_candles(candles: Vec<(u64, f64)>) -> Self {
+        Self { candles }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn series() -> PriceSeries {
+        PriceSeries::from_candles(vec![(60, 100.0), (120, 101.0), (180, 102.0)])
+    }
+
+    #[test]
+    fn returns_the_close_of_the_containing_minute() {
+        assert_eq!(series().at(150), Some(101.0));
+    }
+
+    #[test]
+    fn returns_the_close_on_an_exact_minute_boundary() {
+        assert_eq!(series().at(120), Some(101.0));
+    }
+
+    #[test]
+    fn returns_the_close_at_the_end_of_the_last_minute() {
+        assert_eq!(series().at(239), Some(102.0));
+    }
+
+    #[test]
+    fn returns_none_past_the_end_of_the_series() {
+        // A horizon that has not elapsed yet must drop out rather than reuse the newest close.
+        assert_eq!(series().at(240), None);
+    }
+
+    #[test]
+    fn returns_none_before_the_series_starts() {
+        assert_eq!(series().at(59), None);
+    }
+
+    #[test]
+    fn returns_none_when_empty() {
+        assert_eq!(PriceSeries::default().at(120), None);
+    }
+}

--- a/tools/exclusive-pool-pnl/src/report.rs
+++ b/tools/exclusive-pool-pnl/src/report.rs
@@ -1,0 +1,230 @@
+//! Renders the per-swap table, the totals block, and the JSON artifact.
+
+use anyhow::Result;
+use chrono::DateTime;
+use serde_json::{json, Value};
+
+use crate::{
+    pnl::{totals, SwapPnl, Totals},
+    pool::REFERENCE_SYMBOL,
+};
+
+/// Formats a Unix second as `YYYY-MM-DD HH:MM:SS` UTC.
+fn format_time(timestamp: u64) -> String {
+    DateTime::from_timestamp(timestamp as i64, 0)
+        .map(|t| {
+            t.format("%Y-%m-%d %H:%M:%S")
+                .to_string()
+        })
+        .unwrap_or_else(|| timestamp.to_string())
+}
+
+/// Prints one row per swap, valued at `horizon`.
+pub fn print_swaps(swaps: &[SwapPnl], horizon: u64) {
+    println!(
+        "{:<19} {:>9} {:>5} {:>10} {:>10} {:>9} {:>10} {:>10} {:>10}",
+        "time (UTC)", "block", "pool", "size", "pool px", "ref px", "fee bps", "fee", "LP pnl",
+    );
+    for swap in swaps {
+        let markout = swap
+            .markouts
+            .iter()
+            .find(|m| m.horizon_secs == horizon);
+        // Side is stated from the pool's point of view: what its LPs did with token0.
+        let side = if swap.pool_bought_token0() { "buys" } else { "sells" };
+        let fee_bps = swap
+            .signed_fee_bps
+            .map(|bps| format!("{bps:.1}"))
+            .unwrap_or_else(|| "-".to_string());
+        let pending = if swap.fee.pending { "*" } else { "" };
+        match markout {
+            Some(m) => println!(
+                "{:<19} {:>9} {:>5} {:>10.2} {:>10.2} {:>9.2} {:>10} {:>9.3}{} {:>10.3}",
+                format_time(swap.timestamp),
+                swap.block,
+                side,
+                swap.size(),
+                swap.pool_price,
+                m.reference_price,
+                fee_bps,
+                m.fee_revenue,
+                pending,
+                m.lp_pnl,
+            ),
+            None => println!(
+                "{:<19} {:>9} {:>5} {:>10.2} {:>10.2} {:>9} {:>10} {:>10} {:>10}",
+                format_time(swap.timestamp),
+                swap.block,
+                side,
+                swap.size(),
+                swap.pool_price,
+                "-",
+                fee_bps,
+                "-",
+                "no ref px",
+            ),
+        }
+    }
+    if swaps
+        .iter()
+        .any(|swap| swap.fee.pending)
+    {
+        println!("\n* fee not yet flushed to LPs; Ekubo credits it on the next pool interaction");
+    }
+}
+
+/// Prints the totals block for every requested horizon.
+pub fn print_totals(swaps: &[SwapPnl], horizons: &[u64]) {
+    let all: Vec<Totals> = horizons
+        .iter()
+        .map(|horizon| totals(swaps, *horizon))
+        .collect();
+    let volume: f64 = swaps.iter().map(SwapPnl::size).sum();
+    println!("\nswaps: {}", swaps.len());
+    println!("volume: {volume:.2} (token1 units)");
+    println!("reference: binance {REFERENCE_SYMBOL} 1m closes\n");
+    println!(
+        "{:>10} {:>12} {:>14} {:>10} {:>16} {:>14} {:>10}",
+        "horizon", "priced vol", "fee revenue", "fee bps", "adverse sel.", "net LP pnl", "LP bps",
+    );
+    for t in &all {
+        println!(
+            "{:>9}s {:>12.2} {:>14.3} {:>10.1} {:>16.3} {:>14.3} {:>10.1}",
+            t.horizon_secs,
+            t.volume,
+            t.fee_revenue,
+            t.fee_bps(),
+            t.adverse_selection,
+            t.lp_pnl,
+            t.lp_bps(),
+        );
+    }
+    if all
+        .iter()
+        .any(|t| t.volume + 1e-9 < volume)
+    {
+        println!(
+            "\nA horizon prices less than the full volume when it has not elapsed yet for every \
+             swap; those swaps are excluded from that row."
+        );
+    }
+}
+
+/// Builds the JSON artifact holding every swap and every horizon.
+pub fn to_json(swaps: &[SwapPnl], horizons: &[u64]) -> Value {
+    let rows: Vec<Value> = swaps
+        .iter()
+        .map(|swap| {
+            json!({
+                "block": swap.block,
+                "timestamp": swap.timestamp,
+                "time_utc": format_time(swap.timestamp),
+                "tx": swap.tx,
+                "delta0": swap.delta0,
+                "delta1": swap.delta1,
+                "size": swap.size(),
+                "pool_price": swap.pool_price,
+                "signed_fee_bps": swap.signed_fee_bps,
+                "lp_fee0_raw": swap.fee.amount0.to_string(),
+                "lp_fee1_raw": swap.fee.amount1.to_string(),
+                "lp_fee_pending": swap.fee.pending,
+                "markouts": swap.markouts.iter().map(|m| json!({
+                    "horizon_secs": m.horizon_secs,
+                    "reference_price": m.reference_price,
+                    "adverse_selection": m.adverse_selection,
+                    "fee_revenue": m.fee_revenue,
+                    "lp_pnl": m.lp_pnl,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    let summary: Vec<Value> = horizons
+        .iter()
+        .map(|horizon| {
+            let t = totals(swaps, *horizon);
+            json!({
+                "horizon_secs": t.horizon_secs,
+                "volume": t.volume,
+                "fee_revenue": t.fee_revenue,
+                "fee_bps": t.fee_bps(),
+                "adverse_selection": t.adverse_selection,
+                "lp_pnl": t.lp_pnl,
+                "lp_bps": t.lp_bps(),
+            })
+        })
+        .collect();
+    json!({ "reference_symbol": REFERENCE_SYMBOL, "swaps": rows, "totals": summary })
+}
+
+/// Writes the JSON artifact to `path`.
+pub fn write_json(swaps: &[SwapPnl], horizons: &[u64], path: &std::path::Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    std::fs::write(path, serde_json::to_string_pretty(&to_json(swaps, horizons))?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pnl::{AttributedFee, Markout};
+
+    fn swap() -> SwapPnl {
+        SwapPnl {
+            block: 25_805_516,
+            timestamp: 1_787_339_435,
+            tx: "0xabc".to_string(),
+            delta0: -0.651_354,
+            delta1: 1_522.185,
+            pool_price: 2_336.95,
+            signed_fee_bps: Some(283.6),
+            fee: AttributedFee { amount0: 1, amount1: 0, pending: false },
+            markouts: vec![Markout {
+                horizon_secs: 300,
+                reference_price: 2_411.92,
+                adverse_selection: -48.829,
+                fee_revenue: 44.558,
+                lp_pnl: -4.271,
+            }],
+        }
+    }
+
+    #[test]
+    fn formats_a_timestamp_as_utc() {
+        assert_eq!(format_time(1_787_339_435), "2026-08-21 19:10:35");
+    }
+
+    #[test]
+    fn json_holds_one_row_per_swap_and_one_total_per_horizon() {
+        let value = to_json(&[swap()], &[300, 3_600]);
+        assert_eq!(
+            value["swaps"]
+                .as_array()
+                .expect("array")
+                .len(),
+            1
+        );
+        assert_eq!(
+            value["totals"]
+                .as_array()
+                .expect("array")
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn json_reports_raw_fees_as_strings_to_survive_u128() {
+        let value = to_json(&[swap()], &[300]);
+        assert_eq!(value["swaps"][0]["lp_fee0_raw"], "1");
+    }
+
+    #[test]
+    fn totals_skip_a_horizon_the_swap_has_no_price_for() {
+        let value = to_json(&[swap()], &[3_600]);
+        assert_eq!(value["totals"][0]["volume"], 0.0);
+    }
+}


### PR DESCRIPTION
Adds `tools/exclusive-pool-pnl`, a one-shot report on the exclusive Ekubo V3 pool. The pool is hardcoded in `src/pool.rs`: ETH/USDC behind the `SignedExclusiveSwap` extension.

PnL means profit and loss — what the pool's liquidity providers gained or lost, stated in USDC.

## How to run it

1. Point `RPC_URL` at an Ethereum archive node. The tool reads it from the environment and has no default, so nothing is committed:

   ```bash
   export RPC_URL=<archive node>
   ```

2. Run the full history scan:

   ```bash
   cargo run --release -p exclusive-pool-pnl
   ```

That prints the per-swap table and the totals block. A full scan is about 160 `eth_getLogs` calls and finishes in well under a minute.

### Options

| Flag | Default | Purpose |
|---|---|---|
| `--from-block` | extension deploy block (25648587) | First block to scan |
| `--to-block` | chain head | Last block to scan |
| `--chunk` | `1000` | Block span per `eth_getLogs`; most nodes cap here |
| `--concurrency` | `8` | Maximum in-flight RPC requests |
| `--retries` | `5` | Attempts per request; managed nodes throttle under concurrency |
| `--markout-secs` | `0,300,3600` | Markout horizons in seconds, comma separated |
| `--no-prices` | off | Skip the Binance download and report fees only |
| `--json <path>` | none | Write every swap and total as JSON |

### Examples

Fees only, no network calls to Binance:

```bash
cargo run --release -p exclusive-pool-pnl -- --no-prices
```

One day of blocks, with a JSON artifact and different horizons:

```bash
cargo run --release -p exclusive-pool-pnl -- \
  --from-block 25800000 \
  --markout-secs 60,900 \
  --json out/pool_pnl.json
```

Against a node with a tighter `eth_getLogs` cap, or one that throttles:

```bash
cargo run --release -p exclusive-pool-pnl -- --chunk 500 --concurrency 4
```

Set `RUST_LOG=debug` to see each block range and every RPC retry.

## How it reads the pool

Discovery starts at the extension, which indexes the pool id as topic1. Ekubo core emits its swap event with `log0`, so it cannot be filtered server-side; swaps are decoded from the receipts of the transactions the extension points at. Position updates share the extension's topic and are separated by whether their receipt holds a core swap log.

Fee amounts come from Ekubo's `FeesAccumulated` events rather than from recomputing the signed rate. Ekubo credits an accrued fee on the next pool interaction, so `attribute_fees` shifts each credit back one interaction. Two consequences appear in the output:

- The newest swap's fee is marked pending until something else touches the pool.
- A swap whose fee never reached the pool reports zero LP revenue even though the taker paid it. The three earliest swaps on this pool behave that way.

The `fee bps` column is separate: it is the rate the controller signed into `user_data`, decoded from calldata, and shows what the taker was charged whether or not LPs received it.

## Markout, not LVR

LVR is the loss an LP takes to traders who swap because the pool is mispriced. Nobody can arbitrage this pool — every swap carries a controller signature — so classical LVR is near zero by construction. The report measures markout on the flow Fynd routes in, against Binance ETHUSDC one-minute closes.

`price_guard` providers are not used: they stream or poll the current price to validate a live quote and keep no history, and a markout needs the price at a past timestamp.

A horizon that has not elapsed yet for every swap prices less than the full volume; those swaps drop out of that row rather than reusing a stale price, and the totals block says so.

## Output as of block 25806360

```
swaps: 15
volume: 4056.57 (token1 units)

   horizon   priced vol    fee revenue    fee bps     adverse sel.     net LP pnl     LP bps
        0s      4056.57        117.780      290.3         -128.606        -10.826      -26.7
      300s      4056.57        117.893      290.6         -127.760         -9.867      -24.3
     3600s      4049.58        120.389      297.3         -223.387       -102.998     -254.3
```

Volume on this pool is small, so treat these as anecdote rather than a measured edge. Binance ETHUSDC also carries its own basis against on-chain ETH/USDC, so differences below roughly 30 bps sit inside that noise.

## Tests

29 unit tests covering the three decoders against real transaction bytes, the fee attribution across Ekubo's lag, the markout math, and the price lookup boundaries. `cargo +nightly fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
