### PR TITLE
fix(hindsight): veto same-token trades, count pass-through output once

### DIFF
--- a/tools/hindsight/README.md
+++ b/tools/hindsight/README.md
@@ -218,7 +218,7 @@ against Allium.
 | Add a venue | A `[venues.<name>]` section in the address book — its entry points. No code | The venue's trades still decode when a known solver's frame or log is inside, but the venue label falls back to the raw entry address |
 | Attribute a new venue (owner / appData tag / fee wallet / integrator tag) | The matching address-book map (`[venue_owners]` / `[venue_appdata]` / `[venue_fees]` / `[venue_integrators]`) | The venue's trades are attributed to the underlying router or settler, not the venue |
 | Read a tag from a *new* solver's own data | A `venue_fingerprint` on its `SolverDecoder`, returning the `VenueTag` variant its data carries | The tag is never read, so venues sharing that solver's router fall back to its label |
-| Reject decodes that are not real trades (an NFT purchase's payment leg, a mis-paired wrap) | A check in `veto.rs` | Records that are not trades enter the comparison |
+| Reject decodes that are not real trades (an NFT purchase's payment leg, a mis-paired wrap, a same-token round trip) | A check in `veto.rs` | Records that are not trades enter the comparison |
 | Support a new chain | A `registry/<chain>.toml` address book, an entry in `registry::BUILTIN_CHAINS` | The chain has no built-in book and must be passed via `--registry` |
 
 ### Re-solve monitor (`src/resolve/`)

--- a/tools/hindsight/src/decoder/declared.rs
+++ b/tools/hindsight/src/decoder/declared.rs
@@ -104,8 +104,13 @@ pub(crate) fn declared_flow(
 }
 
 /// Recover a settled `amount_out` the solver's data did not state: the gross amount the declared
-/// recipient received (a solver that declares none delivers to the caller, so the transaction
-/// sender is the fallback anchor).
+/// recipient received from third parties (a solver that declares none delivers to the caller, so
+/// the transaction sender is the fallback anchor).
+///
+/// Third parties only, because a recipient that is a contract can receive the output token a
+/// second time in the same transaction — a transfer to itself, a vault returning what it was
+/// forwarded, a pool it repaid — and summing every receipt then states about twice what the swap
+/// paid. See `TransferLedger::received_from_third_parties`.
 ///
 /// `None` when the recipient received none of the token, or less than the floor the same calldata
 /// enforces — a settled trade cleared its floor by construction, so a smaller receipt means the
@@ -119,7 +124,7 @@ fn recover_output(
     let recipient = declared
         .output_recipient
         .unwrap_or(sender);
-    let amount_out = transfer_ledger.received_by_address(recipient, declared.token_out);
+    let amount_out = transfer_ledger.received_from_third_parties(recipient, declared.token_out);
     if amount_out.is_zero() ||
         amount_out <
             declared
@@ -337,6 +342,29 @@ mod tests {
             declared_flow(&root, &registry, &[], &ledger, sender).err(),
             Some(Veto::OutputNotFound)
         );
+    }
+
+    #[test]
+    fn test_decode_output_receipt_counts_a_pass_through_recipient_once() {
+        // The router — the declared recipient — forwards the output to a vault, which returns
+        // most of it in the same transaction. The round trip is not the swap's payout, so the
+        // settled output is the single receipt from the pool.
+        let registry = Registry::ethereum();
+        let sender = addr(1);
+        let vault = addr(60);
+        let root = root_with_solver_frame(sender, ROUTER, FLY);
+        let logs = vec![make_transfer_log(TOKEN_IN, sender, ROUTER, U256::from(AMOUNT_IN))];
+        let native = vec![
+            (addr(50), ROUTER, U256::from(MIN_AMOUNT_OUT + 1_000)),
+            (ROUTER, vault, U256::from(MIN_AMOUNT_OUT + 1_000)),
+            (vault, ROUTER, U256::from(MIN_AMOUNT_OUT + 900)),
+        ];
+        let ledger = TransferLedger::from_transaction(&logs, &native);
+
+        let (_, flow, _) = declared_flow(&root, &registry, &[], &ledger, sender)
+            .unwrap()
+            .unwrap();
+        assert_eq!(flow.amount_out, U256::from(MIN_AMOUNT_OUT + 1_000));
     }
 
     /// An exact-output read: the output is fixed at 500, the input bounded at 1,000.

--- a/tools/hindsight/src/decoder/transfer_ledger.rs
+++ b/tools/hindsight/src/decoder/transfer_ledger.rs
@@ -184,6 +184,31 @@ impl TransferLedger {
             .fold(U256::ZERO, |total, &(_, _, _, value)| total.saturating_add(value))
     }
 
+    /// Gross amount of `token` that `recipient` received from addresses it did not itself pay
+    /// that token in this transaction (native ETH is `Address::ZERO`). Self-transfers and round
+    /// trips — a downstream contract returning what the recipient forwarded, a pool the recipient
+    /// repaid — are left out, so a pass-through recipient's receipt counts its swap output once.
+    /// Zero when nothing qualifies.
+    pub(crate) fn received_from_third_parties(&self, recipient: Address, token: Address) -> U256 {
+        let mut paid_by_recipient: HashSet<Address> = HashSet::new();
+        for &(transferred, from, to, _) in &self.transfers {
+            if transferred == token && from == recipient {
+                paid_by_recipient.insert(to);
+            }
+        }
+        let mut total = U256::ZERO;
+        for &(transferred, from, to, value) in &self.transfers {
+            if transferred == token &&
+                to == recipient &&
+                from != recipient &&
+                !paid_by_recipient.contains(&from)
+            {
+                total = total.saturating_add(value);
+            }
+        }
+        total
+    }
+
     /// Gross amount of `token` sent by `sender`, regardless of recipient (native ETH is
     /// `Address::ZERO`). Zero when the address sent none of it.
     pub(crate) fn sent_by_address(&self, sender: Address, token: Address) -> U256 {
@@ -660,5 +685,35 @@ mod tests {
             U256::from(999u64)
         );
         assert_eq!(transfer_ledger.received_by_address(addr(200), token), U256::ZERO);
+    }
+
+    #[test]
+    fn test_received_from_third_parties_excludes_self_transfers_and_round_trips() {
+        let recipient = addr(7);
+        let token = addr(10);
+        let vault = addr(60);
+        let pool = addr(61);
+        let logs = vec![
+            // The swap's own payout.
+            make_transfer_log(token, addr(50), recipient, U256::from(1_000)),
+            // A transfer to itself.
+            make_transfer_log(token, recipient, recipient, U256::from(900)),
+            // Forwarded to a vault, which returns most of it.
+            make_transfer_log(token, recipient, vault, U256::from(1_000)),
+            make_transfer_log(token, vault, recipient, U256::from(990)),
+            // A pool that paid the recipient earlier in the transaction and was repaid: excluded
+            // regardless of the order the two legs appear in.
+            make_transfer_log(token, pool, recipient, U256::from(4_585)),
+            make_transfer_log(token, recipient, pool, U256::from(3_932)),
+            // Same recipient, different token: excluded.
+            make_transfer_log(addr(11), addr(50), recipient, U256::from(999)),
+        ];
+        let transfer_ledger = TransferLedger::from_transaction(&logs, &[]);
+        assert_eq!(
+            transfer_ledger.received_from_third_parties(recipient, token),
+            U256::from(1_000u64)
+        );
+        assert_eq!(transfer_ledger.received_by_address(recipient, token), U256::from(7_475u64));
+        assert_eq!(transfer_ledger.received_from_third_parties(addr(200), token), U256::ZERO);
     }
 }

--- a/tools/hindsight/src/decoder/veto.rs
+++ b/tools/hindsight/src/decoder/veto.rs
@@ -24,6 +24,11 @@ use crate::decoder::{
 /// A transaction rejected as not a comparable trade, by the shape that disqualified it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Veto {
+    /// The trade's input and output are the same token: a resolver or arbitrage contract routed
+    /// a token through a solver and back into itself. There is no price to compare — a re-solve
+    /// of X→X is either unsolvable or returns the input — and the settled amount reads as the
+    /// input plus the return, so every such record is a loss of about half.
+    SameToken,
     /// The trader received an NFT: the netted token flow is the payment side of a purchase
     /// (e.g. an NFT sweep through Relay + Seaport), and the real consideration is invisible to
     /// ERC-20 netting — recording it would pair the payment with the change as a swap that never
@@ -90,6 +95,9 @@ pub(crate) fn check(
     registry: &Registry,
     payee: Address,
 ) -> Option<Veto> {
+    if flow.token_in == flow.token_out {
+        return Some(Veto::SameToken);
+    }
     if received_nft(logs, flow.tracked) {
         return Some(Veto::NftPurchase);
     }
@@ -209,6 +217,20 @@ mod tests {
 
     use super::*;
     use crate::decoder::test_utils::{addr, make_nft_transfer_log, make_transfer_log, swap};
+
+    #[test]
+    fn test_check_same_token() {
+        // A resolver's USDC→…→USDC arbitrage read from a solver's calldata: the same token on
+        // both sides, and nothing for a re-solve to compare against.
+        let token = addr(10);
+        let round_trip = swap(token, 1_000, token, 2_000);
+        let transfer_ledger = TransferLedger::from_transaction(&[], &[]);
+
+        assert_eq!(
+            check(&round_trip, &transfer_ledger, &[], &Registry::ethereum(), addr(1)),
+            Some(Veto::SameToken)
+        );
+    }
 
     #[test]
     fn test_received_nft_erc721() {


### PR DESCRIPTION
Two declared-read faults, both producing records that lose exactly half. Over one prod day (ethereum + base) they account for 137 and 75 declared records, −$65k and −$25k of fake losses.

**Same-token trades.** 1inch Fusion resolvers arbitrage USDC → … → USDC through KyberSwap. Kyber's calldata states `srcToken == dstToken`, so the declared read emits a trade with `token_in == token_out` whose settled amount is the input plus the return. A re-solve of X → X has nothing to compare, and every record read as −5000 bps. `veto::check` now rejects these as `Veto::SameToken`, on both decode tiers.

**Output read twice.** `recover_output` summed every transfer of the output token to the declared recipient. When the recipient is a wrapper contract it can receive the token a second time in the same transaction — a transfer to itself, a vault returning what the wrapper forwarded, a pool the wrapper repaid — so the settled output came out at about 2× what the swap paid, with Kyber's own `quoted_amount_out` sitting at half of it. `TransferLedger::received_from_third_parties` leaves out self-transfers and transfers from addresses the recipient itself paid that token to; `recover_output` uses it. `recover_input` still uses `received_by_address` for the refund it subtracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)