### PR TITLE
feat: exclude protocol systems per worker pool

### DIFF
--- a/.claude/CODEBASE.md
+++ b/.claude/CODEBASE.md
@@ -124,7 +124,7 @@ See `docs/ARCHITECTURE.md` for the full architecture diagram and detailed compon
 
 | File | Purpose |
 |---|---|
-| `worker_pools.toml` | Worker pool definitions: algorithm, num_workers, hop limits, timeout. Optional — binary falls back to embedded defaults if not found |
+| `worker_pools.toml` | Worker pool definitions: algorithm, num_workers, hop limits, timeout, `exclude_protocols` (protocol systems that worker pool never routes through). Optional — binary falls back to embedded defaults if not found |
 | `blocklist.toml` | Component IDs to exclude from the Tycho stream. Optional — falls back to tycho-simulation defaults if not found |
 
 ## Testing

--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -9,9 +9,9 @@ applications.
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `algorithm/`          | `Algorithm` trait + built-in `MostLiquidAlgorithm`, `BellmanFordAlgorithm`, `PathFrankWolfeAlgorithm`, `WaterFillAlgorithm`. Pluggable via associated graph types. `AlgorithmConfig` shared by built-ins |
 | `solver.rs`           | `FyndBuilder` assembles the full pipeline (feed + gas + computations + pools + encoder + router). `Solver` runs it                                                                 |
-| `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based |
+| `worker_pool/`        | `WorkerPool` manages dedicated OS threads. `SolverWorker` runs a prioritized select loop (shutdown > market events > derived events > tasks). `TaskQueue` is `async_channel`-based. `SolverWorker::drops_component` decides what stays out of one worker's graph: exclusive components in a `PublicOnly` pool, plus every protocol system in the pool's `exclude_protocols` |
 | `worker_pool_router/` | `WorkerPoolRouter` allocates the worker pools that serve each order (`allocation`: `OrderClass` matched by `SolverPoolHandle::serves`), fans out to those, drops candidates whose pAMM fallback misses `min_amount_out`, ranks the rest by `amount_out_net_gas` descending; price guard (if enabled) validates in rank order; optionally encodes |
-| `feed/`               | `TychoFeed` (WebSocket → MarketState), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`                                                                           |
+| `feed/`               | `TychoFeed` (WebSocket → MarketState), `GasPriceFetcher`, `MarketEvent` broadcasting, `ProtocolRegistry`. `component_filter` drops components from one worker's graph topology and incoming events; `exclusivity` classifies exclusive components |
 | `derived/`            | `ComputationManager` runs `SpotPriceComputation`, `ComponentDepthComputation`, `TokenGasPriceComputation` in dependency order. `ReadinessTracker` gates workers until data is fresh     |
 | `graph/`              | `pub` — `GraphManager` trait (initialize + incremental update), `PetgraphStableDiGraphManager`, `StableDiGraph` (re-exported), `EdgeWeightUpdaterWithDerived`, `Path` type           |
 | `propamm_fallback/`   | `fallback_amount_out` computes the amount out a route delivers when its `propammfallback:` legs fall back to Uniswap V3; the router drops the candidate before ranking when that amount cannot clear `min_amount_out`, which keeps describing the pAMM quote and the user's slippage. `FeeTiers` mirrors the router's `resolvedFee`; `FallbackPoolIndex` indexes `uniswap_v3` components by pair and fee tier; `FeeTierFetcher` reads the tiers from the PropAMMRouter on a timer, in one Multicall3 batch per round. `SharedFeeTiers` is empty until the first successful read, and a worker that finds it empty drops the pAMM route |
@@ -162,7 +162,8 @@ component. There is no per-deployment policy to configure.
 
 Isolation is per worker, not per state: `MarketState` is never duplicated. `PublicOnly` workers filter
 exclusive components out of their local graph topology and incoming `MarketEvent`s (via
-`remove_exclusive_components`/`scope_event`); `IncludeExclusive` workers ingest everything.
+`feed/component_filter.rs`, which every worker also uses for `exclude_protocols`);
+`IncludeExclusive` workers ingest everything.
 
 After public ranking, `combine_with_surplus` overlays any `IncludeExclusive`-scope candidate that
 beats the committed amount and records the difference as `SurplusInfo`

--- a/fynd-core/src/feed/component_filter.rs
+++ b/fynd-core/src/feed/component_filter.rs
@@ -1,0 +1,185 @@
+//! Per-worker component filtering: each worker ingests only the components its worker pool admits.
+//!
+//! `MarketState` is never duplicated. A worker drops what it must not route through from its own
+//! graph topology at startup and from every incoming [`MarketEvent`], so two worker pools reading
+//! the same market can still route through different liquidity. Today two settings feed the
+//! predicate: the worker pool's `LiquidityScope` (see
+//! [`is_exclusive`](super::exclusivity::is_exclusive)) and its `exclude_protocols` list
+//! ([`is_excluded_protocol`]).
+
+use rustc_hash::FxHashMap;
+use tycho_simulation::tycho_common::models::{protocol::ProtocolComponent, Address};
+
+use crate::{
+    feed::{events::MarketEvent, market_data::MarketState},
+    types::ComponentId,
+};
+
+/// Whether `component` belongs to a protocol system in `exclude_protocols`.
+///
+/// An entry names a protocol system exactly (`uniswap_v2`), or, when it ends with `:`, the whole
+/// family under that prefix: `propammfallback:` excludes `propammfallback:fermiswap` and every
+/// other venue the PropAMMRouter serves. An empty list excludes nothing.
+pub(crate) fn is_excluded_protocol(
+    exclude_protocols: &[String],
+    component: &ProtocolComponent,
+) -> bool {
+    exclude_protocols
+        .iter()
+        .any(|entry| match entry.ends_with(':') {
+            true => component
+                .protocol_system
+                .starts_with(entry.as_str()),
+            false => component.protocol_system == *entry,
+        })
+}
+
+/// Removes from `topology` every component `drop` returns `true` for.
+///
+/// A component id the market does not know is kept: the caller's own topology is the authority on
+/// which ids exist, and a filter cannot classify what it cannot read.
+pub(crate) fn remove_components(
+    market: &MarketState,
+    topology: FxHashMap<ComponentId, Vec<Address>>,
+    drop: &dyn Fn(&ProtocolComponent) -> bool,
+) -> FxHashMap<ComponentId, Vec<Address>> {
+    topology
+        .into_iter()
+        .filter(|(id, _)| {
+            market
+                .get_component(id)
+                .is_none_or(|c| !drop(c))
+        })
+        .collect()
+}
+
+/// Removes those component ids from a market event's added/updated/removed lists, so a component
+/// the worker must not route through is never ingested mid-stream.
+pub(crate) fn filter_event(
+    market: &MarketState,
+    event: MarketEvent,
+    drop: &dyn Fn(&ProtocolComponent) -> bool,
+) -> MarketEvent {
+    let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
+        event;
+
+    let added_components = remove_components(market, added_components, drop);
+    let removed_components = filter_component_ids(market, &removed_components, drop);
+    let updated_components = filter_component_ids(market, &updated_components, drop);
+
+    MarketEvent::MarketUpdated { added_components, removed_components, updated_components }
+}
+
+/// Keeps only the component ids `drop` returns `false` for.
+fn filter_component_ids(
+    market: &MarketState,
+    ids: &[ComponentId],
+    drop: &dyn Fn(&ProtocolComponent) -> bool,
+) -> Vec<ComponentId> {
+    ids.iter()
+        .filter(|id| {
+            market
+                .get_component(id)
+                .is_none_or(|c| !drop(c))
+        })
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        algorithm::test_utils::{component, component_with_protocol, token},
+        feed::exclusivity::{is_exclusive, mark_exclusive},
+    };
+
+    fn exclusive_component(id: &str) -> ProtocolComponent {
+        let mut c = component(id, &[token(0x01, "A"), token(0x02, "B")]);
+        mark_exclusive(&mut c);
+        c
+    }
+
+    fn public_component(id: &str) -> ProtocolComponent {
+        component(id, &[token(0x01, "A"), token(0x02, "B")])
+    }
+
+    fn pamm_component(id: &str) -> ProtocolComponent {
+        component_with_protocol(
+            id,
+            "propammfallback:fermiswap",
+            &[token(0x01, "A"), token(0x02, "B")],
+        )
+    }
+
+    fn market_with(components: Vec<ProtocolComponent>) -> MarketState {
+        let mut market = MarketState::new();
+        market.upsert_components(components);
+        market
+    }
+
+    #[rstest::rstest]
+    #[case::family_prefix(&["propammfallback:"], "propammfallback:fermiswap", true)]
+    #[case::exact_system(&["uniswap_v2"], "uniswap_v2", true)]
+    #[case::other_system(&["uniswap_v2"], "uniswap_v3", false)]
+    #[case::exact_entry_is_not_a_prefix(&["propammfallback"], "propammfallback:fermiswap", false)]
+    #[case::no_exclusions(&[], "propammfallback:fermiswap", false)]
+    fn test_is_excluded_protocol(
+        #[case] exclude_protocols: &[&str],
+        #[case] protocol_system: &str,
+        #[case] expected: bool,
+    ) {
+        let exclude_protocols: Vec<String> = exclude_protocols
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let component = component_with_protocol("c-1", protocol_system, &[token(0x01, "A")]);
+
+        assert_eq!(is_excluded_protocol(&exclude_protocols, &component), expected);
+    }
+
+    #[test]
+    fn test_remove_components_drops_exclusive_and_excluded_protocols() {
+        let market = market_with(vec![
+            public_component("pub-1"),
+            exclusive_component("excl-1"),
+            pamm_component("pamm-1"),
+        ]);
+        let exclude_protocols = vec!["propammfallback:".to_string()];
+        let drop =
+            |c: &ProtocolComponent| is_exclusive(c) || is_excluded_protocol(&exclude_protocols, c);
+
+        let filtered = remove_components(&market, market.component_topology(), &drop);
+
+        assert!(filtered.contains_key("pub-1"));
+        assert!(!filtered.contains_key("excl-1"));
+        assert!(!filtered.contains_key("pamm-1"));
+    }
+
+    #[test]
+    fn test_filter_event() {
+        let market = market_with(vec![
+            public_component("pub-1"),
+            exclusive_component("excl-1"),
+            pamm_component("pamm-1"),
+        ]);
+        let ids = || vec!["pub-1".to_string(), "excl-1".to_string(), "pamm-1".to_string()];
+        let event = MarketEvent::MarketUpdated {
+            added_components: FxHashMap::from_iter(ids().into_iter().map(|id| (id, vec![]))),
+            removed_components: ids(),
+            updated_components: ids(),
+        };
+        let exclude_protocols = vec!["propammfallback:".to_string()];
+        let drop =
+            |c: &ProtocolComponent| is_exclusive(c) || is_excluded_protocol(&exclude_protocols, c);
+
+        let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
+            filter_event(&market, event, &drop);
+
+        assert!(added_components.contains_key("pub-1"));
+        assert!(!added_components.contains_key("excl-1"));
+        assert!(!added_components.contains_key("pamm-1"));
+        assert_eq!(removed_components, vec!["pub-1".to_string()]);
+        assert_eq!(updated_components, vec!["pub-1".to_string()]);
+    }
+}

--- a/fynd-core/src/feed/component_filter.rs
+++ b/fynd-core/src/feed/component_filter.rs
@@ -1,11 +1,10 @@
 //! Per-worker component filtering: each worker ingests only the components its worker pool admits.
 //!
 //! `MarketState` is never duplicated. A worker drops what it must not route through from its own
-//! graph topology at startup and from every incoming [`MarketEvent`], so two worker pools reading
+//! graph topology at startup and from every incoming `MarketEvent`, so two worker pools reading
 //! the same market can still route through different liquidity. Today two settings feed the
-//! predicate: the worker pool's `LiquidityScope` (see
-//! [`is_exclusive`](super::exclusivity::is_exclusive)) and its `exclude_protocols` list
-//! ([`is_excluded_protocol`]).
+//! predicate: the worker pool's `LiquidityScope` (via `exclusivity::is_exclusive`) and its
+//! `exclude_protocols` list (via `is_excluded_protocol`).
 
 use rustc_hash::FxHashMap;
 use tycho_simulation::tycho_common::models::{protocol::ProtocolComponent, Address};

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -4,9 +4,9 @@
 //! enter the route a public worker pool returns, while an exclusive-access worker pool routes
 //! through them to capture the surplus they offer above the best public-market rate. Both worker
 //! pool kinds serve the same request; they differ only in which liquidity their workers may route
-//! through. A `PublicOnly` worker feeds this classification to
-//! [`component_filter`](super::component_filter), which keeps such a component out of its graph;
-//! workers of `IncludeExclusive`-scoped worker pools ingest everything.
+//! through. A `PublicOnly` worker feeds this classification to `feed::component_filter`, which
+//! keeps such a component out of its graph; workers of `IncludeExclusive`-scoped worker pools
+//! ingest everything.
 //!
 //! A component is classified from its own data via `is_exclusive`, applied generically to every
 //! ingested component.

--- a/fynd-core/src/feed/exclusivity.rs
+++ b/fynd-core/src/feed/exclusivity.rs
@@ -1,24 +1,17 @@
-//! Exclusive-component classification and per-worker graph filtering.
+//! Exclusive-component classification.
 //!
 //! "Exclusive" means swappable only with off-chain authorization: such components must never
 //! enter the route a public worker pool returns, while an exclusive-access worker pool routes
 //! through them to capture the surplus they offer above the best public-market rate. Both worker
 //! pool kinds serve the same request; they differ only in which liquidity their workers may route
-//! through. Isolation is achieved by filtering each worker's local graph topology/events through
-//! `remove_exclusive_components`/`scope_event` when the worker pool's `LiquidityScope` is
-//! `PublicOnly` — the shared `MarketState` is never duplicated. Workers of
-//! `IncludeExclusive`-scoped worker pools ingest everything.
+//! through. A `PublicOnly` worker feeds this classification to
+//! [`component_filter`](super::component_filter), which keeps such a component out of its graph;
+//! workers of `IncludeExclusive`-scoped worker pools ingest everything.
 //!
 //! A component is classified from its own data via `is_exclusive`, applied generically to every
 //! ingested component.
 
-use rustc_hash::FxHashMap;
-use tycho_simulation::tycho_common::models::{protocol::ProtocolComponent, Address};
-
-use crate::{
-    feed::{events::MarketEvent, market_data::MarketState},
-    types::ComponentId,
-};
+use tycho_simulation::tycho_common::models::protocol::ProtocolComponent;
 
 /// Returns `true` when the component offers exclusive liquidity, i.e. is swappable only with
 /// off-chain authorization. Signaled by the `is_exclusive` static attribute; absence means the
@@ -27,46 +20,6 @@ pub(crate) fn is_exclusive(component: &ProtocolComponent) -> bool {
     component
         .static_attributes
         .contains_key("is_exclusive")
-}
-
-/// Removes exclusive components from a full topology map.
-pub(crate) fn remove_exclusive_components(
-    market: &MarketState,
-    topology: FxHashMap<ComponentId, Vec<Address>>,
-) -> FxHashMap<ComponentId, Vec<Address>> {
-    topology
-        .into_iter()
-        .filter(|(id, _)| {
-            market
-                .get_component(id)
-                .is_none_or(|c| !is_exclusive(c))
-        })
-        .collect()
-}
-
-/// Removes exclusive component ids from a market event's added/updated/removed lists, so an
-/// exclusive component is never ingested mid-stream.
-pub(crate) fn scope_event(market: &MarketState, event: MarketEvent) -> MarketEvent {
-    let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
-        event;
-
-    let added_components = remove_exclusive_components(market, added_components);
-    let removed_components = filter_component_ids(market, &removed_components);
-    let updated_components = filter_component_ids(market, &updated_components);
-
-    MarketEvent::MarketUpdated { added_components, removed_components, updated_components }
-}
-
-/// Keeps only the component ids that are NOT exclusive.
-fn filter_component_ids(market: &MarketState, ids: &[ComponentId]) -> Vec<ComponentId> {
-    ids.iter()
-        .filter(|id| {
-            market
-                .get_component(id)
-                .is_none_or(|c| !is_exclusive(c))
-        })
-        .cloned()
-        .collect()
 }
 
 /// Stamps the `is_exclusive` attribute onto a component's static attributes, so tests can build
@@ -81,10 +34,7 @@ pub(crate) fn mark_exclusive(component: &mut ProtocolComponent) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        algorithm::test_utils::{component, token},
-        feed::{events::MarketEvent, market_data::MarketState},
-    };
+    use crate::algorithm::test_utils::{component, token};
 
     fn exclusive_component(id: &str) -> ProtocolComponent {
         let mut c = component(id, &[token(0x01, "A"), token(0x02, "B")]);
@@ -94,12 +44,6 @@ mod tests {
 
     fn public_component(id: &str) -> ProtocolComponent {
         component(id, &[token(0x01, "A"), token(0x02, "B")])
-    }
-
-    fn market_with(components: Vec<ProtocolComponent>) -> MarketState {
-        let mut market = MarketState::new();
-        market.upsert_components(components);
-        market
     }
 
     fn component_with_extension() -> ProtocolComponent {
@@ -115,35 +59,5 @@ mod tests {
     #[case::untagged_extension(component_with_extension(), false)]
     fn test_is_exclusive(#[case] component: ProtocolComponent, #[case] expected: bool) {
         assert_eq!(is_exclusive(&component), expected);
-    }
-
-    #[test]
-    fn test_remove_exclusive_components() {
-        let market = market_with(vec![public_component("pub-1"), exclusive_component("excl-1")]);
-        let topology = market.component_topology();
-
-        let filtered = remove_exclusive_components(&market, topology);
-        assert!(filtered.contains_key("pub-1"));
-        assert!(!filtered.contains_key("excl-1"));
-    }
-
-    #[test]
-    fn test_scope_event() {
-        let market = market_with(vec![public_component("pub-1"), exclusive_component("excl-1")]);
-        let event = MarketEvent::MarketUpdated {
-            added_components: FxHashMap::from_iter([
-                ("pub-1".to_string(), vec![]),
-                ("excl-1".to_string(), vec![]),
-            ]),
-            removed_components: vec!["pub-1".to_string(), "excl-1".to_string()],
-            updated_components: vec!["pub-1".to_string(), "excl-1".to_string()],
-        };
-
-        let MarketEvent::MarketUpdated { added_components, removed_components, updated_components } =
-            scope_event(&market, event);
-        assert!(added_components.contains_key("pub-1"));
-        assert!(!added_components.contains_key("excl-1"));
-        assert_eq!(removed_components, vec!["pub-1".to_string()]);
-        assert_eq!(updated_components, vec!["pub-1".to_string()]);
     }
 }

--- a/fynd-core/src/feed/mod.rs
+++ b/fynd-core/src/feed/mod.rs
@@ -3,9 +3,11 @@ use std::time::Duration;
 use rustc_hash::FxHashSet;
 use tycho_simulation::tycho_common::models::Chain;
 
+/// Per-worker component filtering: which components reach one worker's graph.
+pub(crate) mod component_filter;
 /// Market events broadcast by the Tycho feed on every block update.
 pub mod events;
-/// Exclusive-component classification and per-worker graph filtering.
+/// Exclusive-component classification.
 pub mod exclusivity;
 pub(crate) mod gas;
 /// Shared market data store (`MarketState`, `MarketData`).

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -173,6 +173,10 @@ pub struct PoolConfig {
     /// Which liquidity this worker pool routes through.
     #[serde(default)]
     liquidity_scope: Option<LiquidityScope>,
+    /// Protocol systems this worker pool's workers never route through, e.g.
+    /// `["propammfallback:"]`. Absent = no restriction.
+    #[serde(default)]
+    exclude_protocols: Option<Vec<String>>,
 }
 
 impl PoolConfig {
@@ -189,6 +193,7 @@ impl PoolConfig {
             max_routes: None,
             connector_tokens: None,
             liquidity_scope: None,
+            exclude_protocols: None,
         }
     }
 
@@ -205,6 +210,19 @@ impl PoolConfig {
     /// Sets the worker pool's liquidity scope.
     pub fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = Some(scope);
+        self
+    }
+
+    /// Returns the protocol systems this worker pool never routes through.
+    pub fn exclude_protocols(&self) -> Option<&[String]> {
+        self.exclude_protocols.as_deref()
+    }
+
+    /// Sets the protocol systems this worker pool never routes through. An entry names a protocol
+    /// system exactly (`"uniswap_v2"`), or the whole family under a prefix when it ends with `:`
+    /// (`"propammfallback:"` covers every venue on the PropAMMRouter).
+    pub fn with_exclude_protocols(mut self, exclude_protocols: Vec<String>) -> Self {
+        self.exclude_protocols = Some(exclude_protocols);
         self
     }
 
@@ -368,6 +386,7 @@ enum PoolEntry {
         max_routes: Option<usize>,
         connector_tokens: Option<FxHashSet<Address>>,
         liquidity_scope: Option<LiquidityScope>,
+        exclude_protocols: Vec<String>,
     },
     Custom(CustomPoolEntry),
 }
@@ -592,6 +611,7 @@ impl FyndBuilder {
             max_routes: None,
             connector_tokens: None,
             liquidity_scope: None,
+            exclude_protocols: Vec::new(),
         });
         self
     }
@@ -697,6 +717,10 @@ impl FyndBuilder {
             max_routes: config.max_routes(),
             connector_tokens,
             liquidity_scope: config.liquidity_scope(),
+            exclude_protocols: config
+                .exclude_protocols()
+                .map(<[String]>::to_vec)
+                .unwrap_or_default(),
         });
         Ok(self)
     }
@@ -795,6 +819,7 @@ impl FyndBuilder {
                     max_routes,
                     connector_tokens,
                     liquidity_scope: _,
+                    exclude_protocols,
                 } => {
                     let mut algo_cfg = AlgorithmConfig::new(
                         min_hops,
@@ -812,6 +837,7 @@ impl FyndBuilder {
                         .num_workers(num_workers)
                         .task_queue_capacity(task_queue_capacity)
                         .liquidity_scope(pool_scope)
+                        .exclude_protocols(exclude_protocols)
                         .fallback_fee_tiers(fallback_fee_tiers.clone());
                     builder.build(
                         market_data.clone(),

--- a/fynd-core/src/worker_pool/pool.rs
+++ b/fynd-core/src/worker_pool/pool.rs
@@ -50,6 +50,8 @@ pub struct WorkerPoolConfig {
     task_queue_capacity: usize,
     /// Which liquidity this worker pool's workers ingest.
     liquidity_scope: LiquidityScope,
+    /// Protocol systems this worker pool's workers never route through.
+    exclude_protocols: Vec<String>,
     /// PropAMMRouter fee tiers, shared with the fetcher that refreshes them.
     fallback_fee_tiers: SharedFeeTiers,
 }
@@ -70,6 +72,7 @@ impl Default for WorkerPoolConfig {
             algorithm_config: AlgorithmConfig::default(),
             task_queue_capacity: 1000,
             liquidity_scope: LiquidityScope::default(),
+            exclude_protocols: Vec::new(),
             fallback_fee_tiers: SharedFeeTiers::default(),
         }
     }
@@ -122,6 +125,7 @@ impl WorkerPool {
 
         // Spawn workers
         let liquidity_scope = config.liquidity_scope;
+        let exclude_protocols = config.exclude_protocols.clone();
         let fallback_fee_tiers = config.fallback_fee_tiers.clone();
         let params = SpawnWorkersParams {
             algorithm: algorithm.clone(),
@@ -135,6 +139,7 @@ impl WorkerPool {
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
             liquidity_scope,
+            exclude_protocols,
             fallback_fee_tiers,
         };
         let workers = config.spawner.spawn(params)?;
@@ -270,6 +275,13 @@ impl WorkerPoolBuilder {
     /// Sets which liquidity this pool's workers ingest.
     pub fn liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.config.liquidity_scope = scope;
+        self
+    }
+
+    /// Sets the protocol systems this pool's workers never route through. An entry names a
+    /// protocol system exactly, or a whole family when it ends with `:` (`propammfallback:`).
+    pub fn exclude_protocols(mut self, exclude_protocols: Vec<String>) -> Self {
+        self.config.exclude_protocols = exclude_protocols;
         self
     }
 

--- a/fynd-core/src/worker_pool/registry.rs
+++ b/fynd-core/src/worker_pool/registry.rs
@@ -63,6 +63,8 @@ pub(crate) struct SpawnWorkersParams {
     pub shutdown_tx: broadcast::Sender<()>,
     /// Liquidity scope applied to every worker in this worker pool.
     pub liquidity_scope: LiquidityScope,
+    /// Protocol systems every worker in this worker pool leaves out of its graph.
+    pub exclude_protocols: Vec<String>,
     /// PropAMMRouter fee tiers, shared with the fetcher that refreshes them.
     pub fallback_fee_tiers: SharedFeeTiers,
 }
@@ -171,6 +173,7 @@ where
         let pool_name = params.pool_name.clone();
         let factory = factory.clone();
         let liquidity_scope = params.liquidity_scope;
+        let exclude_protocols = params.exclude_protocols.clone();
         let fallback_fee_tiers = params.fallback_fee_tiers.clone();
 
         let handle = thread::Builder::new()
@@ -192,6 +195,7 @@ where
                         pool_name,
                     )
                     .with_liquidity_scope(liquidity_scope)
+                    .with_exclude_protocols(exclude_protocols)
                     .with_fallback_fee_tiers(fallback_fee_tiers);
 
                     worker.initialize_graph().await;
@@ -272,6 +276,7 @@ mod tests {
             derived_event_rx,
             shutdown_tx,
             liquidity_scope: LiquidityScope::default(),
+            exclude_protocols: Vec::new(),
             fallback_fee_tiers: SharedFeeTiers::default(),
         }
     }
@@ -312,6 +317,7 @@ mod tests {
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
             liquidity_scope: LiquidityScope::default(),
+            exclude_protocols: Vec::new(),
             fallback_fee_tiers: SharedFeeTiers::default(),
         };
 
@@ -355,6 +361,7 @@ mod tests {
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
                 liquidity_scope: LiquidityScope::default(),
+                exclude_protocols: Vec::new(),
                 fallback_fee_tiers: SharedFeeTiers::default(),
             });
         assert!(registry_err.is_err());
@@ -384,6 +391,7 @@ mod tests {
                 derived_event_rx: derived_event_tx.subscribe(),
                 shutdown_tx: shutdown_tx.clone(),
                 liquidity_scope: LiquidityScope::default(),
+                exclude_protocols: Vec::new(),
                 fallback_fee_tiers: SharedFeeTiers::default(),
             });
 
@@ -414,6 +422,7 @@ mod tests {
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
             liquidity_scope: LiquidityScope::default(),
+            exclude_protocols: Vec::new(),
             fallback_fee_tiers: SharedFeeTiers::default(),
         };
 
@@ -447,6 +456,7 @@ mod tests {
             derived_event_rx,
             shutdown_tx: shutdown_tx.clone(),
             liquidity_scope: LiquidityScope::default(),
+            exclude_protocols: Vec::new(),
             fallback_fee_tiers: SharedFeeTiers::default(),
         };
 

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -15,7 +15,7 @@ use std::{
 use num_bigint::BigUint;
 use tokio::sync::{broadcast, Notify};
 use tracing::{debug, error, info, warn};
-use tycho_simulation::tycho_core::Bytes;
+use tycho_simulation::{tycho_common::models::protocol::ProtocolComponent, tycho_core::Bytes};
 
 use crate::{
     algorithm::Algorithm,
@@ -24,8 +24,9 @@ use crate::{
         SharedDerivedDataRef,
     },
     feed::{
+        component_filter::{filter_event, is_excluded_protocol, remove_components},
         events::{MarketEvent, MarketEventHandler},
-        exclusivity::{remove_exclusive_components, scope_event},
+        exclusivity::is_exclusive,
         market_data::{MarketData, MarketDataView, StateLabel},
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
@@ -86,6 +87,9 @@ where
     pool_name: String,
     /// Which liquidity this worker ingests.
     liquidity_scope: LiquidityScope,
+    /// Protocol systems this worker never routes through. Empty for every worker pool that does
+    /// not set `exclude_protocols`.
+    exclude_protocols: Vec<String>,
     /// Uniswap V3 pools the PropAMMRouter can fall back to, kept current from market events.
     fallback_pools: FallbackPoolIndex,
     /// Fee tiers the PropAMMRouter falls back on, read from chain by `FeeTierFetcher`.
@@ -128,6 +132,7 @@ where
             worker_id,
             pool_name,
             liquidity_scope: LiquidityScope::default(),
+            exclude_protocols: Vec::new(),
             fallback_pools: FallbackPoolIndex::default(),
             fallback_fee_tiers: SharedFeeTiers::default(),
         }
@@ -143,6 +148,19 @@ where
     pub(crate) fn with_liquidity_scope(mut self, scope: LiquidityScope) -> Self {
         self.liquidity_scope = scope;
         self
+    }
+
+    /// Sets the protocol systems this worker never routes through.
+    pub(crate) fn with_exclude_protocols(mut self, exclude_protocols: Vec<String>) -> Self {
+        self.exclude_protocols = exclude_protocols;
+        self
+    }
+
+    /// Whether this worker must keep `component` out of its graph: an exclusive component in a
+    /// `PublicOnly` worker pool, or a component of an excluded protocol system.
+    fn drops_component(&self, component: &ProtocolComponent) -> bool {
+        (self.liquidity_scope == LiquidityScope::PublicOnly && is_exclusive(component)) ||
+            is_excluded_protocol(&self.exclude_protocols, component)
     }
 
     /// A read view of the market the solve runs against: the overlay `label` names, else the live
@@ -174,12 +192,9 @@ where
             // read lock on market data
             let market = self.market_data.read().await;
             let topology = market.component_topology().clone(); // clone to avoid holding the lock
-            match self.liquidity_scope {
-                LiquidityScope::PublicOnly => {
-                    remove_exclusive_components(market.base_market_state(), topology)
-                }
-                LiquidityScope::IncludeExclusive => topology,
-            }
+            remove_components(market.base_market_state(), topology, &|component| {
+                self.drops_component(component)
+            })
         };
 
         self.graph_manager
@@ -195,10 +210,9 @@ where
     pub async fn process_event(&mut self, event: MarketEvent) {
         let event = {
             let market = self.market_data.read().await;
-            match self.liquidity_scope {
-                LiquidityScope::PublicOnly => scope_event(market.base_market_state(), event),
-                LiquidityScope::IncludeExclusive => event,
-            }
+            filter_event(market.base_market_state(), event, &|component| {
+                self.drops_component(component)
+            })
         };
         match event {
             MarketEvent::MarketUpdated { .. } => {
@@ -718,7 +732,10 @@ mod tests {
     use crate::{
         algorithm::{
             most_liquid::DepthAndPrice,
-            test_utils::{component, order, setup_market_weighted, token, MockProtocolSim},
+            test_utils::{
+                component, component_with_protocol, order, setup_market_weighted, token,
+                MockProtocolSim,
+            },
         },
         derived::{
             computation::DerivedComputation,
@@ -1054,6 +1071,47 @@ mod tests {
 
         // Should still timeout because notify woke us up but we're not actually ready
         assert!(result.is_err());
+    }
+
+    /// `exclude_protocols` keeps a whole protocol family out of this worker's graph, while the
+    /// worker pools that do not set it keep routing through those components.
+    #[test]
+    fn test_drops_component_by_excluded_protocol() {
+        let (market, _) = setup_market_weighted(vec![]);
+        let worker = SolverWorker::new(
+            market,
+            DerivedData::new_shared(),
+            MockAlgorithm::new(),
+            0,
+            "test_pool".to_string(),
+        )
+        .with_exclude_protocols(vec![PROPAMM_FALLBACK_PREFIX.to_string()]);
+
+        let pamm =
+            component_with_protocol("pamm-1", "propammfallback:fermiswap", &[token(0x01, "A")]);
+        let public = component("uni-1", &[token(0x01, "A")]);
+
+        assert!(worker.drops_component(&pamm));
+        assert!(!worker.drops_component(&public));
+    }
+
+    /// Without `exclude_protocols` the worker drops nothing on protocol grounds — the liquidity
+    /// scope stays the only reason to leave a component out.
+    #[test]
+    fn test_drops_component_without_exclusions() {
+        let (market, _) = setup_market_weighted(vec![]);
+        let worker = SolverWorker::new(
+            market,
+            DerivedData::new_shared(),
+            MockAlgorithm::new(),
+            0,
+            "test_pool".to_string(),
+        );
+
+        let pamm =
+            component_with_protocol("pamm-1", "propammfallback:fermiswap", &[token(0x01, "A")]);
+
+        assert!(!worker.drops_component(&pamm));
     }
 
     #[tokio::test]

--- a/fynd-rpc/src/config.rs
+++ b/fynd-rpc/src/config.rs
@@ -35,6 +35,16 @@ timeout_ms = 500
 # max_hops = 2
 # timeout_ms = 500
 # liquidity_scope = "include_exclusive"
+
+# Example: a worker pool that never routes through a protocol system. An entry names a system
+# exactly ("uniswap_v2"), or a whole family when it ends with ":" — "propammfallback:" covers
+# every venue on the PropAMMRouter. Absent = no restriction, which is the default.
+# [pools.no_pamm]
+# algorithm = "bellman_ford"
+# num_workers = 3
+# max_hops = 2
+# timeout_ms = 500
+# exclude_protocols = ["propammfallback:"]
 "#;
 
 /// Worker pools configuration loaded from TOML file.
@@ -156,6 +166,7 @@ mod tests {
             timeout_ms = 200
             max_routes = 50
             liquidity_scope = "include_exclusive"
+            exclude_protocols = ["propammfallback:", "uniswap_v2"]
         "#;
         let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
         let pool = &config.pools()["custom"];
@@ -167,6 +178,22 @@ mod tests {
         assert_eq!(pool.timeout_ms(), 200);
         assert_eq!(pool.max_routes(), Some(50));
         assert_eq!(pool.liquidity_scope(), Some(LiquidityScope::IncludeExclusive));
+        assert_eq!(
+            pool.exclude_protocols(),
+            Some(["propammfallback:".to_string(), "uniswap_v2".to_string()].as_slice())
+        );
+    }
+
+    /// A config written before `exclude_protocols` existed keeps parsing, and excludes nothing.
+    #[test]
+    fn test_pool_config_without_exclude_protocols() {
+        let toml = r#"
+            [pools.basic]
+            algorithm = "most_liquid"
+        "#;
+        let config: WorkerPoolsConfig = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.pools()["basic"].exclude_protocols(), None);
     }
 }
 

--- a/worker_pools.toml
+++ b/worker_pools.toml
@@ -26,6 +26,16 @@ timeout_ms = 500
 # timeout_ms = 500
 # liquidity_scope = "include_exclusive"
 
+# Example: a worker pool that never routes through a protocol system. An entry names a system
+# exactly ("uniswap_v2"), or a whole family when it ends with ":" — "propammfallback:" covers
+# every venue on the PropAMMRouter. Absent = no restriction, which is the default.
+# [pools.no_pamm]
+# algorithm = "bellman_ford"
+# num_workers = 3
+# max_hops = 2
+# timeout_ms = 500
+# exclude_protocols = ["propammfallback:"]
+
 # Example: connector_tokens restricts intermediate hops to trusted, liquid tokens,
 # reducing on-chain reversion risk. Absent = all tokens reachable (default behaviour).
 # Run `fynd derive-connector-tokens --top-n 10` to generate a fresh list for your chain.


### PR DESCRIPTION
Stacked on #460.

A worker pool can name protocol systems its workers never route through:

```toml
[pools.no_pamm]
algorithm = "bellman_ford"
num_workers = 3
max_hops = 2
exclude_protocols = ["propammfallback:"]
```

This is important for continuing to generate solutions even when all propamm fallbacks fall below the user-specified min amount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)