### PR TITLE
feat: add Robinhood to hosted API support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,6 +3519,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "reqwest 0.12.28",
+ "rstest",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",

--- a/clients/CLAUDE.md
+++ b/clients/CLAUDE.md
@@ -55,9 +55,9 @@ FyndClientBuilder::new("https://fynd-api.propellerheads.xyz")
 ```
 
 Both are opt-in; omitting them keeps the unauthenticated, unprefixed paths that self-hosted
-Fynd serves. `with_chain` accepts `ethereum`, `base`, `arbitrum`, `bsc`, `polygon`, `unichain`
-and rejects anything else at build time. It also determines the `chain_id` used for signing
-when building via `build_quote_only` (no RPC node to ask); `build` cross-checks the slug
+Fynd serves. `with_chain` accepts `ethereum`, `base`, `arbitrum`, `bsc`, `polygon`, `unichain`,
+`robinhood` and rejects anything else at build time. It also determines the `chain_id` used for
+signing when building via `build_quote_only` (no RPC node to ask); `build` cross-checks the slug
 against the chain the RPC node reports and errors on a mismatch.
 
 **`FyndClient`**

--- a/clients/rust/Cargo.toml
+++ b/clients/rust/Cargo.toml
@@ -41,3 +41,4 @@ wiremock = "0.6"
 serde_json = { workspace = true }
 hex = { workspace = true }
 alloy = { workspace = true, features = ["signer-local"] }
+rstest = { workspace = true }

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -2420,13 +2420,18 @@ mod tests {
         assert!(msg.contains("ethereum"), "error should list supported slugs: {msg}");
     }
 
-    #[test]
-    fn build_quote_only_derives_chain_id_from_chain() {
+    #[rstest::rstest]
+    #[case::base("base", 8453)]
+    #[case::robinhood("robinhood", 4663)]
+    fn build_quote_only_derives_chain_id_from_chain(
+        #[case] chain: &str,
+        #[case] expected_chain_id: u64,
+    ) {
         let client = FyndClientBuilder::new("http://localhost:8080")
-            .with_chain("robinhood")
+            .with_chain(chain)
             .build_quote_only()
             .expect("build_quote_only should succeed");
-        assert_eq!(client.chain_id, 4663);
+        assert_eq!(client.chain_id, expected_chain_id);
     }
 
     #[test]

--- a/clients/rust/src/client.rs
+++ b/clients/rust/src/client.rs
@@ -363,13 +363,14 @@ mod erc20 {
 // ============================================================================
 
 /// Chain slugs accepted by the hosted Fynd gateway, paired with their EVM chain ID.
-const SUPPORTED_CHAINS: [(&str, u64); 6] = [
+const SUPPORTED_CHAINS: [(&str, u64); 7] = [
     ("ethereum", 1),
     ("base", 8453),
     ("arbitrum", 42161),
     ("bsc", 56),
     ("polygon", 137),
     ("unichain", 130),
+    ("robinhood", 4663),
 ];
 
 /// Resolve a chain slug to its EVM chain ID.
@@ -458,10 +459,10 @@ impl FyndClientBuilder {
 
     /// Route requests through the hosted gateway's per-chain paths, e.g. `/v1/base/quote`.
     ///
-    /// Accepts `ethereum`, `base`, `arbitrum`, `bsc`, `polygon`, or `unichain`; an unknown
-    /// slug fails at [`build`](Self::build) / [`build_quote_only`](Self::build_quote_only)
-    /// time. When unset, requests go to `{base_url}/v1/…` without a chain segment, which is
-    /// what self-hosted Fynd expects.
+    /// Accepts `ethereum`, `base`, `arbitrum`, `bsc`, `polygon`, `unichain`, or `robinhood`; an
+    /// unknown slug fails at [`build`](Self::build) / [`build_quote_only`](Self::build_quote_only)
+    /// time. When unset, requests go to `{base_url}/v1/…` without a chain segment, which is what
+    /// self-hosted Fynd expects.
     pub fn with_chain(mut self, chain: impl Into<String>) -> Self {
         self.hosted.chain = Some(chain.into());
         self
@@ -2406,6 +2407,7 @@ mod tests {
         assert_eq!(chain_id_for_slug("bsc").unwrap(), 56);
         assert_eq!(chain_id_for_slug("polygon").unwrap(), 137);
         assert_eq!(chain_id_for_slug("unichain").unwrap(), 130);
+        assert_eq!(chain_id_for_slug("robinhood").unwrap(), 4663);
     }
 
     #[test]
@@ -2421,10 +2423,10 @@ mod tests {
     #[test]
     fn build_quote_only_derives_chain_id_from_chain() {
         let client = FyndClientBuilder::new("http://localhost:8080")
-            .with_chain("base")
+            .with_chain("robinhood")
             .build_quote_only()
             .expect("build_quote_only should succeed");
-        assert_eq!(client.chain_id, 8453);
+        assert_eq!(client.chain_id, 4663);
     }
 
     #[test]

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,8 +58,10 @@ Fynd currently supports **sell orders** only (exact input amount). You specify t
 * Ethereum Mainnet
 * Base
 * Unichain
-
-_Coming soon_: Arbitrum, Polygon, and BSC.
+* Arbitrum
+* Polygon
+* BNB Smart Chain
+* Robinhood Chain
 
 ### Supported Protocols
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,7 +7,7 @@
 
 * [Overview](README.md)
 * [Quickstart](get-started/quickstart/README.md)
-* [Hosted Fynd API (Beta)](get-started/hosted-api.md)
+* [Hosted Fynd API](get-started/hosted-api.md)
 
 ## Guides
 

--- a/docs/get-started/hosted-api.md
+++ b/docs/get-started/hosted-api.md
@@ -19,7 +19,7 @@ layout:
     visible: true
 ---
 
-# Hosted Fynd API (Beta)
+# Hosted Fynd API
 
 {% hint style="warning" %}
 **Beta.** The hosted Fynd API is in beta. Limits, supported chains, and the surface area may change as we scale the service. There is no SLA during beta — status and incidents are posted in [our Telegram group](https://t.me/+B4CNQwv7dgIyYTJl). For production workloads with strict uptime or throughput requirements, see [Scaling beyond the hosted tiers](#scaling-beyond-the-hosted-tiers).
@@ -475,12 +475,13 @@ Each chain is served from its own Fynd backend behind the shared gateway. Send t
 | BNB Smart Chain | `bsc` | 56 | BNB |
 | Polygon | `polygon` | 137 | POL |
 | Unichain | `unichain` | 130 | ETH |
+| Robinhood Chain | `robinhood` | 4663 | ETH |
 
 A request to `/v1/{chain}/…` for a chain that isn't configured returns `404` with `{"error": "unknown_chain", ...}`.
 
 ### Native token swaps
 
-Use the zero address (`0x0000000000000000000000000000000000000000`) as `token_in` or `token_out` to swap the chain's native gas token (ETH on Ethereum/Base/Arbitrum/Unichain, BNB on BSC, POL on Polygon). Native-token `token_in` skips the approval step — the router wraps native gas for you.
+Use the zero address (`0x0000000000000000000000000000000000000000`) as `token_in` or `token_out` to swap the chain's native gas token (ETH on Ethereum/Base/Arbitrum/Unichain/Robinhood Chain, BNB on BSC, POL on Polygon). Native-token `token_in` skips the approval step — the router wraps native gas for you.
 
 ## API key limits by tier
 

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -87,9 +87,7 @@ docker run \
   ghcr.io/propeller-heads/fynd serve --chain base
 ```
 
-These chains ship with built-in Tycho and RPC endpoints (names are case-insensitive): `ethereum`, `base`, `unichain`, `bsc`, `arbitrum`, `polygon`. For any other chain, also pass `--tycho-url` and `--rpc-url` explicitly.
-
-Robinhood Chain is supported as `robinhood`; pass `--tycho-url` and `--rpc-url` explicitly.
+Supported chain names are case-insensitive: `ethereum`, `base`, `unichain`, `bsc`, `arbitrum`, `polygon`, `robinhood`. The first six ship with built-in Tycho and RPC endpoints. For Robinhood Chain, pass `--tycho-url` and `--rpc-url` explicitly.
 
 Your client must target the same chain. If you use the TypeScript client (Step 1), set `chainId` and the viem chain to match the server:
 

--- a/docs/get-started/quickstart/README.md
+++ b/docs/get-started/quickstart/README.md
@@ -89,6 +89,8 @@ docker run \
 
 These chains ship with built-in Tycho and RPC endpoints (names are case-insensitive): `ethereum`, `base`, `unichain`, `bsc`, `arbitrum`, `polygon`. For any other chain, also pass `--tycho-url` and `--rpc-url` explicitly.
 
+Robinhood Chain is supported as `robinhood`; pass `--tycho-url` and `--rpc-url` explicitly.
+
 Your client must target the same chain. If you use the TypeScript client (Step 1), set `chainId` and the viem chain to match the server:
 
 ```typescript

--- a/docs/guides/server-configuration.md
+++ b/docs/guides/server-configuration.md
@@ -97,7 +97,7 @@ Notes:
 
 * **TLS** — hosted endpoints use TLS; a local or plain-HTTP Tycho does not. Add `--disable-tls` when your endpoint is not served over TLS.
 * **API key** — the self-hosted indexer's RPC key is its `AUTH_API_KEY` (default `local-dev-key`). Pass it with `--tycho-api-key` / `TYCHO_API_KEY` if your deployment sets one.
-* **Built-in chains** — Fynd's built-in chains are `ethereum`, `base`, `unichain`, `arbitrum`, `polygon`, `bsc`, `starknet`, `zksync`. Self-hosting Tycho for one of these works out of the box.
+* **Built-in chains** — Fynd's built-in chains are `ethereum`, `base`, `unichain`, `arbitrum`, `polygon`, `bsc`, `robinhood`, `starknet`, `zksync`. Self-hosting Tycho for one of these works out of the box.
 
 #### Custom chains
 


### PR DESCRIPTION
## Summary

- remove (Beta) from the hosted API page title and navigation
- document Robinhood Chain for hosted and self-hosted Fynd
- allow the Rust hosted client to resolve robinhood as chain ID 4663
- refresh the supported-chain overview for Arbitrum, Polygon, and BSC

## Test plan

- ./check.sh (1,570 passed, 10 skipped)
- bash scripts/check-doc-snippets.sh
- git diff --check