### PR TITLE
fix: leave a pAMM out of the graph when its fallback cannot be priced

### DIFF
--- a/fynd-core/src/propamm_fallback/mod.rs
+++ b/fynd-core/src/propamm_fallback/mod.rs
@@ -35,6 +35,32 @@ pub fn has_pamm_leg(route: &Route) -> bool {
     })
 }
 
+/// Whether `component` is a pAMM with no Uniswap V3 pool to fall back on.
+///
+/// A `propammfallback:` leg only reaches the chain through its fallback, so a component whose fee
+/// tier has no pool in this market can never produce a quotable route. Returns `false` for any
+/// other protocol system, and for a component that does not name exactly two tokens: the fallback
+/// resolves per leg from the swap's own pair, so a wider component is left to
+/// [`fallback_amount_out`].
+pub fn lacks_fallback_pool(
+    component: &tycho_simulation::tycho_common::models::protocol::ProtocolComponent,
+    fee_tiers: &FeeTiers,
+    index: &FallbackPoolIndex,
+) -> bool {
+    if !component
+        .protocol_system
+        .starts_with(PROPAMM_FALLBACK_PREFIX)
+    {
+        return false;
+    }
+    let [token_a, token_b] = component.tokens.as_slice() else {
+        return false;
+    };
+    index
+        .pool_for(token_a, token_b, fee_tiers.resolved_tier(token_a, token_b))
+        .is_none()
+}
+
 /// Replays `route` with every `propammfallback:` leg pointing at its Uniswap V3 fallback pool.
 ///
 /// Uses `replay_route`, so split fractions and shared-pool depletion behave exactly as they do for
@@ -622,6 +648,43 @@ mod tests {
                 fee_tier: DEFAULT_TIER,
             }
         );
+    }
+
+    /// The pair-level rule the graph filter uses: a pAMM is only admitted when this market holds
+    /// the Uniswap V3 pool its resolved fee tier names.
+    #[test]
+    fn test_lacks_fallback_pool_follows_the_resolved_tier() {
+        let market = market_with_fallback_pool(DEFAULT_TIER);
+        let view = market
+            .try_read_blocking()
+            .expect("uncontended");
+        let index = FallbackPoolIndex::build(&view);
+        let pamm = util::component_with_protocol(
+            PAMM_COMPONENT,
+            &format!("{PROPAMM_FALLBACK_PREFIX}fermiswap"),
+            &[util::token(1, "WETH"), util::token(2, "USDC")],
+        );
+
+        assert!(!lacks_fallback_pool(&pamm, &FeeTiers::new(DEFAULT_TIER), &index));
+        // Same pool, a tier the router does not resolve to: nothing to fall back on.
+        assert!(lacks_fallback_pool(&pamm, &FeeTiers::new(DEFAULT_TIER + 1), &index));
+    }
+
+    /// Only `propammfallback:` components are judged. Everything else routes on its own terms.
+    #[test]
+    fn test_lacks_fallback_pool_ignores_other_protocols() {
+        let market = market_with_fallback_pool(DEFAULT_TIER);
+        let view = market
+            .try_read_blocking()
+            .expect("uncontended");
+        let index = FallbackPoolIndex::build(&view);
+        let uniswap = util::component_with_protocol(
+            "0xuni",
+            "uniswap_v3",
+            &[util::token(3, "DAI"), util::token(4, "WBTC")],
+        );
+
+        assert!(!lacks_fallback_pool(&uniswap, &FeeTiers::new(DEFAULT_TIER), &index));
     }
 
     /// A split route prices through `replay_route`, so both legs of the split are counted.

--- a/fynd-core/src/worker_pool/worker.rs
+++ b/fynd-core/src/worker_pool/worker.rs
@@ -31,7 +31,8 @@ use crate::{
     },
     graph::{EdgeWeightUpdaterWithDerived, GraphManager},
     propamm_fallback::{
-        fallback_amount_out, has_pamm_leg, FallbackAmountOut, FallbackPoolIndex, SharedFeeTiers,
+        fallback_amount_out, has_pamm_leg, lacks_fallback_pool, FallbackAmountOut,
+        FallbackPoolIndex, FeeTiers, SharedFeeTiers,
     },
     types::internal::SolveTask,
     worker_pool_router::LiquidityScope,
@@ -81,6 +82,12 @@ where
     ready_notify: Arc<Notify>,
     /// Whether the graph has been initialized.
     initialized: bool,
+    /// Whether the fee tiers were known when the graph was last built.
+    ///
+    /// `FeeTierFetcher` runs as its own task, so a worker usually builds its first graph before
+    /// the tiers arrive and admits every pAMM. This records that, so the graph can be rebuilt once
+    /// the tiers land and the pAMMs without a fallback pool can be left out.
+    built_with_fee_tiers: bool,
     /// Worker identifier (for logging).
     worker_id: usize,
     /// Worker pool name (used as the `pool` metric label).
@@ -129,6 +136,7 @@ where
             readiness_tracker: ReadinessTracker::new(requirements),
             ready_notify: Arc::new(Notify::new()),
             initialized: false,
+            built_with_fee_tiers: false,
             worker_id,
             pool_name,
             liquidity_scope: LiquidityScope::default(),
@@ -158,9 +166,34 @@ where
 
     /// Whether this worker must keep `component` out of its graph: an exclusive component in a
     /// `PublicOnly` worker pool, or a component of an excluded protocol system.
+    ///
+    /// Holds for the life of the worker, which is what lets it filter state updates and removals
+    /// as well as additions.
     fn drops_component(&self, component: &ProtocolComponent) -> bool {
         (self.liquidity_scope == LiquidityScope::PublicOnly && is_exclusive(component)) ||
             is_excluded_protocol(&self.exclude_protocols, component)
+    }
+
+    /// Whether this worker must leave `component` out when it builds its graph.
+    ///
+    /// [`drops_component`](Self::drops_component) plus a pAMM whose fallback pool this market does
+    /// not hold. That leg can never produce a quotable route, so leaving it out lets the algorithm
+    /// route around it instead of assembling a route the worker then discards whole.
+    ///
+    /// Only used when building the graph. The fee tiers and the fallback pools both change over
+    /// time, so this answer expires; applying it to a state update or a removal would freeze a
+    /// component's price or strand it in the graph. [`fallback_amount_out`] stays authoritative
+    /// and catches every case this misses.
+    ///
+    /// `fee_tiers` is read once per build rather than per component: `snapshot` copies the map.
+    fn drops_component_on_build(
+        &self,
+        component: &ProtocolComponent,
+        fee_tiers: Option<&FeeTiers>,
+    ) -> bool {
+        self.drops_component(component) ||
+            fee_tiers
+                .is_some_and(|tiers| lacks_fallback_pool(component, tiers, &self.fallback_pools))
     }
 
     /// A read view of the market the solve runs against: the overlay `label` names, else the live
@@ -189,20 +222,23 @@ where
     /// Gets the market topology from MarketState and uses it to build the graph.
     pub async fn initialize_graph(&mut self) {
         let topology = {
-            // read lock on market data
+            // One read: the index and the topology must describe the same market, or a pAMM whose
+            // fallback pool arrived between two reads is left out for the life of the worker.
             let market = self.market_data.read().await;
+            self.fallback_pools = FallbackPoolIndex::build(&market);
             let topology = market.component_topology().clone(); // clone to avoid holding the lock
+            let fee_tiers = self.fallback_fee_tiers.snapshot();
             remove_components(market.base_market_state(), topology, &|component| {
-                self.drops_component(component)
+                self.drops_component_on_build(component, fee_tiers.as_ref())
             })
         };
 
         self.graph_manager
             .initialize_graph(&topology);
-        {
-            let market = self.market_data.read().await;
-            self.fallback_pools = FallbackPoolIndex::build(&market);
-        }
+        self.built_with_fee_tiers = self
+            .fallback_fee_tiers
+            .snapshot()
+            .is_some();
         self.initialized = true;
     }
 
@@ -220,6 +256,15 @@ where
                     let market = self.market_data.read().await;
                     self.fallback_pools
                         .apply_event(&market, &event);
+                }
+                if !self.built_with_fee_tiers &&
+                    self.fallback_fee_tiers
+                        .snapshot()
+                        .is_some()
+                {
+                    // The first graph was built without the tiers, so it admitted every pAMM.
+                    // Rebuild once now that the router's tiers are known.
+                    self.initialize_graph().await;
                 }
                 if let Err(e) = self
                     .graph_manager
@@ -1093,6 +1138,68 @@ mod tests {
 
         assert!(worker.drops_component(&pamm));
         assert!(!worker.drops_component(&public));
+    }
+
+    /// The pAMM rule applies when the graph is built and nowhere else. `drops_component` also
+    /// filters state updates and removals, and a component dropped there would keep a frozen price
+    /// and could never leave the graph.
+    #[test]
+    fn test_drops_component_on_build_pamm_without_fallback_pool() {
+        let (market, _) = setup_market_weighted(vec![]);
+        let worker = SolverWorker::new(
+            market,
+            DerivedData::new_shared(),
+            MockAlgorithm::new(),
+            0,
+            "test_pool".to_string(),
+        );
+        let fee_tiers = FeeTiers::new(3000);
+        let pamm = component_with_protocol(
+            "pamm-1",
+            "propammfallback:fermiswap",
+            &[token(0x01, "A"), token(0x02, "B")],
+        );
+
+        assert!(worker.drops_component_on_build(&pamm, Some(&fee_tiers)));
+        assert!(!worker.drops_component(&pamm));
+    }
+
+    /// The fee tiers arrive on their own task, so the first graph is usually built without them.
+    /// Admitting every pAMM then is what leaves the post-assembly check to catch them.
+    #[test]
+    fn test_drops_component_on_build_pamm_before_fee_tiers() {
+        let (market, _) = setup_market_weighted(vec![]);
+        let worker = SolverWorker::new(
+            market,
+            DerivedData::new_shared(),
+            MockAlgorithm::new(),
+            0,
+            "test_pool".to_string(),
+        );
+
+        let pamm = component_with_protocol(
+            "pamm-1",
+            "propammfallback:fermiswap",
+            &[token(0x01, "A"), token(0x02, "B")],
+        );
+        assert!(!worker.drops_component_on_build(&pamm, None));
+    }
+
+    /// An excluded protocol stays excluded when the graph is built, not just when events arrive.
+    #[test]
+    fn test_drops_component_on_build_excluded_protocol() {
+        let (market, _) = setup_market_weighted(vec![]);
+        let worker = SolverWorker::new(
+            market,
+            DerivedData::new_shared(),
+            MockAlgorithm::new(),
+            0,
+            "test_pool".to_string(),
+        )
+        .with_exclude_protocols(vec!["uniswap_v3".to_string()]);
+
+        let excluded = component_with_protocol("uni-1", "uniswap_v3", &[token(0x01, "A")]);
+        assert!(worker.drops_component_on_build(&excluded, None));
     }
 
     /// Without `exclude_protocols` the worker drops nothing on protocol grounds — the liquidity


### PR DESCRIPTION
## What this changes

A `propammfallback:` leg reaches the chain through Titan's PropAMMRouter, which falls back to a Uniswap V3 pool when the maker's quote goes stale. `min_amount_out` still describes the pAMM quote, so a fallback below it reverts the route — the worker therefore refuses to quote a pAMM leg whose fallback pool this market does not hold.

It made that call in `fallback_amount_out`, after the algorithm had assembled a route, and discarded the whole route. The decision is fixed per pair and fee tier, so the algorithm rebuilt the same doomed routes on every order, and it fell hardest on the algorithms that split: the more venues a route touches, the likelier one leg fails.

The graph now leaves such a component out, so the algorithm routes around it.

## Evidence

On a 5000-order live run against block 25852983, with five pAMM venues streamed, **all 2017 dropped routes were `propammfallback:fermiswap` on USDT/cbBTC**. Its resolved tier is the router's global `fallbackFee` of 3000, and `getPool(USDT, cbBTC, 3000)` is `0x3696Ed1d5A75694dd9779976bC9E7c22e555f934`, which exists with `liquidity() = 0`. Tycho correctly excludes an empty pool, so the market holds no fallback and the refusal is right.

Every drop reported `pair_absent_from_market=true`; none were the native-ETH case, and none were a tier the market held a pool at but the router did not resolve to.

Cost of the old placement, same run: aperture settled $9-11M less order volume than `bellman_ford`, concentrated in three orders at d2 — one of them $7.0M — all lost to this check.

## Shape

`lacks_fallback_pool` lives in `propamm_fallback`, beside the fee tiers and the pool index that answer it. The worker asks; it does not restate the rule.

`drops_component_on_build` is separate from `drops_component`. `drops_component` holds for the life of the worker, which is what lets `filter_event` apply it to state updates and removals as well as additions. The pAMM answer expires — both the fee tiers and the fallback pools change — so filtering an update with it would freeze a component's price and filtering a removal would strand it in the graph.

`FeeTierFetcher` runs as its own task, so a worker usually builds its first graph before the tiers arrive and admits every pAMM. The worker records that and rebuilds once the tiers land.

`fallback_amount_out` stays authoritative. The graph filter saves the work of assembling a route that cannot be quoted; it does not decide whether one can.

## Upstream

`fermiswap` is quoting a pair whose resolved fallback pool has no liquidity. Either that pair should not be quoted, or the router needs a `getPairFee` override naming a tier with a real pool. That would recover the routes rather than skip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)