### PR TITLE
feat(core): build a solver with pending state and a step controller

### DIFF
--- a/fynd-core/CLAUDE.md
+++ b/fynd-core/CLAUDE.md
@@ -61,7 +61,8 @@ Price guard methods: `price_guard_enabled(bool)`, `register_price_provider(Box<d
 
 Additional builder methods: `partial_blocks(bool)` (enable flashblock/partial-block updates),
 `with_pending_indexer(...)` (attach a pending-block indexer), `build_with_pending()` (build with
-pending-block support). `Solver::subscribe_market_events()` returns a broadcast receiver for
+pending-block support), `build_with_pending_and_step_controller()` (the same, plus a
+`BlockStepController` that gates each block; feature `experimental`). `Solver::subscribe_market_events()` returns a broadcast receiver for
 `MarketEvent`s.
 
 ## Adding a Custom Algorithm

--- a/fynd-core/src/feed/tycho_feed.rs
+++ b/fynd-core/src/feed/tycho_feed.rs
@@ -14,10 +14,11 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 use tracing::{debug, info, instrument, span, trace, Instrument, Level};
-#[cfg(feature = "experimental")]
-use tycho_simulation::evm::stream::BlockStepController;
 use tycho_simulation::{
-    evm::{pending::PendingBlockProcessor, stream::ProtocolStreamBuilder},
+    evm::{
+        pending::PendingBlockProcessor,
+        stream::{BlockStepController, ProtocolStreamBuilder},
+    },
     protocol::models::Update,
     rfq::stream::RFQStreamBuilder,
     tycho_client::feed::{component_tracker::ComponentFilter, SynchronizerState},
@@ -57,6 +58,61 @@ pub(crate) struct TychoFeed {
 /// Client-metadata entries Fynd reports to Tycho via the `X-Tycho-Client-Metadata` header.
 fn fynd_client_metadata() -> [(&'static str, &'static str); 1] {
     [("fynd_version", env!("CARGO_PKG_VERSION"))]
+}
+
+/// The handles a caller of [`TychoFeed::run_with_pending`] waits on while the feed sets up.
+///
+/// Every setup failure is fanned out to every handle, so the caller learns the root cause from
+/// whichever one it awaits first.
+pub(crate) struct PendingFeedSetup {
+    pending_tx: oneshot::Sender<Result<PendingBlockProcessor, String>>,
+    step_tx: Option<oneshot::Sender<Result<BlockStepController, String>>>,
+}
+
+impl PendingFeedSetup {
+    /// A setup that delivers the pending processor alone; blocks flow ungated.
+    pub(crate) fn new(pending_tx: oneshot::Sender<Result<PendingBlockProcessor, String>>) -> Self {
+        Self { pending_tx, step_tx: None }
+    }
+
+    /// A setup that also delivers a [`BlockStepController`], gating every block behind it.
+    #[cfg(feature = "experimental")]
+    pub(crate) fn gated(
+        pending_tx: oneshot::Sender<Result<PendingBlockProcessor, String>>,
+        step_tx: oneshot::Sender<Result<BlockStepController, String>>,
+    ) -> Self {
+        Self { pending_tx, step_tx: Some(step_tx) }
+    }
+
+    fn gates_blocks(&self) -> bool {
+        self.step_tx.is_some()
+    }
+
+    fn fail(self, message: &str) {
+        let Self { pending_tx, step_tx } = self;
+        let _ = pending_tx.send(Err(message.to_string()));
+        if let Some(step_tx) = step_tx {
+            let _ = step_tx.send(Err(message.to_string()));
+        }
+    }
+
+    fn deliver(self, pending: PendingBlockProcessor, controller: Option<BlockStepController>) {
+        let Self { pending_tx, step_tx } = self;
+        if pending_tx.send(Ok(pending)).is_err() {
+            tracing::warn!(
+                "PendingBlockProcessor receiver dropped before send; continuing without pending \
+                 updates"
+            );
+        }
+        if let (Some(step_tx), Some(controller)) = (step_tx, controller) {
+            if step_tx.send(Ok(controller)).is_err() {
+                tracing::warn!(
+                    "BlockStepController receiver dropped before send; the dropped controller \
+                     leaves the stream ungated"
+                );
+            }
+        }
+    }
 }
 
 impl TychoFeed {
@@ -263,223 +319,42 @@ impl TychoFeed {
     }
 
     /// Like [`run`](Self::run) but calls [`ProtocolStreamBuilder::build_with_pending`]
-    /// and delivers the [`PendingBlockProcessor`] (or a setup error) via `pending_tx`
-    /// before entering the stream loop.
+    /// and delivers the [`PendingBlockProcessor`] via `setup` before entering the stream
+    /// loop.
     ///
-    /// If setup fails before the processor can be created, the error message is sent
-    /// through the channel so the caller can surface the root cause instead of seeing
-    /// only "channel closed". If the receiver has already been dropped the processor is
-    /// discarded and the feed continues normally.
+    /// When `setup` carries a step channel, every block is gated behind the
+    /// [`BlockStepController`] delivered on it: the caller must call
+    /// [`BlockStepController::trigger_next_block`] for each block to be processed, and
+    /// dropping the controller ungates the stream. Gating needs at least one Tycho-streamed
+    /// protocol; a configuration without one fails with [`DataFeedError::Config`].
+    ///
+    /// If setup fails before the handles can be created, the error message is sent through
+    /// every channel so the caller can surface the root cause instead of seeing only
+    /// "channel closed". Handles whose receiver has already been dropped are discarded and
+    /// the feed continues normally.
     ///
     /// RFQ protocols are handled alongside the EVM stream, identical to [`run`](Self::run).
     /// The `PendingBlockProcessor` only covers EVM on-chain state.
     pub(crate) async fn run_with_pending(
         self,
-        pending_tx: oneshot::Sender<Result<PendingBlockProcessor, String>>,
+        setup: PendingFeedSetup,
         pending_indexers: Vec<(String, Box<dyn TxDeltaIndexer>)>,
     ) -> Result<(), DataFeedError> {
         info!(
             tycho_url = %self.config.tycho_url,
             protocols = ?self.config.protocols,
+            gated = setup.gates_blocks(),
             "Starting Data Feed (with pending)..."
         );
 
-        let tycho_api_key = self
-            .config
-            .tycho_api_key
-            .clone()
-            .or_else(|| std::env::var("TYCHO_API_KEY").ok());
-
-        let all_tokens = match load_all_tokens(
-            self.config.tycho_url.as_str(),
-            !self.config.use_tls,
-            tycho_api_key.as_deref(),
-            true,
-            self.config.chain,
-            Some(self.config.min_token_quality),
-            self.config.traded_n_days_ago,
-        )
-        .await
-        {
-            Ok(t) => t,
-            Err(e) => {
-                let e = DataFeedError::StreamError(e.to_string());
-                let _ = pending_tx.send(Err(e.to_string()));
-                return Err(e);
-            }
-        };
-
-        debug!("Loaded {} tokens from Tycho", all_tokens.len());
-
-        let mut stream_builder = match register_exchanges(
-            ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
-                .skip_state_decode_failures(true),
-            ComponentFilter::with_tvl_range(
-                self.config.min_tvl / self.config.tvl_buffer_ratio,
-                self.config.min_tvl,
-            )
-            .blocklist(
-                self.config
-                    .blocklisted_components
-                    .clone(),
-            ),
-            &self.config.protocols,
-        ) {
-            Ok(sb) => sb,
-            Err(e) => {
-                let _ = pending_tx.send(Err(e.to_string()));
-                return Err(e);
-            }
-        }
-        .auth_key(self.config.tycho_api_key.clone())
-        .skip_state_decode_failures(true)
-        .min_token_quality(self.config.min_token_quality as u32)
-        .add_client_metadata(fynd_client_metadata())
-        .set_tokens(all_tokens.clone())
-        .await;
-
-        for (extractor, indexer) in pending_indexers {
-            stream_builder = match stream_builder.with_pending_indexer(&extractor, indexer) {
-                Ok(sb) => sb,
-                Err(e) => {
-                    let e = DataFeedError::StreamError(e.to_string());
-                    let _ = pending_tx.send(Err(e.to_string()));
-                    return Err(e);
-                }
-            };
-        }
-
-        let (protocol_stream, pending) = match stream_builder
-            .build_with_pending()
-            .await
-        {
-            Ok(pair) => pair,
-            Err(e) => {
-                let e = DataFeedError::StreamError(e.to_string());
-                let _ = pending_tx.send(Err(e.to_string()));
-                return Err(e);
-            }
-        };
-        let mut protocol_stream = Box::pin(protocol_stream);
-
-        if pending_tx.send(Ok(pending)).is_err() {
-            tracing::warn!(
-                "PendingBlockProcessor receiver dropped before send; continuing without pending \
-                 updates"
-            );
-        }
-
-        // Spawn RFQ stream (same as run()) — runs alongside the EVM pending stream.
-        let (mut rfq_rx, mut rfq_handle) = if self
+        let all_rfq = self
             .config
             .protocols
             .iter()
-            .any(|p| p.starts_with("rfq:"))
-        {
-            let rfq_tokens: HashSet<Bytes> = all_tokens.keys().cloned().collect();
-            let rfq_stream_builder = register_rfq(
-                RFQStreamBuilder::new()
-                    .set_tokens(all_tokens)
-                    .await,
-                self.config.chain,
-                self.config.min_tvl,
-                &self.config.protocols,
-                rfq_tokens,
-            )?;
-            let (rfq_tx, rfq_rx) = tokio::sync::mpsc::channel(64);
-            let rfq_handle: JoinHandle<Result<(), DataFeedError>> = tokio::spawn(async move {
-                rfq_stream_builder
-                    .build(rfq_tx)
-                    .await
-                    .map_err(|e| DataFeedError::StreamError(e.to_string()))?;
-                Ok(())
-            });
-            (Some(rfq_rx), Some(rfq_handle))
-        } else {
-            (None, None)
-        };
-
-        loop {
-            tokio::select! {
-                msg = protocol_stream.next() => {
-                    match msg {
-                        Some(msg) => {
-                            trace!("Received message from protocol stream: {:?}", msg);
-                            let msg = msg.map_err(|e| DataFeedError::StreamError(e.to_string()))?;
-                            self.handle_tycho_message(msg).await?;
-                        }
-                        None => {
-                            info!("Protocol stream ended");
-                            break;
-                        }
-                    }
-                }
-                msg = async {
-                    if let Some(rx) = &mut rfq_rx { rx.recv().await }
-                    else { std::future::pending().await }
-                } => {
-                    match msg {
-                        Some(msg) => {
-                            trace!("Received message from RFQ stream: {:?}", msg);
-                            self.handle_tycho_message(msg).await?;
-                        }
-                        None => {
-                            info!("RFQ stream ended");
-                            break;
-                        }
-                    }
-                }
-                rfq_result = async {
-                    if let Some(handle) = &mut rfq_handle { handle.await }
-                    else { std::future::pending().await }
-                } => {
-                    match rfq_result {
-                        Ok(Ok(())) => {
-                            return Err(DataFeedError::StreamError(
-                                "RFQ stream task ended unexpectedly".to_string(),
-                            ));
-                        }
-                        Ok(Err(e)) => {
-                            return Err(DataFeedError::StreamError(format!("RFQ stream error: {e}")));
-                        }
-                        Err(e) => {
-                            return Err(DataFeedError::StreamError(format!("RFQ task panicked: {e}")));
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Like [`run`](Self::run) but gates each block behind a [`BlockStepController`].
-    ///
-    /// Delivers the controller (or an error string) via `controller_tx` once the stream is
-    /// built and before the first block is processed. The caller must call
-    /// [`BlockStepController::trigger_next_block`] for each block to be processed.
-    ///
-    /// Only valid when at least one non-RFQ protocol is configured. Returns
-    /// [`DataFeedError::Config`] if all protocols are RFQ.
-    #[cfg(feature = "experimental")]
-    pub(crate) async fn run_with_step_controller(
-        self,
-        controller_tx: oneshot::Sender<Result<BlockStepController, String>>,
-    ) -> Result<(), DataFeedError> {
-        info!(
-            tycho_url = %self.config.tycho_url,
-            protocols = ?self.config.protocols,
-            "Starting Data Feed (with step controller)..."
-        );
-
-        if self
-            .config
-            .protocols
-            .iter()
-            .all(|p| p.starts_with("rfq:"))
-        {
-            let msg = "step controller requires at least one non-RFQ protocol".to_string();
-            let _ = controller_tx.send(Err(msg.clone()));
+            .all(|p| p.starts_with("rfq:"));
+        if setup.gates_blocks() && all_rfq {
+            let msg = "step controller requires at least one Tycho-streamed protocol".to_string();
+            setup.fail(&msg);
             return Err(DataFeedError::Config(msg));
         }
 
@@ -503,32 +378,30 @@ impl TychoFeed {
             Ok(t) => t,
             Err(e) => {
                 let e = DataFeedError::StreamError(e.to_string());
-                let _ = controller_tx.send(Err(e.to_string()));
+                setup.fail(&e.to_string());
                 return Err(e);
             }
         };
 
         debug!("Loaded {} tokens from Tycho", all_tokens.len());
 
-        let tvl_filter = ComponentFilter::with_tvl_range(
-            self.config.min_tvl / self.config.tvl_buffer_ratio,
-            self.config.min_tvl,
-        )
-        .blocklist(
-            self.config
-                .blocklisted_components
-                .clone(),
-        );
-
         let mut stream_builder = match register_exchanges(
             ProtocolStreamBuilder::new(&self.config.tycho_url, self.config.chain)
                 .skip_state_decode_failures(true),
-            tvl_filter,
+            ComponentFilter::with_tvl_range(
+                self.config.min_tvl / self.config.tvl_buffer_ratio,
+                self.config.min_tvl,
+            )
+            .blocklist(
+                self.config
+                    .blocklisted_components
+                    .clone(),
+            ),
             &self.config.protocols,
         ) {
             Ok(sb) => sb,
             Err(e) => {
-                let _ = controller_tx.send(Err(e.to_string()));
+                setup.fail(&e.to_string());
                 return Err(e);
             }
         }
@@ -541,24 +414,46 @@ impl TychoFeed {
             stream_builder = stream_builder.enable_partial_blocks();
         }
 
-        let stream_builder = stream_builder
+        let mut stream_builder = stream_builder
             .set_tokens(all_tokens.clone())
             .await;
-        let (stream_builder, controller) = stream_builder.with_step_controller();
 
-        let mut protocol_stream = match stream_builder.build().await {
-            Ok(stream) => {
-                let _ = controller_tx.send(Ok(controller));
-                Box::pin(stream)
-            }
-            Err(e) => {
-                let msg = e.to_string();
-                let _ = controller_tx.send(Err(msg.clone()));
-                return Err(DataFeedError::StreamError(msg));
-            }
+        for (extractor, indexer) in pending_indexers {
+            stream_builder = match stream_builder.with_pending_indexer(&extractor, indexer) {
+                Ok(sb) => sb,
+                Err(e) => {
+                    let e = DataFeedError::StreamError(e.to_string());
+                    setup.fail(&e.to_string());
+                    return Err(e);
+                }
+            };
+        }
+
+        // `build_with_pending` wires the gating itself once `with_step_controller` has been
+        // called, so one build serves both the gated and the free-running feed.
+        let (stream_builder, controller) = if setup.gates_blocks() {
+            let (stream_builder, controller) = stream_builder.with_step_controller();
+            (stream_builder, Some(controller))
+        } else {
+            (stream_builder, None)
         };
 
-        // Spawn rfq stream (same as run()).
+        let (protocol_stream, pending) = match stream_builder
+            .build_with_pending()
+            .await
+        {
+            Ok(pair) => pair,
+            Err(e) => {
+                let e = DataFeedError::StreamError(e.to_string());
+                setup.fail(&e.to_string());
+                return Err(e);
+            }
+        };
+        let mut protocol_stream = Box::pin(protocol_stream);
+
+        setup.deliver(pending, controller);
+
+        // Spawn RFQ stream (same as run()) — runs alongside the EVM pending stream.
         let (mut rfq_rx, mut rfq_handle) = if self
             .config
             .protocols
@@ -801,6 +696,42 @@ mod tests {
 
     use super::*;
     use crate::feed::{market_data::MarketData, TychoFeedConfig};
+
+    #[tokio::test]
+    async fn test_pending_feed_setup_fail_reaches_every_handle() {
+        let (pending_tx, pending_rx) = oneshot::channel();
+        let (step_tx, step_rx) = oneshot::channel();
+        let setup = PendingFeedSetup { pending_tx, step_tx: Some(step_tx) };
+
+        setup.fail("tokens did not load");
+
+        assert_eq!(
+            pending_rx
+                .await
+                .unwrap()
+                .err()
+                .as_deref(),
+            Some("tokens did not load")
+        );
+        assert_eq!(step_rx.await.unwrap().err().as_deref(), Some("tokens did not load"));
+    }
+
+    #[tokio::test]
+    async fn test_pending_feed_setup_fail_without_step_channel() {
+        let (pending_tx, pending_rx) = oneshot::channel();
+        let setup = PendingFeedSetup::new(pending_tx);
+
+        setup.fail("tokens did not load");
+
+        assert_eq!(
+            pending_rx
+                .await
+                .unwrap()
+                .err()
+                .as_deref(),
+            Some("tokens did not load")
+        );
+    }
 
     /// Creates a new shared market data instance.
     fn new_shared_market_data() -> MarketData {

--- a/fynd-core/src/lib.rs
+++ b/fynd-core/src/lib.rs
@@ -73,8 +73,9 @@ pub use tycho_simulation::evm::pending::PendingBlockProcessor;
 pub use tycho_simulation::evm::pending::PendingError;
 /// A pending transaction bundle passed to [`PendingBlockProcessor`] for simulation.
 pub use tycho_simulation::evm::pending::PendingUpdate;
-/// Handle returned by [`FyndBuilder::build_with_step_controller`] that controls when each
-/// buffered block is released for decoding. See [`tycho_simulation`] for the full API.
+/// Handle returned by [`FyndBuilder::build_with_pending_and_step_controller`] and
+/// [`FyndBuilder::build_with_step_controller`] that controls when each buffered block is
+/// released for decoding. See [`tycho_simulation`] for the full API.
 #[cfg(feature = "experimental")]
 pub use tycho_simulation::evm::stream::BlockStepController;
 /// Implement this trait and register it via

--- a/fynd-core/src/solver.rs
+++ b/fynd-core/src/solver.rs
@@ -10,12 +10,15 @@
 //!     .algorithm("most_liquid")
 //!     .build()?;
 //! ```
-use std::{str::FromStr, sync::Arc, time::Duration};
+use std::{future::Future, str::FromStr, sync::Arc, time::Duration};
 
 use num_cpus;
 use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::{
+    sync::{broadcast, oneshot},
+    task::JoinHandle,
+};
 use tycho_execution::encoding::evm::swap_encoder::swap_encoder_registry::SwapEncoderRegistry;
 #[cfg(feature = "experimental")]
 use tycho_simulation::evm::stream::BlockStepController;
@@ -37,8 +40,8 @@ use crate::{
         gas::GasPriceFetcher,
         market_data::MarketData,
         metrics_sampler::MetricsSampler,
-        tycho_feed::TychoFeed,
-        TychoFeedConfig,
+        tycho_feed::{PendingFeedSetup, TychoFeed},
+        DataFeedError, TychoFeedConfig,
     },
     graph::EdgeWeightUpdaterWithDerived,
     price_guard::{
@@ -901,46 +904,8 @@ impl FyndBuilder {
     ///
     /// Returns [`SolverBuildError`] if any component fails to initialize.
     pub fn build(self) -> Result<Solver, SolverBuildError> {
-        let mut c = self.assemble_components()?;
-
-        let feed_handle = tokio::spawn(async move {
-            if let Err(e) = c.tycho_feed.run().await {
-                metrics::counter!("tycho_feed_failures_total").increment(1);
-                tracing::error!(error = %e, "tycho feed error");
-            }
-        });
-        let gas_price_handle = tokio::spawn(async move {
-            c.gas_price_fetcher.run().await;
-        });
-        let metrics_sampler =
-            MetricsSampler::new(c.market_data.clone(), defaults::METRICS_SAMPLE_INTERVAL);
-        let metrics_sampler_handle = tokio::spawn(async move { metrics_sampler.run().await });
-        let router_fee_handle = match c.router_fee_fetcher {
-            Some(fetcher) => tokio::spawn(async move { fetcher.run().await }),
-            None => tokio::spawn(async {}),
-        };
-        let computation_handle = tokio::spawn(async move {
-            c.computation_manager
-                .run(c.computation_event_rx, c.computation_shutdown_rx)
-                .await;
-        });
-
-        Ok(Solver {
-            router: c.router,
-            worker_pools: c.worker_pools,
-            market_data: c.market_data,
-            derived_data: c.derived_data,
-            router_fees: c.router_fees,
-            feed_handle,
-            gas_price_handle,
-            metrics_sampler_handle,
-            router_fee_handle,
-            computation_handle,
-            computation_shutdown_tx: c.computation_shutdown_tx,
-            chain: c.chain,
-            router_address: c.router_address,
-            market_event_tx: c.market_event_tx,
-        })
+        let components = self.assemble_components()?;
+        Ok(Self::start(components, |tycho_feed, _pending_indexers| tycho_feed.run()))
     }
 
     /// Assembles and starts all solver components, also returning a [`PendingBlockProcessor`]
@@ -957,136 +922,140 @@ impl FyndBuilder {
     pub async fn build_with_pending(
         self,
     ) -> Result<(Solver, PendingBlockProcessor), SolverBuildError> {
-        let mut c = self.assemble_components()?;
+        let (pending_tx, pending_rx) = oneshot::channel::<Result<PendingBlockProcessor, String>>();
+        let solver = self.start_with_pending(PendingFeedSetup::new(pending_tx))?;
+        let pending = pending_rx
+            .await
+            .map_err(|_| SolverBuildError::PendingChannelClosed)?
+            .map_err(SolverBuildError::FeedSetup)?;
+        Ok((solver, pending))
+    }
 
-        let (pending_tx, pending_rx) =
-            tokio::sync::oneshot::channel::<Result<PendingBlockProcessor, String>>();
+    /// Assembles and starts all solver components, returning the [`PendingBlockProcessor`] of
+    /// [`build_with_pending`](Self::build_with_pending) together with a [`BlockStepController`]
+    /// that decides when each buffered block is released for processing.
+    ///
+    /// Intended for deterministic testing against pending state: hold the feed one block behind
+    /// the chain with [`BlockStepController::peek_next_block`], overlay the block that really
+    /// came next through the processor, then call [`BlockStepController::trigger_next_block`]
+    /// to advance. Dropping the controller ungates the stream so it runs to its natural end.
+    ///
+    /// Only valid when at least one Tycho-streamed protocol is configured.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SolverBuildError`] if any component fails to initialize, no protocol is
+    /// Tycho-streamed, or either handshake channel closes before its handle is delivered.
+    #[cfg(feature = "experimental")]
+    pub async fn build_with_pending_and_step_controller(
+        self,
+    ) -> Result<(Solver, PendingBlockProcessor, BlockStepController), SolverBuildError> {
+        let (pending_tx, pending_rx) = oneshot::channel::<Result<PendingBlockProcessor, String>>();
+        let (controller_tx, controller_rx) =
+            oneshot::channel::<Result<BlockStepController, String>>();
+        let solver = self.start_with_pending(PendingFeedSetup::gated(pending_tx, controller_tx))?;
+        let pending = pending_rx
+            .await
+            .map_err(|_| SolverBuildError::PendingChannelClosed)?
+            .map_err(SolverBuildError::FeedSetup)?;
+        let controller = controller_rx
+            .await
+            .map_err(|_| SolverBuildError::StepControllerChannelClosed)?
+            .map_err(SolverBuildError::FeedSetup)?;
+        Ok((solver, pending, controller))
+    }
 
-        let pending_indexers = c.pending_indexers;
+    /// [`build_with_pending_and_step_controller`](Self::build_with_pending_and_step_controller)
+    /// for a caller that steps blocks but never overlays pending state; the processor is
+    /// dropped.
+    ///
+    /// # Errors
+    ///
+    /// As [`build_with_pending_and_step_controller`](Self::build_with_pending_and_step_controller).
+    #[cfg(feature = "experimental")]
+    pub async fn build_with_step_controller(
+        self,
+    ) -> Result<(Solver, BlockStepController), SolverBuildError> {
+        let (solver, _pending, controller) = self
+            .build_with_pending_and_step_controller()
+            .await?;
+        Ok((solver, controller))
+    }
+
+    fn start_with_pending(self, setup: PendingFeedSetup) -> Result<Solver, SolverBuildError> {
+        let components = self.assemble_components()?;
+        Ok(Self::start(components, move |tycho_feed, pending_indexers| {
+            tycho_feed.run_with_pending(setup, pending_indexers)
+        }))
+    }
+
+    /// Spawns every background task and hands back the running [`Solver`].
+    ///
+    /// `run_feed` chooses how the Tycho feed runs; everything else is the same for every build
+    /// path.
+    fn start<F, Fut>(components: BuiltComponents, run_feed: F) -> Solver
+    where
+        F: FnOnce(TychoFeed, Vec<(String, Box<dyn TxDeltaIndexer>)>) -> Fut,
+        Fut: Future<Output = Result<(), DataFeedError>> + Send + 'static,
+    {
+        let BuiltComponents {
+            tycho_feed,
+            mut gas_price_fetcher,
+            router_fee_fetcher,
+            computation_manager,
+            computation_event_rx,
+            computation_shutdown_tx,
+            computation_shutdown_rx,
+            router,
+            worker_pools,
+            market_data,
+            derived_data,
+            router_fees,
+            chain,
+            router_address,
+            pending_indexers,
+            market_event_tx,
+        } = components;
+
+        let feed = run_feed(tycho_feed, pending_indexers);
         let feed_handle = tokio::spawn(async move {
-            if let Err(e) = c
-                .tycho_feed
-                .run_with_pending(pending_tx, pending_indexers)
-                .await
-            {
+            if let Err(e) = feed.await {
                 metrics::counter!("tycho_feed_failures_total").increment(1);
                 tracing::error!(error = %e, "tycho feed error");
             }
         });
         let gas_price_handle = tokio::spawn(async move {
-            c.gas_price_fetcher.run().await;
+            gas_price_fetcher.run().await;
         });
         let metrics_sampler =
-            MetricsSampler::new(c.market_data.clone(), defaults::METRICS_SAMPLE_INTERVAL);
+            MetricsSampler::new(market_data.clone(), defaults::METRICS_SAMPLE_INTERVAL);
         let metrics_sampler_handle = tokio::spawn(async move { metrics_sampler.run().await });
-        let router_fee_handle = match c.router_fee_fetcher {
+        let router_fee_handle = match router_fee_fetcher {
             Some(fetcher) => tokio::spawn(async move { fetcher.run().await }),
             None => tokio::spawn(async {}),
         };
         let computation_handle = tokio::spawn(async move {
-            c.computation_manager
-                .run(c.computation_event_rx, c.computation_shutdown_rx)
+            computation_manager
+                .run(computation_event_rx, computation_shutdown_rx)
                 .await;
         });
 
-        let pending = pending_rx
-            .await
-            .map_err(|_| SolverBuildError::PendingChannelClosed)?
-            .map_err(SolverBuildError::FeedSetup)?;
-
-        Ok((
-            Solver {
-                router: c.router,
-                worker_pools: c.worker_pools,
-                market_data: c.market_data,
-                derived_data: c.derived_data,
-                router_fees: c.router_fees,
-                feed_handle,
-                gas_price_handle,
-                metrics_sampler_handle,
-                router_fee_handle,
-                computation_handle,
-                computation_shutdown_tx: c.computation_shutdown_tx,
-                chain: c.chain,
-                router_address: c.router_address,
-                market_event_tx: c.market_event_tx,
-            },
-            pending,
-        ))
-    }
-
-    /// Assembles and starts all solver components, also returning a [`BlockStepController`]
-    /// that lets the caller control when each buffered block is released for processing.
-    ///
-    /// Intended for deterministic testing: call [`BlockStepController::trigger_next_block`] to
-    /// step through blocks one at a time, and [`BlockStepController::peek_next_block`] to inspect
-    /// a block before it is decoded. Dropping the controller ungates the stream so it runs to its
-    /// natural end.
-    ///
-    /// Only valid when at least one non-RFQ protocol is configured.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`SolverBuildError`] if any component fails to initialize, all protocols are RFQ,
-    /// or the step-controller channel closes before the controller is delivered.
-    #[cfg(feature = "experimental")]
-    pub async fn build_with_step_controller(
-        self,
-    ) -> Result<(Solver, BlockStepController), SolverBuildError> {
-        let mut c = self.assemble_components()?;
-
-        let (controller_tx, controller_rx) =
-            tokio::sync::oneshot::channel::<Result<BlockStepController, String>>();
-
-        let feed_handle = tokio::spawn(async move {
-            if let Err(e) = c
-                .tycho_feed
-                .run_with_step_controller(controller_tx)
-                .await
-            {
-                tracing::error!(error = %e, "tycho feed error");
-            }
-        });
-        let gas_price_handle = tokio::spawn(async move {
-            c.gas_price_fetcher.run().await;
-        });
-        let metrics_sampler =
-            MetricsSampler::new(c.market_data.clone(), defaults::METRICS_SAMPLE_INTERVAL);
-        let metrics_sampler_handle = tokio::spawn(async move { metrics_sampler.run().await });
-        let router_fee_handle = match c.router_fee_fetcher {
-            Some(fetcher) => tokio::spawn(async move { fetcher.run().await }),
-            None => tokio::spawn(async {}),
-        };
-        let computation_handle = tokio::spawn(async move {
-            c.computation_manager
-                .run(c.computation_event_rx, c.computation_shutdown_rx)
-                .await;
-        });
-
-        let controller = controller_rx
-            .await
-            .map_err(|_| SolverBuildError::StepControllerChannelClosed)?
-            .map_err(SolverBuildError::FeedSetup)?;
-
-        Ok((
-            Solver {
-                router: c.router,
-                worker_pools: c.worker_pools,
-                market_data: c.market_data,
-                derived_data: c.derived_data,
-                router_fees: c.router_fees,
-                feed_handle,
-                gas_price_handle,
-                metrics_sampler_handle,
-                router_fee_handle,
-                computation_handle,
-                computation_shutdown_tx: c.computation_shutdown_tx,
-                chain: c.chain,
-                router_address: c.router_address,
-                market_event_tx: c.market_event_tx,
-            },
-            controller,
-        ))
+        Solver {
+            router,
+            worker_pools,
+            market_data,
+            derived_data,
+            router_fees,
+            feed_handle,
+            gas_price_handle,
+            metrics_sampler_handle,
+            router_fee_handle,
+            computation_handle,
+            computation_shutdown_tx,
+            chain,
+            router_address,
+            market_event_tx,
+        }
     }
 } // impl FyndBuilder
 


### PR DESCRIPTION
Adds `FyndBuilder::build_with_pending_and_step_controller`, which returns the `PendingBlockProcessor` of `build_with_pending` together with a `BlockStepController` that gates every block. A test harness can hold the feed one block behind the chain, overlay the block that came next through the processor, then release it.

`TychoFeed::run_with_pending` takes a `PendingFeedSetup` bundling the two handshake channels and gates the stream when a step channel is present; tycho-simulation's `build_with_pending` already wires the gating once `with_step_controller` has been called. `run_with_step_controller` is removed, and `build_with_step_controller` is the new method with the processor dropped. The three build methods spawn their background tasks through one private `FyndBuilder::start`.

Behaviour change: the pending path now honours `partial_blocks`, as `run` and the old step path did.

Based on tag 0.99.8 so that builder-integration can patch to it while staying on that release. The same change is prepared against main for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)