### PR TITLE
chore: reduce claude pre-push checks to format and relevant tests only

### DIFF
--- a/.claude/knowledge/rust.md
+++ b/.claude/knowledge/rust.md
@@ -53,5 +53,6 @@ refactor the code instead. Comments explain WHY, not WHAT. Wrap comment lines at
 - **Concise test names.** Name tests after what is being tested, not the expected outcome. `test_find_route_options_default`
   not `test_find_route_options_default_is_no_overrides`. Prepend all test names with 'test_'.
 
-After every task is done, run the `run-ci` skill. If that is done, check whether docs need updating with the sync-docs
-skill.
+After every task is done, run `cargo +nightly fmt --all` and the tests that cover what you changed (e.g.
+`cargo nextest run -p fynd-core`). Save the full `run-ci` skill for when you open a PR or change something
+workspace-wide. Then check whether docs need updating with the sync-docs skill.

--- a/.claude/knowledge/version_control.md
+++ b/.claude/knowledge/version_control.md
@@ -2,10 +2,17 @@
 
 ## Workflow
 
-### Before committing
+### Before committing or pushing
 
 1. Re-read your changes for unnecessary complexity and unclear naming
-2. Run the `run-ci` and `sync-docs` skills.
+2. Format: `cargo +nightly fmt --all`
+3. Run only the tests that cover what you changed, e.g. `cargo nextest run -p fynd-core` or
+   `cargo nextest run -E 'test(route_validation)'`. Do not run the whole workspace.
+4. Run the `sync-docs` skill if you changed behaviour that the docs describe.
+
+Do **not** run the full CI pipeline (`run-ci` skill) on every push. Run it when you are about to
+open or update a PR for review, or when a change is wide enough that scoped tests do not cover it
+(workspace-wide refactors, `Cargo.toml`/`Cargo.lock`, RPC types, release prep).
 
 ### Commits
 

--- a/.claude/skills/run-ci/SKILL.md
+++ b/.claude/skills/run-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 allowed-tools: Bash(cargo:*), Bash(pnpm:*), Bash(npx:*), Bash(jq:*), Bash(diff:*), Bash(git diff:*), Bash(git branch:*), Bash(git status:*), Read
-description: "Run the full CI pipeline locally to catch failures before pushing. Use this skill before creating a PR, before pushing commits, or whenever you want to verify that CI will pass. Also use it when the user says 'run ci', 'check ci', 'run tests', 'lint', or 'will ci pass'."
+description: "Run the full CI pipeline locally. Use this skill when opening or updating a PR, when a change is workspace-wide (Cargo.toml/Cargo.lock, RPC types, broad refactor), or when the user says 'run ci', 'check ci', 'full ci', or 'will ci pass'. Do NOT use it for routine commits and pushes — those only need a format run and the tests covering the change."
 user-invocable: true
 ---
 
@@ -8,6 +8,9 @@ user-invocable: true
 
 Run the same checks that GitHub Actions CI runs, locally, to catch failures before they hit the
 remote pipeline. The canonical checks live in `.github/workflows/ci.yaml`.
+
+This is the wide, slow check. For a routine commit or push, run `cargo +nightly fmt --all` and the
+tests covering the change instead (see `.claude/knowledge/version_control.md`).
 
 ## Context
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,5 +32,7 @@ When spawning subagents, pass the relevant knowledge document contents to them.
 - `plan`: Guided feature planning with iterative user input. Gathers requirements, validates assumptions, proposes a
   solution. **Always use this skill** when the user wants to plan, design, or architect a feature before coding. Trigger
   words: "plan", "design", "architect", "think through", "figure out how to".
-- `run-ci`: Run all CI checks locally (format, clippy, tests, OpenAPI drift).
+- `run-ci`: Run all CI checks locally (format, clippy, tests, OpenAPI drift). Use it for PRs and
+  workspace-wide changes, not for routine pushes — those need only a format run and the tests
+  covering the change.
 - `sync-docs`: Review all codebase documentation and update claude docs


### PR DESCRIPTION
Claude running the full CI before every commit/push was tedious and unnecessary. Now it only runs formatting checks and relevant tests only.