### PR TITLE
fix: update Tycho to 0.378.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7921,9 +7921,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-client"
-version = "0.372.0"
+version = "0.378.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6120f820e993df8dfdf3641d3b11ce1eb29fa363099d326df3be792a98c4c1be"
+checksum = "dc0d4aa19823b680081ca151c02be6f43238c679f380db3571c2550cd5502355"
 dependencies = [
  "async-trait",
  "backoff",
@@ -7951,9 +7951,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-common"
-version = "0.372.0"
+version = "0.378.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8272a9d6133cbd5388c4bee1cfae0033b7aaaf99a18f57c18300705baa6cd80"
+checksum = "10719afff6ef37a74c354f3c91baa54ca3fb2dcff9fc69a3a2fd34dd7fca15ee"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -7980,9 +7980,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-ethereum"
-version = "0.372.0"
+version = "0.378.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42aeff097e78b367b203942d1dc0f3f23497e9c19e3c228d00e87e137b4198f1"
+checksum = "efb8a7b3fb4e7f351791a7884176f8b4ae0da0ac6c00b026be10d1953438b201"
 dependencies = [
  "alloy",
  "async-trait",
@@ -8002,9 +8002,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-execution"
-version = "0.372.0"
+version = "0.378.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29cf4dc708f8c5a83dc713655d9d47956f2b770c22219f084e07dd81199e61da"
+checksum = "ab6492cb83a587de682292c3e80d75cc102d4c55de3b6f8e7221c28260a7ad95"
 dependencies = [
  "alloy",
  "chrono",
@@ -8024,9 +8024,9 @@ dependencies = [
 
 [[package]]
 name = "tycho-simulation"
-version = "0.372.0"
+version = "0.378.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e75be42bef0ecc618b63ac299b4ec00c4192f2c4774d030b712c8b515676d0d"
+checksum = "0d573b02813ecc287f17d25e9fc5210bdb0eabbe4e3ea86b86d347e90ce58699"
 dependencies = [
  "alloy",
  "alloy-chains",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,8 +157,8 @@ metrics-exporter-prometheus = "0.16"
 metrics-util = "0.20"
 
 # Tycho
-tycho-execution = ">=0.372.0"
-tycho-simulation = ">=0.372.0"
+tycho-execution = ">=0.378.4"
+tycho-simulation = ">=0.378.4"
 typetag = "0.2"
 
 # Compression


### PR DESCRIPTION
## Summary

- update `tycho-execution` and `tycho-simulation` to `>=0.378.4`
- refresh the lockfile so the Tycho client/common/ethereum/execution/simulation crates resolve together at `0.378.4`
- consume the Robinhood default feed timing change from [tycho#1383](https://github.com/propeller-heads/tycho/pull/1383), increasing the effective readiness timeout from 3 seconds to 6 seconds

## Validation

- `cargo check --package fynd --locked`
- `cargo +nightly fmt --all --check`
- `cargo +nightly clippy --locked --all --all-features --all-targets -- -D warnings -A deprecated`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --locked --package fynd-core --package fynd-rpc-types --package fynd-rpc --package fynd-client`
- `cargo nextest run --workspace --locked --all-targets --all-features --bin fynd` — 1,736 passed, 10 skipped
- independent Claude Code/Fable review — approved with no blocking findings

`./check.sh` compiles the upgraded Tycho crates, then stops on the existing nightly deprecation in `fynd-core/src/encoding/exclusive_swap.rs:115` (`Atomic::fetch_update` was renamed to `try_update`). The clippy command above passes with only that unchanged deprecation allowed.
