### PR TITLE
fix(feed): drop Uniswap V4 pools using a family of nine dynamic-fee hooks

### DIFF
--- a/docs/guides/server-configuration.md
+++ b/docs/guides/server-configuration.md
@@ -246,7 +246,7 @@ components = [
 ```
 
 Uniswap V4 pools are also filtered by hook contract: `BLOCKED_UNISWAP_V4_HOOKS` in
-`fynd-core/src/feed/protocol_registry.rs` drops every `uniswap_v4` / `uniswap_v4_hooks` component
+`fynd-core/src/feed/protocol_registry.rs` drops every `uniswap_v4_hooks` component
 whose `hooks` static attribute matches a listed address, regardless of pool ID.
 
 ## Logging and monitoring

--- a/docs/guides/server-configuration.md
+++ b/docs/guides/server-configuration.md
@@ -245,6 +245,10 @@ components = [
 ]
 ```
 
+Uniswap V4 pools are also filtered by hook contract: `BLOCKED_UNISWAP_V4_HOOKS` in
+`fynd-core/src/feed/protocol_registry.rs` drops every `uniswap_v4` / `uniswap_v4_hooks` component
+whose `hooks` static attribute matches a listed address, regardless of pool ID.
+
 ## Logging and monitoring
 
 ### Logs

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -318,11 +318,8 @@ pub(crate) fn register_exchanges(
                 );
             }
             "uniswap_v4" => {
-                builder = builder.exchange::<UniswapV4State>(
-                    "uniswap_v4",
-                    tvl_filter.clone(),
-                    Some(uniswap_v4_hook_filter),
-                );
+                builder =
+                    builder.exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None);
             }
             "ekubo_v2" => {
                 builder = builder.exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None);

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -79,7 +79,22 @@ pub const EXCLUDE_PREFIX: &str = "exclude:";
 /// Compared against the component's `hooks` static attribute, so one entry covers every pool
 /// the hook is attached to; V4 component IDs are pool IDs, which the component blocklist would
 /// need one at a time.
-const BLOCKED_UNISWAP_V4_HOOKS: &[&str] = &["0x051c99a4583a7137833ad048af442909426d00c4"];
+///
+/// All entries so far are one family of dynamic-fee hooks: `owner()` returns
+/// `0x80390a818c9390ea6190160bd7fddff2cdbdc0ab` and each exposes the same
+/// `getFeeConfig()` / `gasThreshold()` interface, with bytecode that grows from deployment to
+/// deployment. Listed in first-pool block order.
+const BLOCKED_UNISWAP_V4_HOOKS: &[&str] = &[
+    "0x051c99a4583a7137833ad048af442909426d00c4",
+    "0xfa439315b015a4c283ded9815a4af6cef0b90880",
+    "0x1b3b249ee8afdfdc7af0f06a0765de1a49cf80c4",
+    "0x74a7fd29718c6d0124011116d05e62090eff4880",
+    "0xe502d9798d60d4302e46786ff9fbfb548266c880",
+    "0x32514d03d9f73383ad43c6257ad7f4d4588640c4",
+    "0xaebe208bb46e005321b3ea9ade08dc57b90cc0c4",
+    "0x1e000786dc0a1c80eef758b485e90c7193d9c0c4",
+    "0xbf1a0a8608593db7580044b6501fefb310c280c4",
+];
 
 /// Keeps a Uniswap V4 component unless its hook is in [`BLOCKED_UNISWAP_V4_HOOKS`].
 fn uniswap_v4_hook_filter(component: &ComponentWithState) -> bool {
@@ -570,6 +585,7 @@ mod tests {
     #[rstest::rstest]
     #[case::blocked_hook(Some("0x051c99a4583a7137833ad048af442909426d00c4"), false)]
     #[case::blocked_hook_uppercase(Some("0x051C99A4583A7137833AD048AF442909426D00C4"), false)]
+    #[case::blocked_hook_latest(Some("0xbf1a0a8608593db7580044b6501fefb310c280c4"), false)]
     #[case::other_hook(Some("0x0000000000000000000000000000000000000001"), true)]
     #[case::no_hook(None, true)]
     fn test_uniswap_v4_hook_filter(#[case] hook: Option<&str>, #[case] kept: bool) {

--- a/fynd-core/src/feed/protocol_registry.rs
+++ b/fynd-core/src/feed/protocol_registry.rs
@@ -37,7 +37,7 @@ use tycho_simulation::{
         },
         stream::RFQStreamBuilder,
     },
-    tycho_client::feed::component_tracker::ComponentFilter,
+    tycho_client::feed::{component_tracker::ComponentFilter, synchronizer::ComponentWithState},
     tycho_common::models::token::Token,
     tycho_core::Bytes,
 };
@@ -73,6 +73,34 @@ const RFQ_PREFIX: &str = "rfq:";
 /// Marks a `--protocols` entry that drops a protocol system from the list rather than adding one,
 /// e.g. `exclude:vm:fermiswap`.
 pub const EXCLUDE_PREFIX: &str = "exclude:";
+
+/// Uniswap V4 hook contracts whose pools are dropped from the stream.
+///
+/// Compared against the component's `hooks` static attribute, so one entry covers every pool
+/// the hook is attached to; V4 component IDs are pool IDs, which the component blocklist would
+/// need one at a time.
+const BLOCKED_UNISWAP_V4_HOOKS: &[&str] = &["0x051c99a4583a7137833ad048af442909426d00c4"];
+
+/// Keeps a Uniswap V4 component unless its hook is in [`BLOCKED_UNISWAP_V4_HOOKS`].
+fn uniswap_v4_hook_filter(component: &ComponentWithState) -> bool {
+    let Some(hook) = component
+        .component
+        .static_attributes
+        .get("hooks")
+    else {
+        return true;
+    };
+    let hook = hook.to_string();
+    if BLOCKED_UNISWAP_V4_HOOKS.contains(&hook.as_str()) {
+        info!(
+            component_id = %component.component.id,
+            hook,
+            "dropping Uniswap V4 component with blocked hook"
+        );
+        return false;
+    }
+    true
+}
 
 /// The only chain the Titan pAMM price level stream serves.
 ///
@@ -275,8 +303,11 @@ pub(crate) fn register_exchanges(
                 );
             }
             "uniswap_v4" => {
-                builder =
-                    builder.exchange::<UniswapV4State>("uniswap_v4", tvl_filter.clone(), None);
+                builder = builder.exchange::<UniswapV4State>(
+                    "uniswap_v4",
+                    tvl_filter.clone(),
+                    Some(uniswap_v4_hook_filter),
+                );
             }
             "ekubo_v2" => {
                 builder = builder.exchange::<EkuboState>("ekubo_v2", tvl_filter.clone(), None);
@@ -296,7 +327,7 @@ pub(crate) fn register_exchanges(
                 builder = builder.exchange::<UniswapV4State>(
                     "uniswap_v4_hooks",
                     tvl_filter.clone(),
-                    None,
+                    Some(uniswap_v4_hook_filter),
                 );
             }
             "vm:maverick_v2" => {
@@ -507,6 +538,43 @@ mod tests {
     use tycho_simulation::price_level_stream::config::PRICE_LEVEL_STREAM_FAMILY;
 
     use super::*;
+
+    fn uniswap_v4_component(hook: Option<&str>) -> ComponentWithState {
+        let mut static_attributes = HashMap::new();
+        if let Some(hook) = hook {
+            static_attributes.insert("hooks".to_string(), Bytes::from(hook));
+        }
+        ComponentWithState {
+            state: tycho_simulation::tycho_common::models::protocol::ProtocolComponentState {
+                component_id: "0xpool".to_string(),
+                attributes: HashMap::new(),
+                balances: HashMap::new(),
+            },
+            component: tycho_simulation::tycho_common::models::protocol::ProtocolComponent {
+                id: "0xpool".to_string(),
+                protocol_system: "uniswap_v4_hooks".to_string(),
+                protocol_type_name: "uniswap_v4_pool".to_string(),
+                chain: Chain::Ethereum,
+                tokens: vec![],
+                static_attributes,
+                contract_addresses: vec![],
+                change: Default::default(),
+                creation_tx: Bytes::default(),
+                created_at: Default::default(),
+            },
+            component_tvl: None,
+            entrypoints: vec![],
+        }
+    }
+
+    #[rstest::rstest]
+    #[case::blocked_hook(Some("0x051c99a4583a7137833ad048af442909426d00c4"), false)]
+    #[case::blocked_hook_uppercase(Some("0x051C99A4583A7137833AD048AF442909426D00C4"), false)]
+    #[case::other_hook(Some("0x0000000000000000000000000000000000000001"), true)]
+    #[case::no_hook(None, true)]
+    fn test_uniswap_v4_hook_filter(#[case] hook: Option<&str>, #[case] kept: bool) {
+        assert_eq!(uniswap_v4_hook_filter(&uniswap_v4_component(hook)), kept);
+    }
 
     fn register(entries: &[&str]) -> Result<ProtocolStreamBuilder, DataFeedError> {
         register_exchanges(


### PR DESCRIPTION
## Summary
- Add `uniswap_v4_hook_filter` in `fynd-core/src/feed/protocol_registry.rs`, registered for `uniswap_v4_hooks` (the plain `uniswap_v4` stream never emits hooked pools). It drops any component whose `hooks` static attribute is in `BLOCKED_UNISWAP_V4_HOOKS` and logs the dropped component ID.
- The list holds nine hooks that share `owner() == 0x80390a818c9390ea6190160bd7fddff2cdbdc0ab` and the same `getFeeConfig()`/`gasThreshold()` interface (all dynamic-fee, 14 pools total, found by scanning every V4 `Initialize` event from block 24.5M to head): `0x051c99a4…00c4`, `0xfa439315…0880`, `0x1b3b249e…80c4`, `0x74a7fd29…4880`, `0xe502d979…c880`, `0x32514d03…40c4`, `0xaebe208b…c0c4`, `0x1e000786…c0c4`, `0xbf1a0a86…80c4`.
- The existing component blocklist is keyed by pool ID, so blocking a hook there would need one entry per pool; the filter covers every pool a hook is attached to, including ones created after deploy.
- Document the hook filter in `docs/guides/server-configuration.md`.

## Test plan
- [x] `test_uniswap_v4_hook_filter` cases: first blocked hook, uppercase blocked hook, latest blocked hook, other hook, no hook
- [x] `./check.sh` (fmt, clippy, doc, nextest) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)