### PR TITLE
feat(core): scope RFQ quotes to the order id

### DIFF
--- a/fynd-core/src/encoding/encoder.rs
+++ b/fynd-core/src/encoding/encoder.rs
@@ -136,7 +136,10 @@ fn solution_from_quote(
         quote.amount_out().clone(),
         min_amount_out,
         swaps,
-    ))
+    )
+    // Scopes the solution's RFQ quotes (Hashflow effective trader) to this quote request, so
+    // concurrent requests get independent nonce sequences.
+    .with_quote_request_id(quote.order_id().to_string()))
 }
 
 impl Encoder {


### PR DESCRIPTION
Pass the order id as the solution's quote_request_id, so Hashflow quotes are attributed to an address derived from (sender, order id): concurrent orders get independent nonce sequences and stop invalidating each other's quotes.

Blocked on a tycho-execution release with Solution::quote_request_id (kt/fix-hashflow-quotes-order) and the version bump here.