### PR TITLE
fix!: bind exclusive swap signatures to the Tycho router as locker

### DIFF
--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -185,3 +185,8 @@ Encoding a committed leg is protocol-specific: `encoding/exclusive_swap.rs` is E
 an EIP-712 authorization with `EXCLUSIVE_SWAP_CONTROLLER_KEY` and packs it, plus a derived Q32 fee,
 into the `SignedExclusiveSwap` extension's `user_data`. Encoding an exclusive leg without that env
 var fails.
+
+The authorization names the Tycho router (the address `Encoder` resolves for the chain) as its
+authorized locker, and the extension accepts no other caller. Authorizing every locker
+(`Address::ZERO`) would let a third party that reads the signed bytes execute the swap from its own
+contract and spend the nonce, which reverts the original transaction with `NonceAlreadyUsed`.

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -171,7 +171,12 @@ impl Encoder {
                     .build()
             })
             .transpose()?;
-        let exclusive_swap_signer = ExclusiveSwapSigner::from_env(chain.id())?;
+        // Without a router address there is no locker to authorize, and `encode` already fails on
+        // this chain, so an exclusive leg could not be encoded either way.
+        let exclusive_swap_signer = match &router_address {
+            Some(router) => ExclusiveSwapSigner::from_env(chain.id(), router)?,
+            None => None,
+        };
         Ok(Self {
             tycho_encoder,
             chain,
@@ -965,6 +970,7 @@ mod tests {
 
     const CONTROLLER_KEY: &str =
         "0x1111111111111111111111111111111111111111111111111111111111111111";
+    const LOCKER: alloy::primitives::Address = alloy::primitives::Address::repeat_byte(0x77);
 
     fn ekubo_signed_swap(committed: Option<u64>) -> crate::types::Swap {
         let token_in = make_address(0x11);
@@ -1008,7 +1014,7 @@ mod tests {
     fn test_stamp_exclusive_swaps(#[case] committed: Option<u64>, #[case] signed: bool) {
         let quote =
             make_order_quote(990_000).with_route(single_swap_route(ekubo_signed_swap(committed)));
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, LOCKER);
 
         let solution =
             Encoder::stamp_exclusive_swaps(Solution::try_from(&quote).unwrap(), &quote, &signer)

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -1044,6 +1044,24 @@ mod tests {
     }
 
     #[test]
+    fn test_encoder_authorizes_the_router_as_locker() {
+        // nextest runs each test in its own process, so setting the key here affects no other test.
+        std::env::set_var(crate::encoding::exclusive_swap::ENV_CONTROLLER_KEY, CONTROLLER_KEY);
+        let registry = SwapEncoderRegistry::new(Chain::Ethereum)
+            .add_default_encoders(None)
+            .unwrap();
+
+        let encoder = Encoder::new(Chain::Ethereum, registry).unwrap();
+
+        let signer = encoder
+            .exclusive_swap_signer
+            .as_ref()
+            .expect("controller key is set, so the signer must exist");
+        let router = get_router_address(&Chain::Ethereum).unwrap();
+        assert_eq!(signer.authorized_locker(), bytes_to_address(router).unwrap());
+    }
+
+    #[test]
     fn test_try_from_multi_hop_uses_boundary_swap_tokens() {
         let quote = make_order_quote(990).with_route(make_route_with_tokens(&[
             (make_address(0x01), make_address(0x02)),

--- a/fynd-core/src/encoding/exclusive_swap.rs
+++ b/fynd-core/src/encoding/exclusive_swap.rs
@@ -30,7 +30,7 @@ use tycho_simulation::tycho_common::{models::protocol::ProtocolComponent, Bytes}
 use crate::{SolveError, Swap};
 
 /// Environment variable holding the pool controller's private key (hex, with or without `0x`).
-const ENV_CONTROLLER_KEY: &str = "EXCLUSIVE_SWAP_CONTROLLER_KEY";
+pub(crate) const ENV_CONTROLLER_KEY: &str = "EXCLUSIVE_SWAP_CONTROLLER_KEY";
 
 /// Default validity window for a signed quote, in seconds. Well under the extension's 30-day cap.
 const DEFAULT_DEADLINE_WINDOW_SECS: u32 = 120;
@@ -98,6 +98,12 @@ impl ExclusiveSwapSigner {
             deadline_window_secs,
             authorized_locker,
         }
+    }
+
+    /// The locker every payload from this signer authorizes.
+    #[cfg(test)]
+    pub(crate) fn authorized_locker(&self) -> Address {
+        self.authorized_locker
     }
 
     /// Hands out the next unused nonce: `nonce_prefix` in the high 32 bits, the counter in the low

--- a/fynd-core/src/encoding/exclusive_swap.rs
+++ b/fynd-core/src/encoding/exclusive_swap.rs
@@ -50,15 +50,18 @@ pub struct ExclusiveSwapSigner {
     nonce_prefix: u32,
     nonce_counter: AtomicU32,
     deadline_window_secs: u32,
+    authorized_locker: Address,
 }
 
 impl ExclusiveSwapSigner {
     /// Builds a signer from the `EXCLUSIVE_SWAP_CONTROLLER_KEY` env var: `Ok(None)` when unset
     /// (signing disabled), an error when set but invalid.
     ///
+    /// `router_address` becomes the payload's authorized locker — see [`Self::new`].
+    ///
     /// The nonce prefix is random, so no state has to persist across restarts and replicas need no
     /// coordination.
-    pub fn from_env(chain_id: u64) -> Result<Option<Self>, SolveError> {
+    pub fn from_env(chain_id: u64, router_address: &Bytes) -> Result<Option<Self>, SolveError> {
         let Ok(key) = std::env::var(ENV_CONTROLLER_KEY) else {
             return Ok(None);
         };
@@ -67,18 +70,25 @@ impl ExclusiveSwapSigner {
             .map_err(|e| {
                 SolveError::FailedEncoding(format!("invalid {ENV_CONTROLLER_KEY}: {e}"))
             })?;
-        Ok(Some(Self::new(signer, chain_id, rand::random(), DEFAULT_DEADLINE_WINDOW_SECS)))
+        let locker = crate::rpc::to_address(router_address, "router address")
+            .map_err(SolveError::FailedEncoding)?;
+        Ok(Some(Self::new(signer, chain_id, rand::random(), DEFAULT_DEADLINE_WINDOW_SECS, locker)))
     }
 
     /// Creates a signer from explicit parts.
     ///
     /// `nonce_prefix` is the high 32 bits of every nonce handed out; `deadline_window_secs` is
     /// added to the signing-time timestamp to form each payload's deadline.
+    ///
+    /// `authorized_locker` is the only address the extension lets execute the payload. It must be
+    /// the contract that takes the Ekubo lock — the Tycho router. `Address::ZERO` would authorize
+    /// every locker, which makes the signed bytes usable by whoever reads them out of the mempool.
     pub fn new(
         signer: PrivateKeySigner,
         chain_id: u64,
         nonce_prefix: u32,
         deadline_window_secs: u32,
+        authorized_locker: Address,
     ) -> Self {
         Self {
             signer,
@@ -86,6 +96,7 @@ impl ExclusiveSwapSigner {
             nonce_prefix,
             nonce_counter: AtomicU32::new(0),
             deadline_window_secs,
+            authorized_locker,
         }
     }
 
@@ -137,9 +148,9 @@ impl ExclusiveSwapSigner {
             SolveError::FailedEncoding("signed swap deadline overflows u32".to_string())
         })?;
 
-        // No authorized locker: address(0) leaves the swap usable by any locker (see the
-        // extension's `isAuthorized`), matching the reference wiring.
-        let meta = signed_swap_meta(deadline, fee, nonce, Address::ZERO);
+        // The extension's `isAuthorized` accepts only this locker, so a third party that lifts the
+        // signed bytes cannot execute them through its own contract.
+        let meta = signed_swap_meta(deadline, fee, nonce, self.authorized_locker);
         let min_balance_update = min_balance_update_accept_any();
 
         let component = swap.protocol_component();
@@ -337,6 +348,8 @@ mod tests {
         "0x1111111111111111111111111111111111111111111111111111111111111111";
     // SignedExclusiveSwap extension placeholder used by the tycho reference PR.
     const EXTENSION: &str = "0x5519ed5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e";
+    // Stands in for the Tycho router, the only locker allowed to execute a payload.
+    const LOCKER: Address = Address::repeat_byte(0x77);
 
     // Reimplements the extension's `computeFee` (ceil(amount * fee / 2^64)) to check the taker is
     // never charged more than the surplus.
@@ -502,7 +515,7 @@ mod tests {
 
     #[test]
     fn test_build_user_data_layout() {
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, LOCKER);
         let swap = signed_swap(Some(990_000));
 
         let user_data = signer.build_user_data(&swap).unwrap();
@@ -534,7 +547,7 @@ mod tests {
 
     #[test]
     fn test_build_user_data_requires_committed_amount() {
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, LOCKER);
         assert!(signer
             .build_user_data(&signed_swap(None))
             .is_err());
@@ -552,7 +565,7 @@ mod tests {
 
     #[test]
     fn test_nonce_increments_per_payload() {
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 7, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 7, 120, LOCKER);
         let swap = signed_swap(Some(990_000));
 
         let first = signer.build_user_data(&swap).unwrap();
@@ -567,8 +580,8 @@ mod tests {
         let key: PrivateKeySigner = CONTROLLER_KEY.parse().unwrap();
         let swap = signed_swap(Some(990_000));
         // Two processes (a restart, or a second replica) each draw their own prefix.
-        let first = ExclusiveSwapSigner::new(key.clone(), 42, 1, 120);
-        let second = ExclusiveSwapSigner::new(key, 42, 2, 120);
+        let first = ExclusiveSwapSigner::new(key.clone(), 42, 1, 120, LOCKER);
+        let second = ExclusiveSwapSigner::new(key, 42, 2, 120, LOCKER);
 
         let mut nonces = Vec::new();
         for _ in 0..4 {
@@ -581,11 +594,26 @@ mod tests {
     }
 
     #[test]
+    fn test_payload_binds_authorized_locker() {
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 1, 0, 120, LOCKER);
+
+        let user_data = signer
+            .build_user_data(&signed_swap(Some(990_000)))
+            .unwrap();
+
+        // meta starts after the fee(8) prefix; its low 128 bits carry the locker's last 16 bytes.
+        let meta = B256::from_slice(&user_data.as_ref()[8..40]);
+        assert_eq!(&meta.as_slice()[16..32], &LOCKER.as_slice()[4..20]);
+        assert_ne!(&meta.as_slice()[16..32], &[0u8; 16], "an unbound payload is usable by anyone");
+    }
+
+    #[test]
     fn test_nonce_avoids_reserved_sentinel() {
         // The extension never consumes `u64::MAX` — a payload carrying it stays replayable until
         // its deadline. The counter stops one short of `u32::MAX`, so even the widest prefix
         // cannot compose that value.
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, u32::MAX, 120);
+        let signer =
+            ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, u32::MAX, 120, LOCKER);
         let swap = signed_swap(Some(990_000));
         signer
             .nonce_counter
@@ -597,7 +625,7 @@ mod tests {
 
     #[test]
     fn test_exhausted_nonce_counter() {
-        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 1, 120);
+        let signer = ExclusiveSwapSigner::new(CONTROLLER_KEY.parse().unwrap(), 42, 1, 120, LOCKER);
         let swap = signed_swap(Some(990_000));
         signer
             .nonce_counter

--- a/fynd-core/src/encoding/exclusive_swap.rs
+++ b/fynd-core/src/encoding/exclusive_swap.rs
@@ -610,7 +610,6 @@ mod tests {
         // meta starts after the fee(8) prefix; its low 128 bits carry the locker's last 16 bytes.
         let meta = B256::from_slice(&user_data.as_ref()[8..40]);
         assert_eq!(&meta.as_slice()[16..32], &LOCKER.as_slice()[4..20]);
-        assert_ne!(&meta.as_slice()[16..32], &[0u8; 16], "an unbound payload is usable by anyone");
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

For exclusive swaps Fynd signs a short authorization that travels with the
transaction. The Ekubo extension that checks it supports naming one contract as the only caller
allowed to use the authorization. Fynd left that field empty, which means "any caller".

An empty field makes the signed bytes a bearer instrument for as long as they are valid: anyone who
reads them can run the swap themselves. Twice this week a third party did exactly that — took the
signed bytes from a pending transaction, executed the same swap through its own contract two blocks
earlier, and wrapped it in arbitrage. The authorization is single-use, so the original transaction
then arrived at an already-spent authorization and reverted with `NonceAlreadyUsed()`.

## The fix

The signature now names the Tycho router as the only caller allowed to use it. The address comes
from the router address the encoder already resolves for the chain, so nothing new is configured
and no address is hardcoded. A copycat can no longer execute the payload from its own contract; the
only remaining way to use it is through the router itself, which pays the receiver named in the
original calldata.

## Scope

Every fill of these swaps observed on chain takes the Ekubo lock through that same router, so this
binds to the caller already in use rather than changing how swaps execute. Deployments with no
controller key configured are unaffected — they never sign these payloads.

## Not covered

Two related contributors stay open, both outside this change:

- Routes carrying one of these authorizations are submitted through the public mempool with a low
  priority fee, which is what gives a copycat the two blocks it needs. They should go through a
  private route, or pay a competitive tip.
- A route whose authorization is close to expiry should be re-quoted rather than submitted.
