### PR TITLE
fix(fynd-client): expose require/default exports for CommonJS consumers

### DIFF
--- a/clients/typescript/client/package.json
+++ b/clients/typescript/client/package.json
@@ -9,8 +9,10 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Problem

`@kayibal/fynd-client` ships `"type": "module"` with an exports map that only declares `import` and `types`:

```json
"exports": { ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" } }
```

CommonJS consumers therefore can't load it. On Node 22 (which supports `require(esm)`), a `require('@kayibal/fynd-client')` still fails because no `require`/`default` condition matches during CJS resolution:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../@kayibal/fynd-client/package.json
```

This bit our NestJS backend (compiles to CommonJS) when integrating FYND as a swap provider — we're currently working around it with a local pnpm patch.

## Fix

Add `require` and `default` conditions pointing at the same ESM build, and move `types` first so it resolves before the runtime conditions:

```json
"exports": {
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.js",
    "require": "./dist/index.js",
    "default": "./dist/index.js"
  }
}
```

Node 22+ loads the ESM synchronously via `require(esm)`; a single `.d.ts` covers both module systems, so no separate CJS build is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)