### PR TITLE
fix(hindsight): handle a venue fee per side of the LiquidMesh event

### DIFF
--- a/tools/hindsight/src/decoder/mod.rs
+++ b/tools/hindsight/src/decoder/mod.rs
@@ -189,6 +189,9 @@ fn apply_venue_fee(
 ) {
     match fee.side {
         attribution::FeeSide::Input => {
+            if input_already_swap_basis(declared) {
+                return;
+            }
             flow.amount_in = flow
                 .amount_in
                 .saturating_sub(fee.amount);
@@ -222,8 +225,12 @@ fn output_already_gross(
     transfer_ledger: &TransferLedger,
     sender: Address,
 ) -> bool {
-    if declared.is_some_and(|declared| declared.amount_out.is_some()) {
-        return true;
+    if let Some(declared) = declared {
+        if declared.amount_out.is_some() {
+            // A reader that states the trader's receipt rather than the route's output leaves the
+            // fee outside the figure, so it still has to be added back.
+            return !declared.output_is_trader_receipt;
+        }
     }
     let anchor = match declared {
         Some(declared) => declared
@@ -232,6 +239,22 @@ fn output_already_gross(
         None => flow.tracked,
     };
     transfer_ledger.sent_by_address(anchor, flow.token_out) >= fee.amount
+}
+
+/// Whether the recorded `amount_in` is already the amount that reached the pools, in which case
+/// subtracting an input-side venue fee would take the venue's cut off the swap twice.
+///
+/// A venue can charge its cut *beside* the swap rather than out of it: `LiquidMesh` forwards the
+/// trader's whole payment to the pools and the trader pays Trust Wallet's 0.7% in a separate
+/// transfer, so the event's input is the swap's basis already. Verified on Ethereum
+/// (`0x526fb82e…`): the trader sent 300,570,650 to the router, the router sent all 300,570,650 on
+/// to the pool, and the 2,118,826 fee left the trader's own balance separately. Subtracting it
+/// quoted Fynd on 298,451,824 and scored the shortfall as a 70 bps loss.
+///
+/// A netted record has no declared read, so its `amount_in` is the trader's gross payment and the
+/// fee does come out of it.
+fn input_already_swap_basis(declared: Option<&DeclaredSwap>) -> bool {
+    declared.is_some_and(|declared| declared.input_is_swap_basis)
 }
 
 /// The terms the solver declared alongside the trade, or all-`None` for a netted record where no
@@ -555,6 +578,121 @@ mod tests {
 
         apply_venue_fee(&mut flow, &output_fee(85), Some(&declared), &ledger, user);
         assert_eq!(flow.amount_out, U256::from(10_000));
+    }
+
+    /// Trust Wallet's 0.7% cut, as `attribution` reports it on either side.
+    fn trustwallet_fee(side: attribution::FeeSide, amount: u128) -> attribution::VenueFee {
+        attribution::VenueFee { venue: "trustwallet".to_string(), side, amount: U256::from(amount) }
+    }
+
+    #[test]
+    fn test_apply_venue_fee_output_side_event_states_the_trader_receipt() {
+        // Ethereum `0xffd1ec54…`: LiquidMesh's event states 66,424,676 USDT — what the trader
+        // received — while the fee wallet took 468,250 of the 66,892,926 gross. An event-stated
+        // output is normally left alone, but this one is a receipt, so the cut is added back.
+        let user = addr(1);
+        let router = addr(0x60);
+        let wallet = addr(0x99);
+        let (token_in, token_out) = (addr(0xaa), addr(0xbb));
+        let logs = vec![
+            make_transfer_log(token_out, router, user, U256::from(66_424_676u64)),
+            make_transfer_log(token_out, router, wallet, U256::from(468_250u64)),
+        ];
+        let ledger = TransferLedger::from_transaction(&logs, &[]);
+        let declared = DeclaredSwap::from_event(
+            user,
+            token_in,
+            U256::from(26_796_517_999_700_000u64),
+            token_out,
+            U256::from(66_424_676u64),
+        )
+        .with_output_as_trader_receipt();
+        let mut flow = SettledSwap {
+            tracked: user,
+            token_in,
+            amount_in: U256::from(26_796_517_999_700_000u64),
+            token_out,
+            amount_out: U256::from(66_424_676u64),
+        };
+
+        apply_venue_fee(
+            &mut flow,
+            &trustwallet_fee(attribution::FeeSide::Output, 468_250),
+            Some(&declared),
+            &ledger,
+            user,
+        );
+        assert_eq!(flow.amount_out, U256::from(66_892_926u64));
+    }
+
+    #[test]
+    fn test_apply_venue_fee_input_side_beside_the_swap() {
+        // Ethereum `0x526fb82e…`: the trader sent 300,570,650 to the router, the router forwarded
+        // all of it to the pool, and the 2,118,826 fee left the trader's balance separately. The
+        // event's input is the swap's basis, so subtracting the cut would quote Fynd on less input
+        // than the swap had — which read as a 70 bps loss in production.
+        let user = addr(1);
+        let router = addr(0x60);
+        let pool = addr(0x50);
+        let wallet = addr(0x99);
+        let (token_in, token_out) = (addr(0xaa), addr(0xbb));
+        let logs = vec![
+            make_transfer_log(token_in, user, wallet, U256::from(2_118_826u64)),
+            make_transfer_log(token_in, user, router, U256::from(300_570_650u64)),
+            make_transfer_log(token_in, router, pool, U256::from(300_570_650u64)),
+        ];
+        let ledger = TransferLedger::from_transaction(&logs, &[]);
+        let declared = DeclaredSwap::from_event(
+            user,
+            token_in,
+            U256::from(300_570_650u64),
+            token_out,
+            U256::from(8_099u64),
+        )
+        .with_input_as_swap_basis();
+        let mut flow = SettledSwap {
+            tracked: user,
+            token_in,
+            amount_in: U256::from(300_570_650u64),
+            token_out,
+            amount_out: U256::from(8_099u64),
+        };
+
+        apply_venue_fee(
+            &mut flow,
+            &trustwallet_fee(attribution::FeeSide::Input, 2_118_826),
+            Some(&declared),
+            &ledger,
+            user,
+        );
+        assert_eq!(flow.amount_in, U256::from(300_570_650u64));
+    }
+
+    #[test]
+    fn test_apply_venue_fee_input_side_out_of_the_authorized_amount() {
+        // The default, unchanged: a reader whose input is the trader's gross payment (0x's
+        // `AllowanceHolder` amount) still has the cut taken off it.
+        let user = addr(1);
+        let (token_in, token_out) = (addr(0xaa), addr(0xbb));
+        let ledger = TransferLedger::from_transaction(&[], &[]);
+        let declared =
+            DeclaredSwap::from_calldata(token_in, token_out, U256::from(1_000u64), U256::ZERO);
+        let mut flow = SettledSwap {
+            tracked: user,
+            token_in,
+            amount_in: U256::from(1_000u64),
+            token_out,
+            amount_out: U256::from(9_000u64),
+        };
+
+        apply_venue_fee(
+            &mut flow,
+            &trustwallet_fee(attribution::FeeSide::Input, 7),
+            Some(&declared),
+            &ledger,
+            user,
+        );
+        assert_eq!(flow.amount_in, U256::from(993u64));
     }
 
     #[test]

--- a/tools/hindsight/src/decoder/solvers/liquidmesh.rs
+++ b/tools/hindsight/src/decoder/solvers/liquidmesh.rs
@@ -18,14 +18,23 @@
 //!
 //! The layout was recovered over 37 swaps across Ethereum and Base: word 3 was the transaction
 //! sender in all 37, and word 5 was exactly the amount that address received of word 2's token in
-//! all 37. Word 4 is the full amount the trader paid, gross of every fee.
+//! all 37. Word 4 is the amount that entered the swap.
 //!
-//! Word 5 is **net of the venue's fee**, which is what makes the fee matter here. Verified on
-//! Ethereum: the trader sent 39,270 DAI, the router took in 39,272.36 USDT, paid 274.906517 USDT
-//! (0.700%) to Trust Wallet's fee wallet and 38,997.453165 USDT to the trader, and the event
-//! states 38,997.453165. Comparing that against a re-solve of the full input would hand Fynd the
-//! fee as a win, so the wallet is listed in `[venue_fees]` and `attribution::venue` adds the cut
-//! back onto the output. A client whose wallet is not listed keeps its fee inside word 5.
+//! The two words sit on **different bases**, and a venue fee has to be handled per side because
+//! of it. Verified on Ethereum, one transaction per side:
+//!
+//! - **Word 5 is the trader's receipt, net of an output-side fee.** `0xffd1ec54…`: the trader
+//!   received 66,424,676 USDT, the fee wallet 468,250 (0.700% of the 66,892,926 gross), and the
+//!   event states 66,424,676. The fee has to be added back or Fynd's gross quote beats the receipt
+//!   by the fee — so this read is marked `with_output_as_trader_receipt`.
+//! - **Word 4 is the swap's own input, and an input-side fee sits beside the swap, not inside it.**
+//!   `0x526fb82e…`: the trader sent 300,570,650 to the router, the router forwarded all 300,570,650
+//!   to the pool, and the 2,118,826 fee (0.705%) left the trader's balance in its own transfer.
+//!   Subtracting it would quote Fynd on less input than the swap had, so this read is marked
+//!   `with_input_as_swap_basis`.
+//!
+//! Both marks only matter once the venue's wallet is in `[venue_fees]`; a client whose wallet is
+//! not listed keeps its cut inside word 5 either way.
 //!
 //! Word 0 is an identifier that also appears in the fee event, and is not read.
 
@@ -86,13 +95,18 @@ impl SolverDecoder for LiquidMesh {
         if amount_in.is_zero() || amount_out.is_zero() {
             return Ok(None);
         }
-        Ok(Some(DeclaredSwap::from_event(
-            address_at(data, TRADER_WORD),
-            normalize_native(address_at(data, TOKEN_IN_WORD)),
-            amount_in,
-            normalize_native(address_at(data, TOKEN_OUT_WORD)),
-            amount_out,
-        )))
+        Ok(Some(
+            DeclaredSwap::from_event(
+                address_at(data, TRADER_WORD),
+                normalize_native(address_at(data, TOKEN_IN_WORD)),
+                amount_in,
+                normalize_native(address_at(data, TOKEN_OUT_WORD)),
+                amount_out,
+            )
+            // The two words sit on different bases — see the module docs.
+            .with_input_as_swap_basis()
+            .with_output_as_trader_receipt(),
+        ))
     }
 }
 

--- a/tools/hindsight/src/decoder/solvers/mod.rs
+++ b/tools/hindsight/src/decoder/solvers/mod.rs
@@ -74,6 +74,16 @@ pub(crate) struct DeclaredSwap {
     pub declared_quote: Option<U256>,
     /// Unix timestamp of `declared_quote`. Only `KyberSwap`'s `clientData` exposes one.
     pub timestamp: Option<u64>,
+    /// Whether `amount_in` is already the amount that reached the pools, so an input-side venue
+    /// fee must not be subtracted from it a second time. Set by a reader whose source states the
+    /// swap's own input while the venue charges its cut to the trader separately, on top —
+    /// `LiquidMesh`'s event does. Read by `decoder::apply_venue_fee`.
+    pub input_is_swap_basis: bool,
+    /// Whether `amount_out` is the trader's receipt rather than the route's gross output, so an
+    /// output-side venue fee has to be added back even though the source stated an amount. Set by
+    /// a reader whose event reports what the trader received (`LiquidMesh`); `LiFi`'s `toAmount`
+    /// is the gross output and leaves this false. Read by `decoder::apply_venue_fee`.
+    pub output_is_trader_receipt: bool,
 }
 
 impl DeclaredSwap {
@@ -98,6 +108,8 @@ impl DeclaredSwap {
             output_recipient: None,
             declared_quote: None,
             timestamp: None,
+            input_is_swap_basis: false,
+            output_is_trader_receipt: false,
         }
     }
 
@@ -121,6 +133,8 @@ impl DeclaredSwap {
             output_recipient: None,
             declared_quote: None,
             timestamp: None,
+            input_is_swap_basis: false,
+            output_is_trader_receipt: false,
         }
     }
 
@@ -145,12 +159,27 @@ impl DeclaredSwap {
             output_recipient: None,
             declared_quote: None,
             timestamp: None,
+            input_is_swap_basis: false,
+            output_is_trader_receipt: false,
         }
     }
 
     /// Attach the output recipient the same calldata declares.
     pub(crate) fn with_recipient(mut self, output_recipient: Address) -> Self {
         self.output_recipient = Some(output_recipient);
+        self
+    }
+
+    /// Mark `amount_in` as the amount that reached the pools, so an input-side venue fee is not
+    /// subtracted from it again.
+    pub(crate) fn with_input_as_swap_basis(mut self) -> Self {
+        self.input_is_swap_basis = true;
+        self
+    }
+
+    /// Mark `amount_out` as the trader's receipt, so an output-side venue fee is added back to it.
+    pub(crate) fn with_output_as_trader_receipt(mut self) -> Self {
+        self.output_is_trader_receipt = true;
         self
     }
 


### PR DESCRIPTION
Follow-up to [#468](https://github.com/propeller-heads/fynd/pull/468), which listed Trust Wallet's fee wallet in `[venue_fees]` but did not neutralise its 0.7% cut. Measured on the records prod wrote after that deploy: the fee-labelled trades still showed wins at a median **70.5 bps**, and now **−70 bps losses** as well. Both sides were wrong, for opposite reasons.

**The event's two words sit on different bases.**

*Word 5 is the trader's receipt.* On `0xffd1ec54…` the trader received 66,424,676 USDT and the fee wallet took 468,250 of the 66,892,926 gross, and the event states 66,424,676. The cut has to be added back — but `output_already_gross` returned true for *any* event-stated output, on the assumption that an event reports the route's gross result. That holds for LiFi's `toAmount`, which the function's own docs cite, and not for this one, so the correction was skipped and the fake win survived.

*Word 4 is the swap's own input, and an input-side fee is charged beside the swap rather than out of it.* On `0x526fb82e…` the trader sent 300,570,650 to the router, the router forwarded **all** 300,570,650 to the pool, and the 2,118,826 fee (0.705%) left the trader's balance in its own transfer. Subtracting it quoted Fynd on 298,451,824 against a settled output produced by the full amount, which read as a 70 bps loss. Scaling Fynd's output by the input ratio lands within 1 bp of the settled figure, which is what confirms the direction.

**The fix.** Whether either amount is already on the swap's basis varies per reader, so each side becomes a fact the reader states about its own data: `input_is_swap_basis` and `output_is_trader_receipt` on `DeclaredSwap`. `liquidmesh.rs` sets both; every other reader leaves both false, so no other solver's behaviour changes — 0x's `AllowanceHolder` amount is still the trader's gross payment and still has an input-side cut taken off it.

Tests are built from the two transactions above, and each fails if its guard is removed.

Worth noting for whoever adds the next fee wallet: this is the second time the basis question has bitten, so a new `[venue_fees]` entry is worth checking against one transaction per side rather than one overall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)