### PR TITLE
fix(encoding): run the encode off the runtime thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7928,9 +7928,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.370.2"
+version = "0.372.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a9fe8c760d4ace61f2b5d865e42e8caf7723651b3d1a5a3968061015090e18"
+checksum = "6120f820e993df8dfdf3641d3b11ce1eb29fa363099d326df3be792a98c4c1be"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7958,9 +7958,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.370.2"
+version = "0.372.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbefd9172c3e946814a2c1a6091bcc65ee06a8bbd2da8857bd6d8a64ebff541f"
+checksum = "a8272a9d6133cbd5388c4bee1cfae0033b7aaaf99a18f57c18300705baa6cd80"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7987,9 +7987,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.370.2"
+version = "0.372.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8064b80d05cf3f91efd39eedd1823ff502690bb848a9ef147c4f264f70e270c"
+checksum = "42aeff097e78b367b203942d1dc0f3f23497e9c19e3c228d00e87e137b4198f1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8009,9 +8009,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.370.2"
+version = "0.372.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b9c019df25a51c23852514ebbe8ee737bbaa19c9044ee6804c44100629cf31"
+checksum = "29cf4dc708f8c5a83dc713655d9d47956f2b770c22219f084e07dd81199e61da"
 dependencies = [
  "alloy",
  "chrono",
@@ -8031,9 +8031,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.370.2"
+version = "0.372.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02198292d4694cadbc08ed61356320875f9a75d11cd94c30d4ca463756a5229"
+checksum = "7e75be42bef0ecc618b63ac299b4ec00c4192f2c4774d030b712c8b515676d0d"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,8 +153,8 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-tycho-execution = ">=0.370.2"
-tycho-simulation = ">=0.370.2"
+tycho-execution = ">=0.372.0"
+tycho-simulation = ">=0.372.0"
 typetag = "0.2"
 
 # Compression

--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -48,7 +48,7 @@ const BPS_DENOMINATOR: u64 = 10_000;
 ///   no router deployed there — encoding is then unavailable and `encode()` fails clearly.
 /// * `router_fees` - Router fee configuration, refreshed from chain by a background fetcher.
 pub struct Encoder {
-    tycho_encoder: Option<Box<dyn TychoEncoder>>,
+    tycho_encoder: Option<Arc<dyn TychoEncoder>>,
     chain: Chain,
     router_address: Option<Bytes>,
     router_fees: SharedRouterFees,
@@ -169,6 +169,8 @@ impl Encoder {
                     .chain(chain)
                     .swap_encoder_registry(swap_encoder_registry)
                     .build()
+                    // Shared so the encode can move to a blocking thread.
+                    .map(|encoder| Arc::from(encoder) as Arc<dyn TychoEncoder>)
             })
             .transpose()?;
         // Without a router address there is no locker to authorize, and `encode` already fails on
@@ -307,7 +309,16 @@ impl Encoder {
             .iter()
             .map(|(_, s, _, _)| s.clone())
             .collect();
-        let encoded_solutions = tycho_encoder.encode_solutions(solutions)?;
+        // `encode_solutions` blocks. An RFQ swap fetches its signed quote over the network and
+        // waits for it, so on the runtime this would park a worker for a whole round trip, and
+        // every task sharing that worker -- the market feed included -- waits with it.
+        let encoder = Arc::clone(tycho_encoder);
+        let encoded_solutions =
+            tokio::task::spawn_blocking(move || encoder.encode_solutions(solutions))
+                .await
+                .map_err(|e| {
+                    SolveError::FailedEncoding(format!("the encoding task failed: {e}"))
+                })??;
 
         for (encoded_solution, (idx, solution, fee_breakdown, fee_rates)) in encoded_solutions
             .into_iter()
@@ -879,7 +890,7 @@ mod tests {
             rustc_hash::FxHashMap::default(),
         ));
         Encoder {
-            tycho_encoder: Some(Box::new(MockTychoEncoder)),
+            tycho_encoder: Some(Arc::new(MockTychoEncoder)),
             chain,
             router_address: Some(Bytes::from([0u8; 20].as_ref())),
             router_fees,
@@ -1073,6 +1084,21 @@ mod tests {
         assert_eq!(*solution.token_in(), Bytes::from(make_address(0x01).as_ref()));
         assert_eq!(*solution.token_out(), Bytes::from(make_address(0x03).as_ref()));
         assert_eq!(solution.swaps().len(), 2);
+    }
+
+    /// The encode has to leave the runtime thread free while it waits. `spawn_blocking` does;
+    /// `block_in_place` would panic here, because a single-threaded runtime has no other worker to
+    /// move the remaining tasks to.
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_encode_does_not_block_the_runtime_thread() {
+        let encoder = mock_encoder(Chain::Ethereum);
+
+        let encoded = encoder
+            .encode(vec![], EncodingOptions::new(0.01))
+            .await
+            .expect("encoding an empty batch is not an error");
+
+        assert!(encoded.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## How it is blocked today

`Encoder::encode` is `async`, but the work inside it is not. `TychoEncoder::encode_solutions` is a synchronous call, and for an RFQ leg (`rfq:bebop`, `rfq:hashflow`, `rfq:liquorice`, `rfq:metric`) the swap encoder fetches a signed quote over the network before it can produce calldata. It does that with `on_blocking_thread(|| runtime_handle.block_on(request_signed_quote(…)))` — a scoped thread that the caller **joins**. So the calling thread sits idle for a full network round trip.

## What it blocks

The caller is a Tokio worker thread. `WorkerPoolRouter::solve_and_encode` does `encode_quotes(…).await` with no `spawn_blocking` and no `block_in_place`, so the worker is parked for the whole encode.

`#[tokio::main]` gives one runtime shared by everything: the Tycho market feed, the gas price fetcher, the PropAMM fee tier fetchers, the derived-data computations, the metrics sampler and the RPC server. Anything scheduled on a parked worker waits with it. Tokio can steal work while some workers are free, but with as many concurrent encodes as worker threads the runtime stops making progress entirely.

Solving is unaffected — worker pools run on their own OS threads.

## Why it matters beyond latency

A slow quote is the visible symptom; the market feed falling behind is the expensive one. Blocking the runtime delays websocket ingestion, so the market the *next* solve runs against is staler than it should be. That degrades quotes that had nothing to do with the request that blocked.

## The change

`spawn_blocking` moves `encode_solutions` to the blocking pool, which is what that pool is for. `tycho_encoder` becomes an `Arc` so it can cross the thread boundary; `TychoEncoder` is already `Send + Sync`.

`block_in_place` would also free the worker, but it panics on a current-thread runtime — the default for every `#[tokio::test]`. The new test runs the encode on a single-threaded runtime, so that regression fails loudly instead of passing quietly.

## Scope

This does not make encoding faster. Total encode time is unchanged; it stops one slow encode from holding up everything else.

Making the encode itself faster is upstream: propeller-heads/tycho#1365 encodes swap groups and solutions concurrently, so a route's cost becomes its slowest RFQ hop instead of the sum. The two changes are complementary and independent.

Note that no RFQ protocol is registered without `BEBOP_KEY` or `HASHFLOW_USER`/`HASHFLOW_KEY`, so on a deployment without them `encode_solutions` does no I/O and the parked worker returns immediately. This matters the moment RFQ is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)